### PR TITLE
Continuous integration with Appveyor

### DIFF
--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+cd PowerEditor\visual.net                                                               || exit
+msbuild notepadPlus.vcxproj /p:configuration="Unicode Debug" /p:platform=Win32          || exit

--- a/appveyor-build.cmd
+++ b/appveyor-build.cmd
@@ -1,4 +1,8 @@
 @echo off
 
-cd PowerEditor\visual.net                                                               || exit
+cd scintilla\boostregex                                                                 || exit
+buildboost.bat C:\projects\notepad-plus-plus\boost_1_55_0                               || exit
+cd ..\win32                                                                             || exit
+nmake -f scintilla.mak                                                                  || exit
+cd ..\..\PowerEditor\visual.net                                                         || exit
 msbuild notepadPlus.vcxproj /p:configuration="Unicode Debug" /p:platform=Win32          || exit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,2 @@
+build_script:
+  - cmd /k "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\vcvars32.bat" < appveyor-build.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,4 @@
+clone_depth: 1
+
 build_script:
-  - cmd /k "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\vcvars32.bat" < appveyor-build.bat
+  - cmd /k "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\vcvars32.bat" < appveyor-build.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 clone_depth: 1
 
 install:
-  - ps: Invoke-WebRequest -OutFile boost_1_55_0.7z https://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.7z
+  - ps: Invoke-WebRequest -OutFile boost_1_55_0.7z -UserAgent Wget/1.17.1 https://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.7z
   - 7z x boost_1_55_0.7z
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
 clone_depth: 1
 
+install:
+  - ps: Invoke-WebRequest -OutFile boost_1_55_0.7z https://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.7z
+  - 7z x boost_1_55_0.7z
+
 build_script:
   - cmd /k "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\vcvars32.bat" < appveyor-build.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ clone_depth: 1
 
 install:
   - ps: Invoke-WebRequest -OutFile boost_1_55_0.7z -UserAgent Wget/1.17.1 https://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.7z
-  - 7z x boost_1_55_0.7z
+  - 7z x boost_1_55_0.7z 2>nul >nul
 
 build_script:
   - cmd /k "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\vcvars32.bat" < appveyor-build.cmd


### PR DESCRIPTION
This commit adds scripts to support continuous integration with Appveyor.

Registering an account with Appveyor is necessary for this to work, though.