### PR TITLE
remove scintilla deprecated calls/defines

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1519,9 +1519,6 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 	    setSpecialStyle(styleLN);
     }
     setTabSettings(_pParameter->getLangFromID(typeDoc));
-	execute(SCI_SETSTYLEBITS, 8);	// Always use 8 bit mask in Document class (Document::stylingBitsMask),
-									// in that way Editor::PositionIsHotspot will return correct hotspot styleID.
-									// This value has no effect on LexAccessor::mask.
 }
 
 BufferID ScintillaEditView::attachDefaultDoc()


### PR DESCRIPTION
- remove deprecated call to SCI_SETSTYLEBITS, see http://www.scintilla.org/ScintillaDoc.html#DeprecatedMessages

- remove deprecated INDIC1_MASK and INDIC2_MASK, see http://www.scintilla.org/ScintillaDoc.html#DeprecatedMessages
- cleanup code for hotspot handling
- unclear if style_hotspot = INDIC_MAX+1 is a good choice for the hotspot style id, but seems to work, with the code before it was typically 0x40