### PR TITLE
Fixed "HTML Enclose Tag" #868 

### DIFF
--- a/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -143,7 +143,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 		openFound = findText("<", searchStartPoint, 0, 0);
 		styleAt = _pEditView->execute(SCI_GETSTYLEAT, openFound.start);
 		searchStartPoint = openFound.start - 1;
-	} while (openFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || styleAt == SCE_H_COMMENT /*insideComment(openFound.start)*/) && searchStartPoint > 0);
+	} while (openFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || styleAt == SCE_H_COMMENT ) && searchStartPoint > 0);
 
 	if (openFound.success && styleAt != SCE_H_CDATA)
 	{
@@ -155,7 +155,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 			closeFound = findText(">", searchStartPoint, caret, 0);
 			styleAt = _pEditView->execute(SCI_GETSTYLEAT, closeFound.start);
 			searchStartPoint = closeFound.end;
-		} while (closeFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || styleAt == SCE_H_COMMENT/* insideComment(closeFound.start)*/) && searchStartPoint <= caret);
+		} while (closeFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || styleAt == SCE_H_COMMENT) && searchStartPoint <= caret);
 
 		if (!closeFound.success)
 		{
@@ -282,7 +282,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 				std::string tagName;
 				nextChar = _pEditView->execute(SCI_GETCHARAT, position);	
 				// Checking for " or ' is actually wrong here, but it means it works better with invalid XML
-				while(position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'' /*&& !insideComment(position)*/)
+				while(position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'' )
 				{
 					tagName.push_back((char)nextChar);
 					++position;
@@ -381,34 +381,6 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 	return tagFound;
 }
 
-bool XmlMatchedTagsHighlighter::insideComment(int pos) {
-	bool foundComment = false;
-	int cur = pos-1;
-	int nextChar, nextChar2, nextChar3;
-	//int styleAt = _pEditView->execute(SCI_GETSTYLEAT, pos);
-	while (cur > 3 && !foundComment) {
-		nextChar = _pEditView->execute(SCI_GETCHARAT, cur);
-		if (nextChar == '-') {
-			nextChar2 = _pEditView->execute(SCI_GETCHARAT, cur-1);
-			if (nextChar2 == '-') {
-				nextChar3 = _pEditView->execute(SCI_GETCHARAT, cur-2);
-				if (nextChar3 == '!') {
-					foundComment = true;
-					break;
-				}
-			}
-		}
-		else if (nextChar == '>') {
-			// check if it's closing comment tag
-			if (_pEditView->execute(SCI_GETCHARAT, cur-2) == '-' && _pEditView->execute(SCI_GETCHARAT, cur-1) == '-')
-				return false;
-		}
-		cur--;
-	}
-
-	return foundComment;
-}
-
 XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(const std::string& tagName, int start, int end)
 {
 	std::string search("<");
@@ -429,7 +401,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 		{
 			nextChar = _pEditView->execute(SCI_GETCHARAT, result.end);
 			styleAt = _pEditView->execute(SCI_GETSTYLEAT, result.start);
-			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_COMMENT /*!insideComment(result.start)*/)
+			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_COMMENT )
 			{
 				// We've got an open tag for this tag name (i.e. nextChar was space or '>')
 				// Now we need to find the end of the start tag.
@@ -499,7 +471,7 @@ int XmlMatchedTagsHighlighter::findCloseAngle(int startPosition, int endPosition
 		{
 			int style = _pEditView->execute(SCI_GETSTYLEAT, closeAngle.start);
 			// As long as we're not in an attribute (  <TAGNAME attrib="val>ue"> is VALID XML. )
-			if (style != SCE_H_DOUBLESTRING && style != SCE_H_SINGLESTRING && style != SCE_H_COMMENT /*!insideComment(closeAngle.start)*/)
+			if (style != SCE_H_DOUBLESTRING && style != SCE_H_SINGLESTRING && style != SCE_H_COMMENT)
 			{
 				returnPosition = closeAngle.start;
 				isValidClose = true;
@@ -548,7 +520,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 				searchStart = result.start - 1;
 			}
 		
-			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_COMMENT/* !insideComment(result.start)*/) // If what we found was in CDATA section, it's not a valid tag.
+			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_COMMENT) // If what we found was in CDATA section, it's not a valid tag.
 			{
 				// Common case - '>' follows the tag name directly
 				if (nextChar == '>')

--- a/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -401,7 +401,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 		{
 			nextChar = _pEditView->execute(SCI_GETCHARAT, result.end);
 			styleAt = _pEditView->execute(SCI_GETSTYLEAT, result.start);
-			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_COMMENT )
+			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_COMMENT)
 			{
 				// We've got an open tag for this tag name (i.e. nextChar was space or '>')
 				// Now we need to find the end of the start tag.

--- a/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -143,7 +143,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 		openFound = findText("<", searchStartPoint, 0, 0);
 		styleAt = _pEditView->execute(SCI_GETSTYLEAT, openFound.start);
 		searchStartPoint = openFound.start - 1;
-	} while (openFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || insideComment(openFound.start)) && searchStartPoint > 0);		
+	} while (openFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || styleAt == SCE_H_COMMENT /*insideComment(openFound.start)*/) && searchStartPoint > 0);
 
 	if (openFound.success && styleAt != SCE_H_CDATA)
 	{
@@ -155,7 +155,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 			closeFound = findText(">", searchStartPoint, caret, 0);
 			styleAt = _pEditView->execute(SCI_GETSTYLEAT, closeFound.start);
 			searchStartPoint = closeFound.end;
-		} while (closeFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || insideComment(closeFound.start)) && searchStartPoint <= caret);
+		} while (closeFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || styleAt == SCE_H_COMMENT/* insideComment(closeFound.start)*/) && searchStartPoint <= caret);
 
 		if (!closeFound.success)
 		{
@@ -282,7 +282,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 				std::string tagName;
 				nextChar = _pEditView->execute(SCI_GETCHARAT, position);	
 				// Checking for " or ' is actually wrong here, but it means it works better with invalid XML
-				while(position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'' && !insideComment(position))
+				while(position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'' /*&& !insideComment(position)*/)
 				{
 					tagName.push_back((char)nextChar);
 					++position;
@@ -429,7 +429,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 		{
 			nextChar = _pEditView->execute(SCI_GETCHARAT, result.end);
 			styleAt = _pEditView->execute(SCI_GETSTYLEAT, result.start);
-			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && !insideComment(result.start))
+			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_COMMENT /*!insideComment(result.start)*/)
 			{
 				// We've got an open tag for this tag name (i.e. nextChar was space or '>')
 				// Now we need to find the end of the start tag.
@@ -499,7 +499,7 @@ int XmlMatchedTagsHighlighter::findCloseAngle(int startPosition, int endPosition
 		{
 			int style = _pEditView->execute(SCI_GETSTYLEAT, closeAngle.start);
 			// As long as we're not in an attribute (  <TAGNAME attrib="val>ue"> is VALID XML. )
-			if (style != SCE_H_DOUBLESTRING && style != SCE_H_SINGLESTRING && !insideComment(closeAngle.start))
+			if (style != SCE_H_DOUBLESTRING && style != SCE_H_SINGLESTRING && style != SCE_H_COMMENT /*!insideComment(closeAngle.start)*/)
 			{
 				returnPosition = closeAngle.start;
 				isValidClose = true;
@@ -548,7 +548,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 				searchStart = result.start - 1;
 			}
 		
-			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_DOUBLESTRING && !insideComment(result.start)) // If what we found was in CDATA section, it's not a valid tag.
+			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_COMMENT/* !insideComment(result.start)*/) // If what we found was in CDATA section, it's not a valid tag.
 			{
 				// Common case - '>' follows the tag name directly
 				if (nextChar == '>')

--- a/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -143,7 +143,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 		openFound = findText("<", searchStartPoint, 0, 0);
 		styleAt = _pEditView->execute(SCI_GETSTYLEAT, openFound.start);
 		searchStartPoint = openFound.start - 1;
-	} while (openFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING) && searchStartPoint > 0);
+	} while (openFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || insideComment(openFound.start)) && searchStartPoint > 0);		
 
 	if (openFound.success && styleAt != SCE_H_CDATA)
 	{
@@ -155,7 +155,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 			closeFound = findText(">", searchStartPoint, caret, 0);
 			styleAt = _pEditView->execute(SCI_GETSTYLEAT, closeFound.start);
 			searchStartPoint = closeFound.end;
-		} while (closeFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING) && searchStartPoint <= caret);
+		} while (closeFound.success && (styleAt == SCE_H_DOUBLESTRING || styleAt == SCE_H_SINGLESTRING || insideComment(closeFound.start)) && searchStartPoint <= caret);
 
 		if (!closeFound.success)
 		{
@@ -282,7 +282,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 				std::string tagName;
 				nextChar = _pEditView->execute(SCI_GETCHARAT, position);	
 				// Checking for " or ' is actually wrong here, but it means it works better with invalid XML
-				while(position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'')
+				while(position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'' && !insideComment(position))
 				{
 					tagName.push_back((char)nextChar);
 					++position;
@@ -381,6 +381,33 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 	return tagFound;
 }
 
+bool XmlMatchedTagsHighlighter::insideComment(int pos) {
+	bool foundComment = false;
+	int cur = pos-1;
+	int nextChar, nextChar2, nextChar3;
+	//int styleAt = _pEditView->execute(SCI_GETSTYLEAT, pos);
+	while (cur > 3 && !foundComment) {
+		nextChar = _pEditView->execute(SCI_GETCHARAT, cur);
+		if (nextChar == '-') {
+			nextChar2 = _pEditView->execute(SCI_GETCHARAT, cur-1);
+			if (nextChar2 == '-') {
+				nextChar3 = _pEditView->execute(SCI_GETCHARAT, cur-2);
+				if (nextChar3 == '!') {
+					foundComment = true;
+					break;
+				}
+			}
+		}
+		else if (nextChar == '>') {
+			// check if it's closing comment tag
+			if (_pEditView->execute(SCI_GETCHARAT, cur-2) == '-' && _pEditView->execute(SCI_GETCHARAT, cur-1) == '-')
+				return false;
+		}
+		cur--;
+	}
+
+	return foundComment;
+}
 
 XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(const std::string& tagName, int start, int end)
 {
@@ -402,7 +429,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 		{
 			nextChar = _pEditView->execute(SCI_GETCHARAT, result.end);
 			styleAt = _pEditView->execute(SCI_GETSTYLEAT, result.start);
-			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING)
+			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && !insideComment(result.start))
 			{
 				// We've got an open tag for this tag name (i.e. nextChar was space or '>')
 				// Now we need to find the end of the start tag.
@@ -472,7 +499,7 @@ int XmlMatchedTagsHighlighter::findCloseAngle(int startPosition, int endPosition
 		{
 			int style = _pEditView->execute(SCI_GETSTYLEAT, closeAngle.start);
 			// As long as we're not in an attribute (  <TAGNAME attrib="val>ue"> is VALID XML. )
-			if (style != SCE_H_DOUBLESTRING && style != SCE_H_SINGLESTRING)
+			if (style != SCE_H_DOUBLESTRING && style != SCE_H_SINGLESTRING && !insideComment(closeAngle.start))
 			{
 				returnPosition = closeAngle.start;
 				isValidClose = true;
@@ -521,7 +548,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 				searchStart = result.start - 1;
 			}
 		
-			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_DOUBLESTRING) // If what we found was in CDATA section, it's not a valid tag.
+			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_DOUBLESTRING && !insideComment(result.start)) // If what we found was in CDATA section, it's not a valid tag.
 			{
 				// Common case - '>' follows the tag name directly
 				if (nextChar == '>')

--- a/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.h
+++ b/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.h
@@ -63,7 +63,7 @@ private:
 	// Allowed whitespace characters in XML
 	bool isWhitespace(int ch) { return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'; }
 
-
+	bool insideComment(int p);	// added by Amy
 	FindResult findText(const char *text, int start, int end, int flags = 0);
 	FindResult findOpenTag(const std::string& tagName, int start, int end);
 	FindResult findCloseTag(const std::string& tagName, int start, int end);

--- a/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.h
+++ b/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.h
@@ -63,7 +63,6 @@ private:
 	// Allowed whitespace characters in XML
 	bool isWhitespace(int ch) { return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'; }
 
-	bool insideComment(int p);	// added by Amy
 	FindResult findText(const char *text, int start, int end, int flags = 0);
 	FindResult findOpenTag(const std::string& tagName, int start, int end);
 	FindResult findCloseTag(const std::string& tagName, int start, int end);


### PR DESCRIPTION
The code change is to add a check for a comment style inside xmlMatchedTagsHighlighter.cpp, and to ignore opening/closing tags inside a comment. Now HTML and XML tags are properly ignored in comments, and HTML/XML tags highlight the first matching closing tag after the end of the comment, as one would expect.

We tested on Windows 7 and Windows 8.1 with Notepad++ version 6.8.6.
No additional plugins were installed, we just ran as it was compiled, with boost enabled.

Here is a image of the working highlighter, a screenshot of the bug is available in bug report #868
![capture](https://cloud.githubusercontent.com/assets/14284230/11446884/bd984a64-94f2-11e5-8fbd-325e4e8e3ef8.PNG)
