### PR TITLE
Add COBOL to function list

### DIFF
--- a/PowerEditor/src/functionList.xml
+++ b/PowerEditor/src/functionList.xml
@@ -264,24 +264,25 @@ http://notepad-plus-plus.org/features/function-list.html
 			</parser>
 
 			<!-- Variant for COBOL fixed-form reference format -->
-			<parser id="cobol_section_fixed" displayName="COBOL fixed-form reference format">
+			<parser id="cobol_section_fixed" displayName="COBOL fixed-form reference format"
+				commentExpr="(?m-s)(?:^[\d\t ]{6}\*|\*&gt;).*$">
 				<function
-					mainExpr="(?m-s)^.{6}[ D][\t ]{0,3}(?!exit\s)[\w_-]+(\.|((?'seps'([\t ]|\*&gt;.*|([\n\r]+(.{6}([ D]|\*.*)|.{0,6}$)))+)section(\.|((?&seps)(\.|[\w_-]+\.)))))"
+					mainExpr="(?m-s)^.{6}[ D][\t ]{0,3}(?!exit\s)[\w_-]+(\.|((?'seps'([\t ]|([\n\r]+(.{6}[ D]|.{0,6}$)))+)section(\.|(?&seps)(\.|[\w_-]+\.))))"
 					displayMode="$functionName">
 					<functionName>
-						<nameExpr expr="[\w_-]+((?=\.)|((?'seps'([\t ]|\*&gt;.*|([\n\r]+(.{6}([ D]|\*.*)|.{0,6}$)))+)section((?=\.)|(?&seps)((?=\.)|[\w_-]+(?=\.)))))"/>
+						<nameExpr expr="[\w_-]+((?=\.)|((?'seps'([\t ]|([\n\r]+(.{6}[ D]|.{0,6}$)))+)section((?=\.)|(?&seps)((?=\.)|[\w_-]+(?=\.)))))"/>
 					</functionName>
 				</function>
 			</parser>
 
 			<!-- Variant for COBOL free-form reference format -->
-			<parser id="cobol_section_free" displayName="COBOL fixed-form reference format">
-				<!-- Variant without paragraphs (works with comment lines before section header) -->
-                		<function
-					mainExpr="[\s\.](?!exit\s)[\w_-]+\s+section(\s*|(\s+[\w_-]+)?)(?=\.)"
+			<parser id="cobol_section_free" displayName="COBOL fixed-form reference format"
+				commentExpr="(?m-s)(?:\*&gt;).*$">
+				<function
+					mainExpr="(?m-s)(?<=\.)\s*(?!exit\s)[\w_-]+(\s+section(\s*|(\s+[\w_-]+)?))(?=\.)"
 					displayMode="$functionName">
 					<functionName>
-						<nameExpr expr="[\w_-]+\s*section"/>
+						<nameExpr expr="(?m-s)(?<=[\s\.])[\w_-]+(\s*section\s*([\w_-]+)?)?"/>
 					</functionName>
 				</function>
 			</parser>

--- a/PowerEditor/src/functionList.xml
+++ b/PowerEditor/src/functionList.xml
@@ -31,6 +31,14 @@ http://notepad-plus-plus.org/features/function-list.html
 			<association langID="22" id="python_function"/>
 			<association langID="26" id="bash_function"/>
 			<association langID="28" id="nsis_syntax"/>
+			
+		<!--
+			change to "cobol_section_free" if this is the prefered reference format
+			for you, necessary as the parser is quite different and scintilla currently
+			only provides one language
+		-->
+			<association langID="50" id="cobol_section_fixed"/>
+
 		<!--
 			if langID cannot be found above, you can still set the file extensions
 			<association ext=".my_passer_ext1" id="my_passer_id"/>
@@ -252,6 +260,29 @@ http://notepad-plus-plus.org/features/function-list.html
 					</function>
 				</classRange>
 				<function mainExpr="">
+				</function>
+			</parser>
+
+			<!-- Variant for COBOL fixed-form reference format -->
+			<parser id="cobol_section_fixed" displayName="COBOL fixed-form reference format">
+				<function
+					mainExpr="(?m-s)^.{6}[ D][\t ]{0,3}(?!exit\s)[\w_-]+(\.|((?'seps'([\t ]|\*&gt;.*|([\n\r]+(.{6}([ D]|\*.*)|.{0,6}$)))+)section(\.|((?&seps)(\.|[\w_-]+\.)))))"
+					displayMode="$functionName">
+					<functionName>
+						<nameExpr expr="[\w_-]+((?=\.)|((?'seps'([\t ]|\*&gt;.*|([\n\r]+(.{6}([ D]|\*.*)|.{0,6}$)))+)section((?=\.)|(?&seps)((?=\.)|[\w_-]+(?=\.)))))"/>
+					</functionName>
+				</function>
+			</parser>
+
+			<!-- Variant for COBOL free-form reference format -->
+			<parser id="cobol_section_free" displayName="COBOL fixed-form reference format">
+				<!-- Variant without paragraphs (works with comment lines before section header) -->
+                		<function
+					mainExpr="[\s\.](?!exit\s)[\w_-]+\s+section(\s*|(\s+[\w_-]+)?)(?=\.)"
+					displayMode="$functionName">
+					<functionName>
+						<nameExpr expr="[\w_-]+\s*section"/>
+					</functionName>
 				</function>
 			</parser>
 		</parsers>


### PR DESCRIPTION
Plain patch for current npp-version; previously committed at SF as Patch #597
Includes definitions for both fixed-form reference format and free-form reference format, associated is the fixed-form reference format as it's the de-facto standard (the user can change the association if necessary) - won't be needed any more when scintilla provides two different langIDs.