### PR TITLE
Fix some bugs and inconsistencies in installer

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -673,11 +673,11 @@ Section -"Notepad++" mainSection
 	; add all the npp shortcuts for all user or current user
 	CreateDirectory "$SMPROGRAMS\Notepad++"
 	CreateShortCut "$SMPROGRAMS\Notepad++\Notepad++.lnk" "$INSTDIR\notepad++.exe"
-	SetShellVarContext current
-	
 	${If} $createShortcutChecked == ${BST_CHECKED}
 		CreateShortCut "$DESKTOP\Notepad++.lnk" "$INSTDIR\notepad++.exe"
 	${EndIf}
+	
+	SetShellVarContext current
 	
 	${If} $isOldIconChecked == ${BST_CHECKED}
 		SetOutPath "$TEMP\"

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -299,8 +299,8 @@ FunctionEnd
 
 Var noUserDataChecked
 Var allowPluginLoadFromUserDataChecked
-Var isOldIconChecked
 Var createShortcutChecked
+Var isOldIconChecked
 
 ; TODO for optional arg
 ;Var params
@@ -314,12 +314,12 @@ Function OnChange_PluginLoadFromUserDataCheckBox
 	${NSD_GetState} $PluginLoadFromUserDataCheckboxHandle $allowPluginLoadFromUserDataChecked
 FunctionEnd
 
-Function OnChange_OldIconCheckBox
-	${NSD_GetState} $OldIconCheckboxHandle $isOldIconChecked
-FunctionEnd
-
 Function OnChange_ShortcutCheckBox
 	${NSD_GetState} $ShortcutCheckboxHandle $createShortcutChecked
+FunctionEnd
+
+Function OnChange_OldIconCheckBox
+	${NSD_GetState} $OldIconCheckboxHandle $isOldIconChecked
 FunctionEnd
 
 

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -280,7 +280,7 @@ Function ExtraOptions
 	Pop $NoUserDataCheckboxHandle
 	${NSD_OnClick} $NoUserDataCheckboxHandle OnChange_NoUserDataCheckBox
 	
-	${NSD_CreateCheckbox} 0 50 100% 30u "Allow plugins to be loaded from %APPDATA%\\notepad++\\plugins$\nIt could cause a security issue. Turn it on if you know what you are doing."
+	${NSD_CreateCheckbox} 0 50 100% 30u "Allow plugins to be loaded from %APPDATA%\notepad++\plugins$\nIt could cause a security issue. Turn it on if you know what you are doing."
 	Pop $PluginLoadFromUserDataCheckboxHandle
 	${NSD_OnClick} $PluginLoadFromUserDataCheckboxHandle OnChange_PluginLoadFromUserDataCheckBox
 	

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -288,7 +288,7 @@ Function ExtraOptions
 	Pop $ShortcutCheckboxHandle
 	StrCmp $WinVer "8" 0 +2
 	${NSD_Check} $ShortcutCheckboxHandle
-	${NSD_OnClick} $ShortcutCheckboxHandle ShortcutOnChange_OldIconCheckBox
+	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
 
 	${NSD_CreateCheckbox} 0 170 100% 30u "Use the old, obsolete and monstrous icon$\nI won't blame you if you want to get the old icon back :)"
 	Pop $OldIconCheckboxHandle
@@ -318,7 +318,7 @@ Function OnChange_OldIconCheckBox
 	${NSD_GetState} $OldIconCheckboxHandle $isOldIconChecked
 FunctionEnd
 
-Function ShortcutOnChange_OldIconCheckBox
+Function OnChange_ShortcutCheckBox
 	${NSD_GetState} $ShortcutCheckboxHandle $createShortcutChecked
 FunctionEnd
 

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -664,8 +664,12 @@ Section -"Notepad++" mainSection
 	UserInfo::GetAccountType
 	Pop $1
 	StrCmp $1 "Admin" 0 +2
-	
 	SetShellVarContext all
+	
+	; set the shortcuts working directory
+	; http://nsis.sourceforge.net/Docs/Chapter4.html#createshortcut
+	SetOutPath "$INSTDIR\"
+	
 	; add all the npp shortcuts for all user or current user
 	CreateDirectory "$SMPROGRAMS\Notepad++"
 	CreateShortCut "$SMPROGRAMS\Notepad++\Notepad++.lnk" "$INSTDIR\notepad++.exe"

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -524,7 +524,7 @@ Section -"Notepad++" mainSection
 	Delete "$SMPROGRAMS\Notepad++\Notepad++.lnk"
 	Delete "$SMPROGRAMS\Notepad++\readme.lnk"
 	Delete "$SMPROGRAMS\Notepad++\Uninstall.lnk"
-	CreateDirectory "$SMPROGRAMS\Notepad++"
+	RMDir "$SMPROGRAMS\Notepad++"
 
 	; remove unstable plugins
 	CreateDirectory "$INSTDIR\plugins\disabled"


### PR DESCRIPTION
A few fixes concerning shortcuts creation, and a few cosmetic ones.
I did my best to make the changes clear and simple, by splitting into separate commits.

Refs some relevant past NP++ commits:
* [v5.8.2 (2010-10-10)](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/52edd1eb166a64118159031238247c155d77e6f6#diff-0aec993847b3c277dad9d719d29d37d6)
* [v5.8.7 (2011-01-31)](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/3a149d8500e3ac01121dbb82d65bd8674e8cf6cb#diff-0aec993847b3c277dad9d719d29d37d6)
* [v5.9.1 (2011-05-31)](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/cf11f87b77433bb33c391d90985cb0cff3f6d824#diff-0aec993847b3c277dad9d719d29d37d6)