### PR TITLE
scintilla: buffer: fixed invalid read in the stack when loading a file

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -120,7 +120,7 @@ private:
 	size_t _nrBufs;
 	int detectCodepage(char* buf, size_t len);
 
-	bool loadFileData(Document doc, const TCHAR * filename, Utf8_16_Read * UnicodeConvertor, LangType language, int & encoding, formatType *pFormat = NULL);
+	bool loadFileData(Document doc, const TCHAR * filename, char* buffer, Utf8_16_Read * UnicodeConvertor, LangType language, int & encoding, formatType *pFormat = NULL);
 };
 
 #define MainFileManager FileManager::getInstance()


### PR DESCRIPTION
The method `FileManager::loadFileData` uses a stack-based buffer for reading
a file. However, due to the optimization used by `Utf8_16_Read` (`UnicodeConvertor`),
this buffer is not copied, but a pointer to this object is kept.
After `loadFileData`, this object is destroyed, but is used afterward
(via `UnicodeConvertor.getNewBuf`).

This patch actually follows #145 but they are independant