### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2573,7 +2573,7 @@ bool NppParameters::exportUDLToFile(int langIndex2export, generic_string fileNam
 
 	bool b = false;
 
-	if ( langIndex2export >= NB_MAX_USER_LANG )
+	if ( langIndex2export == -1 || langIndex2export >= NB_MAX_USER_LANG )
 	{
 		return false;
 	}

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -3076,7 +3076,6 @@ void ScintillaEditView::changeTextDirection(bool isRTL)
 generic_string ScintillaEditView::getEOLString()
 {
 	const int eol_mode = int(execute(SCI_GETEOLMODE));
-	string newline;
 	if (eol_mode == SC_EOL_CRLF)
 	{
 		return TEXT("\r\n");

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -163,12 +163,12 @@ int GetNextColWithWidth(int SI, int startcol, int direction)
      if(direction == 1){j++;}
      if(direction != 1){j--;}
 
-     while((BGHS[SI].columnwidths[j] == 0)&&(j<=BGHS[SI].cols)&&(j>0))
+     while((j>0)&&(j<=BGHS[SI].cols)&&(BGHS[SI].columnwidths[j] == 0))
          {
          if(direction == 1){j++;}
          if(direction != 1){j--;}
          }
-     if((BGHS[SI].columnwidths[j] > 0)&&(j<=BGHS[SI].cols))
+     if((j<=BGHS[SI].cols)&&(BGHS[SI].columnwidths[j] > 0))
          {
           ReturnValue = j;
          }

--- a/scintilla/lexers/LexUser.cxx
+++ b/scintilla/lexers/LexUser.cxx
@@ -1123,7 +1123,7 @@ static void setBackwards(WordList * kwLists[], StyleContext & sc, bool prefixes[
     int folding = FOLD_NONE;
     int moveForward = 0;
 
-    for (int i=0; i<=MAPPER_TOTAL; ++i)
+    for (int i=0; i<MAPPER_TOTAL; ++i)
     {
         if (nestedKey & maskMapper[i])
         {


### PR DESCRIPTION
[PowerEditor/src/Parameters.cpp:2581]: (warning) Array index -1 is out of bounds. Otherwise there is useless condition at line 2568.
[PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp:3079]: (style) Unused variable: newline
[PowerEditor/src/WinControls/Grid/BabyGrid.cpp:166]: (style) Array index 'j' is used before limits check.
[PowerEditor/src/WinControls/Grid/BabyGrid.cpp:171]: (style) Array index 'j' is used before limits check.
[scintilla/lexers/LexUser.cxx:1128]: (error) Array 'maskMapper[15]' accessed at index 15, which is out of bounds.