### PR TITLE
Prevent override of dirty state on saving snapshot file

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -123,7 +123,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			if (isSnapshotMode && !isDirty)
 			{
 				bool canUndo = _pEditView->execute(SCI_CANUNDO) == TRUE;
-				if (!canUndo && buf->isLoadedDirty())
+				if (!canUndo && buf->isLoadedDirty() && buf->isDirty())
 					isDirty = true;
 			}
 			buf->setDirty(isDirty);


### PR DESCRIPTION
Fixes #173 and #579.
This adds an additional check to the logic originally introduced in commit d2651832ea656a0f9e75b4ed5fe1d2f25912563c so that newly opened snapshot files that have not been modified in the current session don't keep a dirty state after saving. 