### PR TITLE
remove scintilla deprecated calls/defines #1115 part1

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1521,9 +1521,6 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 	    setSpecialStyle(styleLN);
     }
     setTabSettings(_pParameter->getLangFromID(typeDoc));
-	execute(SCI_SETSTYLEBITS, 8);	// Always use 8 bit mask in Document class (Document::stylingBitsMask),
-									// in that way Editor::PositionIsHotspot will return correct hotspot styleID.
-									// This value has no effect on LexAccessor::mask.
 }
 
 BufferID ScintillaEditView::attachDefaultDoc()


### PR DESCRIPTION
Followup with splitted  remove scintilla deprecated calls/defines #1115 part1

- remove deprecated call to SCI_SETSTYLEBITS, see http://www.scintilla.org/ScintillaDoc.html#DeprecatedMessages