### PR TITLE
Added copy-without-highlighting functionality to links

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1863,7 +1863,7 @@ void Notepad_plus::enableCommand(int cmdID, bool doEnable, int which) const
 
 void Notepad_plus::checkClipboard()
 {
-	bool hasSelection = (_pEditView->execute(SCI_GETSELECTIONSTART) != _pEditView->execute(SCI_GETSELECTIONEND));
+	bool hasSelection = true;
 	bool canPaste = (_pEditView->execute(SCI_CANPASTE) != 0);
 	enableCommand(IDM_EDIT_CUT, hasSelection, MENU | TOOLBAR);
 	enableCommand(IDM_EDIT_COPY, hasSelection, MENU | TOOLBAR);

--- a/scintilla/src/Editor.h
+++ b/scintilla/src/Editor.h
@@ -475,7 +475,8 @@ protected:	// ScintillaBase subclass needs access to much of Editor
 
 	virtual void CopyToClipboard(const SelectionText &selectedText) = 0;
 	std::string RangeText(int start, int end) const;
-	void CopySelectionRange(SelectionText *ss, bool allowLineCopy=false);
+	std::string LinkText(int s, int e, int caret, std::string entireLine) const;
+	void CopySelectionRange(SelectionText *ss, bool allowLineCopy=true);
 	void CopyRangeToClipboard(int start, int end);
 	void CopyText(int length, const char *text);
 	void SetDragPosition(SelectionPosition newPos);

--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -2090,11 +2090,9 @@ std::string ScintillaWin::CaseMapString(const std::string &s, int caseMapping) {
 
 void ScintillaWin::Copy() {
 	//Platform::DebugPrintf("Copy\n");
-	if (!sel.Empty()) {
-		SelectionText selectedText;
-		CopySelectionRange(&selectedText);
-		CopyToClipboard(selectedText);
-	}
+	SelectionText selectedText;
+	CopySelectionRange(&selectedText);
+	CopyToClipboard(selectedText);
 }
 
 void ScintillaWin::CopyAllowLine() {


### PR DESCRIPTION
This is a quick-and-dirty implementation of the feature request in #1370. Clicking within a link will enable copying via the context menu, toolbar, and keyboard shortcut without having to highlight the entire thing.
  
A caveat is that this solution piggybacks off Scintilla's line copying setting and as such, the toolbar icon and context menu buttons will be enabled by default. I'm wondering how this solution can be improved.