### PR TITLE
Revert "Make file save dialog modern style" fix #1129

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -254,8 +254,8 @@ TCHAR * FileDialog::doSaveDlg()
 
 	_ofn.Flags |= OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_ENABLESIZING;
 
-	//_ofn.Flags |= OFN_ENABLEHOOK;
-	//_ofn.lpfnHook = OFNHookProc;
+	_ofn.Flags |= OFN_ENABLEHOOK;
+	_ofn.lpfnHook = OFNHookProc;
 
 	TCHAR *fn = NULL;
 	try {


### PR DESCRIPTION
This reverts commit d738f80d7ed01bf1b22f66d8a166cd2fcdfb6fbb to workaround saving files without any extension issue #1129 