### PR TITLE
Fix #953 Find all files crash in 64-bit since 6.7.5

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -3258,7 +3258,7 @@ LRESULT APIENTRY Progress::wndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM l
 		case WM_CREATE:
 		{
 			Progress* pw =(Progress*)((LPCREATESTRUCT)lparam)->lpCreateParams;
-			::SetWindowLongPtr(hwnd, GWLP_USERDATA, PtrToUlong(pw));
+			::SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)pw);
 			return 0;
 		}
 


### PR DESCRIPTION
Fix #953 Find all files crash in 64-bit since 6.7.5