### PR TITLE
Possible fix for #752 - Language not set when creating new file

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -219,7 +219,6 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
 			buf->setEncoding(ndds._codepage);
 			buf->setFormat(ndds._format);
 			buf->setUnicodeMode(ndds._unicodeMode);
-			buf->setLangType(ndds._lang);
 		}
 
         // Notify plugins that current file is about to open


### PR DESCRIPTION
Code:
buf->setLangType(ndds._lang);
doesn't need because buffer has already logic for detecting LangType.
in void Buffer::setFileName(const TCHAR *fn, LangType defaultLang)
P.S. maybe other strings are not needed too...