### PR TITLE
Only set font quality if ClearType is enabled

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -296,8 +296,17 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.execute(SCI_SETCARETLINEVISIBLE, svp1._currentLineHilitingShow);
 	_subEditView.execute(SCI_SETCARETLINEVISIBLE, svp1._currentLineHilitingShow);
 
-	_mainEditView.execute(SCI_SETFONTQUALITY, SC_EFF_QUALITY_LCD_OPTIMIZED);
-	_subEditView.execute(SCI_SETFONTQUALITY, SC_EFF_QUALITY_LCD_OPTIMIZED);
+	UINT uFontSmoothingType = 0;
+	if (!::SystemParametersInfo(SPI_GETFONTSMOOTHINGTYPE, 0, &uFontSmoothingType, 0))
+	{
+		// Fail silently - font smoothing is not important enough to do anything else.
+		assert(false);
+	}
+	else if (uFontSmoothingType == FE_FONTSMOOTHINGCLEARTYPE)
+	{
+		_mainEditView.execute(SCI_SETFONTQUALITY, SC_EFF_QUALITY_LCD_OPTIMIZED);
+		_subEditView.execute(SCI_SETFONTQUALITY, SC_EFF_QUALITY_LCD_OPTIMIZED);
+	}
 
 	_mainEditView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
 	_subEditView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);


### PR DESCRIPTION
Font smoothing should not be on by default. See #216.