### PR TITLE
Changed Tab bar to draw windows file type icons.

### DIFF
--- a/PowerEditor/src/ScitillaComponent/DocTabView.h
+++ b/PowerEditor/src/ScitillaComponent/DocTabView.h
@@ -41,10 +41,12 @@ const int SAVED_IMG_INDEX = 0;
 const int UNSAVED_IMG_INDEX = 1;
 const int REDONLY_IMG_INDEX = 2;
 
+const int UNSAVED_IMG_ALPHA = 200;
+
 class DocTabView : public TabBarPlus
 {
 public :
-	DocTabView():TabBarPlus(), _pView(NULL) {};
+	DocTabView():TabBarPlus(), _pView(NULL), _pIconList(NULL) {};
 	virtual ~DocTabView(){};
 	
 	virtual void destroy() {
@@ -56,7 +58,10 @@ public :
 		TabBarPlus::init(hInst, parent);
 		_pView = pView;
 		if (pIconList)
+		{
+			_pIconList = pIconList;
 			TabBar::setImageList(pIconList->getHandle());
+		}
 		return;
 	};
 
@@ -86,7 +91,13 @@ public :
 
 	virtual void reSizeTo(RECT & rc);
 
+protected :
+	void drawImage(int tabIndex, int imgIndex, HDC hDC, int xPos, int yPos);
+
 private :
+	int DocTabView::addIconForFilename(const TCHAR * name);
+
+	IconList *_pIconList;
 	ScintillaEditView *_pView;
 	static bool _hideTabBarStatus;
 };

--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
@@ -28,6 +28,12 @@
 
 #include "ImageListSet.h"
 
+IconList::~IconList()
+{
+	for (HICONVector::iterator it = _extImglst.begin(), end = _extImglst.end(); it != end; ++it)
+		::DestroyIcon(*it);
+}
+
 void IconList::create(HINSTANCE hInst, int iconSize) 
 {
 	InitCommonControls();
@@ -58,6 +64,14 @@ void IconList::addIcon(int iconID) const
 	::DestroyIcon(hIcon);
 };
 
+int IconList::addExternalIcon(HICON icon)
+{
+	if (icon == NULL)
+		return -1;
+	_extImglst.push_back(icon);
+	return ImageList_AddIcon(_hImglst, icon);
+}
+
 bool IconList::changeIcon(int index, const TCHAR *iconLocation) const
 {
 	HBITMAP hBmp = (HBITMAP)::LoadImage(_hInst, iconLocation, IMAGE_ICON, _iconSize, _iconSize, LR_LOADFROMFILE | LR_LOADMAP3DCOLORS | LR_LOADTRANSPARENT);
@@ -74,6 +88,8 @@ void IconList::setIconSize(int size) const
 	ImageList_SetIconSize(_hImglst, size, size);
 	for (int i = 0 ; i < _iconIDArraySize ; ++i)
 		addIcon(_pIconIDArray[i]);
+	for (HICONVector::const_iterator it = _extImglst.begin(), end = _extImglst.end(); it != end; ++it)
+		ImageList_AddIcon(_hImglst, *it);
 }
 
 void ToolBarIcons::init(ToolBarButtonUnit *buttonUnitArray, int arraySize)

--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
@@ -36,10 +36,13 @@
 const int nbMax = 45;
 #define	IDI_SEPARATOR_ICON -1
 
+typedef std::vector<HICON> HICONVector;
+
 class IconList
 {
 public :
 	IconList() : _hImglst(NULL) {};
+	~IconList();
 	void create(HINSTANCE hInst, int iconSize);
 	void create(int iconSize, HINSTANCE hInst, int *iconIDArray, int iconIDArraySize);
 
@@ -48,6 +51,7 @@ public :
 	};
 	HIMAGELIST getHandle() const {return _hImglst;};
 	void addIcon(int iconID) const;
+	int addExternalIcon(HICON icon);
 	bool changeIcon(int index, const TCHAR *iconLocation) const;
 	void setIconSize(int size) const;
 
@@ -57,6 +61,7 @@ private :
 	int *_pIconIDArray;
 	int _iconIDArraySize;
 	int _iconSize;
+	HICONVector _extImglst;
 };
 
 typedef struct 

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -816,13 +816,13 @@ void TabBarPlus::drawItem(DRAWITEMSTRUCT *pDrawItemStruct)
 		if (_isVertical)
 		{
 			rect.bottom -= imageRect.bottom - imageRect.top;
-			ImageList_Draw(hImgLst, tci.iImage, hDC, xPos, rect.bottom - marge, isSelected?ILD_TRANSPARENT:ILD_SELECTED);
+			drawImage(nTab, tci.iImage, hDC, xPos, rect.bottom - marge);
 			rect.bottom += marge;
 		}
 		else
 		{
 			rect.left += marge;
-			ImageList_Draw(hImgLst, tci.iImage, hDC, rect.left, yPos, isSelected?ILD_TRANSPARENT:ILD_SELECTED);
+			drawImage(nTab, tci.iImage, hDC, rect.left, yPos);
 			rect.left += imageRect.right - imageRect.left;
 		}
 	}
@@ -919,6 +919,13 @@ void TabBarPlus::drawItem(DRAWITEMSTRUCT *pDrawItemStruct)
 	::RestoreDC(hDC, nSavedDC);
 }
 
+void TabBarPlus::drawImage(int tabIndex, int imgIndex, HDC hDC, int xPos, int yPos)
+{
+	if (tabIndex < 0 || imgIndex < 0)
+		return;
+	HIMAGELIST hImgLst = (HIMAGELIST)::SendMessage(_hSelf, TCM_GETIMAGELIST, 0, 0);
+	ImageList_Draw(hImgLst, imgIndex, hDC, xPos, yPos, ILD_TRANSPARENT);
+}
 
 void TabBarPlus::draggingCursor(POINT screenPoint)
 {

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -272,6 +272,7 @@ protected:
 	static HWND _hwndArray[nbCtrlMax];
 
 	void drawItem(DRAWITEMSTRUCT *pDrawItemStruct);
+	virtual void drawImage(int tabIndex, int imgIndex, HDC hDC, int xPos, int yPos);
 	void draggingCursor(POINT screenPoint);
 
 	int getTabIndexAt(const POINT & p)


### PR DESCRIPTION
This is a PR for #446 

Features:
Icon tabs are now drawn using windows file icons. If no icon exists, the current floppy disc is used.
Unsaved tabs are drawn with a red overlay. Read-only files are drawn in grayscale.
Horizontal
![big](https://cloud.githubusercontent.com/assets/6014753/11167650/bdad2f04-8b3a-11e5-81b9-7551526e6660.png)
![reduced](https://cloud.githubusercontent.com/assets/6014753/11167652/bdb423e0-8b3a-11e5-8499-fff4feda5525.png)

Vertical
![vbig](https://cloud.githubusercontent.com/assets/6014753/11167674/4a0860d6-8b3b-11e5-9c04-9b23d7e0741a.png)

The drawItem function of TabBar now delegates drawing the image to a function that is overwritten by DocTabView. The default implementation in TabBar keeps the current functionality.

The number of icons that can be added are limited by the max size of IconList, so >nbmax files will use the default icon.

There is a known issue where unsaved icons will appear sightly discolored when closing and reopening the application.

Edit:
Read only files:
![read only](https://cloud.githubusercontent.com/assets/6014753/11167719/d5c06906-8b3c-11e5-8915-ef0bca35fff7.png)

