### PR TITLE
Fix possible file corruption during macro playback

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -42,6 +42,8 @@ using namespace std;
 
 void Notepad_plus::macroPlayback(Macro macro)
 {
+	LongRunningOperation op;
+
 	_pEditView->execute(SCI_BEGINUNDOACTION);
 
 	for (Macro::iterator step = macro.begin(); step != macro.end(); ++step)


### PR DESCRIPTION
closes #1007, closes #919, closes #834 

When backups are enabled, playing back a macro that takes a while can corrupt a file (see the mentioned issues). I tested this with a ~100,000 line text file, ~3.3MB in size. Created a macro of Down*5, Delete*10. Played this till the end of the file. Took about 20s to run so it had a few backup cycles during it. Reproduced it fairly easily and never had it happen after this adjustment. 