### PR TITLE
Remove unused variable in EncodingMapper.h

### DIFF
--- a/PowerEditor/src/EncodingMapper.h
+++ b/PowerEditor/src/EncodingMapper.h
@@ -7,10 +7,10 @@
 // version 2 of the License, or (at your option) any later version.
 //
 // Note that the GPL places important restrictions on "derived works", yet
-// it does not provide a detailed definition of that term.  To avoid      
-// misunderstandings, we consider an application to constitute a          
+// it does not provide a detailed definition of that term. To avoid
+// misunderstandings, we consider an application to constitute a
 // "derivative work" for the purpose of this license if it does any of the
-// following:                                                             
+// following:
 // 1. Integrates source code from Notepad++.
 // 2. Integrates/includes/aggregates Notepad++ into a proprietary executable
 //    installer, such as those produced by InstallShield.
@@ -18,7 +18,7 @@
 //
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
@@ -30,22 +30,21 @@
 #define ENCODINGMAPPER_H
 
 struct EncodingUnit {
-   int _codePage;
-   char *_aliasList;
+	int _codePage;
+	char *_aliasList;
 };
 
 class EncodingMapper {
 public:
-    static EncodingMapper * getInstance() {return _pSelf;};
-    int getEncodingFromIndex(int index) const;
+	static EncodingMapper * getInstance() {return _pSelf;};
+	int getEncodingFromIndex(int index) const;
 	int getIndexFromEncoding(int encoding) const;
 	int getEncodingFromString(const char * encodingAlias) const;
 
 private:
 	EncodingMapper(){};
 	~EncodingMapper(){};
-    static EncodingMapper *_pSelf;
-    EncodingUnit *_encodings;
+	static EncodingMapper *_pSelf;
 };
 
 #endif // ENCODINGMAPPER_H


### PR DESCRIPTION
And fix tabs/white-spaces in this file.

Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/357