### PR TITLE
Add missing Mutex files to VS2015 project :)

### DIFF
--- a/PowerEditor/visual.net/notepadPlus.vs2015.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vs2015.vcxproj
@@ -141,6 +141,7 @@ copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\MISC\Common\LongRunningOperation.cpp" />
+    <ClCompile Include="..\src\MISC\Common\mutex.cpp" />
     <ClCompile Include="..\src\WinControls\AboutDlg\AboutDlg.cpp" />
     <ClCompile Include="..\src\WinControls\AnsiCharPanel\ansiCharPanel.cpp" />
     <ClCompile Include="..\src\ScitillaComponent\AutoCompletion.cpp" />
@@ -411,6 +412,8 @@ copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\MISC\Common\LongRunningOperation.h" />
+    <ClInclude Include="..\src\MISC\Common\mutex.h" />
+    <ClInclude Include="..\src\MISC\Common\mutex.hxx" />
     <ClInclude Include="..\src\ScitillaComponent\resource.h" />
     <ClInclude Include="..\src\WinControls\AboutDlg\AboutDlg.h" />
     <ClInclude Include="..\src\WinControls\AnsiCharPanel\ansiCharPanel.h" />


### PR DESCRIPTION
Commit 9ad71107e98149dc3e3e628e839d79f042437eca added file references to the new Mutex files in the VS2013 project file. To resolve build errors, these references also need to be added to the VS2015 project.