### PR TITLE
php function commentExpr

### DIFF
--- a/PowerEditor/src/functionList.xml
+++ b/PowerEditor/src/functionList.xml
@@ -172,7 +172,7 @@ http://notepad-plus-plus.org/features/function-list.html
 				</function>
 			</parser>
 			
-            <parser id="php_function" displayName="PHP" commentExpr="((/\*.*?\*)/|(//.*?$))">
+            <parser id="php_function" displayName="PHP" commentExpr="((/\*.*?\*)/|(?<!['&quot;])(//|#).*?$))">
                 <classRange
                     mainExpr="^[\s]*(class|abstract[\s]+class|final[\s]+class)[\t ]+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*([\s]*|[\s]*(extends|implements|(extends[\s]+(\\|[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+[\s]+implements))[\s]+(\,[\s]*|(\\|[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*))+[\s]*)?\{"
                     openSymbole = "\{"


### PR DESCRIPTION
This change of the php function commentExpr enables the # character for comment lines and prevents the strings '//', "//", '#', "#" from breaking everything.