### PR TITLE
Add 2 missing translatable items to original XML (for 6.8.2)

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -797,7 +797,7 @@
                     <Item id="6262" name="Settings on cloud"/>
                     <Item id="6263" name="No Cloud"/>
                     <Item id="6267" name="Set your cloud location path here:"/>
-                    <!--Item id="6261" name="Please restart Notepad++ to take effect."/-->
+                    <Item id="6261" name="Please restart Notepad++ to take effect."/>
                 </Cloud>
 
                 <MISC title="MISC.">
@@ -848,6 +848,7 @@
                 <Item id="2030" name="Initial number:"/>
                 <Item id="2031" name="Increase by:"/>
                 <Item id="2035" name="Leading zeros"/>
+                <Item id="2036" name="Repeat :"/>
                 <Item id="2032" name="Format"/>
                 <Item id="2024" name="Dec"/>
                 <Item id="2025" name="Oct"/>


### PR DESCRIPTION
This is an attempt to add the complete, currently known unofficial strings to original english.xml language template. For version 6.8.2. Don Ho should review them, and make them official.

These 2 item remained from #542, not sure why they were not accepted by Don in #542 