### PR TITLE
Allow user to say no to all "Save" questions.

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -877,3 +877,8 @@ std::vector<generic_string> numericSort(std::vector<generic_string> input, bool 
 	assert(output.size() == input.size());
 	return output;
 }
+
+bool isLeftOrRightShiftPressed()
+{
+	return ((GetAsyncKeyState(VK_LSHIFT) & 0x8000) != 0) || ((GetAsyncKeyState(VK_RSHIFT) & 0x8000) != 0);
+}

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -197,4 +197,6 @@ std::vector<generic_string> repeatString(const generic_string& text, const size_
 std::vector<generic_string> numericSort(std::vector<generic_string> input, bool isDescending);
 std::vector<generic_string> lexicographicSort(std::vector<generic_string> input, bool isDescending);
 
+bool isLeftOrRightShiftPressed();
+
 #endif //M30_IDE_COMMUN_H

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -705,6 +705,10 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 				{
 					return false;
 				}
+				else if (res == IDNO && isLeftOrRightShiftPressed())
+				{
+					break;
+				}
 			}
 		}
 	}
@@ -756,7 +760,10 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 				else if (res == IDCANCEL) 
 				{
 					return false;
-					//otherwise continue (IDNO)
+				}
+				else if (res == IDNO && isLeftOrRightShiftPressed())
+				{
+					break;
 				}
 			}
 		}
@@ -816,6 +823,10 @@ bool Notepad_plus::fileCloseAllGiven(const std::vector<int> &krvecBufferIndexes)
 			else if (res == IDCANCEL)
 			{
 					return false;
+			}
+			else if (res == IDNO && isLeftOrRightShiftPressed())
+			{
+				break;
 			}
 		}
 	}
@@ -884,6 +895,10 @@ bool Notepad_plus::fileCloseAllButCurrent()
 			{
 					return false;
 			}
+			else if (res == IDNO && isLeftOrRightShiftPressed())
+			{
+				break;
+			}
 		}
 	}
 	for(int i = 0; i < _subDocTab.nbItem(); ++i) 
@@ -910,6 +925,10 @@ bool Notepad_plus::fileCloseAllButCurrent()
 			else if (res == IDCANCEL) 
 			{
 					return false;
+			}
+			else if (res == IDNO && isLeftOrRightShiftPressed())
+			{
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
https://sourceforge.net/p/notepad-plus/discussion/331754/thread/3c0340ad/

When closing all files the user is asked if he wants to save all modified files. If he answers no to one of them while holding down one of the shift button, interpret that as "no to all" and don't ask any more questions.

Note that in Notepad_plus::fileCloseAll() there is a branch where isSnapshotMode is true. I haven't touched that one since I don't know exactly how the snapshot mode is supposed to work.