### PR TITLE
Make "Border Width" value 0 truly 0

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -171,9 +171,12 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 		throw std::exception("ScintillaEditView::init : SCINTILLA ERROR - Can not load the dynamic library");
 	}
 
+	int borderWidthPref = ((NppParameters::getInstance())->getSVP())._borderWidth,
+		styleWsExClientEdge = borderWidthPref > 0 ? WS_EX_CLIENTEDGE : 0;
+
 	Window::init(hInst, hPere);
-   _hSelf = ::CreateWindowEx(
-					WS_EX_CLIENTEDGE,\
+	_hSelf = ::CreateWindowEx(
+					styleWsExClientEdge,\
 					TEXT("Scintilla"),\
 					TEXT("Notepad++"),\
 					WS_CHILD | WS_VSCROLL | WS_HSCROLL | WS_CLIPCHILDREN | WS_EX_RTLREADING,\


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/619

This makes possible:
- Direct line selection when mouse is at leftmost pixel of the window.
- Using scrollbar when mouse is at rightmost pixel of the window.

It keeps old behavior when border is more than 0.

Personally, I've been waiting years for this. :smile:

Sample on a XP virtual machine:
![fix-border=0](https://cloud.githubusercontent.com/assets/2916485/9191716/16370b96-3fdb-11e5-9884-5ca8e67ae620.gif)
(Souvenir: the about-box from https://github.com/notepad-plus-plus/notepad-plus-plus/pull/691)