### PR TITLE
Added new Variable: NPP_ROOT_DIRECTORY

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -427,6 +427,7 @@ enum winVer{ WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, W
 	#define NPPM_GETEXTPART				(RUNCOMMAND_USER + EXT_PART)
 	#define NPPM_GETCURRENTWORD			(RUNCOMMAND_USER + CURRENT_WORD)
 	#define NPPM_GETNPPDIRECTORY		(RUNCOMMAND_USER + NPP_DIRECTORY)
+	#define NPPM_GETNPPROOTDIRECTORY	(RUNCOMMAND_USER + NPP_ROOT_DIRECTORY)
 	// BOOL NPPM_GETXXXXXXXXXXXXXXXX(size_t strLen, TCHAR *str)
 	// where str is the allocated TCHAR array,
 	//	     strLen is the allocated array size
@@ -450,6 +451,7 @@ enum winVer{ WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, W
 		#define NPP_DIRECTORY 7
 		#define CURRENT_LINE 8
 		#define CURRENT_COLUMN 9
+		#define NPP_ROOT_DIRECTORY 10
 
 
 // Notification code

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -704,6 +704,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 			return TRUE;
 		}
 
+		case NPPM_GETNPPROOTDIRECTORY:
 		case NPPM_GETNPPDIRECTORY:
 		{
 			const int strSize = MAX_PATH;
@@ -711,6 +712,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 
 			::GetModuleFileName(NULL, str, strSize);
 			PathRemoveFileSpec(str);
+			if (Message == NPPM_GETNPPROOTDIRECTORY)
+				PathRemoveFileSpec(str);
 
 			// For the compability reason, if wParam is 0, then we assume the size of generic_string buffer (lParam) is large enough.
 			// otherwise we check if the generic_string buffer size is enough for the generic_string to copy.

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
@@ -79,6 +79,8 @@ int whichVar(TCHAR *str)
 		return CURRENT_WORD;
 	else if (!lstrcmp(nppDir, str))
 		return NPP_DIRECTORY;
+	else if (!lstrcmp(nppRootDir, str))
+		return NPP_ROOT_DIRECTORY;
 	else if (!lstrcmp(currentLine, str))
 		return CURRENT_LINE;
 	else if (!lstrcmp(currentColumn, str))

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.h
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.h
@@ -34,6 +34,7 @@ const TCHAR fileNamePart[] = TEXT("NAME_PART");
 const TCHAR fileExtPart[] = TEXT("EXT_PART");
 const TCHAR currentWord[] = TEXT("CURRENT_WORD");
 const TCHAR nppDir[] = TEXT("NPP_DIRECTORY");
+const TCHAR nppRootDir[] = TEXT("NPP_ROOT_DIRECTORY");
 const TCHAR currentLine[] = TEXT("CURRENT_LINE");
 const TCHAR currentColumn[] = TEXT("CURRENT_COLUMN");
 


### PR DESCRIPTION
Added a new command variable $(NPP_ROOT_DIRECTORY), for a more portable configuration of Run Commands.

NPP_ROOT_DIRECTORY contains the path to the parent directory (NppRoot) of the Npp directory, for instance:

Variable | Content
---- | ----
FullNppPath1 | [NppRoot]\Notepad++\Notepad++.exe
NPP_DIRECTORY | [NppRoot]\Notepad++
NPP_ROOT_DIRECTORY | [NppRoot]
FullNppPath2 | C:\Notepad++.exe
Both | C:\

When you have some portable applications in a movable path ([X]\App1\; [X]\App2\; [X]\Notepad++\),
this will make the configuration straightforward:

$(NPP_ROOT_DIRECTORY)\App1\App1.exe [params]
$(NPP_ROOT_DIRECTORY)\App2\App2.exe [params]