### PR TITLE
Tab size 0 can no longer be used.

### DIFF
--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1822,6 +1822,8 @@ INT_PTR CALLBACK TabSettings::run_dlgProc(UINT Message, WPARAM wParam, LPARAM/* 
 			        ::GetCursorPos(&p);
 			        int size = tabSizeDlg.doDialog(p);
 			        if (size == -1) return FALSE;
+			        if (size == 0) return FALSE;
+			        //Tab size 0 removal
 
 					::SetDlgItemInt(_hSelf, IDC_TABSIZEVAL_STATIC, size, FALSE);
 					::SetDlgItemInt(_hSelf, IDC_TABSIZEVAL_DISABLE_STATIC, size, FALSE);


### PR DESCRIPTION
So in this problem you can put 0 as a tab size and the program accepts the value. Then when you go back to the editor the tab size is still default, if not changed, or the previous value entered. This fix makes sure if you put 0 then it denies it and keeps the previous value. This is from issue #1341 .