### PR TITLE
Added a -quitOnEmpty command line flag that causes Notepad++ to quit when the last tab is closed.

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3254,6 +3254,17 @@ bool Notepad_plus::canHideView(int whichOne)
 	return canHide;
 }
 
+bool Notepad_plus::isEmpty()
+{
+	if (bothActive()) return false;
+
+	DocTabView * tabToCheck = (_mainWindowStatus & WindowMainActive) ? &_mainDocTab : &_subDocTab;
+	
+	Buffer * buf = MainFileManager->getBufferByID(tabToCheck->getBufferByIndex(0));
+	bool isEmpty = ((tabToCheck->nbItem() == 1) && !buf->isDirty() && buf->isUntitled());
+	return isEmpty;
+}
+
 void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool dontClose)
 {
 	DocTabView * tabToOpen = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -365,7 +365,7 @@ private:
 	bool _sysMenuEntering = false;
 
 	// make sure we don't recursively call doClose when closing the last file with -quitOnEmpty
-	bool _isAttemptingQuitOnEmpty = false;
+	bool _isAttemptingCloseOnQuit = false;
 
 	// For FullScreen/PostIt features
 	VisibleGUIConf	_beforeSpecialView;

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -364,6 +364,8 @@ private:
 
 	bool _sysMenuEntering = false;
 
+	// make sure we don't recursively call doClose when closing the last file with -quitOnEmpty
+	bool _isAttemptingQuitOnEmpty = false;
 
 	// For FullScreen/PostIt features
 	VisibleGUIConf	_beforeSpecialView;
@@ -460,6 +462,8 @@ private:
 	}
 
 	bool canHideView(int whichOne);	//true if view can safely be hidden (no open docs etc)
+
+	bool isEmpty(); // true if we have 1 view with 1 clean, untitled doc
 
 	int switchEditViewTo(int gid);	//activate other view (set focus etc)
 

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -176,6 +176,8 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	if (nppGUI._rememberLastSession && !cmdLineParams->_isNoSession)
 		_notepad_plus_plus_core.loadLastSession();
 
+	nppGUI._quitOnEmpty = cmdLineParams->_quitOnEmpty;
+
 	if (not cmdLineParams->_isPreLaunch)
 	{
 		if (cmdLineParams->isPointValid())

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1616,7 +1616,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 					//Causing them to show on restart even though they are loaded by session
 					_lastRecentFileList.setLock(true);	//only lock when the session is remembered
 				}
+				_isAttemptingCloseOnQuit = true;
 				bool allClosed = fileCloseAll(false, isSnapshotMode);	//try closing files before doing anything else
+				_isAttemptingCloseOnQuit = false;
 
 				if (nppgui._rememberLastSession)
 					_lastRecentFileList.setLock(false);	//only lock when the session is remembered

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -587,6 +587,10 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
 	if (i == -1)
 		return;
 
+	int numInitialOpenBuffers =
+		((_mainWindowStatus & WindowMainActive) == WindowMainActive ? _mainDocTab.nbItem() : 0) +
+		((_mainWindowStatus & WindowSubActive) == WindowSubActive ? _subDocTab.nbItem() : 0);
+
 	if (doDeleteBackup)
 		MainFileManager->deleteCurrentBufferBackup();
 
@@ -663,6 +667,18 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
 		}
 	}
 	command(IDM_VIEW_REFRESHTABAR);
+
+	if (NppParameters::getInstance()->getNppGUI()._quitOnEmpty)
+	{
+		// the user closed the last open tab
+		if (numInitialOpenBuffers == 1 && isEmpty() && !_isAttemptingQuitOnEmpty)
+		{
+			_isAttemptingQuitOnEmpty = true;
+			command(IDM_FILE_EXIT);
+			_isAttemptingQuitOnEmpty = false;
+		}
+	}
+
 	return;
 }
 

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -671,11 +671,9 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
 	if (NppParameters::getInstance()->getNppGUI()._quitOnEmpty)
 	{
 		// the user closed the last open tab
-		if (numInitialOpenBuffers == 1 && isEmpty() && !_isAttemptingQuitOnEmpty)
+		if (numInitialOpenBuffers == 1 && isEmpty() && !_isAttemptingCloseOnQuit)
 		{
-			_isAttemptingQuitOnEmpty = true;
 			command(IDM_FILE_EXIT);
-			_isAttemptingQuitOnEmpty = false;
 		}
 	}
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -213,6 +213,7 @@ struct CmdLineParams
 	int _line2go   = -1;
 	int _column2go = -1;
 	int _pos2go = -1;
+	bool _quitOnEmpty = false;
 
 	POINT _point;
 	bool _isPointXValid = false;
@@ -785,6 +786,7 @@ struct NppGUI final
 	char _rightmostDelimiter = ')';
 	bool _delimiterSelectionOnEntireDocument = false;
 	bool _backSlashIsEscapeCharacterForSql = true;
+	bool _quitOnEmpty = false;
 
 
 	// 0 : do nothing

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -238,6 +238,7 @@ const TCHAR FLAG_HELP[] = TEXT("--help");
 const TCHAR FLAG_ALWAYS_ON_TOP[] = TEXT("-alwaysOnTop");
 const TCHAR FLAG_OPENSESSIONFILE[] = TEXT("-openSession");
 const TCHAR FLAG_RECURSIVE[] = TEXT("-r");
+const TCHAR FLAG_QUIT_ON_EMPTY[] = TEXT("-quitOnEmpty");
 
 
 static void doException(Notepad_plus_Window & notepad_plus_plus)
@@ -302,6 +303,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 	cmdLineParams._point.x = getNumberFromParam('x', params, cmdLineParams._isPointXValid);
 	cmdLineParams._point.y = getNumberFromParam('y', params, cmdLineParams._isPointYValid);
 	cmdLineParams._easterEggName = getEasterEggNameFromParam(params, cmdLineParams._quoteType);
+	cmdLineParams._quitOnEmpty = isInList(FLAG_QUIT_ON_EMPTY, params);
 
 
 	if (showHelp)


### PR DESCRIPTION
Useful for people who use Notead++ for things like editing Git commit messages (using -multiInst -notabbar -nosession), and want to signal they are done editing by closing the tab with Ctrl-W instead of Alt-F4.

Fixes #1006 