### PR TITLE
Removed space before ellipses in German translation

### DIFF
--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -56,7 +56,7 @@
 					<Item subMenuId="view-uncollapseLevel" name="Te&amp;xtblöcke öffnen"/>
 					<Item subMenuId="view-project" name="Projektver&amp;waltung"/>
 					<Item subMenuId="view-tab" name="&amp;Tabs"/>
-					<Item subMenuId="encoding-characterSets" name="&amp;Zeichensatz"/>
+					<Item subMenuId="encoding-characterSets" name="&amp;Weitere"/>
 					<Item subMenuId="encoding-arabic" name="&amp;Arabisch"/>
 					<Item subMenuId="encoding-baltic" name="&amp;Baltisch"/>
 					<Item subMenuId="encoding-celtic" name="&amp;Keltisch"/>
@@ -336,9 +336,9 @@
 				<Item id="1" name="&amp;Weitersuchen"/>
 				<Item id="2" name="&amp;Schließen"/>
 				<Item id="1603" name="Nur &amp;ganze Wörter suchen"/>
-				<Item id="1604" name="Groß-/&amp;Kleinschreibung"/>
+				<Item id="1604" name="Groß-/&amp;Kleinschreibung beachten"/>
 				<Item id="1605" name="&amp;Reguläre Ausdrücke"/>
-				<Item id="1606" name="Am Ende von vorn &amp;beginnen"/>
+				<Item id="1606" name="Am Ende von vorne &amp;beginnen"/>
 				<Item id="1608" name="&amp;Ersetzen"/>
 				<Item id="1609" name="Alle erse&amp;tzen"/>
 				<Item id="1611" name="Erset&amp;zen durch:"/>
@@ -347,7 +347,6 @@
 				<Item id="1614" name="Z&amp;ählen"/>
 				<Item id="1615" name="&amp;Alle suchen"/>
 				<Item id="1616" name="&amp;Lesezeichen setzen"/>
-				<Item id="1617" name="&amp;Treffer markieren"/>
 				<Item id="1618" name="Für &amp;jede Suche löschen"/>
 				<Item id="1620" name="Suchen &amp;nach:"/>
 				<Item id="1621" name="Suchrichtung"/>
@@ -355,7 +354,7 @@
 				<Item id="1625" name="Norma&amp;l"/>
 				<Item id="1626" name="Erwe&amp;itert (\r, \n, \t, \x..., \0)"/>
 				<Item id="1627" name="Unten"/>
-				<Item id="1632" name="In &amp;Markierung"/>
+				<Item id="1632" name="In &amp;Auswahl"/>
 				<Item id="1633" name="Zurücksetzen"/>
 				<Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
 				<Item id="1636" name="In &amp;offenen Dateien suchen"/>
@@ -639,21 +638,21 @@
 					<Item id="6152" name="Sitzungsdateien in einer neuen Instanz öffnen"/>
 					<Item id="6153" name="Immer im Mehrinstanzmodus"/>
 					<Item id="6154" name="Standard (nur eine Instanz)"/>
-					<Item id="6155" name="* Notepad++ muss neu gestartet werden"/>
+					<Item id="6155" name="Nach Änderung der Einstellung muss Notepad++ neu gestartet werden."/>
 				</MultiInstance>
 				<Scintillas title="Oberfläche 2">
 					<Item id="6201" name="Textblock-Faltung"/>
 					<Item id="6202" name="Plus/minus"/>
 					<Item id="6203" name="Pfeile"/>
-					<Item id="6204" name ="Kreise"/>
+					<Item id="6204" name="Kreise"/>
 					<Item id="6205" name="Quadrate"/>
 					<Item id="6206" name="Zeilennummernrand"/>
 					<Item id="6207" name="Lesezeichenrand"/>
 					<Item id="6208" name="Randbegrenzung anzeigen"/>
 					<Item id="6209" name="Anzahl der Spalten:"/>
 					<Item id="6211" name="Rechter Rand"/>
-					<Item id="6212" name="vertikale Linie"/>
-					<Item id="6213" name="farbiger Hintergrund"/>
+					<Item id="6212" name="Vertikale Linie"/>
+					<Item id="6213" name="Farbiger Hintergrund"/>
 					<Item id="6214" name="Aktuelle Zeile hervorheben"/>
 					<Item id="6215" name="Kantenglättung der Schriftarten"/>
 					<Item id="6216" name="Cursoreinstellungen"/>
@@ -661,7 +660,7 @@
 					<Item id="6219" name="Geschwindigkeit"/>
 					<Item id="6221" name="S"/>
 					<Item id="6222" name="L"/>
-					<Item id="6224" name="Gleichzeitiges Editieren"/>
+					<Item id="6224" name="Mehrfaches Editieren"/>
 					<Item id="6225" name="Aktivieren (Strg+Mausklick)"/>
 					<Item id="6226" name="Aus"/>
 					<Item id="6227" name="Umgebrochene Zeilen"/>
@@ -669,17 +668,17 @@
 					<Item id="6229" name="Linksbündig"/>
 					<Item id="6230" name="Hängend"/>
 					<Item id="6231" name="Rahmenbreite"/>
-					<Item id="6234" name="Erweitertes Scrollen deaktivieren"/>
+					<Item id="6234" name="Flüssiges Scrollen deaktivieren (bei Touchpad-Problemen)"/>
 				</Scintillas>
-				<Delimiter title="Trennzeichen für erweiterte Auswahl">
-					<Item id="6251" name="Trennzeichen (Strg+Doppelklick)"/>
+				<Delimiter title="Trennzeichen">
+					<Item id="6251" name="Trennzeichen für erweiterte Auswahl (Strg+Doppelklick)"/>
 					<Item id="6252" name="Anfang"/>
 					<Item id="6255" name="Ende"/>
 					<Item id="6256" name="Über mehrere Zeilen"/>
 					<Item id="6257" name="bla bla bla bla bla bla"/>
 					<Item id="6258" name="bla bla bla bla bla bla bla bla bla bla bla bla"/>
 				</Delimiter>
-				<RecentFilesHistory title="Zuletzt geöffnete Dateien">
+				<RecentFilesHistory title="Zuletzt geöffn. Dateien">
 					<Item id="6304" name="Zuletzt geöffnete Dateien"/>
 					<Item id="6305" name="Beim Programmstart nicht überprüfen"/>
 					<Item id="6306" name="Max. Menüeinträge:"/>
@@ -691,7 +690,7 @@
 					<Item id="6429" name="Anzeige im Dateimenü"/>
 				</RecentFilesHistory>
 				<NewDoc title="Neue Dateien">
-					<Item id="6401" name="Zeilenende-Format"/>
+					<Item id="6401" name="Zeilenenden"/>
 					<Item id="6402" name="Windows"/>
 					<Item id="6403" name="UNIX"/>
 					<Item id="6404" name="Mac"/>
@@ -699,11 +698,11 @@
 					<Item id="6406" name="ANSI"/>
 					<Item id="6407" name="UTF-8 ohne BOM"/>
 					<Item id="6408" name="UTF-8"/>
-					<Item id="6409" name="UCS2 Big Endian"/>
-					<Item id="6410" name="UCS2 Little Endian"/>
+					<Item id="6409" name="UCS-2 Big Endian"/>
+					<Item id="6410" name="UCS-2 Little Endian"/>
 					<Item id="6411" name="Standardsprache"/>
 					<Item id="6419" name="Format für neue Dateien"/>
-					<Item id="6420" name="auch beim Öffnen von ANSI-Dateien"/>
+					<Item id="6420" name="Auch beim Öffnen von ANSI-Dateien"/>
 				</NewDoc>
 				<DefaultDir title="Standardverzeichnis">
 					<Item id="6413" name="Verzeichnis beim Öffnen/Speichern"/>
@@ -717,7 +716,7 @@
 				</FileAssoc>
 				<TabSettings title="Tabulatoren">
 					<Item id="6301" name="Tabulatoren"/>
-					<Item id="6302" name="durch Leerzeichen ersetzen"/>
+					<Item id="6302" name="Durch Leerzeichen ersetzen"/>
 					<Item id="6303" name="Tabulatorbreite:"/>
 					<Item id="6510" name="Standard verwenden"/>
 				</TabSettings>
@@ -771,22 +770,22 @@
 					<Item id="6323" name="Automatische Updates aktivieren"/>
 					<Item id="6324" name="Dokumentenumschalter (Strg+Tab)"/>
 					<Item id="6325" name="Nach Aktualisierung zum Ende scrollen"/>
-					<Item id="6326" name="Alle Wortvorkommnisse markieren"/>
+					<Item id="6326" name="Hervorhebung aktivieren"/>
 					<Item id="6327" name="Tags hervorheben"/>
 					<Item id="6328" name="Attribute hervorheben"/>
 					<Item id="6329" name="HTML-Hervorhebung"/>
-					<Item id="6330" name="PHP/ASP-Bereiche hervorheben"/>
+					<Item id="6330" name="PHP-/ASP-Bereiche hervorheben"/>
 					<Item id="6331" name="Nur Dateinamen in Titelleiste anzeigen"/>
-					<Item id="6332" name="Groß-/Kleinschreibung unterscheiden"/>
-					<Item id="6333" name="Mehrfache Markierung"/>
+					<Item id="6332" name="Groß-/Kleinschreibung beachten"/>
+					<Item id="6333" name="Automatische Hervorhebung bei Auswahl"/>
 					<Item id="6334" name="Kodierung automatisch erkennen"/>
 					<Item id="6335" name="Backslash ist Escapezeichen für SQL"/>
 				</MISC>
 				<Backup title="Sicherheitskopien">
 					<Item id="6801" name="Sicherheitskopie beim Speichern von Dateien"/>
-					<Item id="6315" name="keine"/>
-					<Item id="6316" name="einfach"/>
-					<Item id="6317" name="erweitert"/>
+					<Item id="6315" name="Keine"/>
+					<Item id="6316" name="Einfach"/>
+					<Item id="6317" name="Erweitert"/>
 					<Item id="6804" name="Verzeichnisangabe für die Sicherheitskopien"/>
 					<Item id="6803" name="Verzeichnis:"/>
 					<Item id="6817" name="Sitzungen automatisch speichern"/>
@@ -798,7 +797,7 @@
 				</Backup>
 				<Cloud title="Cloud-Einstellungen">
 					<Item id="6262" name="Einstellungen in der Cloud speichern"/>
-					<Item id="6263" name="aus"/>
+					<Item id="6263" name="Aus"/>
 					<Item id="6267" name="Netzwerkpfad:"/>
 				</Cloud>
 				<AutoCompletion title="Autovervollständigung">
@@ -849,11 +848,12 @@
 				<Item id="2030" name="Beginnen mit"/>
 				<Item id="2031" name="Erhöhen um"/>
 				<Item id="2035" name="Führende &amp;Nullen"/>
+				<Item id="2036" name="Wiederholen"/>
 				<Item id="2032" name="Format"/>
-				<Item id="2024" name="&amp;Dec"/>
-				<Item id="2025" name="&amp;Oct"/>
-				<Item id="2026" name="&amp;Hex"/>
-				<Item id="2027" name="&amp;Bin"/>
+				<Item id="2024" name="&amp;Dezimal"/>
+				<Item id="2025" name="&amp;Oktal"/>
+				<Item id="2026" name="&amp;Hexadezimal"/>
+				<Item id="2027" name="&amp;Binär"/>
 				<Item id="1" name="Ausfüh&amp;ren"/>
 				<Item id="2" name="Abbre&amp;chen"/>
 			</ColumnEditor>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -83,22 +83,22 @@
 					<Item id="10003" name="In &amp;neue Instanz verschieben"/>
 					<Item id="10004" name="In neue Instan&amp;z duplizieren"/>
 					<Item id="41001" name="&amp;Neu"/>
-					<Item id="41002" name="&amp;Öffnen..."/>
+					<Item id="41002" name="&amp;Öffnen …"/>
 					<Item id="41003" name="Schlie&amp;ßen"/>
 					<Item id="41004" name="Alle s&amp;chließen"/>
 					<Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
 					<Item id="41006" name="&amp;Speichern"/>
 					<Item id="41007" name="&amp;Alle speichern"/>
-					<Item id="41008" name="Speichern &amp;unter..."/>
+					<Item id="41008" name="Speichern &amp;unter …"/>
 					<Item id="41009" name="Dateien &amp;links schließen"/>
-					<Item id="41010" name="&amp;Drucken..."/>
+					<Item id="41010" name="&amp;Drucken …"/>
 					<Item id="41011" name="B&amp;eenden"/>
-					<Item id="41012" name="Sit&amp;zung öffnen..."/>
-					<Item id="41013" name="Sitzung speiche&amp;rn..."/>
+					<Item id="41012" name="Sit&amp;zung öffnen …"/>
+					<Item id="41013" name="Sitzung speiche&amp;rn …"/>
 					<Item id="41014" name="Neu &amp;laden"/>
-					<Item id="41015" name="&amp;Kopie speichern unter..."/>
+					<Item id="41015" name="&amp;Kopie speichern unter …"/>
 					<Item id="41016" name="Von Datentr&amp;äger löschen"/>
-					<Item id="41017" name="Um&amp;benennen..."/>
+					<Item id="41017" name="Um&amp;benennen …"/>
 					<Item id="41018" name="Dateien &amp;rechts schließen"/>
 					<Item id="41019" name="E&amp;xplorer"/>
 					<Item id="41020" name="&amp;Eingabeaufforderung"/>
@@ -133,12 +133,12 @@
 					<Item id="42029" name="Vollständigen &amp;Pfad kopieren"/>
 					<Item id="42030" name="Nur Datei&amp;namen kopieren"/>
 					<Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
-					<Item id="42032" name="Makro &amp;mehrfach ausführen..."/>
+					<Item id="42032" name="Makro &amp;mehrfach ausführen …"/>
 					<Item id="42033" name="Schreibschutz-Attribut l&amp;öschen"/>
-					<Item id="42034" name="&amp;Block-Editor..."/>
+					<Item id="42034" name="&amp;Block-Editor …"/>
 					<Item id="42035" name="Zeilen aus&amp;kommentieren"/>
 					<Item id="42036" name="Auskommentierung der Zeilen a&amp;ufheben"/>
-					<Item id="42037" name="Spalten-&amp;Modus..."/>
+					<Item id="42037" name="Spalten-&amp;Modus …"/>
 					<Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
 					<Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
 					<Item id="42040" name="Alle zule&amp;tzt verwendeten Dateien öffnen"/>
@@ -168,10 +168,10 @@
 					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
 					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
 					<Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-					<Item id="43001" name="&amp;Suchen..."/>
+					<Item id="43001" name="&amp;Suchen …"/>
 					<Item id="43002" name="&amp;Weitersuchen"/>
-					<Item id="43003" name="&amp;Ersetzen..."/>
-					<Item id="43004" name="&amp;Gehe zu..."/>
+					<Item id="43003" name="&amp;Ersetzen …"/>
+					<Item id="43004" name="&amp;Gehe zu …"/>
 					<Item id="43005" name="&amp;Lesezeichen setzen/löschen"/>
 					<Item id="43006" name="&amp;Nächstes Lesezeichen"/>
 					<Item id="43007" name="&amp;Vorheriges Lesezeichen"/>
@@ -179,7 +179,7 @@
 					<Item id="43009" name="Suche zugehörige &amp;Klammer"/>
 					<Item id="43010" name="&amp;Rückwärts suchen"/>
 					<Item id="43011" name="&amp;Inkrementelle Suche"/>
-					<Item id="43013" name="In &amp;Dateien suchen..."/>
+					<Item id="43013" name="In &amp;Dateien suchen …"/>
 					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne Verlauf)"/>
 					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne Verlauf)"/>
 					<Item id="43018" name="Zeilen mit Lesezeichen &amp;ausschneiden"/>
@@ -216,12 +216,12 @@
 					<Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
 					<Item id="43050" name="Lesezeichen inver&amp;tieren"/>
 					<Item id="43051" name="Zeilen &amp;ohne Lesezeichen löschen"/>
-					<Item id="43052" name="Suche nach &amp;Zeichencodes..."/>
+					<Item id="43052" name="Suche nach &amp;Zeichencodes …"/>
 					<Item id="43053" name="&amp;Alles zwischen Klammern auswählen"/>
-					<Item id="43054" name="&amp;Hervorheben..."/>
+					<Item id="43054" name="&amp;Hervorheben …"/>
 					<Item id="44009" name="&amp;Post-It"/>
 					<Item id="44010" name="A&amp;lle Textblöcke schließen"/>
-					<Item id="44011" name="Benutzerdefinierte Spra&amp;che..."/>
+					<Item id="44011" name="Benutzerdefinierte Spra&amp;che …"/>
 					<Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>
 					<Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>
 					<Item id="44014" name="Codefaltung ausb&amp;lenden"/>
@@ -242,7 +242,7 @@
 					<Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
 					<Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
 					<Item id="44042" name="Zeilen &amp;ausblenden"/>
-					<Item id="44049" name="Datei-&amp;Info..."/>
+					<Item id="44049" name="Datei-&amp;Info …"/>
 					<Item id="44072" name="&amp;Zur anderen Ansicht wechseln"/>
 					<Item id="44080" name="&amp;Miniaturansicht"/>
 					<Item id="44081" name="Projektfenster &amp;1"/>
@@ -273,30 +273,30 @@
 					<Item id="45011" name="Konv&amp;ertiere zu UTF-8"/>
 					<Item id="45012" name="Konve&amp;rtiere zu UCS-2 Big Endian"/>
 					<Item id="45013" name="Konver&amp;tiere zu UCS-2 Little Endian"/>
-					<Item id="46001" name="&amp;Stile..."/>
+					<Item id="46001" name="&amp;Stile …"/>
 					<Item id="46015" name="MS-DOS-Stil"/>
 					<Item id="46016" name="Normaler Text"/>
 					<Item id="46017" name="Ressourcen-Datei"/>
 					<!-- <Item id="46019" name="MS-INI-Datei"/> -->
 					<Item id="46080" name="Benutzerdefiniert"/>
-					<Item id="46150" name="Eigene Sprache &amp;definieren..."/>
-					<Item id="47000" name="&amp;Info..."/>
+					<Item id="46150" name="Eigene Sprache &amp;definieren …"/>
+					<Item id="47000" name="&amp;Info …"/>
 					<Item id="47001" name="Notepad++ im &amp;Web"/>
 					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
 					<Item id="47005" name="&amp;Erweiterungen"/>
 					<Item id="47006" name="Notepad++ &amp;aktualisieren"/>
-					<Item id="47008" name="In&amp;halt..."/>
-					<Item id="47009" name="&amp;Proxy für Updater einstellen..."/>
-					<Item id="47010" name="&amp;Kommandozeilenparameter..."/>
+					<Item id="47008" name="In&amp;halt …"/>
+					<Item id="47009" name="&amp;Proxy für Updater einstellen …"/>
+					<Item id="47010" name="&amp;Kommandozeilenparameter …"/>
 					<Item id="47011" name="&amp;Support im Chat"/>
-					<Item id="48005" name="&amp;Plugin(s) importieren..."/>
-					<Item id="48006" name="&amp;Design(s) importieren..."/>
-					<Item id="48009" name="&amp;Tastatur..."/>
-					<Item id="48011" name="&amp;Optionen..."/>
-					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen..."/>
-					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen..."/>
-					<Item id="48018" name="&amp;Kontextmenü anpassen..."/>
-					<Item id="49000" name="Externes Programm &amp;ausführen..."/>
+					<Item id="48005" name="&amp;Plugin(s) importieren …"/>
+					<Item id="48006" name="&amp;Design(s) importieren …"/>
+					<Item id="48009" name="&amp;Tastatur …"/>
+					<Item id="48011" name="&amp;Optionen …"/>
+					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen …"/>
+					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen …"/>
+					<Item id="48018" name="&amp;Kontextmenü anpassen …"/>
+					<Item id="49000" name="Externes Programm &amp;ausführen …"/>
 					<Item id="50000" name="&amp;Funktionsvervollständigung"/>
 					<Item id="50001" name="&amp;Wortvervollständigung"/>
 					<Item id="50002" name="Funktions&amp;parameter anzeigen"/>
@@ -309,14 +309,14 @@
 				<Item CMID="0" name="S&amp;chließen"/>
 				<Item CMID="1" name="&amp;Alle anderen schließen"/>
 				<Item CMID="2" name="&amp;Speichern"/>
-				<Item CMID="3" name="Speichern &amp;unter..."/>
+				<Item CMID="3" name="Speichern &amp;unter …"/>
 				<Item CMID="4" name="&amp;Drucken"/>
 				<Item CMID="5" name="In zweite Ansicht &amp;verschieben"/>
 				<Item CMID="6" name="In zw&amp;eite Ansicht duplizieren"/>
 				<Item CMID="7" name="Vollständigen Pfad &amp;kopieren"/>
 				<Item CMID="8" name="Nur Datei&amp;namen kopieren"/>
 				<Item CMID="9" name="Nur Verzeichnis&amp;pfad kopieren"/>
-				<Item CMID="10" name="Um&amp;benennen..."/>
+				<Item CMID="10" name="Um&amp;benennen …"/>
 				<Item CMID="11" name="L&amp;öschen"/>
 				<Item CMID="12" name="Sch&amp;reibschutz"/>
 				<Item CMID="13" name="Schreibschutz au&amp;fheben"/>
@@ -352,7 +352,7 @@
 				<Item id="1621" name="Suchrichtung"/>
 				<Item id="1624" name="Suchmodus"/>
 				<Item id="1625" name="Norma&amp;l"/>
-				<Item id="1626" name="Erwe&amp;itert (\r, \n, \t, \x..., \0)"/>
+				<Item id="1626" name="Erwe&amp;itert (\r, \n, \t, \x…, \0)"/>
 				<Item id="1627" name="Unten"/>
 				<Item id="1632" name="In &amp;Auswahl"/>
 				<Item id="1633" name="Zurücksetzen"/>
@@ -384,7 +384,7 @@
 				<Item id="2008" name="Z&amp;eichen"/>
 			</GoToLine>
 			<!-- Run external program: -->
-			<Run title="Ausführen...">
+			<Run title="Ausführen …">
 				<Item id="1" name="&amp;Ausführen"/>
 				<Item id="2" name="A&amp;bbrechen"/>
 				<Item id="1901" name=".&amp;.."/>
@@ -440,7 +440,7 @@
 				<Item id="20002" name="Umbenennen"/>
 				<Item id="20003" name="Neue erstellen"/>
 				<Item id="20004" name="Löschen"/>
-				<Item id="20005" name="Speichern als..."/>
+				<Item id="20005" name="Speichern als …"/>
 				<Item id="20007" name="Sprache"/>
 				<Item id="20009" name="Erw."/>
 				<Item id="20011" name="Transparenz"/>
@@ -708,7 +708,7 @@
 					<Item id="6413" name="Verzeichnis beim Öffnen/Speichern"/>
 					<Item id="6414" name="Wie aktuelle Datei"/>
 					<Item id="6415" name="Letztes Verzeichnis merken"/>
-					<Item id="6418" name="..."/>
+					<Item id="6418" name="…"/>
 				</DefaultDir>
 				<FileAssoc title="Dateiverknüpfungen">
 					<Item id="4009" name="Unterstützte Erw.:"/>
@@ -900,25 +900,25 @@
 					<Item id="3123" name="Arbeitsbereich öffnen"/>
 					<Item id="3124" name="Arbeitsbereich neu laden"/>
 					<Item id="3125" name="Speichern"/>
-					<Item id="3126" name="Speichern unter..."/>
-					<Item id="3127" name="Kopie speichern unter..."/>
+					<Item id="3126" name="Speichern unter …"/>
+					<Item id="3127" name="Kopie speichern unter …"/>
 					<Item id="3121" name="Neues Projekt hinzufügen"/>
 				</WorkspaceMenu>
 				<ProjectMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen..."/>
+					<Item id="3113" name="Dateien hinzufügen …"/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</ProjectMenu>
 				<FolderMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen..."/>
+					<Item id="3113" name="Dateien hinzufügen …"/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</FolderMenu>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -36,23 +36,23 @@
 					<Item subMenuId="file-recentFiles" name="Zuletzt &amp;verwendet"/>
 					<Item subMenuId="file-openFolder" name="Aktuellen &amp;Ordner öffnen"/>
 					<Item subMenuId="edit-copyToClipboard" name="Datei&amp;pfad kopieren"/>
-					<Item subMenuId="edit-indent" name="Ein&amp;rückung"/>
+					<Item subMenuId="edit-indent" name="E&amp;inrückung"/>
 					<Item subMenuId="edit-convertCaseTo" name="&amp;Groß-/Kleinschreibung"/>
 					<Item subMenuId="edit-lineOperations" name="&amp;Zeilenoperationen"/>
-					<Item subMenuId="edit-comment" name="&amp;Kommentare"/>
+					<Item subMenuId="edit-comment" name="K&amp;ommentare"/>
 					<Item subMenuId="edit-autoCompletion" name="Autovervollst&amp;ändigung"/>
 					<Item subMenuId="edit-eolConversion" name="Format Zeile&amp;nende"/>
 					<Item subMenuId="edit-blankOperations" name="Nicht &amp;druckbare Zeichen"/>
 					<Item subMenuId="edit-pasteSpecial" name= "Einf&amp;ügen spezial"/>
 					<Item subMenuId="search-markAll" name="Alle &amp;Vorkommnisse hervorheben"/>
-					<Item subMenuId="search-unmarkAll" name="Alle &amp;Hervorhebungen löschen"/>
-					<Item subMenuId="search-jumpUp" name="Zu vorheriger Hervorhebung s&amp;pringen"/>
-					<Item subMenuId="search-jumpDown" name="Zu nächster Hervorhebung s&amp;pringen"/>
+					<Item subMenuId="search-unmarkAll" name="Alle Hervorhe&amp;bungen löschen"/>
+					<Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung s&amp;pringen"/>
+					<Item subMenuId="search-jumpDown" name="Zur &amp;nächsten Hervorhebung springen"/>
 					<Item subMenuId="search-bookmark" name="&amp;Lesezeichen"/>
 					<Item subMenuId="view-showSymbol" name="Nicht &amp;druckbare Zeichen"/>
 					<Item subMenuId="view-zoom" name="Z&amp;oom"/>
 					<Item subMenuId="view-moveCloneDocument" name="Datei &amp;verschieben/duplizieren"/>
-					<Item subMenuId="view-collapseLevel" name="Te&amp;xtblöcke schließen"/>
+					<Item subMenuId="view-collapseLevel" name="T&amp;extblöcke schließen"/>
 					<Item subMenuId="view-uncollapseLevel" name="Te&amp;xtblöcke öffnen"/>
 					<Item subMenuId="view-project" name="Projektver&amp;waltung"/>
 					<Item subMenuId="view-tab" name="&amp;Tabs"/>
@@ -77,15 +77,15 @@
 				</SubEntries>
 				<!-- All Menu Items: -->
 				<Commands>
-					<Item id="1001"  name="&amp;Jetzt drucken!"/>
+					<Item id="1001"  name="So&amp;fort drucken"/>
 					<Item id="10001" name="In zweite Ansicht &amp;verschieben"/>
 					<Item id="10002" name="In zweite Ansicht &amp;duplizieren"/>
 					<Item id="10003" name="In &amp;neue Instanz verschieben"/>
 					<Item id="10004" name="In neue Instan&amp;z duplizieren"/>
 					<Item id="41001" name="&amp;Neu"/>
-					<Item id="41002" name="&amp;Öffnen"/>
+					<Item id="41002" name="&amp;Öffnen..."/>
 					<Item id="41003" name="Schlie&amp;ßen"/>
-					<Item id="41004" name="All&amp;e schließen"/>
+					<Item id="41004" name="Alle s&amp;chließen"/>
 					<Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
 					<Item id="41006" name="&amp;Speichern"/>
 					<Item id="41007" name="&amp;Alle speichern"/>
@@ -94,14 +94,14 @@
 					<Item id="41010" name="&amp;Drucken..."/>
 					<Item id="41011" name="B&amp;eenden"/>
 					<Item id="41012" name="Sit&amp;zung öffnen..."/>
-					<Item id="41013" name="Sit&amp;zung speichern..."/>
+					<Item id="41013" name="Sitzung speiche&amp;rn..."/>
 					<Item id="41014" name="Neu &amp;laden"/>
 					<Item id="41015" name="&amp;Kopie speichern unter..."/>
 					<Item id="41016" name="Von Datentr&amp;äger löschen"/>
 					<Item id="41017" name="Um&amp;benennen..."/>
 					<Item id="41018" name="Dateien &amp;rechts schließen"/>
 					<Item id="41019" name="E&amp;xplorer"/>
-					<Item id="41020" name="&amp;Kommandozeile"/>
+					<Item id="41020" name="&amp;Eingabeaufforderung"/>
 					<Item id="41021" name="Zuletzt &amp;geschlossene Datei wieder öffnen"/>
 					<Item id="42001" name="Aus&amp;schneiden"/>
 					<Item id="42002" name="&amp;Kopieren"/>
@@ -110,21 +110,21 @@
 					<Item id="42005" name="&amp;Einfügen"/>
 					<Item id="42006" name="&amp;Löschen"/>
 					<Item id="42007" name="&amp;Alles auswählen"/>
-					<Item id="42008" name="Tab einfügen (&amp;einrücken)"/>
-					<Item id="42009" name="Tab entfernen (&amp;ausrücken)"/>
-					<Item id="42010" name="Zeile/Markierung wie&amp;derholen"/>
+					<Item id="42008" name="Zeileneinzug v&amp;ergrößern"/>
+					<Item id="42009" name="Zeileneinzug ver&amp;kleinern"/>
+					<Item id="42010" name="Zeile &amp;duplizieren"/>
 					<Item id="42012" name="Zeile am Fensterrand &amp;teilen"/>
 					<Item id="42013" name="&amp;Zeilen zusammenfassen"/>
-					<Item id="42014" name="Zeile nach &amp;oben schieben"/>
-					<Item id="42015" name="Zeile nach &amp;unten schieben"/>
+					<Item id="42014" name="Zeile nach &amp;oben verschieben"/>
+					<Item id="42015" name="Zeile nach &amp;unten verschieben"/>
 					<Item id="42016" name="In &amp;Großbuchstaben umwandeln"/>
 					<Item id="42017" name="In &amp;Kleinbuchstaben umwandeln"/>
 					<Item id="42018" name="Aufzeichnung s&amp;tarten"/>
 					<Item id="42019" name="Aufzeichnung st&amp;oppen"/>
 					<Item id="42020" name="Auswa&amp;hl beginnen/beenden"/>
 					<Item id="42021" name="Makro ausfüh&amp;ren"/>
-					<Item id="42022" name="&amp;Zeilenweise ein-/auskommentieren"/>
-					<Item id="42023" name="Markierung &amp;auskommentieren"/>
+					<Item id="42022" name="&amp;Zeilenweise Auskommentierung umschalten"/>
+					<Item id="42023" name="Auswahl &amp;auskommentieren"/>
 					<Item id="42024" name="Leerzeichen und Tabulatoren am Zeilen&amp;ende löschen"/>
 					<Item id="42025" name="Aufgenommenes Makro s&amp;peichern"/>
 					<Item id="42026" name="Schreib&amp;richtung von rechts nach links"/>
@@ -134,26 +134,26 @@
 					<Item id="42030" name="Nur Datei&amp;namen kopieren"/>
 					<Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
 					<Item id="42032" name="Makro &amp;mehrfach ausführen..."/>
-					<Item id="42033" name="Schreibsch&amp;utz-Attribut löschen"/>
+					<Item id="42033" name="Schreibschutz-Attribut l&amp;öschen"/>
 					<Item id="42034" name="&amp;Block-Editor..."/>
 					<Item id="42035" name="Zeilen aus&amp;kommentieren"/>
-					<Item id="42036" name="Zeilen ei&amp;nkommentieren"/>
+					<Item id="42036" name="Auskommentierung der Zeilen a&amp;ufheben"/>
 					<Item id="42037" name="Spalten-&amp;Modus..."/>
 					<Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
 					<Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
-					<Item id="42040" name="Alle zuletzt verwendeten Dateien &amp;öffnen"/>
-					<Item id="42041" name="Liste &amp;löschen"/>
+					<Item id="42040" name="Alle zule&amp;tzt verwendeten Dateien öffnen"/>
+					<Item id="42041" name="L&amp;iste löschen"/>
 					<Item id="42042" name="Leerzeichen und Tabulatoren am Zeilen&amp;anfang löschen"/>
 					<Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang &amp;und -ende löschen"/>
 					<Item id="42044" name="Zeilenumbrüche in Leerzeichen &amp;konvertieren"/>
 					<Item id="42045" name="&amp;Mehrfachen Whitespace und Umbrüche entfernen"/>
 					<Item id="42046" name="Tabulatoren in &amp;Leerzeichen umwandeln"/>
-					<Item id="42047" name="Markierung &amp;einkommentieren"/>
+					<Item id="42047" name="Auskommentierung der Auswahl au&amp;fheben"/>
 					<Item id="42048" name="Binär-Inhalt &amp;kopieren"/>
 					<Item id="42049" name="Binär-Inhalt &amp;ausschneiden"/>
 					<Item id="42050" name="Binär-Inhalt &amp;einfügen"/>
 					<Item id="42051" name="Zeichen&amp;tabelle"/>
-					<Item id="42052" name="Z&amp;wischenablage"/>
+					<Item id="42052" name="Zwis&amp;chenablage"/>
 					<Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am &amp;Zeilenanfang)"/>
 					<Item id="42054" name="Leerzeichen in &amp;Tabulatoren umwandeln (alle)"/>
 					<Item id="42055" name="&amp;Leerzeilen (nur völlig leere) löschen"/>
@@ -162,8 +162,8 @@
 					<Item id="42058" name="Leerzeile u&amp;nter aktueller Zeile einfügen"/>
 					<Item id="42059" name="Zeilen alphabetisch au&amp;fsteigend sortieren"/>
 					<Item id="42060" name="Zeilen alphabetisch a&amp;bsteigend sortieren"/>
-					<Item id="42061" name="Zeilen als Integer aufsteigend sortieren"/>
-					<Item id="42062" name="Zeilen als Integer absteigend sortieren"/>
+					<Item id="42061" name="Zeilen als Ganzzahlen aufsteigend sortieren"/>
+					<Item id="42062" name="Zeilen als Ganzzahlen absteigend sortieren"/>
 					<Item id="42063" name="Zeilen als Dezimalzahlen (Komma) aufsteigend sortieren"/>
 					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
 					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
@@ -180,12 +180,12 @@
 					<Item id="43010" name="&amp;Rückwärts suchen"/>
 					<Item id="43011" name="&amp;Inkrementelle Suche"/>
 					<Item id="43013" name="In &amp;Dateien suchen..."/>
-					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne History)"/>
-					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne History)"/>
-					<Item id="43018" name="&amp;Zeilen mit Lesezeichen ausschneiden"/>
-					<Item id="43019" name="&amp;Zeilen mit Lesezeichen kopieren"/>
+					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne Verlauf)"/>
+					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne Verlauf)"/>
+					<Item id="43018" name="Zeilen mit Lesezeichen &amp;ausschneiden"/>
+					<Item id="43019" name="Zeilen mit Lesezeichen &amp;kopieren"/>
 					<Item id="43020" name="&amp;Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
-					<Item id="43021" name="&amp;Zeilen mit Lesezeichen löschen"/>
+					<Item id="43021" name="Zeilen mit Lesezeichen lös&amp;chen"/>
 					<Item id="43022" name="Hervorhebung &amp;1"/>
 					<Item id="43023" name="Hervorhebung &amp;1 entfernen"/>
 					<Item id="43024" name="Hervorhebung &amp;2"/>
@@ -210,17 +210,17 @@
 					<Item id="43043" name="Hervorhebung &amp;5"/>
 					<Item id="43044" name="Hervorhebung aus &amp;Suche"/>
 					<Item id="43045" name="Suchergebnis-&amp;Fenster"/>
-					<Item id="43046" name="Zu nächstem S&amp;uchergebnis springen"/>
-					<Item id="43047" name="Zu vorherigem S&amp;uchergebnis springen"/>
+					<Item id="43046" name="Zum n&amp;ächsten Suchergebnis springen"/>
+					<Item id="43047" name="Zum vorherigen S&amp;uchergebnis springen"/>
 					<Item id="43048" name="Auswahl oder Wort am &amp;Cursor suchen"/>
 					<Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
 					<Item id="43050" name="Lesezeichen inver&amp;tieren"/>
-					<Item id="43051" name="&amp;Zeilen ohne Lesezeichen löschen"/>
+					<Item id="43051" name="Zeilen &amp;ohne Lesezeichen löschen"/>
 					<Item id="43052" name="Suche nach &amp;Zeichencodes..."/>
-					<Item id="43053" name="Alles zwische&amp;n Klammern auswählen"/>
-					<Item id="43054" name="Vorkommnisse &amp;markieren..."/>
+					<Item id="43053" name="&amp;Alles zwischen Klammern auswählen"/>
+					<Item id="43054" name="&amp;Hervorheben..."/>
 					<Item id="44009" name="&amp;Post-It"/>
-					<Item id="44010" name="Alle Te&amp;xtblöcke schließen"/>
+					<Item id="44010" name="A&amp;lle Textblöcke schließen"/>
 					<Item id="44011" name="Benutzerdefinierte Spra&amp;che..."/>
 					<Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>
 					<Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>
@@ -232,12 +232,12 @@
 					<Item id="44024" name="Schrift ver&amp;kleinern"/>
 					<Item id="44025" name="&amp;Leerzeichen und Tabulatoren anzeigen"/>
 					<Item id="44026" name="Zeilenende anze&amp;igen"/>
-					<Item id="44029" name="Alle Te&amp;xtblöcke öffnen"/>
-					<Item id="44030" name="Te&amp;xtblock schließen"/>
-					<Item id="44031" name="Te&amp;xtblock öffnen"/>
+					<Item id="44029" name="Alle Textblöcke &amp;öffnen"/>
+					<Item id="44030" name="Textblock schlie&amp;ßen"/>
+					<Item id="44031" name="Textblock öff&amp;nen"/>
 					<Item id="44032" name="Voll&amp;bild"/>
-					<Item id="44033" name="Standardgrö&amp;ße"/>
-					<Item id="44034" name="Immer im Vordergrund &amp;halten"/>
+					<Item id="44033" name="&amp;Standardgröße"/>
+					<Item id="44034" name="Immer im Vorder&amp;grund halten"/>
 					<Item id="44035" name="S&amp;ynchrones vertikales Scrollen"/>
 					<Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
 					<Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
@@ -284,7 +284,7 @@
 					<Item id="47001" name="Notepad++ im &amp;Web"/>
 					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
 					<Item id="47005" name="&amp;Erweiterungen"/>
-					<Item id="47006" name="Notepad++ aktualisieren"/>
+					<Item id="47006" name="Notepad++ &amp;aktualisieren"/>
 					<Item id="47008" name="In&amp;halt..."/>
 					<Item id="47009" name="&amp;Proxy für Updater einstellen..."/>
 					<Item id="47010" name="&amp;Kommandozeilenparameter..."/>
@@ -358,7 +358,7 @@
 				<Item id="1632" name="In &amp;Markierung"/>
 				<Item id="1633" name="Zurücksetzen"/>
 				<Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
-				<Item id="1636" name="Suche in allen &amp;offenen Dateien"/>
+				<Item id="1636" name="In &amp;offenen Dateien suchen"/>
 				<Item id="1637" name="In Dateien suchen"/>
 				<Item id="1640" name="Umschaltdialog"/>
 				<Item id="1641" name="Alle in aktiver &amp;Datei suchen"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -89,16 +89,16 @@
 					<Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
 					<Item id="41006" name="&amp;Speichern"/>
 					<Item id="41007" name="&amp;Alle speichern"/>
-					<Item id="41008" name="Speichern &amp;unter ..."/>
+					<Item id="41008" name="Speichern &amp;unter..."/>
 					<Item id="41009" name="Dateien &amp;links schließen"/>
-					<Item id="41010" name="&amp;Drucken ..."/>
+					<Item id="41010" name="&amp;Drucken..."/>
 					<Item id="41011" name="B&amp;eenden"/>
-					<Item id="41012" name="Sit&amp;zung öffnen ..."/>
-					<Item id="41013" name="Sit&amp;zung speichern ..."/>
+					<Item id="41012" name="Sit&amp;zung öffnen..."/>
+					<Item id="41013" name="Sit&amp;zung speichern..."/>
 					<Item id="41014" name="Neu &amp;laden"/>
-					<Item id="41015" name="&amp;Kopie speichern unter ..."/>
+					<Item id="41015" name="&amp;Kopie speichern unter..."/>
 					<Item id="41016" name="Von Datentr&amp;äger löschen"/>
-					<Item id="41017" name="Um&amp;benennen ..."/>
+					<Item id="41017" name="Um&amp;benennen..."/>
 					<Item id="41018" name="Dateien &amp;rechts schließen"/>
 					<Item id="41019" name="E&amp;xplorer"/>
 					<Item id="41020" name="&amp;Kommandozeile"/>
@@ -133,12 +133,12 @@
 					<Item id="42029" name="Vollständigen &amp;Pfad kopieren"/>
 					<Item id="42030" name="Nur Datei&amp;namen kopieren"/>
 					<Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
-					<Item id="42032" name="Makro &amp;mehrfach ausführen ..."/>
+					<Item id="42032" name="Makro &amp;mehrfach ausführen..."/>
 					<Item id="42033" name="Schreibsch&amp;utz-Attribut löschen"/>
-					<Item id="42034" name="&amp;Block-Editor ..."/>
+					<Item id="42034" name="&amp;Block-Editor..."/>
 					<Item id="42035" name="Zeilen aus&amp;kommentieren"/>
 					<Item id="42036" name="Zeilen ei&amp;nkommentieren"/>
-					<Item id="42037" name="Spalten-&amp;Modus ..."/>
+					<Item id="42037" name="Spalten-&amp;Modus..."/>
 					<Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
 					<Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
 					<Item id="42040" name="Alle zuletzt verwendeten Dateien &amp;öffnen"/>
@@ -168,10 +168,10 @@
 					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
 					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
 					<Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-					<Item id="43001" name="&amp;Suchen ..."/>
+					<Item id="43001" name="&amp;Suchen..."/>
 					<Item id="43002" name="&amp;Weitersuchen"/>
-					<Item id="43003" name="&amp;Ersetzen ..."/>
-					<Item id="43004" name="&amp;Gehe zu ..."/>
+					<Item id="43003" name="&amp;Ersetzen..."/>
+					<Item id="43004" name="&amp;Gehe zu..."/>
 					<Item id="43005" name="&amp;Lesezeichen setzen/löschen"/>
 					<Item id="43006" name="&amp;Nächstes Lesezeichen"/>
 					<Item id="43007" name="&amp;Vorheriges Lesezeichen"/>
@@ -179,7 +179,7 @@
 					<Item id="43009" name="Suche zugehörige &amp;Klammer"/>
 					<Item id="43010" name="&amp;Rückwärts suchen"/>
 					<Item id="43011" name="&amp;Inkrementelle Suche"/>
-					<Item id="43013" name="In &amp;Dateien suchen ..."/>
+					<Item id="43013" name="In &amp;Dateien suchen..."/>
 					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne History)"/>
 					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne History)"/>
 					<Item id="43018" name="&amp;Zeilen mit Lesezeichen ausschneiden"/>
@@ -216,12 +216,12 @@
 					<Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
 					<Item id="43050" name="Lesezeichen inver&amp;tieren"/>
 					<Item id="43051" name="&amp;Zeilen ohne Lesezeichen löschen"/>
-					<Item id="43052" name="Suche nach &amp;Zeichencodes ..."/>
+					<Item id="43052" name="Suche nach &amp;Zeichencodes..."/>
 					<Item id="43053" name="Alles zwische&amp;n Klammern auswählen"/>
-					<Item id="43054" name="Vorkommnisse &amp;markieren ..."/>
+					<Item id="43054" name="Vorkommnisse &amp;markieren..."/>
 					<Item id="44009" name="&amp;Post-It"/>
 					<Item id="44010" name="Alle Te&amp;xtblöcke schließen"/>
-					<Item id="44011" name="Benutzerdefinierte Spra&amp;che ..."/>
+					<Item id="44011" name="Benutzerdefinierte Spra&amp;che..."/>
 					<Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>
 					<Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>
 					<Item id="44014" name="Codefaltung ausb&amp;lenden"/>
@@ -242,7 +242,7 @@
 					<Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
 					<Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
 					<Item id="44042" name="Zeilen &amp;ausblenden"/>
-					<Item id="44049" name="Datei-&amp;Info ..."/>
+					<Item id="44049" name="Datei-&amp;Info..."/>
 					<Item id="44072" name="&amp;Zur anderen Ansicht wechseln"/>
 					<Item id="44080" name="&amp;Miniaturansicht"/>
 					<Item id="44081" name="Projektfenster &amp;1"/>
@@ -273,30 +273,30 @@
 					<Item id="45011" name="Konv&amp;ertiere zu UTF-8"/>
 					<Item id="45012" name="Konve&amp;rtiere zu UCS-2 Big Endian"/>
 					<Item id="45013" name="Konver&amp;tiere zu UCS-2 Little Endian"/>
-					<Item id="46001" name="&amp;Stile ..."/>
+					<Item id="46001" name="&amp;Stile..."/>
 					<Item id="46015" name="MS-DOS-Stil"/>
 					<Item id="46016" name="Normaler Text"/>
 					<Item id="46017" name="Ressourcen-Datei"/>
 					<!-- <Item id="46019" name="MS-INI-Datei"/> -->
 					<Item id="46080" name="Benutzerdefiniert"/>
-					<Item id="46150" name="Eigene Sprache &amp;definieren ..."/>
-					<Item id="47000" name="&amp;Info ..."/>
+					<Item id="46150" name="Eigene Sprache &amp;definieren..."/>
+					<Item id="47000" name="&amp;Info..."/>
 					<Item id="47001" name="Notepad++ im &amp;Web"/>
 					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
 					<Item id="47005" name="&amp;Erweiterungen"/>
 					<Item id="47006" name="Notepad++ aktualisieren"/>
-					<Item id="47008" name="In&amp;halt ..."/>
-					<Item id="47009" name="&amp;Proxy für Updater einstellen ..."/>
-					<Item id="47010" name="&amp;Kommandozeilenparameter ..."/>
+					<Item id="47008" name="In&amp;halt..."/>
+					<Item id="47009" name="&amp;Proxy für Updater einstellen..."/>
+					<Item id="47010" name="&amp;Kommandozeilenparameter..."/>
 					<Item id="47011" name="&amp;Support im Chat"/>
-					<Item id="48005" name="&amp;Plugin(s) importieren ..."/>
-					<Item id="48006" name="&amp;Design(s) importieren ..."/>
-					<Item id="48009" name="&amp;Tastatur ..."/>
-					<Item id="48011" name="&amp;Optionen ..."/>
-					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen ..."/>
-					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen ..."/>
-					<Item id="48018" name="&amp;Kontextmenü anpassen ..."/>
-					<Item id="49000" name="Externes Programm &amp;ausführen ..."/>
+					<Item id="48005" name="&amp;Plugin(s) importieren..."/>
+					<Item id="48006" name="&amp;Design(s) importieren..."/>
+					<Item id="48009" name="&amp;Tastatur..."/>
+					<Item id="48011" name="&amp;Optionen..."/>
+					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen..."/>
+					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen..."/>
+					<Item id="48018" name="&amp;Kontextmenü anpassen..."/>
+					<Item id="49000" name="Externes Programm &amp;ausführen..."/>
 					<Item id="50000" name="&amp;Funktionsvervollständigung"/>
 					<Item id="50001" name="&amp;Wortvervollständigung"/>
 					<Item id="50002" name="Funktions&amp;parameter anzeigen"/>
@@ -309,14 +309,14 @@
 				<Item CMID="0" name="S&amp;chließen"/>
 				<Item CMID="1" name="&amp;Alle anderen schließen"/>
 				<Item CMID="2" name="&amp;Speichern"/>
-				<Item CMID="3" name="Speichern &amp;unter ..."/>
+				<Item CMID="3" name="Speichern &amp;unter..."/>
 				<Item CMID="4" name="&amp;Drucken"/>
 				<Item CMID="5" name="In zweite Ansicht &amp;verschieben"/>
 				<Item CMID="6" name="In zw&amp;eite Ansicht duplizieren"/>
 				<Item CMID="7" name="Vollständigen Pfad &amp;kopieren"/>
 				<Item CMID="8" name="Nur Datei&amp;namen kopieren"/>
 				<Item CMID="9" name="Nur Verzeichnis&amp;pfad kopieren"/>
-				<Item CMID="10" name="Um&amp;benennen ..."/>
+				<Item CMID="10" name="Um&amp;benennen..."/>
 				<Item CMID="11" name="L&amp;öschen"/>
 				<Item CMID="12" name="Sch&amp;reibschutz"/>
 				<Item CMID="13" name="Schreibschutz au&amp;fheben"/>
@@ -385,7 +385,7 @@
 				<Item id="2008" name="Z&amp;eichen"/>
 			</GoToLine>
 			<!-- Run external program: -->
-			<Run title="Ausführen ...">
+			<Run title="Ausführen...">
 				<Item id="1" name="&amp;Ausführen"/>
 				<Item id="2" name="A&amp;bbrechen"/>
 				<Item id="1901" name=".&amp;.."/>
@@ -441,7 +441,7 @@
 				<Item id="20002" name="Umbenennen"/>
 				<Item id="20003" name="Neue erstellen"/>
 				<Item id="20004" name="Löschen"/>
-				<Item id="20005" name="Speichern als ..."/>
+				<Item id="20005" name="Speichern als..."/>
 				<Item id="20007" name="Sprache"/>
 				<Item id="20009" name="Erw."/>
 				<Item id="20011" name="Transparenz"/>
@@ -900,25 +900,25 @@
 					<Item id="3123" name="Arbeitsbereich öffnen"/>
 					<Item id="3124" name="Arbeitsbereich neu laden"/>
 					<Item id="3125" name="Speichern"/>
-					<Item id="3126" name="Speichern unter ..."/>
-					<Item id="3127" name="Kopie speichern unter ..."/>
+					<Item id="3126" name="Speichern unter..."/>
+					<Item id="3127" name="Kopie speichern unter..."/>
 					<Item id="3121" name="Neues Projekt hinzufügen"/>
 				</WorkspaceMenu>
 				<ProjectMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen ..."/>
+					<Item id="3113" name="Dateien hinzufügen..."/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen ..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</ProjectMenu>
 				<FolderMenu>
 					<Item id="3111" name="Umbenennen"/>
 					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen ..."/>
+					<Item id="3113" name="Dateien hinzufügen..."/>
 					<Item id="3114" name="Entfernen"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen ..."/>
+					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen..."/>
 					<Item id="3118" name="Nach oben schieben"/>
 					<Item id="3119" name="Nach unten schieben"/>
 				</FolderMenu>


### PR DESCRIPTION
These extra spaces are one of the first things I noticed after installing Notepad++. They're not used anywhere else so I removed them. No other changes.