### PR TITLE
Update german.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -295,7 +295,7 @@
 					<Item id="47001" name="Notepad++ im &amp;Web"/>
 					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
 					<Item id="47003" name="Online-Dokumentation"/>
-					<Item id="47004" name="Notepad++ Online-Forum)"/>
+					<Item id="47004" name="Notepad++ Online-Forum"/>
 					<Item id="47011" name="&amp;Support im Chat"/>
 					<Item id="47005" name="&amp;Erweiterungen"/>
 					<Item id="47006" name="Notepad++ &amp;aktualisieren"/>


### PR DESCRIPTION
Hello,

This commit removes a closing parenthesis in the german text 47004 (probably an accident by original translator)
Not that big of an bug - but I stumbled upon it by accident when using Notepad, and that lonely parenthesis kinda looks [strange](https://xkcd.com/859/) :)

Regards
  ~Mike