### PR TITLE
Fixed Loss of syntax highlighting during "save as" (See issue #1298)

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2604,7 +2604,7 @@ bool NppParameters::exportUDLToFile(size_t langIndex2export, generic_string file
 	return result;
 }
 
-LangType NppParameters::getLangFromExt(const TCHAR *ext)
+LangType NppParameters::getLangFromExt(const TCHAR *ext, LangType defaultLang)
 {
 	int i = getNbLang();
 	i--;
@@ -2634,7 +2634,7 @@ LangType NppParameters::getLangFromExt(const TCHAR *ext)
 		if (isInList(ext, list.c_str()))
 			return l->getLangID();
 	}
-	return L_TEXT;
+	return defaultLang;
 }
 
 void NppParameters::setCloudChoice(const TCHAR *pathChoice)

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1279,7 +1279,7 @@ public:
 
 	int getNbLang() const {return _nbLang;};
 
-	LangType getLangFromExt(const TCHAR *ext);
+	LangType getLangFromExt(const TCHAR *ext, LangType defaultLang = L_TEXT);
 
 	const TCHAR * getLangExtFromName(const TCHAR *langName) const
 	{

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -201,7 +201,7 @@ void Buffer::setFileName(const TCHAR *fn, LangType defaultLang)
 		else // if it's not user lang, then check if it's supported lang
 		{
 			_userLangExt.clear();
-			newLang = pNppParamInst->getLangFromExt(ext);
+			newLang = pNppParamInst->getLangFromExt(ext, defaultLang);
 		}
 	}
 

--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -146,7 +146,7 @@ public:
 	// this method 1. copies the file name
 	//             2. determinates the language from the ext of file name
 	//             3. gets the last modified time
-	void setFileName(const TCHAR *fn, LangType defaultLang = L_TEXT);
+	void setFileName(const TCHAR *fn, LangType defaultLang = L_TEXT, bool dontReDetectLangIfAlreadySet = false);
 
 	const TCHAR * getFullPathName() const {
 		return _fullPathName.c_str();


### PR DESCRIPTION
When i save a file with "save as" that has a language different from "text" the language is preserved as in the "save" command.
For all new or old files that have "text" default value set as language, the language will be auto detected during the "save as" as before but with the plus of use the fallback value that is obtained from the first row content if the file extension is not detected.
With this approach if I change the extension or I save a new file with certain extension after the change of language, the user set language prevails on the language detected by extension.

See issue #1298 

Another way to do this can be by adding another function to see if the file extension is supported and maintain the current selected language only if new file name has an unknown extension, in case that the new file name has different known extension, the language will be updated using the language associated with the new file extension, changing the previous selected language.

If you want to proceed with this new way, please ignore my PR and I'll start from scratch with this new approach.

Let me know.
