### PR TITLE
Improve and simplify drawing of tabs in TabBarPlus

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -135,13 +135,11 @@ protected:
 struct CloseButtonZone
 {
 	CloseButtonZone();
-	bool isHit(int x, int y, const RECT & testZone) const;
-	RECT getButtonRectFrom(const RECT & tabItemRect) const;
+	bool isHit(int x, int y, const RECT & tabRect, bool isVertical) const;
+	RECT getButtonRectFrom(const RECT & tabRect, bool isVertical) const;
 
 	int _width;
-	int _hight;
-	int _fromTop; // distance from top in pixzl
-	int _fromRight; // distance from right in pixzl
+	int _height;
 };
 
 


### PR DESCRIPTION
Changes in this PR:
- All positions are dynamically calculated relative to the tab rectangle now (i.e. no hardcoded pixel values are used to position icons/text anymore)
- Match positioning of icons/text in active and inactive tabs (i.e. elements are not "jumping around" anymore upon selection)

I have some more fixes in line, but I first want to make sure the PR will be accepted like this before putting more work into it.

Some specific fixes:
- Most issues with vertical TabBar are resolved now (it was basically unusable before, for example labels were cut)
- Darkened background of inactive tabs fills the whole tab now (fixes #1011)
- Close button is centered correctly now (fixes #1010)


Here are some screenshot for easy comparison of (old ->new) behavior:
![old_vertical](https://cloud.githubusercontent.com/assets/904570/10866741/66840de8-803f-11e5-8823-c4d8be10fbce.gif)**(old)**   ![vertical](https://cloud.githubusercontent.com/assets/904570/10866747/89701130-803f-11e5-96da-043fe9be8b71.gif)**(new)**

![old_horizontal](https://cloud.githubusercontent.com/assets/904570/10866735/3008b73c-803f-11e5-9f69-1dda20f2ca29.gif)**(old)**
![horizontal](https://cloud.githubusercontent.com/assets/904570/10866733/2a362e16-803f-11e5-8974-2caea60a3d72.gif)**(new)**

When not using the orange top bar for highlighting content of tabs is shifted two pixels to the top when active (standard for Windows tab controls)
![horizontal_alt](https://cloud.githubusercontent.com/assets/904570/10866755/d3b1cf90-803f-11e5-90cd-3a981893681a.gif)

