### PR TITLE
[UPDATE] "Split Lines" uses the edgemode if enabled

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1019,7 +1019,10 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_SPLIT_LINES:
 			_pEditView->execute(SCI_TARGETFROMSELECTION);
-			_pEditView->execute(SCI_LINESSPLIT);
+			if (_pEditView->execute(SCI_GETEDGEMODE) == EDGE_NONE)
+				_pEditView->execute(SCI_LINESSPLIT);
+			else
+				_pEditView->execute(SCI_LINESSPLIT, _pEditView->execute(SCI_TEXTWIDTH, STYLE_LINENUMBER, (LPARAM)"P") * _pEditView->execute(SCI_GETEDGECOLUMN));
 			break;
 
 		case IDM_EDIT_JOIN_LINES:


### PR DESCRIPTION
If the user has enabled the vertical edge, splitting lines will use the column width instead of the window's width.
