### PR TITLE
YAML keywords and indentation

### DIFF
--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -244,7 +244,8 @@
         </Language>
         <Language name="xml" ext="xml xaml xsl xslt xsd xul kml svg mxml xsml wsdl xlf xliff xbl sxbl sitemap gml gpx plist" commentLine="" commentStart="&lt;!--" commentEnd="--&gt;">
         </Language>
-        <Language name="yaml" ext="yml yaml" commentLine="#">
+        <Language name="yaml" ext="yml yaml" commentLine="#" tabSettings="132">
+          <Keywords name="instre1">true false yes no</Keywords>
         </Language>
         <Language name="searchResult" ext="">
             <Keywords name="instre1"></Keywords>


### PR DESCRIPTION
Adds keywords to the YAML lexer. Also force the use of spaces instead of tabs since YAML [requires](http://yaml.org/faq.html) spaces.

![yaml](https://cloud.githubusercontent.com/assets/3694843/12133674/7896180c-b3f5-11e5-8d01-bb60375b24e3.png)
