### PR TITLE
fixed minor memory leak when exporting the parameters to XML

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3401,28 +3401,28 @@ bool NppParameters::writeProjectPanelsSettings() const
 	TiXmlNode *nppRoot = _pXmlUserDoc->FirstChild(TEXT("NotepadPlus"));
 	if (!nppRoot) return false;
 	
-	TiXmlNode *projPanelRootNode = nppRoot->FirstChildElement(TEXT("ProjectPanels"));
-	if (projPanelRootNode)
+	TiXmlNode *oldProjPanelRootNode = nppRoot->FirstChildElement(TEXT("ProjectPanels"));
+	if (nullptr != oldProjPanelRootNode)
 	{
 		// Erase the Project Panel root
-		nppRoot->RemoveChild(projPanelRootNode);
+		nppRoot->RemoveChild(oldProjPanelRootNode);
 	}
 
 	// Create the Project Panel root
-	projPanelRootNode = new TiXmlElement(TEXT("ProjectPanels"));
+	TiXmlElement projPanelRootNode{TEXT("ProjectPanels")};
 
 	// Add 3 Project Panel parameters
 	for (int i = 0 ; i < 3 ; ++i)
 	{
-		TiXmlElement projPanelNode(TEXT("ProjectPanel"));
+		TiXmlElement projPanelNode{TEXT("ProjectPanel")};
 		(projPanelNode.ToElement())->SetAttribute(TEXT("id"), i);
 		(projPanelNode.ToElement())->SetAttribute(TEXT("workSpaceFile"), _workSpaceFilePathes[i]);
 
-		(projPanelRootNode->ToElement())->InsertEndChild(projPanelNode);
+		(projPanelRootNode.ToElement())->InsertEndChild(projPanelNode);
 	}
 
 	// (Re)Insert the Project Panel root
-	(nppRoot->ToElement())->InsertEndChild(*projPanelRootNode);
+	(nppRoot->ToElement())->InsertEndChild(projPanelRootNode);
 	return true;
 }
 


### PR DESCRIPTION
When I was analyzing each step via the debugger, I've found a minor memory leak
when the parameters are saved.
The XML node was obviously not destroyed. However, since it occurs when quitting the application
(AFAIK), this memory leak should not even be visible by the user.