### PR TITLE
Cleanup for explorer style file save dialog

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -808,8 +808,6 @@ winVer getWindowsVersion()
 
 NppParameters * NppParameters::_pSelf = new NppParameters;
 
-int FileDialog::_dialogFileBoxId = (NppParameters::getInstance())->getWinVersion() < WV_W2K?edt1:cmb13;
-
 
 
 

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -248,19 +248,23 @@ TCHAR * FileDialog::doSaveDlg()
 	NppParameters * params = NppParameters::getInstance();
 	_ofn.lpstrInitialDir = params->getWorkingDir();
 
-	NppParameters *pNppParam = NppParameters::getInstance();
-	int index = pNppParam->getFileSaveDlgFilterIndex();
+	//restore persisted filter index 
+	int index = params->getFileSaveDlgFilterIndex();
 
-	if (index != -1)
+	if (_extTypeIndex != -1)
 	{
-		_ofn.nFilterIndex = index;
+		//+1 due to start index of all is 1, zero is reserved for customer mode
+		_ofn.nFilterIndex = _extTypeIndex + 1;
 	}
-	else if (_extTypeIndex != -1)
+	else if (index != -1)
 	{
-		_ofn.nFilterIndex = _extTypeIndex+1;
+		//fallback to last stored file extension as filter
+		_ofn.nFilterIndex = index;
 	}
 	else
 	{
+		//fallback to all
+		//starting with 1, zero is reserved for customer mode
 		_ofn.nFilterIndex = 1;
 	}
 	
@@ -275,8 +279,8 @@ TCHAR * FileDialog::doSaveDlg()
 			params->setWorkingDir(dir);
 		}
 		
-		NppParameters *pNppParam = NppParameters::getInstance();
-		pNppParam->setFileSaveDlgFilterIndex(_ofn.nFilterIndex);
+		//store filter index for the next call to save file dialog 
+		params->setFileSaveDlgFilterIndex(_ofn.nFilterIndex);
 
 	} catch(std::exception e) {
 		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -33,14 +33,11 @@
 
 
 FileDialog *FileDialog::staticThis = NULL;
-//int FileDialog::_dialogFileBoxId = (NppParameters::getInstance())->getWinVersion() < WV_W2K?edt1:cmb13;
 
 FileDialog::FileDialog(HWND hwnd, HINSTANCE hInst) 
 	: _nbCharFileExt(0), _nbExt(0), _fileExt(NULL), _extTypeIndex(-1)
 {
 	staticThis = this;
-    //for (int i = 0 ; i < nbExtMax ; i++)
-    //    _extArray[i][0] = '\0';
 
 	_fileName[0] = '\0';
  
@@ -247,15 +244,27 @@ TCHAR * FileDialog::doSaveDlg()
 {
 	TCHAR dir[MAX_PATH];
 	::GetCurrentDirectory(MAX_PATH, dir); 
-	//_ofn.lpstrInitialDir = dir;
 
 	NppParameters * params = NppParameters::getInstance();
 	_ofn.lpstrInitialDir = params->getWorkingDir();
 
-	_ofn.Flags |= OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_ENABLESIZING;
+	NppParameters *pNppParam = NppParameters::getInstance();
+	int index = pNppParam->getFileSaveDlgFilterIndex();
 
-	//_ofn.Flags |= OFN_ENABLEHOOK;
-	//_ofn.lpfnHook = OFNHookProc;
+	if (index != -1)
+	{
+		_ofn.nFilterIndex = index;
+	}
+	else if (_extTypeIndex != -1)
+	{
+		_ofn.nFilterIndex = _extTypeIndex+1;
+	}
+	else
+	{
+		_ofn.nFilterIndex = 1;
+	}
+	
+	_ofn.Flags |= OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_ENABLESIZING;
 
 	TCHAR *fn = NULL;
 	try {
@@ -265,6 +274,10 @@ TCHAR * FileDialog::doSaveDlg()
 			::GetCurrentDirectory(MAX_PATH, dir);
 			params->setWorkingDir(dir);
 		}
+		
+		NppParameters *pNppParam = NppParameters::getInstance();
+		pNppParam->setFileSaveDlgFilterIndex(_ofn.nFilterIndex);
+
 	} catch(std::exception e) {
 		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 	} catch(...) {
@@ -276,216 +289,5 @@ TCHAR * FileDialog::doSaveDlg()
 	return (fn);
 }
 
-static HWND hFileDlg = NULL;
-static WNDPROC oldProc = NULL;
-static generic_string currentExt = TEXT("");
 
 
-static LRESULT CALLBACK fileDlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	switch (message)
-    {
-		case WM_COMMAND :
-		{
-			switch (wParam)
-			{	
-				case IDOK :
-				{
-					HWND fnControl = ::GetDlgItem(hwnd, FileDialog::_dialogFileBoxId);
-					TCHAR fn[MAX_PATH];
-					::GetWindowText(fnControl, fn, MAX_PATH);
-
-					// Check condition to have the compability of default behaviour 
-					if (*fn == '\0')
-						return oldProc(hwnd, message, wParam, lParam);
-					else if (::PathIsDirectory(fn))
-						return oldProc(hwnd, message, wParam, lParam);
-
-					// Process
-					if (currentExt != TEXT(""))
-					{
-						generic_string fnExt = changeExt(fn, currentExt, false);
-						::SetWindowText(fnControl, fnExt.c_str());
-					}
-					return oldProc(hwnd, message, wParam, lParam);
-				}
-
-				default :
-					break;
-			}
-		}
-	}
-	return oldProc(hwnd, message, wParam, lParam);
-};
-
-
-static TCHAR * get1stExt(TCHAR *ext) { // precondition : ext should be under the format : Batch (*.bat;*.cmd;*.nt)
-	TCHAR *begin = ext;
-	for ( ; *begin != '.' ; begin++);
-	TCHAR *end = ++begin;
-	for ( ; *end != ';' && *end != ')' ; end++);
-	*end = '\0';
-	if (*begin == '*')
-		*begin = '\0';
-	return begin;
-};
-
-static generic_string addExt(HWND textCtrl, HWND typeCtrl) {
-	TCHAR fn[MAX_PATH];
-	::GetWindowText(textCtrl, fn, MAX_PATH);
-	
-	int i = ::SendMessage(typeCtrl, CB_GETCURSEL, 0, 0);
-
-	int cbTextLen = ::SendMessage(typeCtrl, CB_GETLBTEXTLEN, i, 0);
-	TCHAR * ext = new TCHAR[cbTextLen + 1];
-	::SendMessage(typeCtrl, CB_GETLBTEXT, i, (LPARAM)ext);
-	
-	TCHAR *pExt = get1stExt(ext);
-	if (*fn != '\0')
-	{
-		generic_string fnExt = changeExt(fn, pExt);
-		::SetWindowText(textCtrl, fnExt.c_str());
-	}
-
-	generic_string returnExt = pExt;
-	delete[] ext;
-	return returnExt;
-};
-
-
-UINT_PTR CALLBACK FileDialog::OFNHookProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-    switch(uMsg)
-    {
-        case WM_INITDIALOG :
-        {
-			NppParameters *pNppParam = NppParameters::getInstance();
-			int index = pNppParam->getFileSaveDlgFilterIndex();
-
-			::SetWindowLongPtr(hWnd, GWLP_USERDATA, (LONG_PTR)staticThis);
-			hFileDlg = ::GetParent(hWnd);
-			goToCenter(hFileDlg);
-
-			if (index != -1)
-			{
-				HWND typeControl = ::GetDlgItem(hFileDlg, cmb1);
-				::SendMessage(typeControl, CB_SETCURSEL, index, 0);
-			}
-
-			// Don't touch the following 3 lines, they are cursed !!!
-			oldProc = (WNDPROC)::GetWindowLongPtr(hFileDlg, GWLP_WNDPROC);
-			if (oldProc)
-				::SetWindowLongPtr(hFileDlg, GWLP_WNDPROC, (LONG_PTR)fileDlgProc);
-
-			return FALSE;
-		}
-
-		default :
-		{
-			FileDialog *pFileDialog = reinterpret_cast<FileDialog *>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
-			if (!pFileDialog)
-			{
-				return FALSE;
-			}
-			return pFileDialog->run(hWnd, uMsg, wParam, lParam);
-		}
-    }
-}
-
-BOOL APIENTRY FileDialog::run(HWND hWnd, UINT uMsg, WPARAM, LPARAM lParam)
-{
-    switch (uMsg)
-    {
-        case WM_NOTIFY :
-		{
-			LPNMHDR pNmhdr = (LPNMHDR)lParam;
-			switch(pNmhdr->code)
-			{
-                case CDN_INITDONE :
-                {
-                    if (_extTypeIndex == -1)
-                        return TRUE;
-
-                    HWND fnControl = ::GetDlgItem(::GetParent(hWnd), _dialogFileBoxId);
-                    HWND typeControl = ::GetDlgItem(::GetParent(hWnd), cmb1);
-                    ::SendMessage(typeControl, CB_SETCURSEL, _extTypeIndex, 0);
-
-                    currentExt = addExt(fnControl, typeControl);
-                    return TRUE;
-                }
-
-				case CDN_TYPECHANGE :
-				{
-					HWND fnControl = ::GetDlgItem(::GetParent(hWnd), _dialogFileBoxId);
-					HWND typeControl = ::GetDlgItem(::GetParent(hWnd), cmb1);
-					currentExt = addExt(fnControl, typeControl);
-					return TRUE;
-				}
-
-				case CDN_FILEOK :
-				{
-					HWND typeControl = ::GetDlgItem(::GetParent(hWnd), cmb1);
-					int index = ::SendMessage(typeControl, CB_GETCURSEL, 0, 0);
-					NppParameters *pNppParam = NppParameters::getInstance();
-					pNppParam->setFileSaveDlgFilterIndex(index);
-					return TRUE;
-				}
-
-				default :
-					return FALSE;
-			}
-			
-		}
-		default :
-			return FALSE;
-    }
-}
-
-void goToCenter(HWND hwnd)
-{
-    RECT rc;
-	HWND hParent = ::GetParent(hwnd);
-	::GetClientRect(hParent, &rc);
-	
-	//If window coordinates are all zero(ie,window is minimised),then assign desktop as the parent window.
- 	if(rc.left == 0 && rc.right == 0 && rc.top == 0 && rc.bottom == 0)
- 	{
- 		//hParent = ::GetDesktopWindow();
-		::ShowWindow(hParent, SW_SHOWNORMAL);
- 		::GetClientRect(hParent,&rc);
- 	}
-	
-    POINT center;
-    center.x = rc.left + (rc.right - rc.left)/2;
-    center.y = rc.top + (rc.bottom - rc.top)/2;
-    ::ClientToScreen(hParent, &center);
-
-	RECT _rc;
-	::GetWindowRect(hwnd, &_rc);
-	int x = center.x - (_rc.right - _rc.left)/2;
-	int y = center.y - (_rc.bottom - _rc.top)/2;
-
-	::SetWindowPos(hwnd, HWND_TOP, x, y, _rc.right - _rc.left, _rc.bottom - _rc.top, SWP_SHOWWINDOW);
-}
-
-generic_string changeExt(generic_string fn, generic_string ext, bool forceReplaced)
-{
-	if (ext == TEXT(""))
-		return fn;
-
-	generic_string fnExt = fn;
-	
-	int index = fnExt.find_last_of(TEXT("."));
-	generic_string extension = TEXT(".");
-	extension += ext;
-	if (size_t(index) == generic_string::npos)
-	{
-		fnExt += extension;
-	}
-	else if (forceReplaced)
-	{
-		int len = (extension.length() > fnExt.length() - index + 1)?extension.length():fnExt.length() - index + 1;
-		fnExt.replace(index, len, extension);
-	}
-	return fnExt;
-}

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.h
@@ -37,9 +37,6 @@ const int extLenMax = 64;
 
 typedef std::vector<generic_string> stringVector;
 
-generic_string changeExt(generic_string fn, generic_string ext, bool forceReplaced = true);
-void goToCenter(HWND hwnd);
-
 
 class FileDialog
 {
@@ -56,11 +53,6 @@ public:
 	TCHAR * doOpenSingleFileDlg();
 	bool isReadOnly() {return _ofn.Flags & OFN_READONLY;};
     void setExtIndex(int extTypeIndex) {_extTypeIndex = extTypeIndex;};
-
-	static int _dialogFileBoxId;
-protected :
-    static UINT_PTR CALLBACK OFNHookProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    BOOL APIENTRY run(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 private:
 	TCHAR _fileName[MAX_PATH*8];


### PR DESCRIPTION
Followup of https://github.com/notepad-plus-plus/notepad-plus-plus/commit/d738f80d7ed01bf1b22f66d8a166cd2fcdfb6fbb
for issues #176, #284, #316 

- remove unused code used by commented OFN_ENABLEHOOK
- restored some previous functionality by reading the init value for file extension index preselection 