### PR TITLE
Rewrote README.MD for clarity & comprehension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,67 @@
 What is Notepad++ ?
 ===================
 
-[<img src="https://notepad-plus-plus.org/assets/images/communityDiscussionOrange.png">](https://notepad-plus-plus.org/community/)  &nbsp;&nbsp;&nbsp;&nbsp;[![Join the chat at https://gitter.im/notepad-plus-plus/notepad-plus-plus](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/notepad-plus-plus/notepad-plus-plus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Notepad++ is a free (free as in both "free speech" and "free beer") source code editor and Notepad replacement that supports several programming languages and natural languages. Running in the MS Windows environment, its use is governed by GPL License.
+[<img src="https://notepad-plus-plus.org/assets/images/communityDiscussion.png">](https://notepad-plus-plus.org/community/)  &nbsp;&nbsp;&nbsp;&nbsp;[![Join the chat at https://gitter.im/notepad-plus-plus/notepad-plus-plus](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/notepad-plus-plus/notepad-plus-plus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Notepad++ is a free (free as in both "free speech" and "free beer") source code
+editor and Notepad replacement that supports several programming languages and
+natural languages. Running in the MS Windows environment, its use is governed by
+GPL License.
 
 
-To build Notepad++ package from source code:
+To build Notepad++ from source:
 ============================================
 
-There should be several ways to generate Notepad++ binaries, here we show you only the way with which Notepad++ official releases are generated.
-* notepad++.exe: Visual Studio 2013
-* SciLexer.dll: Visual Studio 2013 (with nmake)
+There are two components that need to be built separately:
+- `notepad++.exe`: (depends on `SciLexer.dll`)
+- `SciLexer.dll` : (with nmake)
 
-notepad++.exe:
-Double click on `PowerEditor\visual.net\notepadPlus.vcproj` to launch Notepad++ project in Visual Studio, then build it with the mode you want, that's it.
+You can build Notepad++ with *or* without Boost - The release build of
+Notepad++ is built **with** Boost.
 
-SciLexer.dll:
-From version 6.0, SciLexer.dll comes with release contains boost's PCRE (Perl Compatible Regular Expressions) feature.
-Therefore [Boost](http://www.boost.org/) is needed to compile Scintilla in order to have PCRE support.
+Since `Notepad++` version 6.0, the build of `SciLexer.dll` that is distributed
+uses features from Boost's `Boost.Regex` library.
+
+You can build SciLexer.dll without Boost, ie. with its default POSIX regular
+expression support instead of boost's PCRE one. This is useful if you would
+like to debug Notepad++, but don't have boost.
+
+## To build `notepad++.exe`:
+
+ 1. Open [`PowerEditor\visual.net\notepadPlus.vcproj`](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/visual.net/notepadPlus.vcxproj)
+ 2. Build Notepad++ [like a normal Visual Studio project](https://msdn.microsoft.com/en-us/library/7s88b19e.aspx).
+
+
+
+
+## To build `SciLexer.dll` with boost:
+
 Here are the instructions to build SciLexer.dll for Notepad++:
- 1. Download the [Boost source code](http://sourceforge.net/projects/boost/files/boost/1.55.0/). v1.55 should be used with VS 2013. Then unzip it. In my case, "boost_1_55_0" is copied in `C:\sources\`
+ 1. Download the [Boost source code](http://sourceforge.net/projects/boost/files/boost/1.55.0/). v1.55 should be used with VS 2013. Then unzip it. In my case, `boost_1_55_0` is copied in `C:\sources\`
  2. Go to `scintilla\boostregex\` then run BuildBoost.bat with your boost path. In my case: `BuildBoost.bat C:\sources\boost_1_55_0`
  3. Go in `scintilla\win32\` then run `nmake -f scintilla.mak`
 
-You can build SciLexer.dll without Boost, ie. with its default POSIX regular expression support instead boost's PCRE one. It will work with notepad++.exe, however some functionalities in Notepad++ may be broken.
+
+## To build `SciLexer.dll` *without* boost:
+
+
+This will work with `notepad++.exe`, however some functionality in Notepad++ might be broken.
+
 To build SciLexer.dll without PCRE support:
- 1. Go in `scintilla\win32\`
- 2. Run nmake with an option `nmake NOBOOST=1 -f scintilla.mak`
+ 1. Open a command prompt *for building* ([a.k.a. the *Developer Command Prompt for VS2013*](https://msdn.microsoft.com/en-us/library/f2ccy3wt.aspx))
+    - From the IDE, you can do this by right clicking on a file in Solution Explorer, and clicking "Open Command Prompt". This will open up a command prompt with all the proper environment variables.
+    - From the Windows Start screen/menu, type `Developer Command Prompt for VS2013`, and click/select the result.
+    - From an *already open* command prompt, run `vcvarsall.bat` (e.g. "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat").
+ 2. Change directory (`cd` or `pushd`) to `scintilla\win32\`
+ 3. Build `SciLexer.dll` with one of the following commands:
+    - `nmake NOBOOST=1 -f scintilla.mak`         (normal build)
+    - `nmake NOBOOST=1 DEBUG=1 -f scintilla.mak` (debugging build)
+ 4. Copy `SciLexer.dll` from `scintilla\bin\` to the same directory as `notepad++.exe`.
+    - For the `Unicode Release` configuration, the output directory (where `notepad++.exe` is) is `PowerEditor\bin\`.
+    - For the `Unicode Debug` configuration, the output directory (where `notepad++.exe` is) is `PowerEditor\visual.net\Unicode Debug\`.
 
-Notepad++ Unicode release binary (notepad++.exe) and Scintilla release binary (SciLexer.dll) will be built in the directories `PowerEditor\bin\` and `scintilla\bin\` respectively.
-You have to copy SciLexer.dll in `PowerEditor\bin\` in order to launch notepad++.exe
 
-
-Go to [Notepad++ official site](http://notepad-plus-plus.org/) for more information.
+See the [Notepad++ official site](http://notepad-plus-plus.org/) for more information.
 
 [Notepad++ Contributors](http://notepad-plus-plus.org/contributors)


### PR DESCRIPTION
This is a redo-redo of #348, itself a redo of #347, a follow up to #338 - 338 itself a redo of #233.

Confused yet?

f0fa5e74b8afbc92114e489ccd81eaa9b6aed35e caused all hell to break loose, and GitHub wasn't clear about what the problem was. So did b31e213b7ba3121370a82bb27955a12c4cd0ef0c. I decided to close #348, and to forgo the hoop-jumping of another fragile rebase/squash.


```
commit 9ccd5fb0b5937915c0d20efaeecbadfa1fca7b10
Author: Alexander Riccio <alexander@riccio.com>
Date:   Mon Jun 15 20:05:17 2015 -0400

    Tweaked README.md to be consistent for literals.

    Specifically literal filenames.

commit cb901d331f225b920338e9dfa67bff706a8dd27b
Author: Alexander Riccio <alexander@riccio.com>
Date:   Mon Jun 15 20:03:00 2015 -0400

    fixed up README.md header formatting

commit 19f7ed9f1687787acfc46ecc0a8e76ddeab18a21
Author: Alexander Riccio <alexander@riccio.com>
Date:   Mon Jun 15 19:44:57 2015 -0400

    Rewrote README.MD for clarity & comprehension

Thank you: http://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git/5190323#5190323

fixed missing preposition in README.md

test requested changes

partially fixed 80 column limited text in README.md

Fix "communityDiscussion.png" README.md merge conflict
```