### PR TITLE
Fixed an issue #1273: Visual Studio debug build crash with Run-Time Check Failure #1

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -44,6 +44,13 @@ const bool dirDown = false;
 #define BCKGRD_COLOR (RGB(255,102,102))
 #define TXT_COLOR    (RGB(255,255,255))
 
+// A macro to use instead of WinAPI GetGValue().
+// WinAPI macro GetGValue() use downcast from DWORD to WORD wich cause Visual Studio debug build to
+// crash with Run-Time Check Failure #1 - A cast to a smaller data type has caused a loss of data.
+// New macro is used in accordance with MSDN community additions to GetGValue()
+// https://msdn.microsoft.com/en-us/library/windows/desktop/dd144893%28v=vs.85%29.aspx
+#define GetGValueFix(rgb)   (LOBYTE((((WORD)((rgb) & (WORD)(~0))) >> 8)))
+
 #ifdef UNICODE
 	#define NppMainEntry wWinMain
 	#define generic_strtol wcstol

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -2799,7 +2799,9 @@ INT_PTR CALLBACK DelimiterSettingsDlg::run_dlgProc(UINT Message, WPARAM wParam, 
 			{
 				COLORREF bgColor = getCtrlBgColor(_hSelf);
 				SetTextColor(hdcStatic, RGB(0, 0, 0));
-				SetBkColor(hdcStatic, RGB(GetRValue(bgColor) - 30, GetGValue(bgColor) - 30, GetBValue(bgColor) - 30));
+				// Use GetGValueFix instead of WinAPI GetGValue to fix Visual Studio Run-Time Check Failure #1 - A cast
+				// to a smaller data type has caused a loss of data (issue #1273).
+				SetBkColor(hdcStatic, RGB(GetRValue(bgColor) - 30, GetGValueFix(bgColor) - 30, GetBValue(bgColor) - 30));
 				return TRUE;
 			}
 			return FALSE;


### PR DESCRIPTION
Visual Studio debug build crash with Run-Time Check Failure #1 - A cast to a smaller data type has caused a loss of data.
Use of WinAPI GetGValue() macro replaced with a new macro GetGValueFix() defined in accordance with MSDN community additions to GetGValue() https://msdn.microsoft.com/en-us/library/windows/desktop/dd144893%28v=vs.85%29.aspx