### PR TITLE
Better and more accurate menu entries for Caml & LISP

### DIFF
--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -681,7 +681,7 @@ BEGIN
 		MENUITEM "JSON",                    IDM_LANG_JSON
         MENUITEM "JSP",                     IDM_LANG_JSP
         MENUITEM "KIXtart",                 IDM_LANG_KIX
-        MENUITEM "LISP",                    IDM_LANG_LISP
+        MENUITEM "Common Lisp",             IDM_LANG_LISP
         MENUITEM "Lua",                     IDM_LANG_LUA
         MENUITEM "Makefile",                IDM_LANG_MAKEFILE
         MENUITEM "Matlab",                  IDM_LANG_MATLAB
@@ -731,10 +731,11 @@ BEGIN
         MENUITEM "C",                     IDM_LANG_C
         MENUITEM "C#",                    IDM_LANG_CS
         MENUITEM "C++",                   IDM_LANG_CPP
-        MENUITEM "Caml",                  IDM_LANG_CAML
+        MENUITEM "OCaml",                 IDM_LANG_CAML
         MENUITEM "CMake",                 IDM_LANG_CMAKE
         MENUITEM "COBOL",                 IDM_LANG_COBOL
 		MENUITEM "CoffeeScript",          IDM_LANG_COFFEESCRIPT
+        MENUITEM "Common Lisp",           IDM_LANG_LISP
         MENUITEM "CSS",                   IDM_LANG_CSS
     END
     POPUP "D"
@@ -766,12 +767,8 @@ BEGIN
         MENUITEM "JSP",                   IDM_LANG_JSP
     END
     MENUITEM "KIXtart",                   IDM_LANG_KIX
-    POPUP "L"
-    BEGIN
-        MENUITEM "LISP",                  IDM_LANG_LISP
-        MENUITEM "Lua",                   IDM_LANG_LUA
-    END
-     POPUP "M"
+    MENUITEM "Lua",                       IDM_LANG_LUA
+    POPUP "M"
     BEGIN
         MENUITEM "Makefile",              IDM_LANG_MAKEFILE
         MENUITEM "Matlab",                IDM_LANG_MATLAB

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -731,7 +731,6 @@ BEGIN
         MENUITEM "C",                     IDM_LANG_C
         MENUITEM "C#",                    IDM_LANG_CS
         MENUITEM "C++",                   IDM_LANG_CPP
-        MENUITEM "OCaml",                 IDM_LANG_CAML
         MENUITEM "CMake",                 IDM_LANG_CMAKE
         MENUITEM "COBOL",                 IDM_LANG_COBOL
 		MENUITEM "CoffeeScript",          IDM_LANG_COFFEESCRIPT
@@ -779,7 +778,11 @@ BEGIN
         MENUITEM "Normal Text",           IDM_LANG_TEXT
         MENUITEM "NSIS",                  IDM_LANG_NSIS
     END
-    MENUITEM "Objective-C",               IDM_LANG_OBJC
+    POPUP "O"
+    BEGIN
+        MENUITEM "Objective-C",           IDM_LANG_OBJC
+        MENUITEM "OCaml",                 IDM_LANG_CAML
+    END
     POPUP "P"
     BEGIN
         MENUITEM "Pascal",                IDM_LANG_PASCAL


### PR DESCRIPTION
I tested both LISP and Caml syntax highlightnings to see if they are really antiquated as name implies. Renaming them to better reflect what they more specifically are should be beneficial to everyone, because those are the names with which new user looks first for.