### PR TITLE
Disable the unused gripper of toolbar

### DIFF
--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
@@ -393,7 +393,7 @@ void ToolBar::addToRebar(ReBar * rebar)
 	_rbBand.fMask   = RBBIM_STYLE | RBBIM_CHILD | RBBIM_CHILDSIZE |
 					  RBBIM_SIZE | RBBIM_IDEALSIZE | RBBIM_ID;
 
-	_rbBand.fStyle		= RBBS_VARIABLEHEIGHT | RBBS_USECHEVRON;
+	_rbBand.fStyle		= RBBS_VARIABLEHEIGHT | RBBS_USECHEVRON | RBBS_NOGRIPPER;
 	_rbBand.hwndChild	= getHSelf();
 	_rbBand.wID			= REBAR_BAR_TOOLBAR;	//ID REBAR_BAR_TOOLBAR for toolbar
 	_rbBand.cxMinChild	= 0;

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
@@ -200,8 +200,8 @@ int ToolBar::getWidth() const {
 
 int ToolBar::getHeight() const {
 	DWORD size = (DWORD)SendMessage(_hSelf, TB_GETBUTTONSIZE, 0, 0);
-    DWORD padding = (DWORD)SendMessage(_hSelf, TB_GETPADDING, 0,0);
-	int totalHeight = HIWORD(size) + HIWORD(padding);
+	DWORD padding = (DWORD)SendMessage(_hSelf, TB_GETPADDING, 0, 0);
+	int totalHeight = HIWORD(size) + HIWORD(padding) - 3;
 	return totalHeight;
 }
 


### PR DESCRIPTION
Considering the toolbar is not movable by known means, it doesn't make sense for it to display a gripper.

What I don't understand is why it doesn't work, ie, the toolbar is not movable.
From my research, the gripper appeared in toolbar at version 4.9 (2008)¹, but I couldn't see the toolbar becoming movable. Up to 4.8.5 there was no visible gripper.
¹https://github.com/azabluda/notepad-plus-plus/commit/9e26b31e3ac88276b832ea69c396ea5af3faeb6a

~~I also see we have a whole management around the Gripper ("[Docking Manager](https://github.com/notepad-plus-plus/notepad-plus-plus/tree/master/PowerEditor/src/WinControls/DockingWnd)"). Is this unrelated to the toolbar?~~ (Docking Manager seems related to detachable panels, even though I see many occurrences of the world "toolbar")

@donho I'm sorry about our previous discussion... but could you please clarify this?

The other commit reduces the padding of toolbar slightly, so it looks a bit better, imo.

Yes, this time it was tested. :grin:

Fix #174

![before-after](https://cloud.githubusercontent.com/assets/2916485/9054320/382f594a-3a56-11e5-9d0f-fc6728cb34bc.gif)