### PR TITLE
Em dash instead of hyphen as title parts separator

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2704,7 +2704,7 @@ void Notepad_plus::setTitle()
 	{
 		result += buf->getFullPathName();
 	}
-	result += TEXT(" - ");
+	result += TEXT(" \u2014 ");
 	result += _pPublicInterface->getClassName();
 
 	if (_isAdministrator)

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -1423,7 +1423,7 @@ bool DockingCont::updateCaption()
 	if ((((tTbData*)tcItem.lParam)->uMask & DWS_ADDINFO) && 
 		(lstrlen(((tTbData*)tcItem.lParam)->pszAddInfo) != 0))
 	{
-		_pszCaption += TEXT(" - ");
+		_pszCaption += TEXT(" \u2014 ");
 		_pszCaption += ((tTbData*)tcItem.lParam)->pszAddInfo; 
 	}
 


### PR DESCRIPTION
Changed title parts separator for main window and dockable windows from short hyphen to wider em dash.

---

- Used wider em dash (&mdash;) instead of short hyphen (-) as title parts separator in windows
- For arguments about this see: https://github.com/icsharpcode/SharpDevelop/pull/707
- It's only an escape sequence. So I ask for reviewing the pull request. I couldn't test it. Does it work this way?

Future:
- As you can read in [the issue of the other repository](https://github.com/icsharpcode/SharpDevelop/pull/707), it would be the best to have this string localizable