### PR TITLE
- corrected x64 debug build by adding $(BUILDTARGETPATH) to nppSpecif…

### DIFF
--- a/scintilla/boostregex/BuildBoost.bat
+++ b/scintilla/boostregex/BuildBoost.bat
@@ -10,27 +10,37 @@ SET WORKPATH=%~dp0%
 SET BUILDTARGETPARAM=
 SET BUILDTARGETPATH=
 
-rem :PARAMLOOP
+:PARAMLOOP
 IF [%1]==[] (
   GOTO PARAMCONTINUE
-)
-
-IF NOT [%1]==[--toolset] (
-     SET BOOSTPATH=%1
 )
 
 IF [%1]==[--toolset] (
   SET MSVCTOOLSET=%2
   SHIFT
+  SHIFT
+  GOTO PARAMLOOP
 )
 
-IF [%2]==[-x64] (
+IF [%1]==[-x64] (
+	SET BUILDTARGETPARAM=address-model=64
+	SET BUILDTARGETPATH=address-model-64\
+	SHIFT
+	GOTO PARAMLOOP
+)
+
+IF [%1]==[-itanium] (
 	SET BUILDTARGETPARAM=architecture=ia64
 	SET BUILDTARGETPATH=architecture-ia64\
+	SHIFT
+	GOTO PARAMLOOP
 )
 
-rem SHIFT
-rem GOTO PARAMLOOP
+
+SET BOOSTPATH=%1
+
+SHIFT
+GOTO PARAMLOOP
 :PARAMCONTINUE
 
 IF [%BOOSTPATH%]==[] (
@@ -40,10 +50,9 @@ IF [%BOOSTPATH%]==[] (
 SET TOOLSETCOMMAND=
 
 IF NOT [%MSVCTOOLSET%]==[] (
-	SET TOOLSETCOMMAND=toolset=%MSVCTOOLSET% 
+	SET TOOLSETCOMMAND=toolset=%MSVCTOOLSET%
 )
 
-	
 
 IF NOT EXIST "%BOOSTPATH%\boost\regex.hpp" (
    ECHO Not found: %BOOSTPATH%\boost\regex.hpp
@@ -124,33 +133,38 @@ IF NOT [%MSVCTOOLSET%]==[] (
     GOTO TOOLSETKNOWN
 )
 
+:: VS2015
+IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-14.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc140-mt-s-%BOOSTVERSION%.lib (
+	SET MSVCTOOLSET=msvc-14.0
+)
+
 :: VS2013
 IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-12.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc120-mt-s-%BOOSTVERSION%.lib (
 	SET MSVCTOOLSET=msvc-12.0
 )
 
 :: VS2012
-IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-11.0\release\link-static\runtime-link-static\threading-multi\libboost_regex-vc110-mt-s-%BOOSTVERSION%.lib (
+IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-11.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc110-mt-s-%BOOSTVERSION%.lib (
 	SET MSVCTOOLSET=msvc-11.0
 )
 
 :: VS2010
-IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-10.0\release\link-static\runtime-link-static\threading-multi\libboost_regex-vc100-mt-s-%BOOSTVERSION%.lib (
+IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-10.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc100-mt-s-%BOOSTVERSION%.lib (
 	SET MSVCTOOLSET=msvc-10.0
 )
 
 :: VS2008
-IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-9.0\release\link-static\runtime-link-static\threading-multi\libboost_regex-vc90-mt-s-%BOOSTVERSION%.lib (
+IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-9.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc90-mt-s-%BOOSTVERSION%.lib (
 	SET MSVCTOOLSET=msvc-9.0
 )
 
 :: VS2005
-IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-8.0\release\link-static\runtime-link-static\threading-multi\libboost_regex-vc80-mt-s-%BOOSTVERSION%.lib (
+IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-8.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc80-mt-s-%BOOSTVERSION%.lib (
 	SET MSVCTOOLSET=msvc-8.0
 )
 
 IF [%MSVCTOOLSET%]==[] (
-	ECHO No correctly built boost regex libraries could be found.  
+	ECHO No correctly built boost regex libraries could be found.
 	ECHO Try specifying the MSVC version on the command line.
 	GOTO USAGE
 )
@@ -162,6 +176,11 @@ ECHO Run buildboost.bat without parameters to see the usage.
 
 
 :TOOLSETKNOWN
+
+:: VS2015
+IF [%MSVCTOOLSET%]==[msvc-14.0] (
+	SET BOOSTLIBPATH=%BOOSTPATH%\bin.v2\libs\regex\build\msvc-14.0
+)
 
 :: VS2013
 IF [%MSVCTOOLSET%]==[msvc-12.0] (
@@ -192,8 +211,8 @@ IF [%MSVCTOOLSET%]==[msvc-8.0] (
 IF [%BOOSTLIBPATH%] == [] (
     ECHO ****************************************
 	ECHO ** ERROR
-	ECHO ** Boost library could not be found.  
-	ECHO ** Make sure you've specified the correct boost path on the command line, 
+	ECHO ** Boost library could not be found.
+	ECHO ** Make sure you've specified the correct boost path on the command line,
 	ECHO ** and try adding the toolset version
 	ECHO ****************************************
 	GOTO USAGE
@@ -210,9 +229,9 @@ ECHO Boost::regex built.
 ECHO.
 ECHO Now you need to build scintilla.
 ECHO.
-ECHO From the scintilla\win32 directory 
+ECHO From the scintilla\win32 directory
 ECHO.
-ECHO   nmake -f scintilla.mak 
+ECHO   nmake -f scintilla.mak
 ECHO.
 ECHO.
 
@@ -226,11 +245,11 @@ ECHO.
 ECHO.
 ECHO Boost is available free from www.boost.org
 ECHO.
-ECHO Unzip the file downloaded from www.boost.org, and give the absolute path 
+ECHO Unzip the file downloaded from www.boost.org, and give the absolute path
 ECHO as the first parameter to buildboost.bat
 ECHO.
 ECHO e.g.
-ECHO buildboost.bat d:\libs\boost_1_55_0           
+ECHO buildboost.bat d:\libs\boost_1_55_0
 
 ECHO.
 ECHO To build 64 bit version, add "-x64" flag after the full file path.
@@ -241,15 +260,16 @@ ECHO.
 ECHO.
 ECHO You can specify which version of the Visual Studio compiler to use
 ECHO with --toolset.
-ECHO Use:   
+ECHO Use:
 ECHO   --toolset msvc-8.0     for Visual studio 2005
 ECHO   --toolset msvc-9.0     for Visual Studio 2008
 ECHO   --toolset msvc-10.0    for Visual Studio 2010
 ECHO   --toolset msvc-11.0    for Visual Studio 2012
 ECHO   --toolset msvc-12.0    for Visual Studio 2013
+ECHO   --toolset msvc-14.0    for Visual Studio 2015
 ECHO.
 ECHO.
-ECHO e.g.  To build with boost in d:\libs\boost_1_55_0 with Visual Studio 2008
+ECHO e.g.  To build with boost in d:\libs\boost_1_55_0 with Visual Studio 2013
 ECHO.
 ECHO         buildboost.bat --toolset msvc-9.0 d:\libs\boost_1_55_0
 ECHO.
@@ -259,7 +279,7 @@ GOTO EOF
 :BUILDERROR
 ECHO There was an error building boost.  Please see the messages above for details.
 ECHO  - Have you got a clean extract from a recent boost version, such as 1.55?
-ECHO  - Download a fresh copy from www.boost.org and extract it to a directory, 
+ECHO  - Download a fresh copy from www.boost.org and extract it to a directory,
 ECHO    and run the batch again with the name of that directory
 
 :EOF

--- a/scintilla/boostregex/BuildBoost.bat
+++ b/scintilla/boostregex/BuildBoost.bat
@@ -133,6 +133,10 @@ IF NOT [%MSVCTOOLSET%]==[] (
     GOTO TOOLSETKNOWN
 )
 
+:: VS201x
+IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-15.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc150-mt-s-%BOOSTVERSION%.lib (
+	SET MSVCTOOLSET=msvc-15.0
+
 :: VS2015
 IF EXIST %BOOSTPATH%\bin.v2\libs\regex\build\msvc-14.0\release\%BUILDTARGETPATH%link-static\runtime-link-static\threading-multi\libboost_regex-vc140-mt-s-%BOOSTVERSION%.lib (
 	SET MSVCTOOLSET=msvc-14.0
@@ -176,6 +180,11 @@ ECHO Run buildboost.bat without parameters to see the usage.
 
 
 :TOOLSETKNOWN
+
+:: VS201x
+IF [%MSVCTOOLSET%]==[msvc-15.0] (
+	SET BOOSTLIBPATH=%BOOSTPATH%\bin.v2\libs\regex\build\msvc-15.0
+)
 
 :: VS2015
 IF [%MSVCTOOLSET%]==[msvc-14.0] (
@@ -267,11 +276,12 @@ ECHO   --toolset msvc-10.0    for Visual Studio 2010
 ECHO   --toolset msvc-11.0    for Visual Studio 2012
 ECHO   --toolset msvc-12.0    for Visual Studio 2013
 ECHO   --toolset msvc-14.0    for Visual Studio 2015
+ECHO   --toolset msvc-15.0    for Visual Studio 201x
 ECHO.
 ECHO.
 ECHO e.g.  To build with boost in d:\libs\boost_1_55_0 with Visual Studio 2013
 ECHO.
-ECHO         buildboost.bat --toolset msvc-9.0 d:\libs\boost_1_55_0
+ECHO         buildboost.bat --toolset msvc-12.0 d:\libs\boost_1_55_0
 ECHO.
 GOTO EOF
 

--- a/scintilla/boostregex/nppSpecifics.mak
+++ b/scintilla/boostregex/nppSpecifics.mak
@@ -54,7 +54,7 @@ $(DIR_O)\BoostRegexSearch.obj:: ../boostregex/BoostRegexSearch.cxx ../src/CharCl
 !MESSAGE from scintilla\BoostRegex directory with the path where 
 !MESSAGE you have extracted the boost archive (from www.boost.org)
 !MESSAGE e.g. 
-!MESSAGE       buildboost.bat d:\libs\boost_1_48_0
+!MESSAGE       buildboost.bat d:\libs\boost_1_55_0
 !MESSAGE
 !MESSAGE If you want to build scintilla without Boost (and just 
 !MESSAGE use the limited  built-in regular expressions), 

--- a/scintilla/boostregex/nppSpecifics.mak
+++ b/scintilla/boostregex/nppSpecifics.mak
@@ -31,7 +31,7 @@ CXXFLAGS=$(CXXFLAGS) -DSCI_OWNREGEX -arch:IA32
 !ENDIF
 
 !IFDEF DEBUG
-LDFLAGS=$(LDFLAGS) -LIBPATH:$(BOOSTLIBPATH)\debug\link-static\runtime-link-static\threading-multi
+LDFLAGS=$(LDFLAGS) -LIBPATH:$(BOOSTLIBPATH)\debug\$(BUILDTARGETPATH)link-static\runtime-link-static\threading-multi
 !ELSE
 LDFLAGS=$(LDFLAGS) -LIBPATH:$(BOOSTLIBPATH)\release\$(BUILDTARGETPATH)link-static\runtime-link-static\threading-multi
 !ENDIF


### PR DESCRIPTION
- corrected x64 debug build by adding $(BUILDTARGETPATH) to nppSpecifics.mak needed for #1943
- corrected x64 parameter by address-model=64, see [(http://www.boost.org/build/doc/html/bbv2/reference/tools.html#v2.reference.tools.compiler.msvc.64)]
- added new option for the itanium aka architecture=ia64
- added build option for vs2015
- corrected build script to reenable adding the optional parts (--toolset, -x64, -itanium) before or after the BOOSTPATH
- changed vs 2008 -> vs 2013 in the example
- removed trailing spaces