### PR TITLE
Minor performance tweaks

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2372,12 +2372,7 @@ pair<int, int> ScintillaEditView::getSelectionLinesRange() const
 
     range.first = execute(SCI_LINEFROMPOSITION, start);
     range.second = execute(SCI_LINEFROMPOSITION, end);
-    if (range.first > range.second)
-	{
-		int temp = range.first;
-		range.first = range.second;
-		range.second = temp;
-	}
+
     return range;
 }
 
@@ -2448,7 +2443,7 @@ void ScintillaEditView::convertSelectedTextTo(bool Case)
 	size_t selectionStart = execute(SCI_GETSELECTIONSTART);
 	size_t selectionEnd = execute(SCI_GETSELECTIONEND);
 
-	int strSize = ((selectionEnd > selectionStart)?(selectionEnd - selectionStart):(selectionStart - selectionEnd))+1;
+	int strSize = (selectionEnd - selectionStart) + 1;
 	if (strSize)
 	{
 		char *selectedStr = new char[strSize+1];

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -466,11 +466,11 @@ public:
 			return false;
 		long start = long(execute(SCI_GETSELECTIONSTART));
 		long end = long(execute(SCI_GETSELECTIONEND));
-		selByte = (start < end)?end-start:start-end;
+		selByte = end - start;
 
 		start = long(execute(SCI_LINEFROMPOSITION, start));
 		end = long(execute(SCI_LINEFROMPOSITION, end));
-		selLine = (start < end)?end-start:start-end;
+		selLine = end - start;
 		if (selLine)
 			++selLine;
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -539,9 +539,6 @@ public:
 
 	void expand(int &line, bool doExpand, bool force = false, int visLevels = 0, int level = -1);
 
-	void currentLineUp() const;
-	void currentLineDown() const;
-
 	std::pair<int, int> getSelectionLinesRange() const;
     void currentLinesUp() const;
     void currentLinesDown() const;


### PR DESCRIPTION
A few small commits to address some minor tweaks. It isn't easy to create an issue for this PR, so hopefully it can be discussed here.

* 7d3b54e - Scintilla has built in commands to move lines up/down, so this takes advantage of them which I'm sure is a bit more efficient since Scintilla can do it all at once internally instead of multiple calls to `currentLineUp()` etc. 
* d9190d0 - Some checks can be skipped since `SCI_GETSELECTIONSTART` is always the lesser of the two selection endpoints.
* 3b39bc2 - ~~When selecting a section of text Notepad++ would copy the *entire* selection to count the characters (this can spike memory when editing large files) -- Scintilla can do it internally with the [`SCI_COUNTCHARACTERS`](http://www.scintilla.org/ScintillaDoc.html#SCI_COUNTCHARACTERS) command. **NOTE:**  I've tested this as much as possible but I am not very familiar with the various character encodings,  so hopefully someone can verify this works with different encodings.~~ Removed due to Scintilla bug.