### PR TITLE
Add "php" string to PHP auto-complete

### DIFF
--- a/PowerEditor/installer/APIs/php.xml
+++ b/PowerEditor/installer/APIs/php.xml
@@ -10336,6 +10336,7 @@
 				<Param name="[resource connection]"/>
 			</Overload>
 		</KeyWord>
+		<KeyWord name="php"/>
 		<KeyWord name="phpcredits" func="yes">
 			<Overload retVal="bool">
 				<Param name="[int flag=CREDITS_ALL]"/>


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/279