### PR TITLE
Add 3 missing translatable items to master XML for 6.8.8

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <NotepadPlus>
-    <Native-Langue name="English" filename="english.xml" version="6.8.2">
+    <Native-Langue name="English" filename="english.xml" version="6.8.8">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -280,6 +280,7 @@
                     <Item id="47003" name="Online Documentation"/>
 					<Item id="47004" name="Notepad++ Community (Forum)"/>
                     <Item id="47011" name="Live Support"/>
+                    <Item id="47012" name="Debug Info"/>
                     <Item id="47005" name="Get More Plugins"/>
                     <Item id="47006" name="Update Notepad++"/>
                     <Item id="47009" name="Set Updater Proxy..."/>
@@ -661,6 +662,7 @@
                     <Item id="6214" name="Enable current line highlighting"/>
 					<Item id="6215" name="Enable smooth font"/>
                     <Item id="6231" name="Border Width"/>
+                    <Item id="6235" name="No edge"/>
                 </Scintillas>
 
                 <NewDoc title="New Document">
@@ -683,6 +685,7 @@
                     <Item id="6413" name="Default Directory (Open/Save)"/>
                     <Item id="6414" name="Follow current document"/>
                     <Item id="6415" name="Remember last used directory"/>
+                    <Item id="6430" name="Use new style save dialog (without file extension feature)"/>
                 </DefaultDir>
 
                 <FileAssoc title="File Association">


### PR DESCRIPTION
This is an attempt to add the complete, currently known unofficial strings to original english.xml language template. For version 6.8.8. Don Ho should review them, and make them official.