### PR TITLE
empty files line endings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,35 @@
 # Contributing
 
-Your pull requests are welcome; however, they may not be accepted for various reasons.
 
+## Reporting Issues
 
+Bug reports are appreciated. Following a few guidelines listed below will help speed up the process of getting them fixed. 
 
-## Before you contribute
+1. Search the issue tracker to see if it has already been reported.
+2. Disable your plugins to see if one of them is the problem. You can do this by renaming your `plugins` folder to something else.
+3. Only report an issue with a plugin if it is one of the standard plugins included in the Notepad++ installation. Any other plugin issue should be reported to its respective issue tracker. The standard plugins include (for v6.8.3):
+    * NppFTP
+    * NppExport
+    * Plugin Manager
+    * Converter
+    * mimeTools
+4. Include additional information such as:
+    * A detailed explanation
+    * Operating System version
+    * Notepad++ version
+    * List of installed plugins (if it is related to a plugin)
+    * Screen shots (if applicable)
+    * ...and any other relevant information
 
-All Pull Requests, except for translations and user documentation, need to be attached to a issue on GitHub. For Pull Requests regarding enhancements and questions, the issue must first be approved by one of project's administrators before being merged into the project. An approved issue will have the label `Accepted`. For issues that have not been accepted, you may request to be assigned to that issue.
+## Pull Requests
+
+Your pull requests are welcome; however, they may not be accepted for various reasons. All Pull Requests, except for translations and user documentation, need to be attached to a issue on GitHub. For Pull Requests regarding enhancements and questions, the issue must first be approved by one of project's administrators before being merged into the project. An approved issue will have the label `Accepted`. For issues that have not been accepted, you may request to be assigned to that issue.
 
 Opening a issue beforehand allows the administrators and the community to discuss bugs and enhancements before work begins, preventing wasted effort.
 
 
 
-## Guidelines for pull requests
+### Guidelines for pull requests
 
 1. Respect Notepad++ coding style.
 2. Make a single change per commit.
@@ -23,7 +40,7 @@ In short: The easier the code review is, the better the chance your pull request
 
 
 
-## Coding style
+### Coding style
 ![stay clean](https://notepad-plus-plus.org/assets/images/good-bad-practice.jpg)
 
 

--- a/PowerEditor/bin/change.log
+++ b/PowerEditor/bin/change.log
@@ -1,3 +1,7 @@
+Notepad++ v6.8.5 bug-fixes:
+1.  Fix Javascript autocompletion not working regression.
+
+
 Notepad++ v6.8.4 bug-fixes and enhancements:
 
 1.  Improve document switching performance while folding restoring.

--- a/PowerEditor/bin/change.log
+++ b/PowerEditor/bin/change.log
@@ -1,18 +1,24 @@
-Notepad++ v6.8.3 bug-fixes:
+Notepad++ v6.8.4 bug-fixes and enhancements:
 
-1.  Fix a crash issue by using wild card (*) to open files on command line.
-2.  Fix the problem of display refresh missing on exit.
-3.  Fix plugin shortcut configuration lost problem by using option -noPlugin.
-4.  Fix Norwegian localization bad display and wrong encoding.
-5.  Fix functionList display problem under high DPI.
-6.  Fix Norwegian localization bad display and wrong encoding.
+1.  Improve document switching performance while folding restoring.
+2.  Enhance Javascript syntax highlighting: 2 groups of keywords more for syntax highlighting customization.
+3.  Improve auto-insert usability: the open symbols (", ', (, [ and { ) triggers the close symbols according to the context.
+4.  Apply new added language auto-detection (for php, xml, html and bash) in the case of unknown file extension.
+4.  Add JSON language support.
+5.  Fix macro playback inserting/removing characters randomly.
+6.  Fix Save All button is still enabled problem while no file to save.
+7.  Make file save dialog modern style.
+8.  Fix auto-insert for xml comment incorrect insertion.
+9.  Fix user command save problem on exit.
+10. Fix macro save problem on exit.
+11. Fix the restoring from system tray problem while running in admin mode.
+12. Fix smart highlighting not working in some case.
+13. Enlarge tabbar height.
 
 
 Included plugins:
 
-1.  NppFTP 0.26.3
-2.  NppExport v0.2.8
-3.  Plugin Manager 1.3.5
-4.  Converter 3.0
-5.  Mime Tool 1.9
-
+1.  NppExport v0.2.8
+2.  Plugin Manager 1.3.5
+3.  Converter 3.0
+4.  Mime Tool 1.9

--- a/PowerEditor/installer/nativeLang/bengali.xml
+++ b/PowerEditor/installer/nativeLang/bengali.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-	::Arabic language file for Notepad++ ::
+	::Bengali language file for Notepad++ ::
 
 	** created By:- Dhairya Parekh **
 		Email- d.parekh93@hotmail.com

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -56,7 +56,7 @@
 					<Item subMenuId="view-uncollapseLevel" name="Te&amp;xtblöcke öffnen"/>
 					<Item subMenuId="view-project" name="Projektver&amp;waltung"/>
 					<Item subMenuId="view-tab" name="&amp;Tabs"/>
-					<Item subMenuId="encoding-characterSets" name="&amp;Zeichensatz"/>
+					<Item subMenuId="encoding-characterSets" name="&amp;Weitere"/>
 					<Item subMenuId="encoding-arabic" name="&amp;Arabisch"/>
 					<Item subMenuId="encoding-baltic" name="&amp;Baltisch"/>
 					<Item subMenuId="encoding-celtic" name="&amp;Keltisch"/>
@@ -336,9 +336,9 @@
 				<Item id="1" name="&amp;Weitersuchen"/>
 				<Item id="2" name="&amp;Schließen"/>
 				<Item id="1603" name="Nur &amp;ganze Wörter suchen"/>
-				<Item id="1604" name="Groß-/&amp;Kleinschreibung"/>
+				<Item id="1604" name="Groß-/&amp;Kleinschreibung beachten"/>
 				<Item id="1605" name="&amp;Reguläre Ausdrücke"/>
-				<Item id="1606" name="Am Ende von vorn &amp;beginnen"/>
+				<Item id="1606" name="Am Ende von vorne &amp;beginnen"/>
 				<Item id="1608" name="&amp;Ersetzen"/>
 				<Item id="1609" name="Alle erse&amp;tzen"/>
 				<Item id="1611" name="Erset&amp;zen durch:"/>
@@ -347,7 +347,6 @@
 				<Item id="1614" name="Z&amp;ählen"/>
 				<Item id="1615" name="&amp;Alle suchen"/>
 				<Item id="1616" name="&amp;Lesezeichen setzen"/>
-				<Item id="1617" name="&amp;Treffer markieren"/>
 				<Item id="1618" name="Für &amp;jede Suche löschen"/>
 				<Item id="1620" name="Suchen &amp;nach:"/>
 				<Item id="1621" name="Suchrichtung"/>
@@ -355,7 +354,7 @@
 				<Item id="1625" name="Norma&amp;l"/>
 				<Item id="1626" name="Erwe&amp;itert (\r, \n, \t, \x..., \0)"/>
 				<Item id="1627" name="Unten"/>
-				<Item id="1632" name="In &amp;Markierung"/>
+				<Item id="1632" name="In &amp;Auswahl"/>
 				<Item id="1633" name="Zurücksetzen"/>
 				<Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
 				<Item id="1636" name="In &amp;offenen Dateien suchen"/>
@@ -639,21 +638,21 @@
 					<Item id="6152" name="Sitzungsdateien in einer neuen Instanz öffnen"/>
 					<Item id="6153" name="Immer im Mehrinstanzmodus"/>
 					<Item id="6154" name="Standard (nur eine Instanz)"/>
-					<Item id="6155" name="* Notepad++ muss neu gestartet werden"/>
+					<Item id="6155" name="Nach Änderung der Einstellung muss Notepad++ neu gestartet werden."/>
 				</MultiInstance>
 				<Scintillas title="Oberfläche 2">
 					<Item id="6201" name="Textblock-Faltung"/>
 					<Item id="6202" name="Plus/minus"/>
 					<Item id="6203" name="Pfeile"/>
-					<Item id="6204" name ="Kreise"/>
+					<Item id="6204" name="Kreise"/>
 					<Item id="6205" name="Quadrate"/>
 					<Item id="6206" name="Zeilennummernrand"/>
 					<Item id="6207" name="Lesezeichenrand"/>
 					<Item id="6208" name="Randbegrenzung anzeigen"/>
 					<Item id="6209" name="Anzahl der Spalten:"/>
 					<Item id="6211" name="Rechter Rand"/>
-					<Item id="6212" name="vertikale Linie"/>
-					<Item id="6213" name="farbiger Hintergrund"/>
+					<Item id="6212" name="Vertikale Linie"/>
+					<Item id="6213" name="Farbiger Hintergrund"/>
 					<Item id="6214" name="Aktuelle Zeile hervorheben"/>
 					<Item id="6215" name="Kantenglättung der Schriftarten"/>
 					<Item id="6216" name="Cursoreinstellungen"/>
@@ -661,7 +660,7 @@
 					<Item id="6219" name="Geschwindigkeit"/>
 					<Item id="6221" name="S"/>
 					<Item id="6222" name="L"/>
-					<Item id="6224" name="Gleichzeitiges Editieren"/>
+					<Item id="6224" name="Mehrfaches Editieren"/>
 					<Item id="6225" name="Aktivieren (Strg+Mausklick)"/>
 					<Item id="6226" name="Aus"/>
 					<Item id="6227" name="Umgebrochene Zeilen"/>
@@ -669,17 +668,17 @@
 					<Item id="6229" name="Linksbündig"/>
 					<Item id="6230" name="Hängend"/>
 					<Item id="6231" name="Rahmenbreite"/>
-					<Item id="6234" name="Erweitertes Scrollen deaktivieren"/>
+					<Item id="6234" name="Flüssiges Scrollen deaktivieren (bei Touchpad-Problemen)"/>
 				</Scintillas>
-				<Delimiter title="Trennzeichen für erweiterte Auswahl">
-					<Item id="6251" name="Trennzeichen (Strg+Doppelklick)"/>
+				<Delimiter title="Trennzeichen">
+					<Item id="6251" name="Trennzeichen für erweiterte Auswahl (Strg+Doppelklick)"/>
 					<Item id="6252" name="Anfang"/>
 					<Item id="6255" name="Ende"/>
 					<Item id="6256" name="Über mehrere Zeilen"/>
 					<Item id="6257" name="bla bla bla bla bla bla"/>
 					<Item id="6258" name="bla bla bla bla bla bla bla bla bla bla bla bla"/>
 				</Delimiter>
-				<RecentFilesHistory title="Zuletzt geöffnete Dateien">
+				<RecentFilesHistory title="Zuletzt geöffn. Dateien">
 					<Item id="6304" name="Zuletzt geöffnete Dateien"/>
 					<Item id="6305" name="Beim Programmstart nicht überprüfen"/>
 					<Item id="6306" name="Max. Menüeinträge:"/>
@@ -691,7 +690,7 @@
 					<Item id="6429" name="Anzeige im Dateimenü"/>
 				</RecentFilesHistory>
 				<NewDoc title="Neue Dateien">
-					<Item id="6401" name="Zeilenende-Format"/>
+					<Item id="6401" name="Zeilenenden"/>
 					<Item id="6402" name="Windows"/>
 					<Item id="6403" name="UNIX"/>
 					<Item id="6404" name="Mac"/>
@@ -699,11 +698,11 @@
 					<Item id="6406" name="ANSI"/>
 					<Item id="6407" name="UTF-8 ohne BOM"/>
 					<Item id="6408" name="UTF-8"/>
-					<Item id="6409" name="UCS2 Big Endian"/>
-					<Item id="6410" name="UCS2 Little Endian"/>
+					<Item id="6409" name="UCS-2 Big Endian"/>
+					<Item id="6410" name="UCS-2 Little Endian"/>
 					<Item id="6411" name="Standardsprache"/>
 					<Item id="6419" name="Format für neue Dateien"/>
-					<Item id="6420" name="auch beim Öffnen von ANSI-Dateien"/>
+					<Item id="6420" name="Auch beim Öffnen von ANSI-Dateien"/>
 				</NewDoc>
 				<DefaultDir title="Standardverzeichnis">
 					<Item id="6413" name="Verzeichnis beim Öffnen/Speichern"/>
@@ -717,7 +716,7 @@
 				</FileAssoc>
 				<TabSettings title="Tabulatoren">
 					<Item id="6301" name="Tabulatoren"/>
-					<Item id="6302" name="durch Leerzeichen ersetzen"/>
+					<Item id="6302" name="Durch Leerzeichen ersetzen"/>
 					<Item id="6303" name="Tabulatorbreite:"/>
 					<Item id="6510" name="Standard verwenden"/>
 				</TabSettings>
@@ -771,22 +770,22 @@
 					<Item id="6323" name="Automatische Updates aktivieren"/>
 					<Item id="6324" name="Dokumentenumschalter (Strg+Tab)"/>
 					<Item id="6325" name="Nach Aktualisierung zum Ende scrollen"/>
-					<Item id="6326" name="Alle Wortvorkommnisse markieren"/>
+					<Item id="6326" name="Hervorhebung aktivieren"/>
 					<Item id="6327" name="Tags hervorheben"/>
 					<Item id="6328" name="Attribute hervorheben"/>
 					<Item id="6329" name="HTML-Hervorhebung"/>
-					<Item id="6330" name="PHP/ASP-Bereiche hervorheben"/>
+					<Item id="6330" name="PHP-/ASP-Bereiche hervorheben"/>
 					<Item id="6331" name="Nur Dateinamen in Titelleiste anzeigen"/>
-					<Item id="6332" name="Groß-/Kleinschreibung unterscheiden"/>
-					<Item id="6333" name="Mehrfache Markierung"/>
+					<Item id="6332" name="Groß-/Kleinschreibung beachten"/>
+					<Item id="6333" name="Automatische Hervorhebung bei Auswahl"/>
 					<Item id="6334" name="Kodierung automatisch erkennen"/>
 					<Item id="6335" name="Backslash ist Escapezeichen für SQL"/>
 				</MISC>
 				<Backup title="Sicherheitskopien">
 					<Item id="6801" name="Sicherheitskopie beim Speichern von Dateien"/>
-					<Item id="6315" name="keine"/>
-					<Item id="6316" name="einfach"/>
-					<Item id="6317" name="erweitert"/>
+					<Item id="6315" name="Keine"/>
+					<Item id="6316" name="Einfach"/>
+					<Item id="6317" name="Erweitert"/>
 					<Item id="6804" name="Verzeichnisangabe für die Sicherheitskopien"/>
 					<Item id="6803" name="Verzeichnis:"/>
 					<Item id="6817" name="Sitzungen automatisch speichern"/>
@@ -798,7 +797,7 @@
 				</Backup>
 				<Cloud title="Cloud-Einstellungen">
 					<Item id="6262" name="Einstellungen in der Cloud speichern"/>
-					<Item id="6263" name="aus"/>
+					<Item id="6263" name="Aus"/>
 					<Item id="6267" name="Netzwerkpfad:"/>
 				</Cloud>
 				<AutoCompletion title="Autovervollständigung">
@@ -849,11 +848,12 @@
 				<Item id="2030" name="Beginnen mit"/>
 				<Item id="2031" name="Erhöhen um"/>
 				<Item id="2035" name="Führende &amp;Nullen"/>
+				<Item id="2036" name="Wiederholen"/>
 				<Item id="2032" name="Format"/>
-				<Item id="2024" name="&amp;Dec"/>
-				<Item id="2025" name="&amp;Oct"/>
-				<Item id="2026" name="&amp;Hex"/>
-				<Item id="2027" name="&amp;Bin"/>
+				<Item id="2024" name="&amp;Dezimal"/>
+				<Item id="2025" name="&amp;Oktal"/>
+				<Item id="2026" name="&amp;Hexadezimal"/>
+				<Item id="2027" name="&amp;Binär"/>
 				<Item id="1" name="Ausfüh&amp;ren"/>
 				<Item id="2" name="Abbre&amp;chen"/>
 			</ColumnEditor>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -83,22 +83,22 @@
 					<Item id="10003" name="In &amp;neue Instanz verschieben"/>
 					<Item id="10004" name="In neue Instan&amp;z duplizieren"/>
 					<Item id="41001" name="&amp;Neu"/>
-					<Item id="41002" name="&amp;Öffnen..."/>
+					<Item id="41002" name="&amp;Öffnen …"/>
 					<Item id="41003" name="Schlie&amp;ßen"/>
 					<Item id="41004" name="Alle s&amp;chließen"/>
 					<Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
 					<Item id="41006" name="&amp;Speichern"/>
 					<Item id="41007" name="&amp;Alle speichern"/>
-					<Item id="41008" name="Speichern &amp;unter..."/>
+					<Item id="41008" name="Speichern &amp;unter …"/>
 					<Item id="41009" name="Dateien &amp;links schließen"/>
-					<Item id="41010" name="&amp;Drucken..."/>
+					<Item id="41010" name="&amp;Drucken …"/>
 					<Item id="41011" name="B&amp;eenden"/>
-					<Item id="41012" name="Sit&amp;zung öffnen..."/>
-					<Item id="41013" name="Sitzung speiche&amp;rn..."/>
+					<Item id="41012" name="Sit&amp;zung öffnen …"/>
+					<Item id="41013" name="Sitzung speiche&amp;rn …"/>
 					<Item id="41014" name="Neu &amp;laden"/>
-					<Item id="41015" name="&amp;Kopie speichern unter..."/>
+					<Item id="41015" name="&amp;Kopie speichern unter …"/>
 					<Item id="41016" name="Von Datentr&amp;äger löschen"/>
-					<Item id="41017" name="Um&amp;benennen..."/>
+					<Item id="41017" name="Um&amp;benennen …"/>
 					<Item id="41018" name="Dateien &amp;rechts schließen"/>
 					<Item id="41019" name="E&amp;xplorer"/>
 					<Item id="41020" name="&amp;Eingabeaufforderung"/>
@@ -133,12 +133,12 @@
 					<Item id="42029" name="Vollständigen &amp;Pfad kopieren"/>
 					<Item id="42030" name="Nur Datei&amp;namen kopieren"/>
 					<Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
-					<Item id="42032" name="Makro &amp;mehrfach ausführen..."/>
+					<Item id="42032" name="Makro &amp;mehrfach ausführen …"/>
 					<Item id="42033" name="Schreibschutz-Attribut l&amp;öschen"/>
-					<Item id="42034" name="&amp;Block-Editor..."/>
+					<Item id="42034" name="&amp;Block-Editor …"/>
 					<Item id="42035" name="Zeilen aus&amp;kommentieren"/>
 					<Item id="42036" name="Auskommentierung der Zeilen a&amp;ufheben"/>
-					<Item id="42037" name="Spalten-&amp;Modus..."/>
+					<Item id="42037" name="Spalten-&amp;Modus …"/>
 					<Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
 					<Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
 					<Item id="42040" name="Alle zule&amp;tzt verwendeten Dateien öffnen"/>
@@ -168,10 +168,10 @@
 					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
 					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
 					<Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-					<Item id="43001" name="&amp;Suchen..."/>
+					<Item id="43001" name="&amp;Suchen …"/>
 					<Item id="43002" name="&amp;Weitersuchen"/>
-					<Item id="43003" name="&amp;Ersetzen..."/>
-					<Item id="43004" name="&amp;Gehe zu..."/>
+					<Item id="43003" name="&amp;Ersetzen …"/>
+					<Item id="43004" name="&amp;Gehe zu …"/>
 					<Item id="43005" name="&amp;Lesezeichen setzen/löschen"/>
 					<Item id="43006" name="&amp;Nächstes Lesezeichen"/>
 					<Item id="43007" name="&amp;Vorheriges Lesezeichen"/>
@@ -179,7 +179,7 @@
 					<Item id="43009" name="Suche zugehörige &amp;Klammer"/>
 					<Item id="43010" name="&amp;Rückwärts suchen"/>
 					<Item id="43011" name="&amp;Inkrementelle Suche"/>
-					<Item id="43013" name="In &amp;Dateien suchen..."/>
+					<Item id="43013" name="In &amp;Dateien suchen …"/>
 					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne Verlauf)"/>
 					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne Verlauf)"/>
 					<Item id="43018" name="Zeilen mit Lesezeichen &amp;ausschneiden"/>
@@ -216,12 +216,12 @@
 					<Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
 					<Item id="43050" name="Lesezeichen inver&amp;tieren"/>
 					<Item id="43051" name="Zeilen &amp;ohne Lesezeichen löschen"/>
-					<Item id="43052" name="Suche nach &amp;Zeichencodes..."/>
+					<Item id="43052" name="Suche nach &amp;Zeichencodes …"/>
 					<Item id="43053" name="&amp;Alles zwischen Klammern auswählen"/>
-					<Item id="43054" name="&amp;Hervorheben..."/>
+					<Item id="43054" name="&amp;Hervorheben …"/>
 					<Item id="44009" name="&amp;Post-It"/>
 					<Item id="44010" name="A&amp;lle Textblöcke schließen"/>
-					<Item id="44011" name="Benutzerdefinierte Spra&amp;che..."/>
+					<Item id="44011" name="Benutzerdefinierte Spra&amp;che …"/>
 					<Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>
 					<Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>
 					<Item id="44014" name="Codefaltung ausb&amp;lenden"/>
@@ -242,7 +242,7 @@
 					<Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
 					<Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
 					<Item id="44042" name="Zeilen &amp;ausblenden"/>
-					<Item id="44049" name="Datei-&amp;Info..."/>
+					<Item id="44049" name="Datei-&amp;Info …"/>
 					<Item id="44072" name="&amp;Zur anderen Ansicht wechseln"/>
 					<Item id="44080" name="&amp;Miniaturansicht"/>
 					<Item id="44081" name="Projektfenster &amp;1"/>
@@ -273,30 +273,30 @@
 					<Item id="45011" name="Konv&amp;ertiere zu UTF-8"/>
 					<Item id="45012" name="Konve&amp;rtiere zu UCS-2 Big Endian"/>
 					<Item id="45013" name="Konver&amp;tiere zu UCS-2 Little Endian"/>
-					<Item id="46001" name="&amp;Stile..."/>
+					<Item id="46001" name="&amp;Stile …"/>
 					<Item id="46015" name="MS-DOS-Stil"/>
 					<Item id="46016" name="Normaler Text"/>
 					<Item id="46017" name="Ressourcen-Datei"/>
 					<!-- <Item id="46019" name="MS-INI-Datei"/> -->
 					<Item id="46080" name="Benutzerdefiniert"/>
-					<Item id="46150" name="Eigene Sprache &amp;definieren..."/>
-					<Item id="47000" name="&amp;Info..."/>
+					<Item id="46150" name="Eigene Sprache &amp;definieren …"/>
+					<Item id="47000" name="&amp;Info …"/>
 					<Item id="47001" name="Notepad++ im &amp;Web"/>
 					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
 					<Item id="47005" name="&amp;Erweiterungen"/>
 					<Item id="47006" name="Notepad++ &amp;aktualisieren"/>
-					<Item id="47008" name="In&amp;halt..."/>
-					<Item id="47009" name="&amp;Proxy für Updater einstellen..."/>
-					<Item id="47010" name="&amp;Kommandozeilenparameter..."/>
+					<Item id="47008" name="In&amp;halt …"/>
+					<Item id="47009" name="&amp;Proxy für Updater einstellen …"/>
+					<Item id="47010" name="&amp;Kommandozeilenparameter …"/>
 					<Item id="47011" name="&amp;Support im Chat"/>
-					<Item id="48005" name="&amp;Plugin(s) importieren..."/>
-					<Item id="48006" name="&amp;Design(s) importieren..."/>
-					<Item id="48009" name="&amp;Tastatur..."/>
-					<Item id="48011" name="&amp;Optionen..."/>
-					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen..."/>
-					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen..."/>
-					<Item id="48018" name="&amp;Kontextmenü anpassen..."/>
-					<Item id="49000" name="Externes Programm &amp;ausführen..."/>
+					<Item id="48005" name="&amp;Plugin(s) importieren …"/>
+					<Item id="48006" name="&amp;Design(s) importieren …"/>
+					<Item id="48009" name="&amp;Tastatur …"/>
+					<Item id="48011" name="&amp;Optionen …"/>
+					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen …"/>
+					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen …"/>
+					<Item id="48018" name="&amp;Kontextmenü anpassen …"/>
+					<Item id="49000" name="Externes Programm &amp;ausführen …"/>
 					<Item id="50000" name="&amp;Funktionsvervollständigung"/>
 					<Item id="50001" name="&amp;Wortvervollständigung"/>
 					<Item id="50002" name="Funktions&amp;parameter anzeigen"/>
@@ -309,14 +309,14 @@
 				<Item CMID="0" name="S&amp;chließen"/>
 				<Item CMID="1" name="&amp;Alle anderen schließen"/>
 				<Item CMID="2" name="&amp;Speichern"/>
-				<Item CMID="3" name="Speichern &amp;unter..."/>
+				<Item CMID="3" name="Speichern &amp;unter …"/>
 				<Item CMID="4" name="&amp;Drucken"/>
 				<Item CMID="5" name="In zweite Ansicht &amp;verschieben"/>
 				<Item CMID="6" name="In zw&amp;eite Ansicht duplizieren"/>
 				<Item CMID="7" name="Vollständigen Pfad &amp;kopieren"/>
 				<Item CMID="8" name="Nur Datei&amp;namen kopieren"/>
 				<Item CMID="9" name="Nur Verzeichnis&amp;pfad kopieren"/>
-				<Item CMID="10" name="Um&amp;benennen..."/>
+				<Item CMID="10" name="Um&amp;benennen …"/>
 				<Item CMID="11" name="L&amp;öschen"/>
 				<Item CMID="12" name="Sch&amp;reibschutz"/>
 				<Item CMID="13" name="Schreibschutz au&amp;fheben"/>
@@ -352,7 +352,7 @@
 				<Item id="1621" name="Suchrichtung"/>
 				<Item id="1624" name="Suchmodus"/>
 				<Item id="1625" name="Norma&amp;l"/>
-				<Item id="1626" name="Erwe&amp;itert (\r, \n, \t, \x..., \0)"/>
+				<Item id="1626" name="Erwe&amp;itert (\r, \n, \t, \x…, \0)"/>
 				<Item id="1627" name="Unten"/>
 				<Item id="1632" name="In &amp;Auswahl"/>
 				<Item id="1633" name="Zurücksetzen"/>
@@ -384,7 +384,7 @@
 				<Item id="2008" name="Z&amp;eichen"/>
 			</GoToLine>
 			<!-- Run external program: -->
-			<Run title="Ausführen...">
+			<Run title="Ausführen …">
 				<Item id="1" name="&amp;Ausführen"/>
 				<Item id="2" name="A&amp;bbrechen"/>
 				<Item id="1901" name=".&amp;.."/>
@@ -440,7 +440,7 @@
 				<Item id="20002" name="Umbenennen"/>
 				<Item id="20003" name="Neue erstellen"/>
 				<Item id="20004" name="Löschen"/>
-				<Item id="20005" name="Speichern als..."/>
+				<Item id="20005" name="Speichern als …"/>
 				<Item id="20007" name="Sprache"/>
 				<Item id="20009" name="Erw."/>
 				<Item id="20011" name="Transparenz"/>
@@ -708,7 +708,7 @@
 					<Item id="6413" name="Verzeichnis beim Öffnen/Speichern"/>
 					<Item id="6414" name="Wie aktuelle Datei"/>
 					<Item id="6415" name="Letztes Verzeichnis merken"/>
-					<Item id="6418" name="..."/>
+					<Item id="6418" name="…"/>
 				</DefaultDir>
 				<FileAssoc title="Dateiverknüpfungen">
 					<Item id="4009" name="Unterstützte Erw.:"/>
@@ -900,25 +900,25 @@
 					<Item id="3123" name="Arbeitsbereich öffnen"/>
 					<Item id="3124" name="Arbeitsbereich neu laden"/>
 					<Item id="3125" name="Speichern"/>
-					<Item id="3126" name="Speichern unter..."/>
-					<Item id="3127" name="Kopie speichern unter..."/>
+					<Item id="3126" name="Speichern unter …"/>
+					<Item id="3127" name="Kopie speichern unter …"/>
 					<Item id="3121" name="Neues Projekt hinzufügen"/>
 				</WorkspaceMenu>
 				<ProjectMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen..."/>
+					<Item id="3113" name="Dateien hinzufügen …"/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</ProjectMenu>
 				<FolderMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen..."/>
+					<Item id="3113" name="Dateien hinzufügen …"/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</FolderMenu>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -36,23 +36,23 @@
 					<Item subMenuId="file-recentFiles" name="Zuletzt &amp;verwendet"/>
 					<Item subMenuId="file-openFolder" name="Aktuellen &amp;Ordner öffnen"/>
 					<Item subMenuId="edit-copyToClipboard" name="Datei&amp;pfad kopieren"/>
-					<Item subMenuId="edit-indent" name="Ein&amp;rückung"/>
+					<Item subMenuId="edit-indent" name="E&amp;inrückung"/>
 					<Item subMenuId="edit-convertCaseTo" name="&amp;Groß-/Kleinschreibung"/>
 					<Item subMenuId="edit-lineOperations" name="&amp;Zeilenoperationen"/>
-					<Item subMenuId="edit-comment" name="&amp;Kommentare"/>
+					<Item subMenuId="edit-comment" name="K&amp;ommentare"/>
 					<Item subMenuId="edit-autoCompletion" name="Autovervollst&amp;ändigung"/>
 					<Item subMenuId="edit-eolConversion" name="Format Zeile&amp;nende"/>
 					<Item subMenuId="edit-blankOperations" name="Nicht &amp;druckbare Zeichen"/>
 					<Item subMenuId="edit-pasteSpecial" name= "Einf&amp;ügen spezial"/>
 					<Item subMenuId="search-markAll" name="Alle &amp;Vorkommnisse hervorheben"/>
-					<Item subMenuId="search-unmarkAll" name="Alle &amp;Hervorhebungen löschen"/>
-					<Item subMenuId="search-jumpUp" name="Zu vorheriger Hervorhebung s&amp;pringen"/>
-					<Item subMenuId="search-jumpDown" name="Zu nächster Hervorhebung s&amp;pringen"/>
+					<Item subMenuId="search-unmarkAll" name="Alle Hervorhe&amp;bungen löschen"/>
+					<Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung s&amp;pringen"/>
+					<Item subMenuId="search-jumpDown" name="Zur &amp;nächsten Hervorhebung springen"/>
 					<Item subMenuId="search-bookmark" name="&amp;Lesezeichen"/>
 					<Item subMenuId="view-showSymbol" name="Nicht &amp;druckbare Zeichen"/>
 					<Item subMenuId="view-zoom" name="Z&amp;oom"/>
 					<Item subMenuId="view-moveCloneDocument" name="Datei &amp;verschieben/duplizieren"/>
-					<Item subMenuId="view-collapseLevel" name="Te&amp;xtblöcke schließen"/>
+					<Item subMenuId="view-collapseLevel" name="T&amp;extblöcke schließen"/>
 					<Item subMenuId="view-uncollapseLevel" name="Te&amp;xtblöcke öffnen"/>
 					<Item subMenuId="view-project" name="Projektver&amp;waltung"/>
 					<Item subMenuId="view-tab" name="&amp;Tabs"/>
@@ -77,15 +77,15 @@
 				</SubEntries>
 				<!-- All Menu Items: -->
 				<Commands>
-					<Item id="1001"  name="&amp;Jetzt drucken!"/>
+					<Item id="1001"  name="So&amp;fort drucken"/>
 					<Item id="10001" name="In zweite Ansicht &amp;verschieben"/>
 					<Item id="10002" name="In zweite Ansicht &amp;duplizieren"/>
 					<Item id="10003" name="In &amp;neue Instanz verschieben"/>
 					<Item id="10004" name="In neue Instan&amp;z duplizieren"/>
 					<Item id="41001" name="&amp;Neu"/>
-					<Item id="41002" name="&amp;Öffnen"/>
+					<Item id="41002" name="&amp;Öffnen..."/>
 					<Item id="41003" name="Schlie&amp;ßen"/>
-					<Item id="41004" name="All&amp;e schließen"/>
+					<Item id="41004" name="Alle s&amp;chließen"/>
 					<Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
 					<Item id="41006" name="&amp;Speichern"/>
 					<Item id="41007" name="&amp;Alle speichern"/>
@@ -94,14 +94,14 @@
 					<Item id="41010" name="&amp;Drucken..."/>
 					<Item id="41011" name="B&amp;eenden"/>
 					<Item id="41012" name="Sit&amp;zung öffnen..."/>
-					<Item id="41013" name="Sit&amp;zung speichern..."/>
+					<Item id="41013" name="Sitzung speiche&amp;rn..."/>
 					<Item id="41014" name="Neu &amp;laden"/>
 					<Item id="41015" name="&amp;Kopie speichern unter..."/>
 					<Item id="41016" name="Von Datentr&amp;äger löschen"/>
 					<Item id="41017" name="Um&amp;benennen..."/>
 					<Item id="41018" name="Dateien &amp;rechts schließen"/>
 					<Item id="41019" name="E&amp;xplorer"/>
-					<Item id="41020" name="&amp;Kommandozeile"/>
+					<Item id="41020" name="&amp;Eingabeaufforderung"/>
 					<Item id="41021" name="Zuletzt &amp;geschlossene Datei wieder öffnen"/>
 					<Item id="42001" name="Aus&amp;schneiden"/>
 					<Item id="42002" name="&amp;Kopieren"/>
@@ -110,21 +110,21 @@
 					<Item id="42005" name="&amp;Einfügen"/>
 					<Item id="42006" name="&amp;Löschen"/>
 					<Item id="42007" name="&amp;Alles auswählen"/>
-					<Item id="42008" name="Tab einfügen (&amp;einrücken)"/>
-					<Item id="42009" name="Tab entfernen (&amp;ausrücken)"/>
-					<Item id="42010" name="Zeile/Markierung wie&amp;derholen"/>
+					<Item id="42008" name="Zeileneinzug v&amp;ergrößern"/>
+					<Item id="42009" name="Zeileneinzug ver&amp;kleinern"/>
+					<Item id="42010" name="Zeile &amp;duplizieren"/>
 					<Item id="42012" name="Zeile am Fensterrand &amp;teilen"/>
 					<Item id="42013" name="&amp;Zeilen zusammenfassen"/>
-					<Item id="42014" name="Zeile nach &amp;oben schieben"/>
-					<Item id="42015" name="Zeile nach &amp;unten schieben"/>
+					<Item id="42014" name="Zeile nach &amp;oben verschieben"/>
+					<Item id="42015" name="Zeile nach &amp;unten verschieben"/>
 					<Item id="42016" name="In &amp;Großbuchstaben umwandeln"/>
 					<Item id="42017" name="In &amp;Kleinbuchstaben umwandeln"/>
 					<Item id="42018" name="Aufzeichnung s&amp;tarten"/>
 					<Item id="42019" name="Aufzeichnung st&amp;oppen"/>
 					<Item id="42020" name="Auswa&amp;hl beginnen/beenden"/>
 					<Item id="42021" name="Makro ausfüh&amp;ren"/>
-					<Item id="42022" name="&amp;Zeilenweise ein-/auskommentieren"/>
-					<Item id="42023" name="Markierung &amp;auskommentieren"/>
+					<Item id="42022" name="&amp;Zeilenweise Auskommentierung umschalten"/>
+					<Item id="42023" name="Auswahl &amp;auskommentieren"/>
 					<Item id="42024" name="Leerzeichen und Tabulatoren am Zeilen&amp;ende löschen"/>
 					<Item id="42025" name="Aufgenommenes Makro s&amp;peichern"/>
 					<Item id="42026" name="Schreib&amp;richtung von rechts nach links"/>
@@ -134,26 +134,26 @@
 					<Item id="42030" name="Nur Datei&amp;namen kopieren"/>
 					<Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
 					<Item id="42032" name="Makro &amp;mehrfach ausführen..."/>
-					<Item id="42033" name="Schreibsch&amp;utz-Attribut löschen"/>
+					<Item id="42033" name="Schreibschutz-Attribut l&amp;öschen"/>
 					<Item id="42034" name="&amp;Block-Editor..."/>
 					<Item id="42035" name="Zeilen aus&amp;kommentieren"/>
-					<Item id="42036" name="Zeilen ei&amp;nkommentieren"/>
+					<Item id="42036" name="Auskommentierung der Zeilen a&amp;ufheben"/>
 					<Item id="42037" name="Spalten-&amp;Modus..."/>
 					<Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
 					<Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
-					<Item id="42040" name="Alle zuletzt verwendeten Dateien &amp;öffnen"/>
-					<Item id="42041" name="Liste &amp;löschen"/>
+					<Item id="42040" name="Alle zule&amp;tzt verwendeten Dateien öffnen"/>
+					<Item id="42041" name="L&amp;iste löschen"/>
 					<Item id="42042" name="Leerzeichen und Tabulatoren am Zeilen&amp;anfang löschen"/>
 					<Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang &amp;und -ende löschen"/>
 					<Item id="42044" name="Zeilenumbrüche in Leerzeichen &amp;konvertieren"/>
 					<Item id="42045" name="&amp;Mehrfachen Whitespace und Umbrüche entfernen"/>
 					<Item id="42046" name="Tabulatoren in &amp;Leerzeichen umwandeln"/>
-					<Item id="42047" name="Markierung &amp;einkommentieren"/>
+					<Item id="42047" name="Auskommentierung der Auswahl au&amp;fheben"/>
 					<Item id="42048" name="Binär-Inhalt &amp;kopieren"/>
 					<Item id="42049" name="Binär-Inhalt &amp;ausschneiden"/>
 					<Item id="42050" name="Binär-Inhalt &amp;einfügen"/>
 					<Item id="42051" name="Zeichen&amp;tabelle"/>
-					<Item id="42052" name="Z&amp;wischenablage"/>
+					<Item id="42052" name="Zwis&amp;chenablage"/>
 					<Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am &amp;Zeilenanfang)"/>
 					<Item id="42054" name="Leerzeichen in &amp;Tabulatoren umwandeln (alle)"/>
 					<Item id="42055" name="&amp;Leerzeilen (nur völlig leere) löschen"/>
@@ -162,8 +162,8 @@
 					<Item id="42058" name="Leerzeile u&amp;nter aktueller Zeile einfügen"/>
 					<Item id="42059" name="Zeilen alphabetisch au&amp;fsteigend sortieren"/>
 					<Item id="42060" name="Zeilen alphabetisch a&amp;bsteigend sortieren"/>
-					<Item id="42061" name="Zeilen als Integer aufsteigend sortieren"/>
-					<Item id="42062" name="Zeilen als Integer absteigend sortieren"/>
+					<Item id="42061" name="Zeilen als Ganzzahlen aufsteigend sortieren"/>
+					<Item id="42062" name="Zeilen als Ganzzahlen absteigend sortieren"/>
 					<Item id="42063" name="Zeilen als Dezimalzahlen (Komma) aufsteigend sortieren"/>
 					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
 					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
@@ -180,12 +180,12 @@
 					<Item id="43010" name="&amp;Rückwärts suchen"/>
 					<Item id="43011" name="&amp;Inkrementelle Suche"/>
 					<Item id="43013" name="In &amp;Dateien suchen..."/>
-					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne History)"/>
-					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne History)"/>
-					<Item id="43018" name="&amp;Zeilen mit Lesezeichen ausschneiden"/>
-					<Item id="43019" name="&amp;Zeilen mit Lesezeichen kopieren"/>
+					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne Verlauf)"/>
+					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne Verlauf)"/>
+					<Item id="43018" name="Zeilen mit Lesezeichen &amp;ausschneiden"/>
+					<Item id="43019" name="Zeilen mit Lesezeichen &amp;kopieren"/>
 					<Item id="43020" name="&amp;Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
-					<Item id="43021" name="&amp;Zeilen mit Lesezeichen löschen"/>
+					<Item id="43021" name="Zeilen mit Lesezeichen lös&amp;chen"/>
 					<Item id="43022" name="Hervorhebung &amp;1"/>
 					<Item id="43023" name="Hervorhebung &amp;1 entfernen"/>
 					<Item id="43024" name="Hervorhebung &amp;2"/>
@@ -210,17 +210,17 @@
 					<Item id="43043" name="Hervorhebung &amp;5"/>
 					<Item id="43044" name="Hervorhebung aus &amp;Suche"/>
 					<Item id="43045" name="Suchergebnis-&amp;Fenster"/>
-					<Item id="43046" name="Zu nächstem S&amp;uchergebnis springen"/>
-					<Item id="43047" name="Zu vorherigem S&amp;uchergebnis springen"/>
+					<Item id="43046" name="Zum n&amp;ächsten Suchergebnis springen"/>
+					<Item id="43047" name="Zum vorherigen S&amp;uchergebnis springen"/>
 					<Item id="43048" name="Auswahl oder Wort am &amp;Cursor suchen"/>
 					<Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
 					<Item id="43050" name="Lesezeichen inver&amp;tieren"/>
-					<Item id="43051" name="&amp;Zeilen ohne Lesezeichen löschen"/>
+					<Item id="43051" name="Zeilen &amp;ohne Lesezeichen löschen"/>
 					<Item id="43052" name="Suche nach &amp;Zeichencodes..."/>
-					<Item id="43053" name="Alles zwische&amp;n Klammern auswählen"/>
-					<Item id="43054" name="Vorkommnisse &amp;markieren..."/>
+					<Item id="43053" name="&amp;Alles zwischen Klammern auswählen"/>
+					<Item id="43054" name="&amp;Hervorheben..."/>
 					<Item id="44009" name="&amp;Post-It"/>
-					<Item id="44010" name="Alle Te&amp;xtblöcke schließen"/>
+					<Item id="44010" name="A&amp;lle Textblöcke schließen"/>
 					<Item id="44011" name="Benutzerdefinierte Spra&amp;che..."/>
 					<Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>
 					<Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>
@@ -232,12 +232,12 @@
 					<Item id="44024" name="Schrift ver&amp;kleinern"/>
 					<Item id="44025" name="&amp;Leerzeichen und Tabulatoren anzeigen"/>
 					<Item id="44026" name="Zeilenende anze&amp;igen"/>
-					<Item id="44029" name="Alle Te&amp;xtblöcke öffnen"/>
-					<Item id="44030" name="Te&amp;xtblock schließen"/>
-					<Item id="44031" name="Te&amp;xtblock öffnen"/>
+					<Item id="44029" name="Alle Textblöcke &amp;öffnen"/>
+					<Item id="44030" name="Textblock schlie&amp;ßen"/>
+					<Item id="44031" name="Textblock öff&amp;nen"/>
 					<Item id="44032" name="Voll&amp;bild"/>
-					<Item id="44033" name="Standardgrö&amp;ße"/>
-					<Item id="44034" name="Immer im Vordergrund &amp;halten"/>
+					<Item id="44033" name="&amp;Standardgröße"/>
+					<Item id="44034" name="Immer im Vorder&amp;grund halten"/>
 					<Item id="44035" name="S&amp;ynchrones vertikales Scrollen"/>
 					<Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
 					<Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
@@ -284,7 +284,7 @@
 					<Item id="47001" name="Notepad++ im &amp;Web"/>
 					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
 					<Item id="47005" name="&amp;Erweiterungen"/>
-					<Item id="47006" name="Notepad++ aktualisieren"/>
+					<Item id="47006" name="Notepad++ &amp;aktualisieren"/>
 					<Item id="47008" name="In&amp;halt..."/>
 					<Item id="47009" name="&amp;Proxy für Updater einstellen..."/>
 					<Item id="47010" name="&amp;Kommandozeilenparameter..."/>
@@ -358,7 +358,7 @@
 				<Item id="1632" name="In &amp;Markierung"/>
 				<Item id="1633" name="Zurücksetzen"/>
 				<Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
-				<Item id="1636" name="Suche in allen &amp;offenen Dateien"/>
+				<Item id="1636" name="In &amp;offenen Dateien suchen"/>
 				<Item id="1637" name="In Dateien suchen"/>
 				<Item id="1640" name="Umschaltdialog"/>
 				<Item id="1641" name="Alle in aktiver &amp;Datei suchen"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -89,16 +89,16 @@
 					<Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
 					<Item id="41006" name="&amp;Speichern"/>
 					<Item id="41007" name="&amp;Alle speichern"/>
-					<Item id="41008" name="Speichern &amp;unter ..."/>
+					<Item id="41008" name="Speichern &amp;unter..."/>
 					<Item id="41009" name="Dateien &amp;links schließen"/>
-					<Item id="41010" name="&amp;Drucken ..."/>
+					<Item id="41010" name="&amp;Drucken..."/>
 					<Item id="41011" name="B&amp;eenden"/>
-					<Item id="41012" name="Sit&amp;zung öffnen ..."/>
-					<Item id="41013" name="Sit&amp;zung speichern ..."/>
+					<Item id="41012" name="Sit&amp;zung öffnen..."/>
+					<Item id="41013" name="Sit&amp;zung speichern..."/>
 					<Item id="41014" name="Neu &amp;laden"/>
-					<Item id="41015" name="&amp;Kopie speichern unter ..."/>
+					<Item id="41015" name="&amp;Kopie speichern unter..."/>
 					<Item id="41016" name="Von Datentr&amp;äger löschen"/>
-					<Item id="41017" name="Um&amp;benennen ..."/>
+					<Item id="41017" name="Um&amp;benennen..."/>
 					<Item id="41018" name="Dateien &amp;rechts schließen"/>
 					<Item id="41019" name="E&amp;xplorer"/>
 					<Item id="41020" name="&amp;Kommandozeile"/>
@@ -133,12 +133,12 @@
 					<Item id="42029" name="Vollständigen &amp;Pfad kopieren"/>
 					<Item id="42030" name="Nur Datei&amp;namen kopieren"/>
 					<Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
-					<Item id="42032" name="Makro &amp;mehrfach ausführen ..."/>
+					<Item id="42032" name="Makro &amp;mehrfach ausführen..."/>
 					<Item id="42033" name="Schreibsch&amp;utz-Attribut löschen"/>
-					<Item id="42034" name="&amp;Block-Editor ..."/>
+					<Item id="42034" name="&amp;Block-Editor..."/>
 					<Item id="42035" name="Zeilen aus&amp;kommentieren"/>
 					<Item id="42036" name="Zeilen ei&amp;nkommentieren"/>
-					<Item id="42037" name="Spalten-&amp;Modus ..."/>
+					<Item id="42037" name="Spalten-&amp;Modus..."/>
 					<Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
 					<Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
 					<Item id="42040" name="Alle zuletzt verwendeten Dateien &amp;öffnen"/>
@@ -168,10 +168,10 @@
 					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
 					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
 					<Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-					<Item id="43001" name="&amp;Suchen ..."/>
+					<Item id="43001" name="&amp;Suchen..."/>
 					<Item id="43002" name="&amp;Weitersuchen"/>
-					<Item id="43003" name="&amp;Ersetzen ..."/>
-					<Item id="43004" name="&amp;Gehe zu ..."/>
+					<Item id="43003" name="&amp;Ersetzen..."/>
+					<Item id="43004" name="&amp;Gehe zu..."/>
 					<Item id="43005" name="&amp;Lesezeichen setzen/löschen"/>
 					<Item id="43006" name="&amp;Nächstes Lesezeichen"/>
 					<Item id="43007" name="&amp;Vorheriges Lesezeichen"/>
@@ -179,7 +179,7 @@
 					<Item id="43009" name="Suche zugehörige &amp;Klammer"/>
 					<Item id="43010" name="&amp;Rückwärts suchen"/>
 					<Item id="43011" name="&amp;Inkrementelle Suche"/>
-					<Item id="43013" name="In &amp;Dateien suchen ..."/>
+					<Item id="43013" name="In &amp;Dateien suchen..."/>
 					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne History)"/>
 					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne History)"/>
 					<Item id="43018" name="&amp;Zeilen mit Lesezeichen ausschneiden"/>
@@ -216,12 +216,12 @@
 					<Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
 					<Item id="43050" name="Lesezeichen inver&amp;tieren"/>
 					<Item id="43051" name="&amp;Zeilen ohne Lesezeichen löschen"/>
-					<Item id="43052" name="Suche nach &amp;Zeichencodes ..."/>
+					<Item id="43052" name="Suche nach &amp;Zeichencodes..."/>
 					<Item id="43053" name="Alles zwische&amp;n Klammern auswählen"/>
-					<Item id="43054" name="Vorkommnisse &amp;markieren ..."/>
+					<Item id="43054" name="Vorkommnisse &amp;markieren..."/>
 					<Item id="44009" name="&amp;Post-It"/>
 					<Item id="44010" name="Alle Te&amp;xtblöcke schließen"/>
-					<Item id="44011" name="Benutzerdefinierte Spra&amp;che ..."/>
+					<Item id="44011" name="Benutzerdefinierte Spra&amp;che..."/>
 					<Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>
 					<Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>
 					<Item id="44014" name="Codefaltung ausb&amp;lenden"/>
@@ -242,7 +242,7 @@
 					<Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
 					<Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
 					<Item id="44042" name="Zeilen &amp;ausblenden"/>
-					<Item id="44049" name="Datei-&amp;Info ..."/>
+					<Item id="44049" name="Datei-&amp;Info..."/>
 					<Item id="44072" name="&amp;Zur anderen Ansicht wechseln"/>
 					<Item id="44080" name="&amp;Miniaturansicht"/>
 					<Item id="44081" name="Projektfenster &amp;1"/>
@@ -273,30 +273,30 @@
 					<Item id="45011" name="Konv&amp;ertiere zu UTF-8"/>
 					<Item id="45012" name="Konve&amp;rtiere zu UCS-2 Big Endian"/>
 					<Item id="45013" name="Konver&amp;tiere zu UCS-2 Little Endian"/>
-					<Item id="46001" name="&amp;Stile ..."/>
+					<Item id="46001" name="&amp;Stile..."/>
 					<Item id="46015" name="MS-DOS-Stil"/>
 					<Item id="46016" name="Normaler Text"/>
 					<Item id="46017" name="Ressourcen-Datei"/>
 					<!-- <Item id="46019" name="MS-INI-Datei"/> -->
 					<Item id="46080" name="Benutzerdefiniert"/>
-					<Item id="46150" name="Eigene Sprache &amp;definieren ..."/>
-					<Item id="47000" name="&amp;Info ..."/>
+					<Item id="46150" name="Eigene Sprache &amp;definieren..."/>
+					<Item id="47000" name="&amp;Info..."/>
 					<Item id="47001" name="Notepad++ im &amp;Web"/>
 					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
 					<Item id="47005" name="&amp;Erweiterungen"/>
 					<Item id="47006" name="Notepad++ aktualisieren"/>
-					<Item id="47008" name="In&amp;halt ..."/>
-					<Item id="47009" name="&amp;Proxy für Updater einstellen ..."/>
-					<Item id="47010" name="&amp;Kommandozeilenparameter ..."/>
+					<Item id="47008" name="In&amp;halt..."/>
+					<Item id="47009" name="&amp;Proxy für Updater einstellen..."/>
+					<Item id="47010" name="&amp;Kommandozeilenparameter..."/>
 					<Item id="47011" name="&amp;Support im Chat"/>
-					<Item id="48005" name="&amp;Plugin(s) importieren ..."/>
-					<Item id="48006" name="&amp;Design(s) importieren ..."/>
-					<Item id="48009" name="&amp;Tastatur ..."/>
-					<Item id="48011" name="&amp;Optionen ..."/>
-					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen ..."/>
-					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen ..."/>
-					<Item id="48018" name="&amp;Kontextmenü anpassen ..."/>
-					<Item id="49000" name="Externes Programm &amp;ausführen ..."/>
+					<Item id="48005" name="&amp;Plugin(s) importieren..."/>
+					<Item id="48006" name="&amp;Design(s) importieren..."/>
+					<Item id="48009" name="&amp;Tastatur..."/>
+					<Item id="48011" name="&amp;Optionen..."/>
+					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen..."/>
+					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen..."/>
+					<Item id="48018" name="&amp;Kontextmenü anpassen..."/>
+					<Item id="49000" name="Externes Programm &amp;ausführen..."/>
 					<Item id="50000" name="&amp;Funktionsvervollständigung"/>
 					<Item id="50001" name="&amp;Wortvervollständigung"/>
 					<Item id="50002" name="Funktions&amp;parameter anzeigen"/>
@@ -309,14 +309,14 @@
 				<Item CMID="0" name="S&amp;chließen"/>
 				<Item CMID="1" name="&amp;Alle anderen schließen"/>
 				<Item CMID="2" name="&amp;Speichern"/>
-				<Item CMID="3" name="Speichern &amp;unter ..."/>
+				<Item CMID="3" name="Speichern &amp;unter..."/>
 				<Item CMID="4" name="&amp;Drucken"/>
 				<Item CMID="5" name="In zweite Ansicht &amp;verschieben"/>
 				<Item CMID="6" name="In zw&amp;eite Ansicht duplizieren"/>
 				<Item CMID="7" name="Vollständigen Pfad &amp;kopieren"/>
 				<Item CMID="8" name="Nur Datei&amp;namen kopieren"/>
 				<Item CMID="9" name="Nur Verzeichnis&amp;pfad kopieren"/>
-				<Item CMID="10" name="Um&amp;benennen ..."/>
+				<Item CMID="10" name="Um&amp;benennen..."/>
 				<Item CMID="11" name="L&amp;öschen"/>
 				<Item CMID="12" name="Sch&amp;reibschutz"/>
 				<Item CMID="13" name="Schreibschutz au&amp;fheben"/>
@@ -385,7 +385,7 @@
 				<Item id="2008" name="Z&amp;eichen"/>
 			</GoToLine>
 			<!-- Run external program: -->
-			<Run title="Ausführen ...">
+			<Run title="Ausführen...">
 				<Item id="1" name="&amp;Ausführen"/>
 				<Item id="2" name="A&amp;bbrechen"/>
 				<Item id="1901" name=".&amp;.."/>
@@ -441,7 +441,7 @@
 				<Item id="20002" name="Umbenennen"/>
 				<Item id="20003" name="Neue erstellen"/>
 				<Item id="20004" name="Löschen"/>
-				<Item id="20005" name="Speichern als ..."/>
+				<Item id="20005" name="Speichern als..."/>
 				<Item id="20007" name="Sprache"/>
 				<Item id="20009" name="Erw."/>
 				<Item id="20011" name="Transparenz"/>
@@ -900,25 +900,25 @@
 					<Item id="3123" name="Arbeitsbereich öffnen"/>
 					<Item id="3124" name="Arbeitsbereich neu laden"/>
 					<Item id="3125" name="Speichern"/>
-					<Item id="3126" name="Speichern unter ..."/>
-					<Item id="3127" name="Kopie speichern unter ..."/>
+					<Item id="3126" name="Speichern unter..."/>
+					<Item id="3127" name="Kopie speichern unter..."/>
 					<Item id="3121" name="Neues Projekt hinzufügen"/>
 				</WorkspaceMenu>
 				<ProjectMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen ..."/>
+					<Item id="3113" name="Dateien hinzufügen..."/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen ..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</ProjectMenu>
 				<FolderMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen ..."/>
+					<Item id="3113" name="Dateien hinzufügen..."/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen ..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</FolderMenu>

--- a/PowerEditor/installer/nativeLang/polish.xml
+++ b/PowerEditor/installer/nativeLang/polish.xml
@@ -14,7 +14,7 @@
                     <Item menuId = "settings" name="&amp;Ustawienia"/>
                     <Item menuId = "macro" name="&amp;Makra"/>
                     <Item menuId = "run" name="U&amp;ruchom"/>
-                    <Item idName="Plugins" name="Plu&amp;giny"/>
+                    <Item idName="Plugins" name="W&amp;tyczki"/>
                     <Item idName="Window" name="&amp;Okno"/>
                 </Entries>
 
@@ -25,22 +25,22 @@
                     <Item subMenuId="file-recentFiles" name="Ostatnie pliki"/>
                     <Item subMenuId="edit-copyToClipboard" name="Kopiuj do schowka"/>
                     <Item subMenuId="edit-indent" name="Wcięcia"/>
-                    <Item subMenuId="edit-convertCaseTo" name="Duże / małe litery"/>
+                    <Item subMenuId="edit-convertCaseTo" name="Duże/małe litery"/>
                     <Item subMenuId="edit-lineOperations" name="Operacje na liniach"/>
                     <Item subMenuId="edit-comment" name="Komentarze"/>
-                    <Item subMenuId="edit-autoCompletion" name="Auto-uzupełnianie"/>
+                    <Item subMenuId="edit-autoCompletion" name="Autouzupełnianie"/>
                     <Item subMenuId="edit-eolConversion" name="Konwersja znaku końca linii"/>
 					<Item subMenuId="edit-blankOperations" name="Operacje na białych znakach"/>
-					<Item subMenuId="edit-pasteSpecial" name="Wklej Specjalnie"/>
-                    <Item subMenuId="search-markAll" name="Zaznacz Wszystko"/>
-                    <Item subMenuId="search-unmarkAll" name="Odznacz Wszystko"/>
-                    <Item subMenuId="search-jumpUp" name="Skocz Wyżej"/>
-                    <Item subMenuId="search-jumpDown" name="Skocz Niżej"/>
+					<Item subMenuId="edit-pasteSpecial" name="Wklej specjalnie"/>
+                    <Item subMenuId="search-markAll" name="Zaznacz wszystko"/>
+                    <Item subMenuId="search-unmarkAll" name="Odznacz wszystko"/>
+                    <Item subMenuId="search-jumpUp" name="Przejdź wyżej"/>
+                    <Item subMenuId="search-jumpDown" name="Przejdź niżej"/>
                     <Item subMenuId="search-bookmark" name="Zakładki"/>
                     <Item subMenuId="view-showSymbol" name="Pokaż niewidoczne znaki"/>
                     <Item subMenuId="view-zoom" name="Powiększenie"/>
-                    <Item subMenuId="view-moveCloneDocument" name="Przenieś / sklonuj bieżący dokument"/>
-                    <Item subMenuId="view-tab"  name="Tab"/>
+                    <Item subMenuId="view-moveCloneDocument" name="Przenieś/sklonuj bieżący dokument"/>
+                    <Item subMenuId="view-tab" name="Zakładki"/>
                     <Item subMenuId="view-collapseLevel" name="Zwiń poziom"/>
                     <Item subMenuId="view-uncollapseLevel" name="Rozwiń poziom"/>
                     <Item subMenuId="view-project" name="Projekt"/>
@@ -84,14 +84,14 @@
                     <Item id="41011" name="Za&amp;kończ"/>
                     <Item id="41012" name="Załaduj sesję..."/>
                     <Item id="41013" name="Zapisz sesję..."/>
-                    <Item id="41014" name="Przeładuj z dysku"/>
+                    <Item id="41014" name="Odśwież z dysku"/>
                     <Item id="41015" name="Zapisz kopię jako..."/>
                     <Item id="41016" name="Usuń z dysku"/>
                     <Item id="41017" name="Zmień nazwę..."/>
 					<Item id="41009" name = "Zamknij wszystkie na lewo"/>
 					<Item id="41018" name = "Zamknij wszystkie na prawo"/>
-					<Item id="41019" name = "Explorator"/>
-					<Item id="41020" name = "cmd"/>
+					<Item id="41019" name = "Eksplorator"/>
+					<Item id="41020" name = "Konsola Windows"/>
                     <Item id="42001" name="Wyt&amp;nij"/>
                     <Item id="42002" name="&amp;Kopiuj"/>
                     <Item id="42003" name="C&amp;ofnij"/>
@@ -103,27 +103,27 @@
                     <Item id="42009" name="Usuń TAB (wcięcie)"/>
                     <Item id="42010" name="Powtórz bieżący wiersz"/>
                     <Item id="42012" name="Podziel wiersze"/>
-                    <Item id="42013" name="Złącz wiersze"/>
+                    <Item id="42013" name="Połącz wiersze"/>
                     <Item id="42014" name="Przesuń bieżący wiersz do góry"/>
                     <Item id="42015" name="Przesuń bieżący wiersz w dół"/>
                     <Item id="42016" name="Zamiana na duże litery"/>
                     <Item id="42017" name="Zamiana na małe litery"/>
                     <Item id="42018" name="&amp;Rozpocznij nagrywanie"/>
                     <Item id="42019" name="&amp;Zakończ nagrywanie"/>
-					<Item id="42020" name="Rozpocznij/Zakończ Zaznaczenie"/>
+					<Item id="42020" name="Rozpocznij/zakończ zaznaczenie"/>
                     <Item id="42021" name="&amp;Odtwórz"/>
-                    <Item id="42022" name="Wstaw / usuń komentarz blokowy"/>
-                    <Item id="42023" name="Kontynuj komentarz"/>
+                    <Item id="42022" name="Wstaw/usuń komentarz blokowy"/>
+                    <Item id="42023" name="Kontynuuj komentarz"/>
                     <Item id="42024" name="Usuń spacje na końcach linii"/>
                     <Item id="42025" name="Zapisz bieżące makro"/>
                     <Item id="42026" name="Kierunek tekstu z prawej do lewej"/>
                     <Item id="42027" name="Kierunek tekstu z lewej do prawej"/>
                     <Item id="42028" name="Zablokuj edycję"/>
-                    <Item id="42029" name="Skopiuj ścieżkę pliku do schowka"/>
-                    <Item id="42030" name="Skopiuj nazwę pliku do schowka"/>
-                    <Item id="42031" name="Skopiuj ścieżkę katalogu do schowka"/>
+                    <Item id="42029" name="Skopiuj pełną ścieżkę pliku"/>
+                    <Item id="42030" name="Skopiuj nazwę pliku"/>
+                    <Item id="42031" name="Skopiuj katalog pliku"/>
                     <Item id="42032" name="Uruchom makro wielokrotnie..."/>
-                    <Item id="42033" name="Wyczyść flagę 'tylko do odczytu'"/>
+                    <Item id="42033" name="Wyłącz tryb 'tylko do odczytu'"/>
                     <Item id="42034" name="Edytor kolumn..."/>
                     <Item id="42035" name="Wstaw komentarz blokowy"/>
                     <Item id="42036" name="Usuń komentarz blokowy"/>
@@ -135,15 +135,15 @@
 					<Item id="42042" name="Usuń spacje na początkach linii"/>
 					<Item id="42043" name="Usuń spacje na początkach i końcach linii"/>
 					<Item id="42044" name="Znak końca linii na spację"/>
-					<Item id="42045" name="Usuń n iepotrzebne Białe znaki i puste linie"/>
-					<Item id="42046" name="Tabulacja na Spację"/>
+					<Item id="42045" name="Usuń niepotrzebne Białe znaki i puste linie"/>
+					<Item id="42046" name="Tabulacja na spację"/>
 					<Item id="42047" name="Spacja na tabulację"/>
-					<Item id="42048" name="&amp;Kopiuj treść Binarną"/>
-					<Item id="42049" name="Wy&amp;tnij treść Binarną"/>
-					<Item id="42050" name="&amp;Wklej treść Binarną"/>
+					<Item id="42048" name="&amp;Kopiuj treść binarną"/>
+					<Item id="42049" name="Wy&amp;tnij treść binarną"/>
+					<Item id="42050" name="&amp;Wklej treść binarną"/>
 					<Item id="42051" name="Panel &amp;tablicy znaków "/>
 					<Item id="42052" name="Historia scho&amp;wka"/>
-					<Item id="42053" name = "Spacje na tabulatory (wiodące)"/>
+					<Item id="42053" name = "Spacje na tabulatory (początkowe)"/>
 					<Item id="42054" name = "Spacje na tabulatory (wszędzie)"/>
 					<Item id="42055" name = "Usuwanie pustych linii"/>
 					<Item id="42056" name = "Usuwanie pustych linii (zawierających białe znaki)"/>
@@ -155,7 +155,7 @@
                     <Item id="43002" name="&amp;Następne wystąpienie"/>
                     <Item id="43003" name="Zamień..."/>
                     <Item id="43004" name="Idź do wiersza..."/>
-                    <Item id="43005" name="Wstaw / usuń zakładkę"/>
+                    <Item id="43005" name="Wstaw/usuń zakładkę"/>
                     <Item id="43006" name="Następna zakładka"/>
                     <Item id="43007" name="Poprzednia zakładka"/>
                     <Item id="43008" name="Wyczyść wszystkie zakładki"/>
@@ -182,24 +182,24 @@
                     <Item id="43030" name="Wyróżnienie 5"/>
                     <Item id="43031" name="Usuń wyróżnienie 5"/>
                     <Item id="43032" name="Usuń wszystkie wyróżnienia"/>
-                    <Item id="43033" name="1szy styl"/>
-                    <Item id="43034" name="2gi styl"/>
-                    <Item id="43035" name="3ci styl"/>
-                    <Item id="43036" name="4ty styl"/>
-                    <Item id="43037" name="5ty styl"/>
+                    <Item id="43033" name="1. styl"/>
+                    <Item id="43034" name="2. styl"/>
+                    <Item id="43035" name="3. styl"/>
+                    <Item id="43036" name="4. styl"/>
+                    <Item id="43037" name="5. styl"/>
                     <Item id="43038" name="Szukaj stylu"/>
-                    <Item id="43039" name="1szy styl"/>
-                    <Item id="43040" name="2gi styl"/>
-                    <Item id="43041" name="3ci styl"/>
-                    <Item id="43042" name="4ty styl"/>
-                    <Item id="43043" name="5ty styl"/>
+                    <Item id="43039" name="1. styl"/>
+                    <Item id="43040" name="2. styl"/>
+                    <Item id="43041" name="3. styl"/>
+                    <Item id="43042" name="4. styl"/>
+                    <Item id="43043" name="5. styl"/>
                     <Item id="43044" name="Szukaj stylu"/>
-                    <Item id="43045" name="Okno Wyników Wyszukiwania"/>
-                    <Item id="43046" name="Następny wynik Wyszukiwania"/>
-                    <Item id="43047" name="Poprzedni Wynik Wyszukiwania"/>
-                    <Item id="43048" name="Zaznacz i Szukaj Następnego"/>
-                    <Item id="43049" name="Zaznacz i Szukaj Poprzedniegos"/>
-                    <Item id="43050" name="Odwróć Zakładki"/>
+                    <Item id="43045" name="Okno wyników wyszukiwania"/>
+                    <Item id="43046" name="Następny wynik wyszukiwania"/>
+                    <Item id="43047" name="Poprzedni wynik wyszukiwania"/>
+                    <Item id="43048" name="Zaznacz i szukaj następnego"/>
+                    <Item id="43049" name="Zaznacz i szukaj poprzedniego"/>
+                    <Item id="43050" name="Odwróć zakładki"/>
 					<Item id="43051" name="Usuń linie bez &amp;zakładek"/>
 					<Item id="43052" name="Szukaj znaków z zakresu..."/>
 					<Item id="43053" name = "Zaznacz wszystko pomiędzy odpowiadającymi nawiasami"/>
@@ -212,7 +212,7 @@
                     <Item id="44019" name="Pokaż wszystkie znaki"/>
                     <Item id="44020" name="Pokaż prowadnice poziomów"/>
                     <Item id="44022" name="Zawijaj wiersze"/>
-                    <Item id="44023" name="Z&amp;większ"/>
+                    <Item id="44023" name="Po&amp;większ"/>
                     <Item id="44024" name="Z&amp;mniejsz"/>
                     <Item id="44025" name="Pokaż białe znaki i tabulatory"/>
                     <Item id="44026" name="Pokaż znaki nowej linii"/>
@@ -226,7 +226,7 @@
                     <Item id="44036" name="Synchronizuj przewijanie poziome"/>
                     <Item id="44041" name="Pokaż symbol zawijania"/>
                     <Item id="44042" name="Ukryj zaznaczone wiersze"/>
-                    <Item id="44049" name="&amp;Informacje o pliku ..."/>
+                    <Item id="44049" name="&amp;Informacje o pliku..."/>
                     <Item id="44072" name="Przejdź do drugiego widoku"/>
 
 					<Item id="44080" name="Mapa dokumentu"/>
@@ -247,8 +247,8 @@
 					<Item id="44096" name = "Poprzednia zakładka"/>
 
                     <Item id="45001" name="Konwertuj na format Windows"/>
-                    <Item id="45002" name="Konwertuj na format UNIX"/>
-                    <Item id="45003" name="Konwertuj na format MAC"/>
+                    <Item id="45002" name="Konwertuj na format Unix"/>
+                    <Item id="45003" name="Konwertuj na format Mac"/>
                     <Item id="45004" name="Koduj w ANSI"/>
                     <Item id="45005" name="Koduj w UTF-8"/>
                     <Item id="45006" name="Koduj w UCS-2 Big Endian"/>
@@ -264,32 +264,32 @@
 					<Item id="46015" name="Styl MS-DOS"/>
 					<Item id="46016" name="Zwykły tekst"/>
 					<Item id="46017" name="Plik zasobów"/>
-                    <Item id="46080" name="Zdefiniowane przez Użytkownika"/>
+                    <Item id="46080" name="Zdefiniowane przez użytkownika"/>
 					<Item id="46150" name="Zdefiniuj własny język..."/>
                     <Item id="47000" name="O programie..."/>
                     <Item id="47001" name="Strona główna programu"/>
                     <Item id="47002" name="Strona projektu Notepad++"/>
                     <Item id="47003" name="Pomoc online"/>
                     <Item id="47004" name="Forum"/>
-                    <Item id="47005" name="Pobierz pluginy"/>
+                    <Item id="47005" name="Pobierz wtyczki"/>
 					<Item id="47006" name="Uaktualnij Notepad++"/>
-					<Item id="47007" name="FAQ"/>
+					<Item id="47007" name="Często zadawane pytania"/>
 					<Item id="47008" name="Pomoc"/>
-                    <Item id="48005" name="Importuj Plugin(y) ..."/>
-                    <Item id="48006" name="Import Motyw(y) ..."/>
+                    <Item id="48005" name="Importuj wtyczki..."/>
+                    <Item id="48006" name="Import motywy..."/>
                     <Item id="48009" name="Skróty klawiaturowe..."/>
                     <Item id="48011" name="Preferencje..."/>
 
-					<Item id="48016" name="Zmień Skrót/Usuń Makro..."/>
-					<Item id="48017" name="Zmień Skrót/Usuń Polecenie..."/>
-					<Item id="48018" name="Edycja Menu Kontekstowego"/>
+					<Item id="48016" name="Zmień skrót/usuń makro..."/>
+					<Item id="48017" name="Zmień skrót/usuń polecenie..."/>
+					<Item id="48018" name="Edycja menu kontekstowego"/>
 
                     <Item id="49000" name="U&amp;ruchom..."/>
 
                     <Item id="50000" name="Uzupełnianie funkcji"/>
                     <Item id="50001" name="Uzupełnianie słów"/>
                     <Item id="50002" name="Podpowiadanie parametrów funkcji"/>
-					<Item id="50006" name = "Uzupełnianie ścieżki do plików i katalogów"/>
+					<Item id="50006" name ="Uzupełnianie ścieżki do plików i katalogów"/>
 
                 </Commands>
             </Main>
@@ -301,22 +301,22 @@
                     <Item CMID="2" name="Zapisz mnie"/>
                     <Item CMID="3" name="Zapisz mnie jako..."/>
                     <Item CMID="4" name="Wydrukuj mnie"/>
-                    <Item CMID="5" name="Pokaż / ukryj drugi widok"/>
+                    <Item CMID="5" name="Pokaż/ukryj drugi widok"/>
                     <Item CMID="6" name="Sklonuj do drugiego widoku"/>
                     <Item CMID="7" name="Ścieżka pliku do schowka"/>
                     <Item CMID="8" name="Nazwa pliku do schowka"/>
                     <Item CMID="9" name="Ścieżka katalogu do schowka"/>
-                    <Item CMID="10" name="Zmień mi nazwę"/>
+                    <Item CMID="10" name="Zmień moją nazwę"/>
                     <Item CMID="11" name="Usuń mnie z dysku"/>
                     <Item CMID="12" name="Zablokuj edycję"/>
-                    <Item CMID="13" name="Wyczyść flagę 'tylko do odczytu'"/>
+                    <Item CMID="13" name="Włącz tryb 'tylko do odczytu'"/>
                     <Item CMID="14" name="Przejdź do nowej instancji"/>
                     <Item CMID="15" name="Otwórz w nowej instancji"/>
-                    <Item CMID="16" name="Przeładuj"/>
-					<Item CMID="17" name="Zamknij wszystko po Lewo"/>
-                    <Item CMID="18" name="Zamknij wszystko po Prawo"/>
+                    <Item CMID="16" name="Odśwież"/>
+					<Item CMID="17" name="Zamknij wszystko po lewej"/>
+                    <Item CMID="18" name="Zamknij wszystko po prawej"/>
                     <Item CMID="19" name="Otwórz folder zawierający w Eksploratorze"/>
-                    <Item CMID="20" name="Otwórz folder zawierający w cmd"/>
+                    <Item CMID="20" name="Otwórz folder zawierający w Konsoli Windows"/>
             </TabBar>
         </Menu>
 
@@ -331,7 +331,7 @@
                 <Item id="1606" name="Wracaj na początek pliku"/>
                 <Item id="1608" name="Z&amp;amień"/>
                 <Item id="1609" name="Zamień &amp;wszystkie"/>
-                <Item id="1611" name="Zamień &amp;na :"/>
+                <Item id="1611" name="Zamień &amp;na:"/>
                 <Item id="1612" name="W &amp;górę"/>
                 <Item id="1613" name="W &amp;dół"/>
                 <Item id="1614" name="Policz wystąpienia"/>
@@ -351,7 +351,7 @@
                 <Item id="1635" name="Zamień we wszystkich otwartych dokumentach"/>
                 <Item id="1636" name="Szukaj we wszystkich otwartych dokumentach"/>
                 <Item id="1637" name="Szukaj w plikach"/>
-                <Item id="1640" name="Przełącz dialog"/>
+                <Item id="1640" name="Przełącz okno"/>
 			 	<Item id="1641" name="Znajdź wszystkie w bieżącym dokumencie"/>
                 <Item id="1654" name="Filtry:"/>
                 <Item id="1655" name="Katalog:"/>
@@ -368,7 +368,7 @@
             <GoToLine title="Idź do linii #">
                 <Item id="2007" name="Linia"/>
                 <Item id="2008" name="Przesunięcie"/>
-                <Item id="1" name="&amp;Idź !"/>
+                <Item id="1" name="&amp;Przejdź!"/>
                 <Item id="2" name="Nigdzie nie idę"/>
                 <Item id="2004" name="Jesteś tutaj:"/>
                 <Item id="2005" name="Chcesz iść do:"/>
@@ -390,7 +390,7 @@
 				<Item id="2906" name="W górę"/>
 				<Item id="2907" name="W dół"/>
 				<Item id="2908" name="Kierunek"/>
-				<Item id="2909" name="po dojściu do końca zacznij od początku"/>
+				<Item id="2909" name="po osiągnięciu końca zacznij od początku"/>
 				<Item id="2910" name="Szukaj"/>
 			</FindCharsInRange>
 
@@ -402,7 +402,7 @@
                 <Item id="2" name="Anuluj"/>
                 <Item id="2301" name="Zapisz i zamknij"/>
                 <Item id="2303" name="Przezroczystość"/>
-				<Item id="2306" name="Dostępne style : "/>
+				<Item id="2306" name="Dostępne style: "/>
                 <SubDialog>
                     <Item id="2204" name="Pogrubione"/>
                     <Item id="2205" name="Pochyłe"/>
@@ -411,7 +411,7 @@
                     <Item id="2208" name="Nazwa czcionki:"/>
                     <Item id="2209" name="Wielkość czcionki:"/>
                     <!--
-                    <Item id="2210" name="Uwaga : Definicja tego stylu będzie domyślną dla wszystkich niezdefiniowanych stylów"/>
+                    <Item id="2210" name="Uwaga: definicja tego stylu będzie domyślną dla wszystkich niezdefiniowanych stylów"/>
                     -->
                     <Item id="2211" name="Nazwa stylu:"/>
                     <Item id="2212" name="Wybór kolorów"/>
@@ -439,8 +439,8 @@
                 <Item id="20003" name="Nowy..."/>
                 <Item id="20004" name="Usuń"/>
                 <Item id="20005" name="Zapisz jako..."/>
-                <Item id="20007" name="Język : "/>
-                <Item id="20009" name="Rozsz. :"/>
+                <Item id="20007" name="Język: "/>
+                <Item id="20009" name="Rozsz.:"/>
                 <Item id="20011" name="Przezroczystość"/>
                 <Item id="20012" name="Ignoruj wielk. liter"/>
 				<Item id="20015" name="Import"/>
@@ -448,7 +448,7 @@
 				<Item id="0" name = "Styl kolorów"/>
 				<Item id="1" name = "Kolor pierwszego planu"/>
 				<Item id="2" name = "Kolor tła"/>
-				<Item id="3" name = "Styl Czcionki"/>
+				<Item id="3" name = "Styl czcionki"/>
 				<Item id="4" name = "Nazwa:"/>
 				<Item id="5" name = "Wielkość:"/>
 				<Item id="6" name = "Pogrubienie"/>
@@ -493,7 +493,7 @@
                     <Item id="21102" name="Styler"/>
                     <Item id="21104" name="tymczasowe miejsce dok:"/>
                     <Item id="21105" name="Dokumentacja:"/>
-                    <Item id="21106" name="Zwijaj ściśle (Zwiń również puste linie)"/>
+                    <Item id="21106" name="Zwijaj ściśle (zwiń również puste linie)"/>
                     <Item id="21127" name="Styler"/>
                     <Item id="21201" name="Ustawienia początkowego słowa kluczowego"/>
 					<Item id="21220" name="Zwijanie dla stylu 1 kodu:"/>
@@ -502,7 +502,7 @@
                     <Item id="21226" name="Zamknięcie:"/>
                     <Item id="21227" name="Styler"/>
                     <Item id="21301" name="Ustawienia końcowego słowa kluczowego"/>
-					<Item id="21320" name="Zwijanie dla stylu 2 kodu: (wymagane separatory):"/>
+					<Item id="21320" name="Zwijanie kodu dla stylu 2 (wymagane separatory):"/>
 					<Item id="21324" name="Otwarcie:"/>
                     <Item id="21325" name="Środek:"/>
                     <Item id="21326" name="Zamknięcie:"/>
@@ -513,14 +513,14 @@
                     <Item id="21426" name="Zamknięcie:"/>
                 </Folder>
                 <Keywords title="Lista słów kluczowych">
-                    <Item id="22101" name="1sza grupa"/>
-                    <Item id="22201" name="2ga grupa"/>
-                    <Item id="22301" name="3cia grupa"/>
-                    <Item id="22401" name="4ta grupa"/>
-                    <Item id="22451" name="5ta grupa"/>
-                    <Item id="22501" name="6ta grupa"/>
-                    <Item id="22551" name="7ma grupa"/>
-                    <Item id="22601" name="8ma grupa"/>
+                    <Item id="22101" name="1. grupa"/>
+                    <Item id="22201" name="2. grupa"/>
+                    <Item id="22301" name="3. grupa"/>
+                    <Item id="22401" name="4. grupa"/>
+                    <Item id="22451" name="5. grupa"/>
+                    <Item id="22501" name="6. grupa"/>
+                    <Item id="22551" name="7. grupa"/>
+                    <Item id="22601" name="8. grupa"/>
                     <Item id="22113" name="Tryb prefiksu"/>
                     <Item id="22213" name="Tryb prefiksu"/>
                     <Item id="22313" name="Tryb prefiksu"/>
@@ -543,8 +543,8 @@
                     <Item id="22622" name="Styler"/>
                 </Keywords>
                 <Comment title="Komentarze &amp;&amp; Liczby">
-                    <Item id="23001" name="Zazwól zwijać komentarze"/>
-					<Item id="23002" name = "Linie komentarza musą zaczynać się na początku linii"/>
+                    <Item id="23001" name="Zezwól na zawijanie komentarzy"/>
+					<Item id="23002" name = "Linie komentarza muszą zaczynać się na początku linii"/>
                     <Item id="23003" name="Pozycja linii komentarza"/>
                     <Item id="23004" name="Zezwól wszędzie"/>
                     <Item id="23005" name="Wymuś na początku linii"/>
@@ -562,7 +562,7 @@
 					<Item id="23221" name = "Prefiksy liczb (hex, oct, ...): "/>
 					<Item id="23223" name = "Symbole zakresu: "/>
 					<Item id="23225" name = "Możliwe rozszerzenia dla liczb: "/>
-					<Item id="23227" name = "Znaki dodatkowe w liczbach z perfiksu: "/>
+					<Item id="23227" name = "Znaki dodatkowe w liczbach z prefiksu: "/>
                     <Item id="23230" name="Przedrostek 1"/>
                     <Item id="23232" name="Przedrostek 2"/>
                     <Item id="23234" name="Dodatki 1"/>
@@ -643,7 +643,7 @@
                     <Item id="6102" name="Ukryj"/>
                     <Item id="6103" name="Małe ikony"/>
                     <Item id="6104" name="Duże ikony"/>
-                    <Item id="6105" name="Małe standardowe ikony"/>
+                    <Item id="6105" name="Małe, standardowe ikony"/>
                     <Item id="6106" name="Pasek zakładek"/>
                     <Item id="6107" name="Mały"/>
                     <Item id="6108" name="Blokowanie (bez przeciągania)"/>
@@ -662,7 +662,7 @@
                     <Item id="6121" name="Menu główne"/>
                     <Item id="6122" name="Ukryj (klawisz Alt lub F10 przełącza widoczność)"/>
                     <Item id="6123" name="Język"/>
-                    <Item id="6125" name="Przełącznik Dokumentów"/>
+                    <Item id="6125" name="Przełącznik dokumentów"/>
                     <Item id="6126" name="Pokaż"/>
 					<Item id="6127" name = "Nie używaj kolumny z rozszerzeniami"/>
                 </Global>
@@ -675,7 +675,7 @@
                     <Item id="6206" name="Margines z numerami wierszy"/>
                     <Item id="6207" name="Margines zakładek"/>
                     <Item id="6208" name="Pokaż krawędź pionową"/>
-                    <Item id="6209" name="Liczba kolumn : "/>
+                    <Item id="6209" name="Liczba kolumn: "/>
                     <Item id="6211" name="Ustawienia krawędzi pionowej"/>
                     <Item id="6212" name="W formie linii"/>
                     <Item id="6213" name="Podświetlenie tła"/>
@@ -685,8 +685,8 @@
                     <Item id="6219" name="Miganie:"/>
                     <Item id="6221" name="Sz"/>
                     <Item id="6222" name="W"/>
-                    <Item id="6224" name="Ustawienia Edycji Wieloliniowej"/>
-                    <Item id="6225" name="Aktywuj (Ctrl+Zaznaczenie myszką)"/>
+                    <Item id="6224" name="Ustawienia edycji wieloliniowej"/>
+                    <Item id="6225" name="Aktywuj (Ctrl + zaznaczenie myszką)"/>
                     <Item id="6226" name="Brak"/>
                     <Item id="6227" name="Zawijanie wierszy"/>
                     <Item id="6228" name="Domyślne"/>
@@ -695,7 +695,7 @@
 					<Item id="6231" name="Grubość ramki"/>
                     <Item id="6301" name="Tabulatory"/>
                     <Item id="6302" name="Zamień na spacje"/>
-                    <Item id="6303" name="Szerokość tabulatora : "/>
+                    <Item id="6303" name="Szerokość tabulatora: "/>
 					<Item id="6234" name = "Wyłącz wspomaganie przewijania (jeśli masz problem z touchpadem)"/>
 
                 </Scintillas>
@@ -712,24 +712,23 @@
                     <Item id="6408" name="UTF-8"/>
                     <Item id="6409" name="UCS2 Big endian"/>
                     <Item id="6410" name="UCS2 Little endian"/>
-                    <Item id="6411" name="Domyślny język :"/>
-                    <Item id="6413" name="Katalog otwarcia / zapisu pliku"/>
+                    <Item id="6411" name="Domyślny język:"/>
+                    <Item id="6413" name="Katalog otwarcia/zapisu pliku"/>
                     <Item id="6414" name="Z bieżącego dokumentu"/>
                     <Item id="6415" name="Ostatnio używany"/>
                     <Item id="6418" name="..."/>
                     <Item id="6419" name="Nowy dokument"/>
                     <Item id="6420" name="Zastosuj do otwartych plików ANSI"/>
-					<Item id="6421" name="Jamachama"/>
-                    <Item id="6424" name="W Podmenu"/>
+                    <Item id="6424" name="W podmenu"/>
                     <Item id="6425" name="Tylko nazwa pliku"/>
-                    <Item id="6426" name="Pełna ścieżka do Pliku"/>
-                    <Item id="6427" name="Dostosuj Max. Długość:"/>
+                    <Item id="6426" name="Pełna ścieżka do pliku"/>
+                    <Item id="6427" name="Dostosuj maks. długość:"/>
                 </NewDoc>
 
                 <DefaultDir title="Folder domyślny">
-                    <Item id="6413" name="Folder domyślny (Otwórz/Zapisz)"/>
+                    <Item id="6413" name="Folder domyślny (otwórz/zapisz)"/>
                     <Item id="6414" name="Według bieżącego dokumentu"/>
-                    <Item id="6415" name="Zapamiętaj ostatnio użyty foler"/>
+                    <Item id="6415" name="Zapamiętaj ostatnio użyty folder"/>
                 </DefaultDir>
 
                 <FileAssoc title="Powiązania plików">
@@ -749,7 +748,7 @@
 
                 <TabSettings title="Ustawienia tabulacji">
                     <Item id="6301" name="Ustawienia tabulacji"/>
-                    <Item id="6302" name="Zastąp przez spacje"/>
+                    <Item id="6302" name="Zastąp spacją"/>
                     <Item id="6303" name="Rozmiar tab: "/>
                     <Item id="6510" name="Użyj wartości domyślnej"/>
                 </TabSettings>
@@ -781,17 +780,17 @@
                     <Item id="6723" name="Dodaj"/>
                     <Item id="6725" name="Parametr:"/>
 					<Item id="6727" name="Wybierz miejsce:"/>
-                    <Item id="6728" name="Nagłówek i Stopka"/>
+                    <Item id="6728" name="Nagłówek i stopka"/>
                 </Print>
 
-                <RecentFilesHistory title="Historia najnowszych plików">
-                    <Item id="6304" name="Historia najnowszych plików"/>
+                <RecentFilesHistory title="Historia ostatnich plików">
+                    <Item id="6304" name="Historia ostatnich plików"/>
                     <Item id="6305" name="Nie sprawdzaj podczas uruchomienia"/>
                     <Item id="6306" name="Maks. liczba wpisów:"/>
                     <Item id="6424" name="W podmenu"/>
                     <Item id="6425" name="Tylko nazwa pliku"/>
-                    <Item id="6426" name="Pełna ścieżjka z nazwą"/>
-                    <Item id="6427" name="Dostosuj maksymalną długść:"/>
+                    <Item id="6426" name="Pełna ścieżka z nazwą"/>
+                    <Item id="6427" name="Dostosuj maksymalną długość:"/>
                     <Item id="6429" name="Wyświetl"/>
                 </RecentFilesHistory>
 
@@ -804,18 +803,18 @@
                     <Item id="6803" name="Folder:"/>
                 </Backup>
 
-                <AutoCompletion title="Auto-Uzupełnianie">
-                    <Item id="6807" name="Auto-Uzupełnianie"/>
-                    <Item id="6808" name="Włącz auto-uzupełnianie dla wszystkich wejść"/>
+                <AutoCompletion title="Autouzupełnianie">
+                    <Item id="6807" name="Autouzupełnianie"/>
+                    <Item id="6808" name="Włącz autouzupełnianie dla wszystkich wejść"/>
                     <Item id="6809" name="Uzupełnianie funkcji"/>
                     <Item id="6810" name="Uzupełnianie słów"/>
                     <Item id="6811" name="Od"/>
                     <Item id="6813" name=". znaku"/>
-                    <Item id="6814" name="Poprawne wartości: 1 - 9"/>
+                    <Item id="6814" name="Poprawne wartości: 1-9"/>
                     <Item id="6815" name="Podpowiedź parametrów funkcji na wejściu"/>
 					<Item id="6816" name = "Uzupełnianie funkcji i słów"/>
-                    <Item id="6851" name="Auto-Wstawianie"/>
-                    <Item id="6857" name="tag zamyk. html/xml"/>
+                    <Item id="6851" name="Autowstawianie"/>
+                    <Item id="6857" name="tag zamyk. HTML/XML"/>
                     <Item id="6858" name="Otwórz"/>
                     <Item id="6859" name="Zamknij"/>
                     <Item id="6860" name="Pasująca para 1:"/>
@@ -823,8 +822,8 @@
                     <Item id="6866" name="Pasująca para 3:"/>
                 </AutoCompletion>
 
-                <MultiInstance title="Wielo-Instancyjność">
-                    <Item id="6151" name="Ustawienia Wielo-instancyjności"/>
+                <MultiInstance title="Wieloinstancyjność">
+                    <Item id="6151" name="Ustawienia wieloinstancyjności"/>
                     <Item id="6152" name="Otwórz sesję w nowej instancji Notepad++"/>
                     <Item id="6153" name="Zawsze w trybie wieloinstancyjnym"/>
                     <Item id="6154" name="Domyślna (jedna instancja)"/>
@@ -836,8 +835,6 @@
                     <Item id="6252" name="Otwórz"/>
                     <Item id="6255" name="Zamknij"/>
                     <Item id="6256" name="Dopuszczaj wiele linii"/>
-                    <Item id="6257" name = "bla bla bla bla bla bla"/>
-                    <Item id="6258" name = "bla bla bla bla bla bla bla bla bla bla bla bla"/>
                 </Delimiter>
 
                 <MISC title="Inne">
@@ -846,7 +843,7 @@
                     <Item id="6117" name="Kolejność ostatniego użycia (MRU)"/>
                     <Item id="6304" name="Historia plików"/>
                     <Item id="6305" name="Nie sprawdzaj przy uruchamianiu"/>
-                    <Item id="6306" name="Maksymalna ilość plików :"/>
+                    <Item id="6306" name="Maksymalna ilość plików:"/>
                     <Item id="6307" name="Włącz"/>
                     <Item id="6308" name="Minimalizuj do ikony paska zadań"/>
                     <Item id="6309" name="Zapamiętaj bieżącą sesję do nast. uruchomienia"/>
@@ -855,7 +852,7 @@
                     <Item id="6318" name="Obsługa hiperłączy w tekście"/>
                     <Item id="6319" name="Włącz"/>
                     <Item id="6320" name="Nie podkreślaj"/>
-                    <Item id="6322" name="Rozszerz. pliku sesji :"/>
+                    <Item id="6322" name="Rozszerz. pliku sesji:"/>
                     <Item id="6323" name="Włącz autoaktualizację Notepad++"/>
                     <Item id="6324" name="Przełączanie między dokum. (Ctrl+TAB)"/>
                     <Item id="6325" name="Przewiń na koniec po uaktualnieniu"/>
@@ -863,13 +860,13 @@
                     <Item id="6327" name="Włącz"/>
                     <Item id="6328" name="Podświetlaj atrybuty"/>
                     <Item id="6329" name="Podświetlanie pasujących tagów"/>
-                    <Item id="6330" name="Podświetlaj strefy php/asp"/>
+                    <Item id="6330" name="Podświetlaj strefy PHP/ASP"/>
 					<Item id="6331" name="Tylko nazwa pliku w pasku tytułu"/>
 					<Item id="6332" name = "Rozróżnianie WIELKICH i małych liter"/>
 					<Item id="6333" name = "Inteligentne podświetlanie"/>
                 </MISC>
 
-                <Backup title="Kopia / Autouzupełnianie">
+                <Backup title="Kopia/Autouzupełnianie">
                     <Item id="6801" name="Kopia zapasowa"/>
                     <Item id="6315" name="Brak"/>
                     <Item id="6316" name="Prosta kopia"/>
@@ -882,7 +879,7 @@
                     <Item id="6810" name="Uzupełnianie wyrazów"/>
                     <Item id="6811" name="Od"/>
                     <Item id="6813" name="znaków"/>
-                    <Item id="6814" name="Możliwe wartości: 1 - 9"/>
+                    <Item id="6814" name="Możliwe wartości: 1-9"/>
                     <Item id="6815" name="Podpowiadanie parametrów funkcji"/>
                 </Backup>
             </Preference>
@@ -924,37 +921,37 @@
 Musisz uruchomić ponownie Notepad++ by zastosować zmiany wprowadzone w contextMenu.xml."/>
 			<NppHelpAbsentWarning title="Plik nie istnieje" message="
 nie istnieje. Pobierz go ze stron Notepad++."/>
-			<SaveCurrentModifWarning title="Zapisz Bieżące Zmiany" message="Wymagane jest zapisanie bieżących zmian.
+			<SaveCurrentModifWarning title="Zapisz bieżące zmiany" message="Wymagane jest zapisanie zmian.
 Zapisane zmiany nie będą mogły zostać wycofane.
 
 Kontynuować?"/>
-			<LoseUndoAbilityWarning title="Utrata Możliwości Cofnięcia" message="Wymagane jest zapisanie bieżących zmian.
+			<LoseUndoAbilityWarning title="Utrata możliwości cofnięcia" message="Wymagane jest zapisanie zmian.
 Zapisane zmiany nie będą mogły zostać wycofane.
 
 Kontynuować?"/>
 
-			<CannotMoveDoc title="Przeniesienie do nowej instancji Notepad++" message="Dokument został zmieniony, zapisz go i spróbuj ponownie."/>
+			<CannotMoveDoc title="Przeniesienie do nowej instancji Notepad++" message="Dokument został zmieniony. Zapisz go i spróbuj ponownie."/>
 			<DocReloadWarning title="Przeładowanie pliku" message="Czy na pewno załadować ponownie bieżący plik i utracić zmiany wykonane dotąd w Notepad++?"/>
 			<FileLockedWarning title="Nieudany zapis" message="Sprawdź, czy plik nie jest otwarty w innym programie"/>
 			<FileAlreadyOpenedInNpp title="" message="Plik jest już otwarty w Notepad++."/>
 			<DeleteFileFailed title="Usunięcie pliku" message="Nie udało się usunąć pliku"/>
 
-			<ColumnModeTip title="Podpowiedź kolumnowego trybu zaznaczania" message="Użyj 'Alt+zaznaczenie myszką' lub 'Alt+Shift+strzałki'
+			<ColumnModeTip title="Podpowiedź kolumnowego trybu zaznaczania" message="Użyj 'Alt + zaznaczenie myszką' lub 'Alt + Shift + kursory'
 by przejść do blokowego trybu zaznaczania"/>
 
 			<NbFileToOpenImportantWarning title="Otwarcie wielu plików" message="Mają być otwarte pliki: $INT_REPLACE$.\rKontynuować?"/>
 		</MessageBox>
 
         <ClipboardHistory>
-			<PanelTitle name="Historia Schowka"/>
+			<PanelTitle name="Historia schowka"/>
         </ClipboardHistory>
         <DocSwitcher>
-			<PanelTitle name="Doc Switcher"/>
+			<PanelTitle name="Przełącznik dokumentów"/>
 			<ColumnName name="Nazwa"/>
 			<ColumnExt name="Roz."/>
         </DocSwitcher>
         <AsciiInsertion>
-			<PanelTitle name="Panel wstawiania ASCII"/>
+			<PanelTitle name="Tablica znaków ASCII"/>
 			<ColumnVal name="Wartość"/>
 			<ColumnChar name="Znak"/>
         </AsciiInsertion>
@@ -964,7 +961,7 @@ by przejść do blokowego trybu zaznaczania"/>
         <FunctionList>
 			<PanelTitle name="Lista funkcji"/>
 			<SortTip name="Sortuj" />
-			<ReloadTip name="Przeładuj" />
+			<ReloadTip name="Odśwież" />
         </FunctionList>
 		<ProjectManager>
 			<PanelTitle name="Projekt"/>
@@ -977,9 +974,9 @@ by przejść do blokowego trybu zaznaczania"/>
 					<Item id="1" name="Edycja"/>
 				</Entries>
 				<WorkspaceMenu>
-					<Item id="3122" name="Nowy Obszar roboczy"/>
-					<Item id="3123" name="Otwórz Obszar roboczy"/>
-					<Item id="3124" name="Wczytaj ponownie Obszar roboczy"/>
+					<Item id="3122" name="Nowy obszar roboczy"/>
+					<Item id="3123" name="Otwórz obszar roboczy"/>
+					<Item id="3124" name="Wczytaj ponownie obszar roboczy"/>
 					<Item id="3125" name="Zapisz"/>
 					<Item id="3126" name="Zapisz jako..."/>
 					<Item id="3127" name="Zapisz kopię jako..."/>

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -36,10 +36,10 @@
 ; Define the application name
 !define APPNAME "Notepad++"
 
-!define APPVERSION "6.8.4"
+!define APPVERSION "6.8.5"
 !define APPNAMEANDVERSION "${APPNAME} v${APPVERSION}"
 !define VERSION_MAJOR 6
-!define VERSION_MINOR 84
+!define VERSION_MINOR 85
 
 !define APPWEBSITE "http://notepad-plus-plus.org/"
 

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -36,10 +36,10 @@
 ; Define the application name
 !define APPNAME "Notepad++"
 
-!define APPVERSION "6.8.3"
+!define APPVERSION "6.8.4"
 !define APPNAMEANDVERSION "${APPNAME} v${APPVERSION}"
 !define VERSION_MAJOR 6
-!define VERSION_MINOR 83
+!define VERSION_MINOR 84
 
 !define APPWEBSITE "http://notepad-plus-plus.org/"
 

--- a/PowerEditor/installer/packageAll.bat
+++ b/PowerEditor/installer/packageAll.bat
@@ -60,7 +60,6 @@ mkdir .\zipped.package.release\themes
 mkdir .\zipped.package.release\plugins
 mkdir .\zipped.package.release\plugins\APIs
 mkdir .\zipped.package.release\plugins\Config
-mkdir .\zipped.package.release\plugins\Config\Hunspell
 mkdir .\zipped.package.release\plugins\doc
 
 

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -39,7 +39,7 @@ enum LangType {L_TEXT, L_PHP , L_C, L_CPP, L_CS, L_OBJC, L_JAVA, L_RC,\
 			   L_ASM, L_DIFF, L_PROPS, L_PS, L_RUBY, L_SMALLTALK, L_VHDL, L_KIX, L_AU3,\
 			   L_CAML, L_ADA, L_VERILOG, L_MATLAB, L_HASKELL, L_INNO, L_SEARCHRESULT,\
 			   L_CMAKE, L_YAML, L_COBOL, L_GUI4CLI, L_D, L_POWERSHELL, L_R, L_JSP,\
-			   L_COFFEESCRIPT, L_JSON,\
+			   L_COFFEESCRIPT, L_JSON, L_JAVASCRIPT,\
 			   // The end of enumated language type, so it should be always at the end
 			   L_EXTERNAL};
 enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV_S2003, WV_XPX64, WV_VISTA, WV_WIN7, WV_WIN8, WV_WIN81};

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2572,7 +2572,7 @@ enum LangType Notepad_plus::menuID2LangType(int cmdID)
         case IDM_LANG_XML :
             return L_XML;
         case IDM_LANG_JS :
-            return L_JS;
+			return L_JAVASCRIPT;
 		case IDM_LANG_JSON:
 			return L_JSON;
         case IDM_LANG_PHP :

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3169,7 +3169,9 @@ bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne)
 				toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
 			}
 			tabToClose->deletItemAt((size_t)index); //delete first
+			_isFolding = true; // So we can ignore events while folding is taking place
 			activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
+			_isFolding = false;
 		}
 	}
 	else

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -369,6 +369,7 @@ private:
 	// Keystroke macro recording and playback
 	Macro _macro;
 	bool _recordingMacro = false;
+	bool _playingBackMacro = false;
 	RunMacroDlg _runMacroDlg;
 
 	// For hotspot

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -637,7 +637,11 @@ void Notepad_plus::command(int id)
 
 		case IDM_MACRO_PLAYBACKRECORDEDMACRO:
 			if (!_recordingMacro) // if we're not currently recording, then playback the recorded keystrokes
+			{
+				_playingBackMacro = true;
 				macroPlayback(_macro);
+				_playingBackMacro = false;
+			}
 			break;
 
 		case IDM_MACRO_RUNMULTIMACRODLG :

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -242,7 +242,10 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			{
 				activateBuffer(bufferToClose, iView);
 			}
-			fileClose(bufferToClose, iView);
+
+			if (fileClose(bufferToClose, iView))
+				checkDocState();
+
 			break;
 		}
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -515,17 +515,19 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 		case SCN_CHARADDED:
 		{
-			const NppGUI & nppGui = NppParameters::getInstance()->getNppGUI();
-			bool indentMaintain = nppGui._maitainIndent;
-			if (indentMaintain)
-				maintainIndentation(static_cast<TCHAR>(notification->ch));
+			if (!_recordingMacro && !_playingBackMacro) // No macro recording or playing back
+			{
+				const NppGUI & nppGui = NppParameters::getInstance()->getNppGUI();
+				bool indentMaintain = nppGui._maitainIndent;
+				if (indentMaintain)
+					maintainIndentation(static_cast<TCHAR>(notification->ch));
 
-			AutoCompletion * autoC = isFromPrimary?&_autoCompleteMain:&_autoCompleteSub;
-			bool isColumnMode = _pEditView->execute(SCI_GETSELECTIONS) > 1; // Multi-Selection || Column mode)
-			if (nppGui._matchedPairConf.hasAnyPairsPair() && !isColumnMode)
-				autoC->insertMatchedChars(notification->ch, nppGui._matchedPairConf);
-			autoC->update(notification->ch);
-
+				AutoCompletion * autoC = isFromPrimary ? &_autoCompleteMain : &_autoCompleteSub;
+				bool isColumnMode = _pEditView->execute(SCI_GETSELECTIONS) > 1; // Multi-Selection || Column mode)
+				if (nppGui._matchedPairConf.hasAnyPairsPair() && !isColumnMode)
+					autoC->insertMatchedChars(notification->ch, nppGui._matchedPairConf);
+				autoC->update(notification->ch);
+			}
 			break;
 		}
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -263,8 +263,11 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			switchEditViewTo(iView);
 			BufferID bufid = _pDocTab->getBufferByIndex(_pDocTab->getCurrentTabIndex());
 			if (bufid != BUFFER_INVALID)
+			{
+				_isFolding = true; // So we can ignore events while folding is taking place
 				activateBuffer(bufid, iView);
-
+				_isFolding = false;
+			}
 			break;
 		}
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5889,6 +5889,7 @@ int NppParameters::langTypeToCommandID(LangType lt) const
 		case L_XML :
 			id = IDM_LANG_XML; break;
 		case L_JS :
+		case L_JAVASCRIPT:
 			id = IDM_LANG_JS; break;
 		case L_JSON:
 			id = IDM_LANG_JSON; break;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -909,9 +909,7 @@ struct Lang final
 		for (int i = 0 ; i < NB_LIST ; _langKeyWordList[i] = NULL, ++i);
 	}
 
-	Lang(LangType langID, const TCHAR *name)
-		: _langID(langID)
-		, _langName(name ? name : TEXT(""))
+	Lang(LangType langID, const TCHAR *name) : _langID(langID), _langName(name ? name : TEXT(""))
 	{
 		for (int i = 0 ; i < NB_LIST ; _langKeyWordList[i] = NULL, ++i);
 	}

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -575,7 +575,10 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 					}
 				}
 
-				if (isCharPrevBlank && isCharNextBlank)
+				if ((isCharPrevBlank && isCharNextBlank) ||
+					(charPrev == '(' && charNext == ')') || (charPrev == '(' && isCharNextBlank) || (isCharPrevBlank && charNext == ')') ||
+					(charPrev == '[' && charNext == ']') || (charPrev == '[' && isCharNextBlank) || (isCharPrevBlank && charNext == ']') ||
+					(charPrev == '{' && charNext == '}') || (charPrev == '{' && isCharNextBlank) || (isCharPrevBlank && charNext == '}'))
 				{
 					matchedChars = "\"";
 					_insertedMatchedChars.add(MatchedCharInserted(char(character), caretPos - 1));
@@ -596,7 +599,10 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 					}
 				}
 
-				if (isCharPrevBlank && isCharNextBlank)
+				if ((isCharPrevBlank && isCharNextBlank) ||
+					(charPrev == '(' && charNext == ')') || (charPrev == '(' && isCharNextBlank) || (isCharPrevBlank && charNext == ')') ||
+					(charPrev == '[' && charNext == ']') || (charPrev == '[' && isCharNextBlank) || (isCharPrevBlank && charNext == ']') ||
+					(charPrev == '{' && charNext == '}') || (charPrev == '{' && isCharNextBlank) || (isCharPrevBlank && charNext == '}'))
 				{
 					matchedChars = "'";
 					_insertedMatchedChars.add(MatchedCharInserted(char(character), caretPos - 1));

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -504,7 +504,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 	bool isCharPrevBlank = (charPrev == ' ' || charPrev == '\t' || charPrev == '\n' || charPrev == '\r' || charPrev == '\0');
 	int docLen = _pEditView->getCurrentDocLen();
 	bool isCharNextBlank = (charNext == ' ' || charNext == '\t' || charNext == '\n' || charNext == '\r' || caretPos == docLen);
-
+	bool isInSandwich = (charPrev == '(' && charNext == ')') || (charPrev == '[' && charNext == ']') || (charPrev == '{' && charNext == '}');
 
 	// User defined matched pairs should be checked firstly
 	for (size_t i = 0, len = matchedPairs.size(); i < len; ++i)
@@ -531,7 +531,8 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 		case int('('):
 			if (matchedPairConf._doParentheses)
 			{
-				if (isCharNextBlank)
+				if (isCharNextBlank || isInSandwich)
+
 				{
 					matchedChars = ")";
 					_insertedMatchedChars.add(MatchedCharInserted(char(character), caretPos - 1));
@@ -542,7 +543,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 		case int('['):
 			if (matchedPairConf._doBrackets)
 			{
-				if (isCharNextBlank)
+				if (isCharNextBlank || isInSandwich)
 				{
 					matchedChars = "]";
 					_insertedMatchedChars.add(MatchedCharInserted(char(character), caretPos - 1));
@@ -553,7 +554,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 		case int('{'):
 			if (matchedPairConf._doCurlyBrackets)
 			{
-				if (isCharNextBlank)
+				if (isCharNextBlank || isInSandwich)
 				{
 					matchedChars = "}";
 					_insertedMatchedChars.add(MatchedCharInserted(char(character), caretPos - 1));
@@ -575,10 +576,10 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 					}
 				}
 
-				if ((isCharPrevBlank && isCharNextBlank) ||
-					(charPrev == '(' && charNext == ')') || (charPrev == '(' && isCharNextBlank) || (isCharPrevBlank && charNext == ')') ||
-					(charPrev == '[' && charNext == ']') || (charPrev == '[' && isCharNextBlank) || (isCharPrevBlank && charNext == ']') ||
-					(charPrev == '{' && charNext == '}') || (charPrev == '{' && isCharNextBlank) || (isCharPrevBlank && charNext == '}'))
+				if ((isCharPrevBlank && isCharNextBlank) || isInSandwich ||
+					(charPrev == '(' && isCharNextBlank) || (isCharPrevBlank && charNext == ')') ||
+					(charPrev == '[' && isCharNextBlank) || (isCharPrevBlank && charNext == ']') ||
+					(charPrev == '{' && isCharNextBlank) || (isCharPrevBlank && charNext == '}'))
 				{
 					matchedChars = "\"";
 					_insertedMatchedChars.add(MatchedCharInserted(char(character), caretPos - 1));
@@ -599,10 +600,10 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 					}
 				}
 
-				if ((isCharPrevBlank && isCharNextBlank) ||
-					(charPrev == '(' && charNext == ')') || (charPrev == '(' && isCharNextBlank) || (isCharPrevBlank && charNext == ')') ||
-					(charPrev == '[' && charNext == ']') || (charPrev == '[' && isCharNextBlank) || (isCharPrevBlank && charNext == ']') ||
-					(charPrev == '{' && charNext == '}') || (charPrev == '{' && isCharNextBlank) || (isCharPrevBlank && charNext == '}'))
+				if ((isCharPrevBlank && isCharNextBlank) || isInSandwich ||
+					(charPrev == '(' && isCharNextBlank) || (isCharPrevBlank && charNext == ')') ||
+					(charPrev == '[' && isCharNextBlank) || (isCharPrevBlank && charNext == ']') ||
+					(charPrev == '{' && isCharNextBlank) || (isCharPrevBlank && charNext == '}'))
 				{
 					matchedChars = "'";
 					_insertedMatchedChars.add(MatchedCharInserted(char(character), caretPos - 1));

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -669,18 +669,20 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 
 void AutoCompletion::update(int character)
 {
+	if (!character)
+		return;
+
 	const NppGUI & nppGUI = NppParameters::getInstance()->getNppGUI();
 	if (!_funcCompletionActive && nppGUI._autocStatus == nppGUI.autoc_func)
 		return;
 
-	if (nppGUI._funcParams || _funcCalltip.isVisible()) {
-		if (_funcCalltip.updateCalltip(character)) {	//calltip visible because triggered by autocomplete, set mode
+	if (nppGUI._funcParams || _funcCalltip.isVisible())
+	{
+		if (_funcCalltip.updateCalltip(character)) //calltip visible because triggered by autocomplete, set mode
+		{
 			return;	//only return in case of success, else autocomplete
 		}
 	}
-
-	if (!character)
-		return;
 
 	//If autocomplete already active, let Scintilla handle it
 	if (_pEditView->execute(SCI_AUTOCACTIVE) != 0)
@@ -698,7 +700,6 @@ void AutoCompletion::update(int character)
 			showApiComplete();
 		else if (nppGUI._autocStatus == nppGUI.autoc_both)
 			showApiAndWordComplete();
-
 	}
 }
 
@@ -844,6 +845,9 @@ const TCHAR * AutoCompletion::getApiFileName()
 
 	if (_curLang > L_EXTERNAL)
         _curLang = L_TEXT;
+
+	if (_curLang == L_JAVASCRIPT)
+        _curLang = L_JS;
 
 	return ScintillaEditView::langNames[_curLang].lexerName;
 

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1261,8 +1261,19 @@ LangType FileManager::detectLanguageFromTextBegining(const unsigned char *data, 
 	std::string htmlHeader2 = "<html>"; // length : 6
 	std::string htmlHeader1 = "<!DOCTYPE html>"; // length : 15
 	
-	const size_t longestLength = htmlHeader1.length(); // longest length - html header Length
+	const size_t longestLength = htmlHeader1.length(); // longest length : html header Length
+	const size_t shortestLength = xmlHeader.length();
+	
 	size_t i = 0;
+	
+	if (dataLen <= shortestLength)
+		return L_TEXT;
+
+	// Eliminate BOM if present
+	if ((data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) || // UTF8 BOM
+		(data[0] == 0xFE && data[1] == 0xFF && data[2] == 0x00) || // UTF16 BE BOM
+		(data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00))   // UTF16 LE BOM
+		i += 3;
 
 	for (; i < dataLen; ++i)
 	{

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -621,9 +621,8 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
 		buf->setUnicodeMode(ndds._unicodeMode);
 		buf->setEncoding(-1);
 
-		// if a language has been detected, and the detected value is different from the file extension,
-		// we use the detected value
-		if (detectedLang != L_TEXT && detectedLang != buf->getLangType())
+		// if no file extension, and the language has been detected,  we use the detected value
+		if ((buf->getLangType() == L_TEXT) && (detectedLang != L_TEXT))
 			buf->setLangType(detectedLang);
 
 		if (encoding == -1)

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -630,11 +630,11 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
 			// 3 formats : WIN_FORMAT, UNIX_FORMAT and MAC_FORMAT
 			if (nullptr != UnicodeConvertor.getNewBuf())
 			{
-				FormatType format = getEOLFormatForm(UnicodeConvertor.getNewBuf(), UnicodeConvertor.getNewSize());
+				FormatType format = getEOLFormatForm(UnicodeConvertor.getNewBuf(), UnicodeConvertor.getNewSize(),ndds._format);
 				buf->setFormat(format);
 			}
 			else
-				buf->setFormat(FormatType::osdefault);
+				buf->setFormat(ndds._format);
 
 			UniMode um = UnicodeConvertor.getEncoding();
 			if (um == uni7Bit)
@@ -681,13 +681,17 @@ bool FileManager::reloadBuffer(BufferID id)
 	{
 		if (encoding == -1)
 		{
+			NppParameters *pNppParamInst = NppParameters::getInstance();
+			const NewDocDefaultSettings & ndds = (pNppParamInst->getNppGUI()).getNewDocDefaultSettings(); // for ndds._format
+			
 			if (nullptr != UnicodeConvertor.getNewBuf())
 			{
-				FormatType format = getEOLFormatForm(UnicodeConvertor.getNewBuf(), UnicodeConvertor.getNewSize());
+				FormatType format = getEOLFormatForm(UnicodeConvertor.getNewBuf(), UnicodeConvertor.getNewSize(),ndds._format);
 				buf->setFormat(format);
 			}
-			else
-				buf->setFormat(FormatType::osdefault);
+			else{
+				buf->setFormat(ndds._format);
+			}
 
 			buf->setUnicodeMode(UnicodeConvertor.getEncoding());
 		}
@@ -1464,7 +1468,17 @@ inline bool FileManager::loadFileData(Document doc, const TCHAR * filename, char
 
 	// broadcast the format
 	if (pFormat != nullptr)
-		*pFormat = (format != FormatType::unknown) ? format : FormatType::osdefault;
+	{
+		if (format == FormatType::unknown){
+			NppParameters *pNppParamInst = NppParameters::getInstance();
+			const NewDocDefaultSettings & ndds = (pNppParamInst->getNppGUI()).getNewDocDefaultSettings(); // for ndds._format
+			*pFormat = ndds._format;
+		}
+		else
+		{
+			*pFormat = format;
+		}
+	}
 
 	_pscratchTilla->execute(SCI_EMPTYUNDOBUFFER);
 	_pscratchTilla->execute(SCI_SETSAVEPOINT);

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -692,6 +692,7 @@ protected:
 	//Complex lexers (same lexer, different language)
 	void setXmlLexer(LangType type);
  	void setCppLexer(LangType type);
+	void setJsLexer();
 	void setTclLexer();
     void setObjCLexer(LangType type);
 	void setUserLexer(const TCHAR *userLangName = NULL);

--- a/PowerEditor/src/ScitillaComponent/SmartHighlighter.h
+++ b/PowerEditor/src/ScitillaComponent/SmartHighlighter.h
@@ -38,8 +38,8 @@ public:
 private:
 	FindReplaceDlg * _pFRDlg;
 
-	bool isQualifiedWord(const char *str) const;
-	bool isWordChar(char ch) const;
+	bool isQualifiedWord(const char *str, char listChar[]) const;
+	bool isWordChar(char ch, char listChar[]) const;
 };
 
 #endif //SMARTHIGHLIGHTER_H

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -244,6 +244,9 @@ void FunctionListPanel::reload()
 
 	const TCHAR *fn = ((*_ppEditView)->getCurrentBuffer())->getFileName();
 	LangType langID = ((*_ppEditView)->getCurrentBuffer())->getLangType();
+	if (langID == L_JAVASCRIPT)
+		langID = L_JS;
+
 	const TCHAR *udln = NULL;
 	if (langID == L_USER)
 	{

--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -110,8 +110,15 @@
             <Keywords name="instre1">instanceof assert if else switch case default break goto return for while do continue new throw throws try catch finally this super extends implements import true false null</Keywords>
             <Keywords name="type1">package transient strictfp void char short int long double float const static volatile byte boolean class interface native private protected public final abstract synchronized enum</Keywords>
         </Language>
-        <Language name="javascript" ext="js jsm" commentLine="//" commentStart="/*" commentEnd="*/">
+		<!-- Embbeded javascript -->
+        <Language name="javascript" ext="" commentLine="//" commentStart="/*" commentEnd="*/">
             <Keywords name="instre1">abstract boolean break byte case catch char class const continue debugger default delete do double else enum export extends final finally float for from function goto if implements import in instanceof int interface let long native new of package private protected public return short static super switch synchronized this throw throws transient try typeof var void volatile while with true false prototype</Keywords>
+        </Language>
+        <Language name="javascript.js" ext="js jsm" commentLine="//" commentStart="/*" commentEnd="*/">
+            <Keywords name="instre1">abstract boolean break byte case catch char class const continue debugger default delete do double else enum export extends final finally float for from function goto if implements import in instanceof int interface let long native new of package private protected public return short static super switch synchronized this throw throws transient try typeof var void volatile while with true false prototype</Keywords>
+			<Keywords name="type1">Array Date eval hasOwnProperty Infinity isFinite isNaN isPrototypeOf Math NaN Number Object prototype String toString undefined valueOf</Keywords>
+			<Keywords name="instre2">alert all anchor anchors area assign blur button checkbox clearInterval clearTimeout clientInformation close closed confirm constructor crypto decodeURI decodeURIComponent defaultStatus document element elements embed embeds encodeURI encodeURIComponent escape event fileUpload focus form forms frame innerHeight innerWidth layer layers link location mimeTypes navigate navigator frames frameRate hidden history image images offscreenBuffering open opener option outerHeight outerWidth packages pageXOffset pageYOffset parent parseFloat parseInt password pkcs11 plugin prompt propertyIsEnum radio reset screenX screenY scroll secure select self setInterval setTimeout status submit taint text textarea top unescape untaint window</Keywords>
+			<Keywords name="type2">onblur onclick onerror onfocus onkeydown onkeypress onkeyup onmouseover onload onmouseup onmousedown onsubmit</Keywords>
         </Language>
 		<Language name="json" ext="json" commentLine="" commentStart="" commentEnd=""/>
         <Language name="jsp" ext="jsp" commentLine="//" commentStart="/*" commentEnd="*/"/>

--- a/PowerEditor/src/resource.h
+++ b/PowerEditor/src/resource.h
@@ -26,13 +26,13 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #pragma once
 
-#define NOTEPAD_PLUS_VERSION TEXT("Notepad++ v6.8.4")
+#define NOTEPAD_PLUS_VERSION TEXT("Notepad++ v6.8.5")
 
 
 // should be X.Y : ie. if VERSION_DIGITALVALUE == 4, 7, 1, 0 , then X = 4, Y = 71
 // ex : #define VERSION_VALUE TEXT("5.63\0")
-#define VERSION_VALUE TEXT("6.84\0")
-#define VERSION_DIGITALVALUE 6, 8, 4, 0
+#define VERSION_VALUE TEXT("6.85\0")
+#define VERSION_DIGITALVALUE 6, 8, 5, 0
 
 #ifndef IDC_STATIC
 #define IDC_STATIC    -1

--- a/PowerEditor/src/resource.h
+++ b/PowerEditor/src/resource.h
@@ -26,13 +26,13 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #pragma once
 
-#define NOTEPAD_PLUS_VERSION TEXT("Notepad++ v6.8.3")
+#define NOTEPAD_PLUS_VERSION TEXT("Notepad++ v6.8.4")
 
 
 // should be X.Y : ie. if VERSION_DIGITALVALUE == 4, 7, 1, 0 , then X = 4, Y = 71
 // ex : #define VERSION_VALUE TEXT("5.63\0")
-#define VERSION_VALUE TEXT("6.83\0")
-#define VERSION_DIGITALVALUE 6, 8, 3, 0
+#define VERSION_VALUE TEXT("6.84\0")
+#define VERSION_DIGITALVALUE 6, 8, 4, 0
 
 #ifndef IDC_STATIC
 #define IDC_STATIC    -1

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -380,7 +380,7 @@
             <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
-        <LexerType name="javascript" desc="Javascript" ext="">
+        <LexerType name="javascript" desc="Javascript (embbeded)" ext="">
             <WordsStyle name="DEFAULT" styleID="41" fgColor="000000" bgColor="F2F4FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="45" fgColor="FF0000" bgColor="F2F4FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="WORD" styleID="46" fgColor="000000" bgColor="F2F4FF" fontName="" fontStyle="0" fontSize="" />
@@ -392,6 +392,24 @@
             <WordsStyle name="COMMENT" styleID="42" fgColor="008000" bgColor="F2F4FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTLINE" styleID="43" fgColor="008000" bgColor="F2F4FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTDOC" styleID="44" fgColor="008080" bgColor="F2F4FF" fontName="" fontStyle="0" fontSize="" />
+        </LexerType>
+        <LexerType name="javascript.js" desc="Javascript" ext="">
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="WINDOW INSTRUCTION" styleID="19" fgColor="804000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="000080" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -414,7 +414,7 @@
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="373737" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="800000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
         </LexerType>

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -391,9 +391,6 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <Image Include="..\src\icons\cut_dis.ico" />
     <Image Include="..\src\icons\cut_off.ico" />
     <Image Include="..\src\icons\cut_on.ico" />
-    <Image Include="..\src\default_close.ico" />
-    <Image Include="..\src\default_new.ico" />
-    <Image Include="..\src\default_open.ico" />
     <Image Include="..\src\icons\delete.ico" />
     <Image Include="..\src\icons\dupli_dis.ico" />
     <Image Include="..\src\icons\dupli_off.ico" />
@@ -405,11 +402,6 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <Image Include="..\src\icons\findrep_on.ico" />
     <Image Include="..\src\icons\findReplace.bmp" />
     <Image Include="..\src\icons\findResult.ico" />
-    <Image Include="..\src\hot_close.ico" />
-    <Image Include="..\src\hot_new.ico" />
-    <Image Include="..\src\hot_open.ico" />
-    <Image Include="..\src\icons\icon10.ico" />
-    <Image Include="..\src\icons\imp_off.ico" />
     <Image Include="..\src\icons\imprim_off.ico" />
     <Image Include="..\src\icons\imprim_on.ico" />
     <Image Include="..\src\icons\indentGuide.bmp" />
@@ -520,8 +512,6 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <None Include="..\src\cursors\drag.cur" />
     <None Include="..\src\cursors\drag_interdit.cur" />
     <None Include="..\src\cursors\drag_plus.cur" />
-    <None Include="..\src\WinControls\ColourPicker\rt_manif.bin" />
-    <None Include="..\src\cursors\up.cur" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\MISC\Common\LongRunningOperation.h" />
@@ -533,7 +523,7 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClInclude Include="..\src\WinControls\Grid\BabyGrid.h" />
     <ClInclude Include="..\src\WinControls\Grid\BabyGridWrapper.h" />
     <ClInclude Include="..\src\ScitillaComponent\Buffer.h" />
-    <ClInclude Include="..\uchardet\CharDistribution.h" />
+    <ClInclude Include="..\src\uchardet\CharDistribution.h" />
     <ClInclude Include="..\src\WinControls\ClipboardHistory\clipboardHistoryPanel.h" />
     <ClInclude Include="..\src\WinControls\ClipboardHistory\clipboardHistoryPanel_rc.h" />
     <ClInclude Include="..\src\ScitillaComponent\colors.h" />
@@ -573,7 +563,7 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClInclude Include="..\src\menuCmdID.h" />
     <ClInclude Include="..\src\MISC\Exception\MiniDumper.h" />
     <ClInclude Include="..\src\Notepad_plus.h" />
-    <ClInclude Include="..\src\Misc\PluginsManager\Notepad_plus_msgs.h" />
+    <ClInclude Include="..\src\MISC\PluginsManager\Notepad_plus_msgs.h" />
     <ClInclude Include="..\src\Notepad_plus_Window.h" />
     <ClInclude Include="..\src\uchardet\nsBig5Prober.h" />
     <ClInclude Include="..\src\uchardet\nsCharSetProber.h" />
@@ -594,8 +584,8 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClInclude Include="..\src\uchardet\nsUniversalDetector.h" />
     <ClInclude Include="..\src\uchardet\nsUTF8Prober.h" />
     <ClInclude Include="..\src\Parameters.h" />
-    <ClInclude Include="..\src\Misc\PluginsManager\PluginInterface.h" />
-    <ClInclude Include="..\src\Misc\PluginsManager\PluginsManager.h" />
+    <ClInclude Include="..\src\MISC\PluginsManager\PluginInterface.h" />
+    <ClInclude Include="..\src\MISC\PluginsManager\PluginsManager.h" />
     <ClInclude Include="..\src\WinControls\Preference\preferenceDlg.h" />
     <ClInclude Include="..\src\ScitillaComponent\Printer.h" />
     <ClInclude Include="..\src\uchardet\prmem.h" />

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -100,7 +100,7 @@
       <BasicRuntimeChecks>UninitializedLocalUsageCheck</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>false</TreatWarningAsError>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <SmallerTypeCheck>true</SmallerTypeCheck>

--- a/PowerEditor/visual.net/notepadPlus.vs2015.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vs2015.vcxproj
@@ -397,9 +397,6 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <Image Include="..\src\icons\cut_dis.ico" />
     <Image Include="..\src\icons\cut_off.ico" />
     <Image Include="..\src\icons\cut_on.ico" />
-    <Image Include="..\src\default_close.ico" />
-    <Image Include="..\src\default_new.ico" />
-    <Image Include="..\src\default_open.ico" />
     <Image Include="..\src\icons\delete.ico" />
     <Image Include="..\src\icons\dupli_dis.ico" />
     <Image Include="..\src\icons\dupli_off.ico" />
@@ -411,11 +408,6 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <Image Include="..\src\icons\findrep_on.ico" />
     <Image Include="..\src\icons\findReplace.bmp" />
     <Image Include="..\src\icons\findResult.ico" />
-    <Image Include="..\src\hot_close.ico" />
-    <Image Include="..\src\hot_new.ico" />
-    <Image Include="..\src\hot_open.ico" />
-    <Image Include="..\src\icons\icon10.ico" />
-    <Image Include="..\src\icons\imp_off.ico" />
     <Image Include="..\src\icons\imprim_off.ico" />
     <Image Include="..\src\icons\imprim_on.ico" />
     <Image Include="..\src\icons\indentGuide.bmp" />
@@ -526,8 +518,6 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <None Include="..\src\cursors\drag.cur" />
     <None Include="..\src\cursors\drag_interdit.cur" />
     <None Include="..\src\cursors\drag_plus.cur" />
-    <None Include="..\src\WinControls\ColourPicker\rt_manif.bin" />
-    <None Include="..\src\cursors\up.cur" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\MISC\Common\LongRunningOperation.h" />
@@ -539,7 +529,7 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClInclude Include="..\src\WinControls\Grid\BabyGrid.h" />
     <ClInclude Include="..\src\WinControls\Grid\BabyGridWrapper.h" />
     <ClInclude Include="..\src\ScitillaComponent\Buffer.h" />
-    <ClInclude Include="..\uchardet\CharDistribution.h" />
+    <ClInclude Include="..\src\uchardet\CharDistribution.h" />
     <ClInclude Include="..\src\WinControls\ClipboardHistory\clipboardHistoryPanel.h" />
     <ClInclude Include="..\src\WinControls\ClipboardHistory\clipboardHistoryPanel_rc.h" />
     <ClInclude Include="..\src\ScitillaComponent\colors.h" />
@@ -579,7 +569,7 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClInclude Include="..\src\menuCmdID.h" />
     <ClInclude Include="..\src\MISC\Exception\MiniDumper.h" />
     <ClInclude Include="..\src\Notepad_plus.h" />
-    <ClInclude Include="..\src\Misc\PluginsManager\Notepad_plus_msgs.h" />
+    <ClInclude Include="..\src\MISC\PluginsManager\Notepad_plus_msgs.h" />
     <ClInclude Include="..\src\Notepad_plus_Window.h" />
     <ClInclude Include="..\src\uchardet\nsBig5Prober.h" />
     <ClInclude Include="..\src\uchardet\nsCharSetProber.h" />
@@ -600,8 +590,8 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClInclude Include="..\src\uchardet\nsUniversalDetector.h" />
     <ClInclude Include="..\src\uchardet\nsUTF8Prober.h" />
     <ClInclude Include="..\src\Parameters.h" />
-    <ClInclude Include="..\src\Misc\PluginsManager\PluginInterface.h" />
-    <ClInclude Include="..\src\Misc\PluginsManager\PluginsManager.h" />
+    <ClInclude Include="..\src\MISC\PluginsManager\PluginInterface.h" />
+    <ClInclude Include="..\src\MISC\PluginsManager\PluginsManager.h" />
     <ClInclude Include="..\src\WinControls\Preference\preferenceDlg.h" />
     <ClInclude Include="..\src\ScitillaComponent\Printer.h" />
     <ClInclude Include="..\src\uchardet\prmem.h" />


### PR DESCRIPTION
when a user creates a new file, uses user preferences
however when opening an empty file where notepad++ can't detect the line endings, it uses windows line endings

I've proposed a coupe of changes. First noticing that on construction Buffer::_format is set to the users eol preference, theres no need for a default fallback to be set.

1) FileManager::loadFileData sets *pFormat to -1 when it can't detect a line ending (empty file)
2) FileManager::loadFile and FileManager::ReloadBuffer only set the line ending of the buffer when format!=-1, thus uses the users preference