### PR TITLE
Activate last dialog when N++ is reactivated

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -130,7 +130,7 @@ Notepad_plus::Notepad_plus(): _mainWindowStatus(0), _pDocTab(NULL), _pEditView(N
 	_linkTriggered(true), _isHotspotDblClicked(false), _isFolding(false), 
 	_sysMenuEntering(false),
 	_autoCompleteMain(&_mainEditView), _autoCompleteSub(&_subEditView), _smartHighlighter(&_findReplaceDlg),
-	_isFileOpening(false), _pAnsiCharPanel(NULL), _pClipboardHistoryPanel(NULL)
+	_isFileOpening(false), _pAnsiCharPanel(NULL), _pClipboardHistoryPanel(NULL), _hLastFocusedDialog(NULL)
 {
 	ZeroMemory(&_prevSelectedRange, sizeof(_prevSelectedRange));
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -436,6 +436,8 @@ private:
 	DocumentMap *_pDocMap;
 	FunctionListPanel *_pFuncList;
 
+	HWND _hLastFocusedDialog;
+
 	BOOL notify(SCNotification *notification);
 	void specialCmd(int id);
 	void command(int id);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1320,6 +1320,12 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 		{
 			if (wParam == TRUE) // if npp is about to be activated
 			{
+				if (::IsWindow(_hLastFocusedDialog) && Message == WM_ACTIVATEAPP)
+				{
+					::SetFocus(_hLastFocusedDialog);
+					_hLastFocusedDialog = NULL;
+				}
+
 				const NppGUI & nppgui = pNppParam->getNppGUI();
 				if (LOWORD(wParam) && (nppgui._fileAutoDetection != cdDisabled))
 				{
@@ -1327,6 +1333,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 					checkModifiedDocument();
 					return FALSE;
 				}
+			}
+			else if (Message == WM_ACTIVATEAPP)
+			{
+				// Is about to be deactivated. Save the dialog which is currently selected so we can activate again later.
+				_hLastFocusedDialog = ::GetFocus();
 			}
 			break;
 		}


### PR DESCRIPTION
See earlier discussion in #378.

When N++ is deactivated, we should save the currently focused window. When N++ is activated again, we should set focus to the window that we saved.

Problem: there is potentially a race condition between "IsWindow" and "SetFocus".

Test cases:

1.
Open N++.
Open Find dialog.
Make sure the "Find what" textbox is selected.
Alt-Tab out.
Alt-Tab back in.
Expected: "Find what" is still selected.

2.
Open N++.
Open Find dialog.
Now make sure that *Scintilla* is selected.
Alt-Tab out.
Alt-Tab back in.
Expected: Scintilla is selected (and *not* "Find what").