### PR TITLE
(Easy to integrate!) Added new message that allows plugins to disable the auto-completion on each input

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -419,6 +419,12 @@ enum winVer{ WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, W
 	#define NPPM_DISABLEAUTOUPDATE (NPPMSG + 95) // 2119 in decimal
 	// VOID NPPM_DISABLEAUTOUPDATE(0, 0)
 
+	#define NPPM_SETAUTOCOMPLETIONDISABLEDONCHARADDED (NPPMSG + 97)
+	// BOOL NPPM_SETAUTOCOMPLETIONDISABLEDONCHARADDED(0, 0/1)
+	// Allows plugins to programmatically disable the autocompletion shown when typing characters
+	// the user can still call the autocompletion window manually
+	// Return : the previous status (true if disabled, false otherwise)
+
 #define	RUNCOMMAND_USER    (WM_USER + 3000)
 	#define NPPM_GETFULLCURRENTPATH		(RUNCOMMAND_USER + FULL_CURRENT_PATH)
 	#define NPPM_GETCURRENTDIRECTORY	(RUNCOMMAND_USER + CURRENT_DIRECTORY)

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -471,6 +471,14 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 			return TRUE;
 		}
 
+		case NPPM_SETAUTOCOMPLETIONDISABLEDONCHARADDED:
+		{
+			bool isFromPrimary = _pEditView == &_mainEditView;
+			AutoCompletion * autoC = isFromPrimary ? &_autoCompleteMain : &_autoCompleteSub;
+			autoC->_disabledOnCharAdded = bool(lParam != 0);
+			return !autoC->_disabledOnCharAdded;
+		}
+
 		case WM_SIZE:
 		{
 			RECT rc;

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -715,6 +715,10 @@ void AutoCompletion::update(int character)
 	if (_pEditView->execute(SCI_AUTOCACTIVE) != 0)
 		return;
 
+	// let the plugins the possibility to simulate nppGUI._autocStatus == nppGUI.autoc_none
+	if (_disabledOnCharAdded)
+		return;
+
 	const int wordSize = 64;
 	TCHAR s[wordSize];
 	_pEditView->getWordToCurrentPos(s, wordSize);

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.h
@@ -94,6 +94,8 @@ public:
 	void callTipClick(int direction);
 	void getCloseTag(char *closeTag, size_t closeTagLen, size_t caretPos, LangType language);
 
+	bool _disabledOnCharAdded;
+
 private:
 	bool _funcCompletionActive;
 	ScintillaEditView * _pEditView;


### PR DESCRIPTION
Hello,

First of all, thank you for that awesome tool!

I'm suggesting to add a new NPPM message that would allow the plugins to programmatically disable the auto-completion from showing when characters are added to the text (basically it would act like the user unchecked _Enable auto-completion on each input_).

This would allow plugins to implement custom auto-completion for certain type of files (disabling the default Npp auto-completion) while maintaining the option checked for the user so the default auto-completion can still be used on other files.

Thank you for your consideration ;)
