### PR TITLE
Fix Context menu not shown regression bug [fixes issue #383]

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1513,7 +1513,6 @@ bool Notepad_plus::replaceInFiles()
 		{
 			updateOnCount += filesPerPercent;
 			progress.setPercent((i * 100) / filesCount, fileNames.at(i).c_str());
-			progress.flushCallerUserInput();
 		}
 		else
 		{
@@ -1522,7 +1521,6 @@ bool Notepad_plus::replaceInFiles()
 	}
 
 	progress.close();
-	progress.flushCallerUserInput();
 
 	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
 	_invisibleEditView.setCurrentBuffer(oldBuf);
@@ -1602,7 +1600,6 @@ bool Notepad_plus::findInFiles()
 		{
 			updateOnCount += filesPerPercent;
 			progress.setPercent((i * 100) / filesCount, fileNames.at(i).c_str());
-			progress.flushCallerUserInput();
 		}
 		else
 		{
@@ -1611,7 +1608,6 @@ bool Notepad_plus::findInFiles()
 	}
 
 	progress.close();
-	progress.flushCallerUserInput();
 
 	_findReplaceDlg.finishFilesSearch(nbTotal);
 

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -3112,21 +3112,7 @@ void Progress::setPercent(unsigned percent, const TCHAR *fileName) const
 }
 
 
-void Progress::flushCallerUserInput() const
-{
-	MSG msg;
-	for (HWND hwnd = _hCallerWnd; hwnd; hwnd = ::GetParent(hwnd))
-	{
-		if (::PeekMessage(&msg, hwnd, 0, 0, PM_QS_INPUT | PM_REMOVE))
-		{
-			while (::PeekMessage(&msg, hwnd, 0, 0, PM_QS_INPUT | PM_REMOVE));
-			::UpdateWindow(hwnd);
-		}
-	}
-}
-
-
-DWORD Progress::threadFunc(LPVOID data)
+DWORD WINAPI Progress::threadFunc(LPVOID data)
 {
 	Progress* pw = static_cast<Progress*>(data);
 	return (DWORD)pw->thread();

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -431,7 +431,6 @@ public:
 	}
 
 	void setPercent(unsigned percent, const TCHAR *fileName) const;
-	void flushCallerUserInput() const;
 
 private:
 	static const TCHAR cClassName[];


### PR DESCRIPTION
After FindInFiles operation context menu was no longer accessible.
This patch fixes this regression.