### PR TITLE
Restore position when opening recent closed file

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3178,7 +3178,7 @@ bool Notepad_plus::canHideView(int whichOne)
 	return canHide;
 }
 
-void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool dontClose)
+void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool dontClose, int tabIndex)
 {
 	DocTabView * tabToOpen = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
 	ScintillaEditView * viewToOpen = (whichOne == MAIN_VIEW)?&_mainEditView:&_subEditView;
@@ -3213,7 +3213,7 @@ void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool dontClose)
 	}
 	else
 	{
-		tabToOpen->addBuffer(id);
+		tabToOpen->addBuffer(id, tabIndex);
 	}
 }
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -127,6 +127,7 @@
 #include "localization.h"
 #include <vector>
 #include <iso646.h>
+#include <map>
 
 
 #define MENU 0x01
@@ -222,7 +223,7 @@ public:
 
 // fileOperations
 	//The doXXX functions apply to a single buffer and dont need to worry about views, with the excpetion of doClose, since closing one view doesnt have to mean the document is gone
-	BufferID doOpen(const TCHAR *fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const TCHAR *backupFileName = NULL, time_t fileNameTimestamp = 0);
+	BufferID doOpen(const TCHAR *fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const TCHAR *backupFileName = NULL, time_t fileNameTimestamp = 0, int tabIndex = -1);
 	bool doReload(BufferID id, bool alert = true);
 	bool doSave(BufferID, const TCHAR * filename, bool isSaveCopy = false);
 	void doClose(BufferID, int whichOne, bool doDeleteBackup = false);
@@ -436,6 +437,12 @@ private:
 	DocumentMap *_pDocMap;
 	FunctionListPanel *_pFuncList;
 
+	std::map<generic_string, int> _lastSeenAtIndex_Main;
+	std::map<generic_string, int> _lastSeenAtIndex_Sub;
+	void saveTabIndexForPath(const generic_string& fullPath, int tabIndex);
+	int getSuggestedTaxIndexForPath(const generic_string& fullPath);
+	void resetAllSavedTabIndexes();
+
 	BOOL notify(SCNotification *notification);
 	void specialCmd(int id);
 	void command(int id);
@@ -476,7 +483,7 @@ private:
 	void docGotoAnotherEditView(FileTransferMode mode);	//TransferMode
 	void docOpenInNewInstance(FileTransferMode mode, int x = 0, int y = 0);
 
-	void loadBufferIntoView(BufferID id, int whichOne, bool dontClose = false);		//Doesnt _activate_ the buffer
+	void loadBufferIntoView(BufferID id, int whichOne, bool dontClose = false, int tabIndex = -1);		//Doesnt _activate_ the buffer
 	bool removeBufferFromView(BufferID id, int whichOne);	//Activates alternative of possible, or creates clean document if not clean already
 
 	bool activateBuffer(BufferID id, int whichOne);			//activate buffer in that view if found

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2483,9 +2483,12 @@ void Notepad_plus::command(int id)
 			break;
 		}
 
-		case IDM_CLEAN_RECENT_FILE_LIST :
+		case IDM_CLEAN_RECENT_FILE_LIST:
+		{
+			resetAllSavedTabIndexes();
 			_lastRecentFileList.clear();
 			break;
+		}
 
 		case IDM_EDIT_RTL :
 		case IDM_EDIT_LTR :
@@ -2572,7 +2575,13 @@ void Notepad_plus::command(int id)
 			generic_string lastOpenedFullPath = _lastRecentFileList.getFirstItem();
 			if (lastOpenedFullPath != TEXT(""))
 			{
-				BufferID lastOpened = doOpen(lastOpenedFullPath.c_str());
+				bool isRecursive = false;
+				bool isReadOnly = false;
+				int encoding = -1;
+				const TCHAR *backupFileName = NULL;
+				time_t fileNameTimestamp = 0;
+				int tabIndex = getSuggestedTaxIndexForPath(lastOpenedFullPath);
+				BufferID lastOpened = doOpen(lastOpenedFullPath.c_str(), isRecursive, isReadOnly, encoding, backupFileName, fileNameTimestamp, tabIndex);
 				if (lastOpened != BUFFER_INVALID)
 				{
 					switchToFile(lastOpened);

--- a/PowerEditor/src/ScitillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScitillaComponent/DocTabView.cpp
@@ -37,7 +37,7 @@
 
 bool DocTabView::_hideTabBarStatus = false;
 
-void DocTabView::addBuffer(BufferID buffer)
+void DocTabView::addBuffer(BufferID buffer, int tabIndex)
 {
 	if (buffer == BUFFER_INVALID)	//valid only
 		return;
@@ -53,7 +53,8 @@ void DocTabView::addBuffer(BufferID buffer)
 	tie.iImage = index; 
 	tie.pszText = (TCHAR *)buf->getFileName();
 	tie.lParam = (LPARAM)buffer;
-	::SendMessage(_hSelf, TCM_INSERTITEM, _nbItem++, reinterpret_cast<LPARAM>(&tie));
+	::SendMessage(_hSelf, TCM_INSERTITEM, tabIndex == -1 ? _nbItem : tabIndex, reinterpret_cast<LPARAM>(&tie));
+	_nbItem++;
 	bufferUpdated(buf, BufferChangeMask);
 
 	::SendMessage(_hParent, WM_SIZE, 0, 0);

--- a/PowerEditor/src/ScitillaComponent/DocTabView.h
+++ b/PowerEditor/src/ScitillaComponent/DocTabView.h
@@ -60,7 +60,7 @@ public :
 		return;
 	};
 
-	void addBuffer(BufferID buffer);
+	void addBuffer(BufferID buffer, int tabIndex);
 	void closeBuffer(BufferID buffer);
 	void bufferUpdated(Buffer * buffer, int mask);
 


### PR DESCRIPTION
If you have three tabs open:

```
a b c
```

And close b:

````
a c
````

After pressing Ctrl-Shift-T, b will be at the end:

```
a c b
```

I think would be better if b's position was remembered so you would get back the way it looked originally:

```
a b c
```

This matches the way browsers work.