### PR TITLE
Skip auto-complete of XML processing instructions

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -404,6 +404,9 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	if (tagHead[1] == '/') // "</toto>" will be ignored
 		return;
 
+	if (tagHead[1] == '?') // "<?" (Processing Instructions) will be ignored
+		return;
+
 	if (strncmp(tagHead, "<!--", 4) == 0) // Comments will be ignored
 		return;
 

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -368,7 +368,7 @@ bool AutoCompletion::showFunctionComplete()
 	return false;
 }
 
-void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t caretPos, LangType language)
+void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t caretPos, bool isHTML)
 {
 	char prev = (char)_pEditView->execute(SCI_GETCHARAT, caretPos - 2);
 	char prevprev = (char)_pEditView->execute(SCI_GETCHARAT, caretPos - 3);
@@ -407,21 +407,15 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	if (strncmp(tagHead, "<!--", 4) == 0) // Comments will be ignored
 		return;
 
-	if (language == L_HTML) // for HTML: "br", "hr", "img", "link", "!doctype" and "meta" will be ignored
+	if (isHTML) // for HTML: "br", "hr", "img", "link", "!doctype" and "meta" will be ignored
 	{
-		const char *disallowedTags[] = { "br", "hr", "img", "link", "meta", "!doctype" };
+		char *disallowedTags[] = { "br", "hr", "img", "link", "meta", "!doctype" };
 		size_t disallowedTagsLen = sizeof(disallowedTags) / sizeof(char *);
 		for (size_t i = 0; i < disallowedTagsLen; ++i)
 		{
 			if (strnicmp(tagHead + 1, disallowedTags[i], strlen(disallowedTags[i])) == 0)
 				return;
 		}
-	}
-	else if (language == L_XML)
-	{
-		// Ignore "?xml"
-		if (strnicmp(tagHead + 1, "?xml", strlen("?xml")) == 0)
-			return;
 	}
 
 	closeTag[0] = '<';
@@ -642,7 +636,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 		{
 			if (matchedPairConf._doHtmlXmlTag && (_curLang == L_HTML || _curLang == L_XML))
 			{
-				getCloseTag(closeTag, tagMaxLen, caretPos, _curLang);
+				getCloseTag(closeTag, tagMaxLen, caretPos, _curLang == L_HTML);
 				if (closeTag[0] != '\0')
 					matchedChars = closeTag;
 			}

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.h
@@ -92,7 +92,7 @@ public:
 	void insertMatchedChars(int character, const MatchedPairConf & matchedPairConf);
 	void update(int character);
 	void callTipClick(int direction);
-	void getCloseTag(char *closeTag, size_t closeTagLen, size_t caretPos, LangType language);
+	void getCloseTag(char *closeTag, size_t closeTagLen, size_t caretPos, bool isHTML);
 
 private:
 	bool _funcCompletionActive;


### PR DESCRIPTION
Fixes #2050. This reverts a previous commit and makes the behavior more generic. 