### PR TITLE
Possible fix for #725 - Cannot open files that contain ASCII NUL(0x00) correctly

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1334,6 +1334,7 @@ inline bool FileManager::loadFileData(Document doc, const TCHAR * filename, char
 						encoding = detectCodepage(data, lenFile);
                 }
                 isFirstTime = false;
+				UnicodeConvertor->setTotalDataLength(fileSize);
             }
 
 			if (encoding != -1)

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -205,7 +205,7 @@ void Utf8_16_Read::determineEncoding()
 		m_nSkip = 3;
 	}
 	// try to detect UTF-16 little-endian without BOM
-	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest) && (totalDataLength ? totalDataLength % 2 == 0 : true))
+	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest) && (_totalDataLength ? _totalDataLength % 2 == 0 : true))
 	{
 		m_eEncoding = uni16LE_NoBOM;
 		m_nSkip = 0;

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -205,7 +205,7 @@ void Utf8_16_Read::determineEncoding()
 		m_nSkip = 3;
 	}
 	// try to detect UTF-16 little-endian without BOM
-	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest) && m_nLen % 2 == 0)
+	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest) && (totalDataLength) ? totalDataLength % 2 == 0 : true)
 	{
 		m_eEncoding = uni16LE_NoBOM;
 		m_nSkip = 0;

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -205,7 +205,7 @@ void Utf8_16_Read::determineEncoding()
 		m_nSkip = 3;
 	}
 	// try to detect UTF-16 little-endian without BOM
-	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest))
+	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest) && m_nLen % 2 == 0)
 	{
 		m_eEncoding = uni16LE_NoBOM;
 		m_nSkip = 0;

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -205,7 +205,7 @@ void Utf8_16_Read::determineEncoding()
 		m_nSkip = 3;
 	}
 	// try to detect UTF-16 little-endian without BOM
-	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest) && (totalDataLength) ? totalDataLength % 2 == 0 : true)
+	else if (m_nLen > 1 && m_pBuf[0] != NULL && m_pBuf[1] == NULL && IsTextUnicode(m_pBuf, m_nLen, &uniTest) && (totalDataLength ? totalDataLength % 2 == 0 : true))
 	{
 		m_eEncoding = uni16LE_NoBOM;
 		m_nSkip = 0;

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -119,8 +119,8 @@ public:
 	size_t calcCurPos(size_t pos);
     static UniMode determineEncoding(const unsigned char *buf, int bufLen);
 
-	unsigned __int64 getTotalDataLength() const { return totalDataLength; }
-	void setTotalDataLength(unsigned __int64 newLength) { totalDataLength = newLength; }
+	unsigned __int64 getTotalDataLength() const { return _totalDataLength; }
+	void setTotalDataLength(unsigned __int64 newLength) { _totalDataLength = newLength; }
 
 protected:
 	void determineEncoding();
@@ -139,7 +139,7 @@ private:
 	size_t          m_nLen;
 	Utf16_Iter      m_Iter16;
 
-	unsigned __int64 totalDataLength = 0;
+	unsigned __int64 _totalDataLength = 0;
 };
 
 // Read in a UTF-8 buffer and write out to UTF-16 or UTF-8

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -119,6 +119,9 @@ public:
 	size_t calcCurPos(size_t pos);
     static UniMode determineEncoding(const unsigned char *buf, int bufLen);
 
+	unsigned __int64 getTotalDataLength() const { return totalDataLength; }
+	void setTotalDataLength(unsigned __int64 newLength) { totalDataLength = newLength; }
+
 protected:
 	void determineEncoding();
 
@@ -135,6 +138,8 @@ private:
 	bool            m_bFirstRead;
 	size_t          m_nLen;
 	Utf16_Iter      m_Iter16;
+
+	unsigned __int64 totalDataLength = 0;
 };
 
 // Read in a UTF-8 buffer and write out to UTF-16 or UTF-8


### PR DESCRIPTION
For all files type of UTF-16 (with/without BOM, BE/LE) "filesize % 2 == 0" must be true
P.S. even new line symbol have length of two bytes.
http://www.fileformat.info/info/unicode/char/000A/index.htm
http://www.fileformat.info/info/unicode/char/000d/index.htm
