### PR TITLE
Fix: text area had a border when "Border Width" option was set to 0

### DIFF
--- a/PowerEditor/src/ScitillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScitillaComponent/DocTabView.cpp
@@ -224,4 +224,15 @@ void DocTabView::reSizeTo(RECT & rc)
 		rc.bottom -= (borderWidth * 2);
 		_pView->reSizeTo(rc);
 	}
+
+	//Control the border style of ScintillaEditView window, according to our border width value
+	static bool hasBorder = true;
+	if (borderWidth > 0 && !hasBorder) {
+		_pView->removeWindowBorder(false); //ScintillaEditView::removeWindowBorder
+		hasBorder = true;
+	}
+	else if (borderWidth == 0 && hasBorder) {
+		_pView->removeWindowBorder(true); //if we set borderWidth to 0, we want the editor window without any border
+		hasBorder = false;
+	}
 }

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -3017,6 +3017,19 @@ void ScintillaEditView::changeTextDirection(bool isRTL)
 	::SetWindowLongPtr(_hSelf, GWL_EXSTYLE, exStyle);
 }
 
+void ScintillaEditView::removeWindowBorder(bool mustRemove)
+{ //Called in DocTabView::reSizeTo
+	long exStyle = ::GetWindowLongPtr(_hSelf, GWL_EXSTYLE);
+
+	if (not mustRemove)
+		exStyle |= WS_EX_CLIENTEDGE;
+	else
+		exStyle &= ~WS_EX_CLIENTEDGE;
+
+	::SetWindowLongPtr(_hSelf, GWL_EXSTYLE, exStyle);
+	::SetWindowPos(_hSelf, NULL, 0,0,0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+}
+
 generic_string ScintillaEditView::getEOLString()
 {
 	const int eol_mode = int(execute(SCI_GETEOLMODE));

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -644,6 +644,7 @@ public:
 	void sortLines(size_t fromLine, size_t toLine, ISorter *pSort);
 	void changeTextDirection(bool isRTL);
 	bool isTextDirectionRTL() const;
+	void removeWindowBorder(bool mustRemove);
 
 protected:
 	static HINSTANCE _hLib;


### PR DESCRIPTION
This is a possible fix for https://github.com/notepad-plus-plus/notepad-plus-plus/issues/619.

This makes possible:
- Direct selection of entire line when mouse is at leftmost pixel of the window.
- Using scrollbar when mouse is at rightmost pixel of the window.

It keeps old behavior when border is more than 0.

Sample:
![fix-border=0](https://cloud.githubusercontent.com/assets/2916485/9191716/16370b96-3fdb-11e5-9884-5ca8e67ae620.gif)