### PR TITLE
Fix PowerShell lexer

### DIFF
--- a/scintilla/lexers/LexPowerShell.cxx
+++ b/scintilla/lexers/LexPowerShell.cxx
@@ -75,7 +75,7 @@ static void ColourisePowerShellDoc(unsigned int startPos, int length, int initSt
 			}
 		} else if (sc.state == SCE_POWERSHELL_STRING) {
 			// This is a doubles quotes string
-			if (sc.ch == '\"') {
+			if (sc.ch == '\"' && sc.chPrev != '`') {
 				sc.ForwardSetState(SCE_POWERSHELL_DEFAULT);
 			}
 		} else if (sc.state == SCE_POWERSHELL_CHARACTER) {


### PR DESCRIPTION
Backtick is an escape character in a double-quoted string.

Notepad++
![text_npp](https://cloud.githubusercontent.com/assets/8997754/16764662/b8f64286-482f-11e6-975e-84917ee53428.png)

PowerShell ISE
![text_posh](https://cloud.githubusercontent.com/assets/8997754/16764664/b9e8c402-482f-11e6-994b-84e587d66953.png)
