### PR TITLE
Recognize new file type when created from the command line

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -209,7 +209,6 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
     }
 
     bool globbing = wcsrchr(longFileName, TCHAR('*')) || wcsrchr(longFileName, TCHAR('?'));
-	bool isOpenningNewEmptyFile = false;
 
 	if (!isSnapshotMode) // if not backup mode, or backupfile path is invalid
 	{
@@ -229,7 +228,6 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
 					if (res)
 					{
 						isCreateFileSuccessful = true;
-						isOpenningNewEmptyFile = true;
 					}
 					else
 					{
@@ -299,16 +297,6 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
         // if file is read only, we set the view read only
         if (isReadOnly)
             buf->setUserReadOnly(true);
-
-		// if it's a new created file, then use new file default settings
-		if (isOpenningNewEmptyFile)
-		{
-			const NewDocDefaultSettings & ndds = (NppParameters::getInstance()->getNppGUI()).getNewDocDefaultSettings();
-			buf->setEncoding(ndds._codepage);
-			buf->setEolFormat(ndds._format);
-			buf->setUnicodeMode(ndds._unicodeMode);
-			buf->setLangType(ndds._lang);
-		}
 
         // Notify plugins that current file is about to open
         scnN.nmhdr.code = NPPN_FILEBEFOREOPEN;


### PR DESCRIPTION
Hi @donho 
This commit fixes the issue of notepad++ defaulting to 'Normal text file' file type when creating new file form the command like

> notepad++.exe new_example_file.cpp

Issue: #2016 
Signed-off-by: Vineel Kumar Reddy Kovvuri <vineel.kovvuri@gmail.com>