### PR TITLE
Add UDL for Tab settings

### DIFF
--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -243,6 +243,8 @@
             <Keywords name="instre2"></Keywords>
             <Keywords name="type1"></Keywords>
         </Language>
+        <!-- User Defined Language -->
+        <Language name="udf"/>
 <!--
         <Language name="" ext="" commentLine="" commentStart="" commentEnd="">
             <Keywords name="instre1"></Keywords>


### PR DESCRIPTION
Added option to add UDL to Preferences -> Tab settings.

![preferences - tab settings](https://cloud.githubusercontent.com/assets/14962885/10269343/066ade70-6ad5-11e5-85ef-5ac0cf636a57.png)

I need to set specific tab settings for ABAP language (defined in UDL). It uses fixed 2 spaces tab setting in code editor (no way to change it there). So I'd like to use _4 Chars / Tab_ for all other languages, and _2 Chars / Space_ for UDL(ABAP). 
Standard way is, that UDL use "[Default]" Tab settings. So I came to first option.

Set "[Default]" as I want it for UDL to _2/Space_, and uncheck _use default value_ for all other languages. Problem was, that if default is _4/Tab_, configuration will revert back which results in checking all languages back to "use default value", as it thinks it's default (_4/Tab_). So no way here. Here I've found workaround for this,  to add to all nodes in file `langs.model.xml` (force) setting for tab `tabSettings="4"`. That way I was able to change settings without reverting back to default value = resulting deletion of `tabSettings="4"` from profile file `langs.xml`. But still it's hard to uncheck everything, and also loosing "[Defalt]" option in the process.

So I look to code a little, did some tests, and found out, that there's better workaround. Add following line to `langs.model.xml` or existing profile file `langs.xml`: `<Language name="udf"/>`
This way it will add option for this language to Preferences, so it's possible to set custom setting for all User Defined Languages. And this way I was able to set it like I need to. To have separated setting for UDL, and yet had default value for all other languages.

As it's working, I think it's good idea to make it usable for all users. It's not like we can have separated setting of Tab for every UDL. Sure we would like to. But at least it's a small step forward.
