### PR TITLE
Fix slow tab switching of folded XML (Issue #236 & #329)

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3167,7 +3167,9 @@ bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne)
 				toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
 			}
 			tabToClose->deletItemAt((size_t)index); //delete first
+			_isFolding = true; // So we can ignore events while folding is taking place
 			activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
+			_isFolding = false;
 		}
 	}
 	else

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -263,8 +263,11 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			switchEditViewTo(iView);
 			BufferID bufid = _pDocTab->getBufferByIndex(_pDocTab->getCurrentTabIndex());
 			if (bufid != BUFFER_INVALID)
+			{
+				_isFolding = true; // So we can ignore events while folding is taking place
 				activateBuffer(bufid, iView);
-
+				_isFolding = false;
+			}
 			break;
 		}
 


### PR DESCRIPTION
Resolved slow tab switching of an folded XML file by deleting the SCNotification code that causes a recursion. 
:)