### PR TITLE
Fix issue #220 "Choice Chinese fonts name take no effect"

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -451,7 +451,7 @@ void ScintillaEditView::setSpecialStyle(const Style & styleToSet)
     if (styleToSet._fontName && lstrcmp(styleToSet._fontName, TEXT("")) != 0)
 	{
 		WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-		const char * fontNameA = wmc->wchar2char(styleToSet._fontName, CP_ACP);
+		const char * fontNameA = wmc->wchar2char(styleToSet._fontName, CP_UTF8);
 		execute(SCI_STYLESETFONT, (WPARAM)styleID, (LPARAM)fontNameA);
 	}
 	int fontStyle = styleToSet._fontStyle;


### PR DESCRIPTION
Present version scintilla(x>3.5.3) accepts a font name only in utf-8.

See also>
http://sourceforge.net/p/scintilla/bugs/1684/
http://www.scintilla.org/ScintillaHistory.html