### PR TITLE
Fix "new  0.txt" using two spaces

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1106,7 +1106,7 @@ BufferID FileManager::bufferFromDocument(Document doc, bool dontIncrease, bool d
 {
 	generic_string newTitle = UNTITLED_STR;
 	TCHAR nb[10];
-	wsprintf(nb, TEXT(" %d"), 0);
+	wsprintf(nb, TEXT("%d"), 0);
 	newTitle += nb;
 
 	if (!dontRef)


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/97, https://github.com/notepad-plus-plus/notepad-plus-plus/issues/183