### PR TITLE
Fix untranslated options in File menu

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -95,7 +95,7 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{VK_NULL,    IDM_FILE_PRINTNOW,                            false, false, false, nullptr},
 	{VK_F4,      IDM_FILE_EXIT,                                false, true,  false, nullptr},
 
-	{ VK_T,      IDM_FILE_RESTORELASTCLOSEDFILE,               true,  false,  true, TEXT("Restore Recent Closed File")},
+	{ VK_T,      IDM_FILE_RESTORELASTCLOSEDFILE,               true,  false,  true, nullptr},
 
 //	{VK_NULL,    IDM_EDIT_UNDO,                                false, false, false, nullptr},
 //	{VK_NULL,    IDM_EDIT_REDO,                                false, false, false, nullptr},

--- a/PowerEditor/src/lastRecentFileList.cpp
+++ b/PowerEditor/src/lastRecentFileList.cpp
@@ -101,7 +101,7 @@ void LastRecentFileList::updateMenu()
 		//add separators
 		NativeLangSpeaker *pNativeLangSpeaker = pNppParam->getNativeLangSpeaker();
 
-		generic_string recentFileList = pNativeLangSpeaker->getSpecialMenuEntryName("RecentFiles");
+		generic_string recentFileList = pNativeLangSpeaker->getSpecialMenuEntryName("file-recentFiles");
 		generic_string openRecentClosedFile = pNativeLangSpeaker->getNativeLangMenuString(IDM_FILE_RESTORELASTCLOSEDFILE);
 		generic_string openAllFiles = pNativeLangSpeaker->getNativeLangMenuString(IDM_OPEN_ALL_RECENT_FILE);
 		generic_string cleanFileList = pNativeLangSpeaker->getNativeLangMenuString(IDM_CLEAN_RECENT_FILE_LIST);


### PR DESCRIPTION
Small change to fix two options in the "File" menu not being translated:

- The "Recent files" submenu turns to English (ignoring translation xml) when you make it disapear and re-appear in the Preferences->Recent Files history->In Submenu.
- The option "Restore Recent Closed File"

