### PR TITLE
Not localized caption of FindReplaceDlg

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -266,6 +266,10 @@ public :
 		tie.mask = TCIF_TEXT;
 		tie.pszText = (TCHAR *)name2change;
 		TabCtrl_SetItem(_tab.getHSelf(), index, &tie);
+
+		TCHAR label[MAX_PATH];
+		_tab.getCurrentTitle(label, MAX_PATH);
+		::SetWindowText(_hSelf, label);
 	}
 	void beginNewFilesSearch()
 	{


### PR DESCRIPTION
Fixed not localized caption of FindReplaceDlg  when it appear first
time.