### PR TITLE
Fix smarthighlight

### DIFF
--- a/PowerEditor/src/ScitillaComponent/SmartHighlighter.h
+++ b/PowerEditor/src/ScitillaComponent/SmartHighlighter.h
@@ -38,8 +38,8 @@ public:
 private:
 	FindReplaceDlg * _pFRDlg;
 
-	bool isQualifiedWord(const char *str) const;
-	bool isWordChar(char ch) const;
+	bool isQualifiedWord(const char *str, char listChar[]) const;
+	bool isWordChar(char ch, char listChar[]) const;
 };
 
 #endif //SMARTHIGHLIGHTER_H


### PR DESCRIPTION
Hi,
With notepad++ it is possible to select the entire word when double click on word, all words selected are highlight (smart Highlight).
But code to select word by double click is not the same as smart highlight feature.
My commit Fix smarthighlight.

more explain :
http://sourceforge.net/p/notepad-plus/patches/652/

Cyrillev