### PR TITLE
buffer: fix dereferencing past end

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1275,7 +1275,7 @@ LangType FileManager::detectLanguageFromTextBegining(const unsigned char *data, 
 	auto nl = buf2Test.find("\n");
 	auto crnl = min(cr, nl);
 	if (crnl != std::string::npos && crnl < longestLength)
-		buf2Test = std::string((const char *)data + i, crnl);
+		buf2Test.resize(crnl);
 
 	// First test for a Unix-like Shebang
 	// See https://en.wikipedia.org/wiki/Shebang_%28Unix%29 for more details about Shebang

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1280,31 +1280,34 @@ LangType FileManager::detectLanguageFromTextBegining(const unsigned char *data, 
 	// First test for a Unix-like Shebang
 	// See https://en.wikipedia.org/wiki/Shebang_%28Unix%29 for more details about Shebang
 	std::string shebang = "#!";
-	auto res = std::mismatch(shebang.begin(), shebang.end(), buf2Test.begin());
-	if (res.first == shebang.end())
+	if (buf2Test.length() > shebang.length()) 
 	{
-		// Make a list of the most commonly used languages
-		const size_t SHEBANG_LANGUAGES = 6;
-		FirstLineLanguages ShebangLangs[SHEBANG_LANGUAGES] = {
-			{ "sh",		L_BASH },
-			{ "python", L_PYTHON },
-			{ "perl",	L_PERL },
-			{ "php",	L_PHP },
-			{ "ruby",	L_RUBY },
-			{ "node",	L_JAVASCRIPT }
-		};
-
-		// Go through the list of languages
-		for (i = 0; i < SHEBANG_LANGUAGES; ++i)
+		auto res = std::mismatch(shebang.begin(), shebang.end(), buf2Test.begin());
+		if (res.first == shebang.end())
 		{
-			if (buf2Test.find(ShebangLangs[i].pattern) != std::string::npos)
-			{
-				return ShebangLangs[i].lang;
-			}
-		}
+			// Make a list of the most commonly used languages
+			const size_t SHEBANG_LANGUAGES = 6;
+			FirstLineLanguages ShebangLangs[SHEBANG_LANGUAGES] = {
+				{ "sh", L_BASH },
+				{ "python", L_PYTHON },
+				{ "perl", L_PERL },
+				{ "php", L_PHP },
+				{ "ruby", L_RUBY },
+				{ "node", L_JAVASCRIPT }
+			};
 
-		// Unrecognized shebang (there is always room for improvement ;-)
-		return L_TEXT;
+			// Go through the list of languages
+			for (i = 0; i < SHEBANG_LANGUAGES; ++i)
+			{
+				if (buf2Test.find(ShebangLangs[i].pattern) != std::string::npos)
+				{
+					return ShebangLangs[i].lang;
+				}
+			}
+
+			// Unrecognized shebang (there is always room for improvement ;-)
+			return L_TEXT;
+		}
 	}
 
 	// Are there any other patterns we know off?
@@ -1318,10 +1321,13 @@ LangType FileManager::detectLanguageFromTextBegining(const unsigned char *data, 
 
 	for (i = 0; i < FIRST_LINE_LANGUAGES; ++i)
 	{
-		res = std::mismatch(languages[i].pattern.begin(), languages[i].pattern.end(), buf2Test.begin());
-		if (res.first == languages[i].pattern.end())
+		if (buf2Test.length() >= languages[i].pattern.length())
 		{
-			return languages[i].lang;
+			auto res = std::mismatch(languages[i].pattern.begin(), languages[i].pattern.end(), buf2Test.begin());
+			if (res.first == languages[i].pattern.end())
+			{
+				return languages[i].lang;
+			}
 		}
 	}
 


### PR DESCRIPTION
Language detector attempts to dereference past the end of test buffer
when this buffer consists only of "#" char. This causes assertions
to be triggered with debug builds.
While at it, don't copy data again after determining test buffer's
end of line, just shrink it if necessary.

Signed-off-by: Piotr Dałek piotr.dalek@ts.fujitsu.com
