### PR TITLE
windows 10 detection in getWinVersion()

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -42,7 +42,7 @@ enum LangType {L_TEXT, L_PHP , L_C, L_CPP, L_CS, L_OBJC, L_JAVA, L_RC,\
 			   L_COFFEESCRIPT,\
 			   // The end of enumated language type, so it should be always at the end
 			   L_EXTERNAL};
-enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV_S2003, WV_XPX64, WV_VISTA, WV_WIN7, WV_WIN8, WV_WIN81};
+enum winVer{WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV_S2003, WV_XPX64, WV_VISTA, WV_WIN7, WV_WIN8, WV_WIN81, WV_WIN10 };
 
 
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -750,6 +750,9 @@ winVer getWindowsVersion()
    {
 		case VER_PLATFORM_WIN32_NT:
 		{
+			if (osvi.dwMajorVersion == 8 && osvi.dwMinorVersion == 4)
+				return WV_WIN10;
+
 			if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3)
 				return WV_WIN81;
 


### PR DESCRIPTION
- added WV_WIN10 to winVer enum for windows 10
- added detection of win version 10, WV_UNKNOWN will been used otherwise, also there seems to be no negative sideeffect of that 
- maybe affected: \notepad-plus-plus\PowerEditor\src\Parameters.cpp(970):		if (_winVersion >= WV_VISTA)
-   maybe affected: \notepad-plus-plus\PowerEditor\src\NppCommands.cpp(2319):			if (ver <= WV_XP)
-   maybe affected: \notepad-plus-plus\PowerEditor\src\WinControls\OpenSaveFileDialog\FileDialog.cpp(50):	if (_winVersion < WV_W2K)
-   maybe affected: \notepad-plus-plus\PowerEditor\src\Parameters.cpp(811):int FileDialog::_dialogFileBoxId = (NppParameters::getInstance())->getWinVersion() < WV_W2K?edt1:cmb13;



