### PR TITLE
Function List panel fixes

### DIFF
--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -91,6 +91,9 @@ DockingCont::DockingCont()
 	_captionGapDynamic = NppParameters::getInstance()->_dpiManager.scaleY(_captionGapDynamic);
 	_closeButtonPosLeftDynamic = NppParameters::getInstance()->_dpiManager.scaleX(_closeButtonPosLeftDynamic);
 	_closeButtonPosTopDynamic = NppParameters::getInstance()->_dpiManager.scaleY(_closeButtonPosTopDynamic);
+
+	_closeButtonWidth = NppParameters::getInstance()->_dpiManager.scaleX(12); // bitmap image is 12x12
+	_closeButtonHeight = NppParameters::getInstance()->_dpiManager.scaleY(12);
 }
 
 DockingCont::~DockingCont()
@@ -569,9 +572,9 @@ void DockingCont::drawCaptionItem(DRAWITEMSTRUCT *pDrawItemStruct)
 
 	// select correct bitmap
 	if ((_isMouseOver == TRUE) && (_isMouseDown == TRUE))
-		hBmpCur = ::LoadBitmap(_hInst, MAKEINTRESOURCE(IDB_CLOSE_DOWN));
+		hBmpCur = (HBITMAP)::LoadImage(_hInst, MAKEINTRESOURCE(IDB_CLOSE_DOWN), IMAGE_BITMAP, _closeButtonWidth, _closeButtonHeight, 0);
 	else
-		hBmpCur = ::LoadBitmap(_hInst, MAKEINTRESOURCE(IDB_CLOSE_UP));
+		hBmpCur = (HBITMAP)::LoadImage(_hInst, MAKEINTRESOURCE(IDB_CLOSE_UP), IMAGE_BITMAP, _closeButtonWidth, _closeButtonHeight, 0);
 
 	// blit bitmap into the destination
 	::GetObject(hBmpCur, sizeof(bmp), &bmp);
@@ -608,7 +611,7 @@ eMousePos DockingCont::isInRect(HWND hwnd, int x, int y)
 		{
 			ret = posCaption;
 		}
-		else if ((x > rc.right - (12 + _closeButtonPosLeftDynamic)) && (x < (rc.right - _closeButtonPosLeftDynamic)) &&
+		else if ((x > rc.right - (_closeButtonWidth + _closeButtonPosLeftDynamic)) && (x < (rc.right - _closeButtonPosLeftDynamic)) &&
 			(y >(rc.top + _closeButtonPosTopDynamic)) && (y < (rc.bottom - _closeButtonPosTopDynamic)))
 		{
 			ret = posClose;
@@ -621,7 +624,7 @@ eMousePos DockingCont::isInRect(HWND hwnd, int x, int y)
 			ret = posCaption;
 		}
 		else if ((x > rc.left + _closeButtonPosLeftDynamic) && (x < rc.right - _closeButtonPosLeftDynamic) &&
-			(y >(rc.top + _closeButtonPosTopDynamic)) && (y < (rc.top + (12 + _closeButtonPosLeftDynamic))))
+			(y >(rc.top + _closeButtonPosTopDynamic)) && (y < (rc.top + (_closeButtonHeight + _closeButtonPosLeftDynamic))))
 		{
 			ret = posClose;
 		}

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
@@ -236,6 +236,8 @@ private:
 	int _captionGapDynamic = CAPTION_GAP;
 	int _closeButtonPosLeftDynamic = CLOSEBTN_POS_LEFT;
 	int _closeButtonPosTopDynamic = CLOSEBTN_POS_TOP;
+	int _closeButtonWidth;
+	int _closeButtonHeight;
 
 	// data of added windows
 	std::vector<tTbData *>		_vTbData;

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -104,9 +104,11 @@ public:
 
 	virtual void setBackgroundColor(COLORREF bgColour) {
 		TreeView_SetBkColor(_treeView.getHSelf(), bgColour);
+		TreeView_SetBkColor(_treeViewSearchResult.getHSelf(), bgColour);
     };
 	virtual void setForegroundColor(COLORREF fgColour) {
 		TreeView_SetTextColor(_treeView.getHSelf(), fgColour);
+		TreeView_SetTextColor(_treeViewSearchResult.getHSelf(), fgColour);
     };
 
     void setParent(HWND parent2set){


### PR DESCRIPTION
Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/733

- Fix: when search field is not empty, Function List's background color does not follow Npp theme.

- Fix: close button and textual search box now scale in high-dpi.

- Fix: icons' image not centered in icons' rectangle.

- Fix: when double-clicking the panel's toolbar, it briefly displayed a dialog to customize icons, but we can't use it there.

[Known issues](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/733):
- I couldn't made toolbar icon images scale properly in high-dpi; I imagine they need to be in a ImageList, something I don't know how to use.
- TreeView icons should also be scaled, and I've done it, but they displayed strange gray background, so I decided to leave it as is now.
- It would be better to wrap icons when they don't fit in panel's width, but I don't know how to refresh the toolbar properly.

<table>
    <tr>
        <td><img src="https://cloud.githubusercontent.com/assets/2916485/9321558/6035ff6e-453e-11e5-9ddc-8171665e0010.gif" alt="before-after-150dpi"></td>
        <td>(150dpi)</td>
    </tr>
</table>