### PR TITLE
minimal fix for the crash seen with issue #1887

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3172,7 +3172,14 @@ void NppParameters::feedUserKeywordList(TiXmlNode *node)
 				if (globalMappper().keywordIdMapper.find(keywordsName) != globalMappper().keywordIdMapper.end())
 				{
 					id = globalMappper().keywordIdMapper[keywordsName];
-					lstrcpy(_userLangArray[_nbUserLang - 1]->_keywordLists[id], kwl);
+					if (_tcslen(kwl) < max_char)
+					{
+						lstrcpy(_userLangArray[_nbUserLang - 1]->_keywordLists[id], kwl);
+					}
+					else
+					{
+						lstrcpy(_userLangArray[_nbUserLang - 1]->_keywordLists[id], TEXT("imported string too long, needs to be < max_char(30720)"));
+					}
 				}
 			}
 		}

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -720,7 +720,7 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 			bool inSingleQuote = false;
 			bool nonWSFound = false;
 			int index = 0;
-			for (size_t j=0, len = strlen(keyWords_char); j<len; ++j)
+			for (size_t j=0, len = strlen(keyWords_char); j<len && index < (max_char-1); ++j)
 			{
 				if (!inSingleQuote && keyWords_char[j] == '"')
 				{


### PR DESCRIPTION
, see https://github.com/notepad-plus-plus/notepad-plus-plus/issues/1887
, tested with the attached https://github.com/notepad-plus-plus/notepad-plus-plus/files/278989/practice.txt, after rename to xml on 6.9.2, crash happens due to out-of-bounds access to imported keyword list entry > max_char corrupting _keywordLists of _userLangArray

@donho: 
- not fixed is the part for UDL import pre 2.0. Is this still relevant?
- problematic input is just replaced by a hardcoded error text, is it necessary to have the keyword input limited to max_char or could we use the dynamic generic_string instead?
e.g. 
`std::array<generic_string, SCE_USER_KWLIST_TOTAL> _keywordLists;`
instead of 
`TCHAR _keywordLists[SCE_USER_KWLIST_TOTAL][max_char];`, see https://github.com/chcg/notepad-plus-plus/commit/2769a86538ce2bb94ccab0db64a2622ef49d99d2 for a first impl
- seems that the UDL import can't report a failure from NppParameters::feedUserKeywordList(), ...further import helper.