### PR TITLE
fix two NULL pointer dereferences

### DIFF
--- a/PowerEditor/src/WinControls/StatusBar/StatusBar.cpp
+++ b/PowerEditor/src/WinControls/StatusBar/StatusBar.cpp
@@ -65,6 +65,10 @@ void StatusBar::init(HINSTANCE hInst, HWND hPere, int nbParts)
 
     // Allocate an array for holding the right edge coordinates.
     _hloc = ::LocalAlloc(LHND, sizeof(int) * _nbParts);
+	if (_hloc == NULL)
+	{
+		throw std::runtime_error( "StatusBar::init : LocalAlloc failed!" );
+	}
     _lpParts = (LPINT)::LocalLock(_hloc);
 
 	RECT rc;

--- a/PowerEditor/src/WinControls/StatusBar/StatusBar.cpp
+++ b/PowerEditor/src/WinControls/StatusBar/StatusBar.cpp
@@ -65,10 +65,10 @@ void StatusBar::init(HINSTANCE hInst, HWND hPere, int nbParts)
 
     // Allocate an array for holding the right edge coordinates.
     _hloc = ::LocalAlloc(LHND, sizeof(int) * _nbParts);
-	if (_hloc == NULL)
-	{
-		throw std::runtime_error( "StatusBar::init : LocalAlloc failed!" );
-	}
+    if (_hloc == NULL)
+    {
+        throw std::runtime_error( "StatusBar::init : LocalAlloc failed!" );
+    }
     _lpParts = (LPINT)::LocalLock(_hloc);
 
 	RECT rc;


### PR DESCRIPTION
A multitude of user reported crashes (Searching the SourceForge bug tracker for "crash NULL" returns *six hundred and fifty seven tickets*) are due to `NULL` pointer dereferences. This Pull Request fixes two of them.