### PR TITLE
Change search direction when pressing 'shift' while searching

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -817,8 +817,20 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 					if (isMacroRecording)
 						saveInMacro(wParam, FR_OP_FIND);
 
+					bool direction_bak = _options._whichDirection;
+					// if shift-key is pressed, revert search direction
+					// if shift-key is not pressed, use the normal setting
+					SHORT shift = GetKeyState(VK_SHIFT);
+					if (shift & SHIFTED)
+					{
+						_options._whichDirection = !_options._whichDirection;
+					}
+
 					FindStatus findStatus = FSFound;
 					processFindNext(_options._str2Search.c_str(), _env, &findStatus);
+					// restore search direction which may have been overwritten because shift-key was pressed
+					_options._whichDirection = direction_bak;
+
 					if (findStatus == FSEndReached)
 						setStatusbarMessage(TEXT("Find: Found the 1st occurrence from the top. The end of the document has been reached."), FSEndReached);
 					else if (findStatus == FSTopReached)


### PR DESCRIPTION
As requested in issue #1739 

I realize the issue has not been 'accepted' yet. However if you decide to accept the issue, this code realizes the requested behavior.
The solution temporarily overwrites _options._whichDirection, because the variable _options is passed to processFindNext. It is set back to the original value after the call.
An alternative is to copy the whole _options variable into a new variable and modify that one. That way, you don't have to set the original value again. It's safer for exceptions, but requires a copy. Because it looks like raised exceptions here immediately stop the program anyway, I chose the first option.
