### PR TITLE
Avoid out-of bounds read access issue introduced with

### DIFF
--- a/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
@@ -61,6 +61,7 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView)
 	int listCharSize = pHighlightView->execute(SCI_GETWORDCHARS, 0, 0);
 	char *listChar = new char[listCharSize+1];
 	pHighlightView->execute(SCI_GETWORDCHARS, 0, (LPARAM)listChar);
+	listChar[listCharSize] = '\0';
 	
 	bool valid = true;
 	//The word has to consist if wordChars only, and the characters before and after something else


### PR DESCRIPTION
Bugfix on PR Fix smarthighlight #187
, see also comments added in the PR.

String returned by SCI_GETWORDCHARS from scintilla is not null terminated, so check for strlen in isWordChar() below on listChar is dangerous as strlen accesses data after the buffer until the first following null is found in memory
- seen with MS Application Verifier on x64 release
- expected to also happen on win32 x86 release
- for debug typically the memory is preallocated with zero, so this issue is maybe not visible for debug builds