### PR TITLE
Add grave accent to list of non-word characters

### DIFF
--- a/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
@@ -170,6 +170,7 @@ bool SmartHighlighter::isWordChar(char ch) const
 		case '$':
 		case '"':
 		case '\'':
+		case '`':
 		case '~':
 		case '&':
 		case '{':


### PR DESCRIPTION
http://sourceforge.net/p/notepad-plus/bugs/5339/

```
`abc'
` abc'
```

After double-clicking on the second abc, nothing is highlighted, unlike when you double-click on the third abc.