### PR TITLE
Fix regression introduced in v6.6 ("new 0.txt")

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1106,7 +1106,7 @@ BufferID FileManager::bufferFromDocument(Document doc, bool dontIncrease, bool d
 {
 	generic_string newTitle = UNTITLED_STR;
 	TCHAR nb[10];
-	wsprintf(nb, TEXT("%d"), 0);
+	wsprintf(nb, TEXT("%d"), 1);
 	newTitle += nb;
 
 	if (!dontRef)


### PR DESCRIPTION
Passing through discussion in PR https://github.com/notepad-plus-plus/notepad-plus-plus/pull/546, which proposed a more complicated solution to keep "new 0" as initial file name, the correct behavior should be "new 1" instead of "new 0" for the initial file name, as it was before, according to @MarkMaldaba at https://github.com/notepad-plus-plus/notepad-plus-plus/issues/182#issuecomment-118370436:
> This is a regression, not an enhancement. Old versions of Notepad++ (e.g. 6.2.1) would open with "new 1". In the latest version (6.7.9.2) it opens with "new 0". There was obviously a regression introduced somewhere between those two versions. "new 1" is the correct numbering for humans
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/182#issuecomment-118370436

This is standard among many programs. Photoshop, for instance, starts with "Untitled-1".

I tracked this issue started at commit https://github.com/notepad-plus-plus/notepad-plus-plus/commit/85a6d2c05498dc789ff5ab1ac491bcd063e112dd (included in v6.6) which introduced the `nextUntitledNewNumber()` function.

An alternative fix, other than the proposed in my commit, might be changing the same line as below (but with some extra processing):
```diff
-wsprintf(nb, TEXT("%d"), 0);
+wsprintf(nb, TEXT(" %d"), nextUntitledNewNumber());
```
This commit
Fix #182
Close #546