### PR TITLE
Report the correct crashed plugin

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -470,10 +470,10 @@ void PluginsManager::notify(const SCNotification *notification)
 			}
 			catch (...)
 			{
-				TCHAR funcInfo[128];
+				TCHAR funcInfo[256];
 				generic_sprintf(funcInfo, TEXT("notify(SCNotification *notification) : \r notification->nmhdr.code == %d\r notification->nmhdr.hwndFrom == %p\r notification->nmhdr.idFrom == %d"),\
 					scNotif.nmhdr.code, scNotif.nmhdr.hwndFrom, scNotif.nmhdr.idFrom);
-				pluginCrashAlert(_pluginsCommands[i]._pluginName.c_str(), funcInfo);
+				pluginCrashAlert(_pluginInfos[i]->_moduleName.c_str(), funcInfo);
 			}
 		}
 	}
@@ -498,7 +498,7 @@ void PluginsManager::relayNppMessages(UINT Message, WPARAM wParam, LPARAM lParam
 			{
 				TCHAR funcInfo[128];
 				generic_sprintf(funcInfo, TEXT("relayNppMessages(UINT Message : %d, WPARAM wParam : %d, LPARAM lParam : %d)"), Message, wParam, lParam);
-				pluginCrashAlert(_pluginsCommands[i]._pluginName.c_str(), TEXT(""));
+				pluginCrashAlert(_pluginInfos[i]->_moduleName.c_str(), funcInfo);
 			}
 		}
 	}
@@ -529,7 +529,7 @@ bool PluginsManager::relayPluginMessages(UINT Message, WPARAM wParam, LPARAM lPa
 				{
 					TCHAR funcInfo[128];
 					generic_sprintf(funcInfo, TEXT("relayPluginMessages(UINT Message : %d, WPARAM wParam : %d, LPARAM lParam : %d)"), Message, wParam, lParam);
-					pluginCrashAlert(_pluginsCommands[i]._pluginName.c_str(), funcInfo);
+					pluginCrashAlert(_pluginInfos[i]->_moduleName.c_str(), funcInfo);
 				}
 				return true;
             }

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -142,9 +142,9 @@ private:
 	void pluginCrashAlert(const TCHAR *pluginName, const TCHAR *funcSignature)
 	{
 		generic_string msg = pluginName;
-		msg += TEXT(" just crash in\r");
+		msg += TEXT(" just crashed in\r");
 		msg += funcSignature;
-		::MessageBox(NULL, msg.c_str(), TEXT(" just crash in\r"), MB_OK|MB_ICONSTOP);
+		::MessageBox(NULL, msg.c_str(), TEXT("Plugin Crash"), MB_OK|MB_ICONSTOP);
 	}
 
 	bool isInLoadedDlls(const TCHAR *fn) const


### PR DESCRIPTION
Closes #1980.

Before: 
![before](https://cloud.githubusercontent.com/assets/3694843/16210799/ebaf1d72-370b-11e6-8bc5-022c127ad92b.png)

After:
![after](https://cloud.githubusercontent.com/assets/3694843/16210801/ee5fcbc0-370b-11e6-9cbc-f2aae9914d71.png)
