### PR TITLE
Extra space in default document name at startup

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1106,7 +1106,7 @@ BufferID FileManager::bufferFromDocument(Document doc, bool dontIncrease, bool d
 {
 	generic_string newTitle = UNTITLED_STR;
 	TCHAR nb[10];
-	wsprintf(nb, TEXT(" %d"), 0);
+	wsprintf(nb, TEXT("%d"), 0);
 	newTitle += nb;
 
 	if (!dontRef)


### PR DESCRIPTION
Fixed extra space between UNTITLED_STR and document number "0" when creating a new buffer on start up through the function FileManager::bufferFromDocument(). Resolves issue #97.