### PR TITLE
Fixed naming conventions on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ Function names are not separated from the first parenthesis.</h5>
 
 #### NAMING CONVENTIONS
 
-1. ##### Classes (camel case)
+1. ##### Classes (pascal case)
 
   * ###### Good:
     ```cpp
@@ -195,8 +195,8 @@ Function names are not separated from the first parenthesis.</h5>
     {};
     ```
 
-1. <h5>methods (camel case + begins with a lower case)<br>
-method parameters (camel case + begins with a lower case)</h5>
+1. <h5>methods (camel case)<br>
+method parameters (camel case)</h5>
 
   ```cpp
   void myMethod(uint myVeryLongParameter);


### PR DESCRIPTION
The file was refering to PascalCase as camelCase. While these things are usually not set in stone, in camelCase the first letter is lower most (if not all) of the time.

See: https://msdn.microsoft.com/en-us/library/x2dbyw72(v=vs.71).aspx