### PR TITLE
Update Notepad_plus.cpp to fix issue #749

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2187,6 +2187,12 @@ void Notepad_plus::addHotSpot()
 
 	_pEditView->getVisibleStartAndEndPosition(&startPos, &endPos);
 
+        if (_pEditView->getCurrentBuffer()->getLangType() == L_TEXT)
+	{
+		_pEditView->execute(SCI_STARTSTYLING, startPos, 0xFF);
+		_pEditView->execute(SCI_SETSTYLING, endPos - startPos, static_cast<unsigned char>(STYLE_DEFAULT));
+	}
+
 	_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
 
 	_pEditView->execute(SCI_SETTARGETSTART, startPos);


### PR DESCRIPTION
This fixes issue #749. It is not the best solution, but if a regular text document is opened, before finding any hot spots, we reset the text style of everything in view (clearing previously styled hotspots). Would love feedback if pull request is rejected.