### PR TITLE
Use critical section in LongRunningOperation

### DIFF
--- a/PowerEditor/src/MISC/Common/LongRunningOperation.cpp
+++ b/PowerEditor/src/MISC/Common/LongRunningOperation.cpp
@@ -27,17 +27,23 @@
 
 
 #include "LongRunningOperation.h"
+#include <Windows.h>
 
-// Due to retro-compatibility reason (with xp sp2), we use ::CreateMutex() instead of std::recursive_mutex 
-// TODO :  use Windows Mutex to lock/unlock operations
+static CRITICAL_SECTION _longRunningOpSection;
 
+void initializeLongRunninOperationCriticalSection()
+{
+	::InitializeCriticalSection(&_longRunningOpSection);
+}
+
+// Due to retro-compatibility reason (with xp sp2), we use Windows' critical section instead of std::recursive_mutex.
 
 LongRunningOperation::LongRunningOperation()
 {
-	//_operationMutex.lock();
+	::EnterCriticalSection(&_longRunningOpSection);
 }
 
 LongRunningOperation::~LongRunningOperation()
 {
-	//_operationMutex.unlock();
+	::LeaveCriticalSection(&_longRunningOpSection);
 }

--- a/PowerEditor/src/MISC/Common/LongRunningOperation.h
+++ b/PowerEditor/src/MISC/Common/LongRunningOperation.h
@@ -29,6 +29,8 @@
 #ifndef M30_IDE_LONGRUNNINGOPERATION_h
 #define M30_IDE_LONGRUNNINGOPERATION_h
 
+void initializeLongRunninOperationCriticalSection();
+
 class LongRunningOperation
 {
 public:

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -29,6 +29,7 @@
 #include "Process.h"
 #include "Win32Exception.h"	//Win32 exception
 #include "MiniDumper.h"			//Write dump files
+#include "LongRunningOperation.h"
 
 typedef std::vector<const TCHAR*> ParamVector;
 
@@ -254,6 +255,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 	::CreateMutex(NULL, false, TEXT("nppInstance"));
 	if (::GetLastError() == ERROR_ALREADY_EXISTS)
 		TheFirstOne = false;
+
+	initializeLongRunninOperationCriticalSection();
 
 	bool isParamePresent;
 	bool showHelp = isInList(FLAG_HELP, params);


### PR DESCRIPTION
For compat with XP we need to use something other than std::recursive_mutex.

Note that the critical section is never deleted explicitly, it is done when the program exits.