### PR TITLE
Add thousands separator for Summary and Statusbar

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -26,6 +26,7 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <algorithm>
 #include <stdexcept>
+#include <sstream>
 #include <shlwapi.h>
 #include <shlobj.h>
 #include <uxtheme.h>
@@ -37,6 +38,7 @@
 
 WcharMbcsConvertor* WcharMbcsConvertor::_pSelf = new WcharMbcsConvertor;
 
+typedef std::basic_stringstream<TCHAR> generic_stringstream;
 
 
 
@@ -53,6 +55,13 @@ void printStr(const TCHAR *str2print)
 	::MessageBox(NULL, str2print, TEXT(""), MB_OK);
 }
 
+generic_string commafyInt(size_t n)
+{
+	generic_stringstream ss;
+	ss.imbue(std::locale(""));
+	ss << n;
+	return ss.str();
+}
 
 std::string getFileContent(const TCHAR *file2read)
 {

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -71,6 +71,7 @@ generic_string getFolderName(HWND parent, const TCHAR *defaultDir = NULL);
 
 void printInt(int int2print);
 void printStr(const TCHAR *str2print);
+generic_string commafyInt(size_t n);
 
 void writeLog(const TCHAR *logFileName, const char *log2write);
 int filter(unsigned int code, struct _EXCEPTION_POINTERS *ep);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3031,19 +3031,22 @@ void Notepad_plus::updateStatusBar()
 
 	long selected_length = _pEditView->getSelectedLength();
 	if (selected_length != -1)
-		wsprintf(strSel, TEXT("Sel : %d | %d"), selected_length, selLine);
+		wsprintf(strSel, TEXT("Sel : %s | %s"), commafyInt(selected_length).c_str(), commafyInt(selLine).c_str());
 	else
 		wsprintf(strSel, TEXT("Sel : %s"), TEXT("N/A"));
 
-    wsprintf(strLnCol, TEXT("Ln : %d    Col : %d    %s"),\
-        (_pEditView->getCurrentLineNumber() + 1), \
-        (_pEditView->getCurrentColumnNumber() + 1),\
-        strSel);
+	wsprintf(strLnCol, TEXT("Ln : %s    Col : %s    %s"),
+		commafyInt(_pEditView->getCurrentLineNumber() + 1).c_str(),
+		commafyInt(_pEditView->getCurrentColumnNumber() + 1).c_str(),
+		strSel);
 
     _statusBar.setText(strLnCol, STATUSBAR_CUR_POS);
 
     TCHAR strDocLen[256];
-	wsprintf(strDocLen, TEXT("length : %d    lines : %d"), _pEditView->getCurrentDocLen(), _pEditView->execute(SCI_GETLINECOUNT));
+	wsprintf(strDocLen, TEXT("length : %s    lines : %s"),
+		commafyInt(_pEditView->getCurrentDocLen()).c_str(),
+		commafyInt(_pEditView->execute(SCI_GETLINECOUNT)).c_str());
+
     _statusBar.setText(strDocLen, STATUSBAR_DOC_SIZE);
     _statusBar.setText(_pEditView->execute(SCI_GETOVERTYPE) ? TEXT("OVR") : TEXT("INS"), STATUSBAR_TYPING_MODE);
 }

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1686,10 +1686,8 @@ void Notepad_plus::command(int id)
 				characterNumber += curBuf->getFileTime(Buffer::ft_modified);
 				characterNumber += TEXT("\r");
 
-				TCHAR fileLenStr[64];
-				generic_sprintf(fileLenStr, TEXT("%I64u"), static_cast<UINT64>( fileLen ) );
 				characterNumber += fileLenLabel;
-				characterNumber += fileLenStr;
+				characterNumber += commafyInt(static_cast<UINT64>(fileLen)).c_str();
 				characterNumber += TEXT("\r");
 				characterNumber += TEXT("\r");
 			}
@@ -1710,42 +1708,27 @@ void Notepad_plus::command(int id)
 			auto nbSelByte = getSelectedBytes();
 			auto nbRange = getSelectedAreas();
 
-			TCHAR nbCharStr[32];
-			TCHAR nbWordStr[16];
-			TCHAR nbByteStr[32];
-			TCHAR nbLineStr[32];
-			TCHAR nbSelStr[32];
-			TCHAR nbSelByteStr[32];
-			TCHAR nbRangeStr[8];
-
-			generic_sprintf(nbCharStr, TEXT("%d"), nbChar);
 			characterNumber += nbCharLabel;
-			characterNumber += nbCharStr;
+			characterNumber += commafyInt(nbChar).c_str();
 			characterNumber += TEXT("\r");
 
-			generic_sprintf(nbWordStr, TEXT("%d"), nbWord);
 			characterNumber += nbWordLabel;
-			characterNumber += nbWordStr;
+			characterNumber += commafyInt(nbWord).c_str();
 			characterNumber += TEXT("\r");
 
-			generic_sprintf(nbLineStr, TEXT("%d"), static_cast<int>( nbLine ) );
 			characterNumber += nbLineLabel;
-			characterNumber += nbLineStr;
+			characterNumber += commafyInt(static_cast<int>(nbLine)).c_str();
 			characterNumber += TEXT("\r");
 
-			generic_sprintf(nbByteStr, TEXT("%d"), nbByte);
 			characterNumber += nbByteLabel;
-			characterNumber += nbByteStr;
+			characterNumber += commafyInt(nbByte).c_str();
 			characterNumber += TEXT("\r");
 
-			generic_sprintf(nbSelStr, TEXT("%d"), nbSel);
-			generic_sprintf(nbSelByteStr, TEXT("%d"), nbSelByte);
-			generic_sprintf(nbRangeStr, TEXT("%d"), nbRange);
-			characterNumber += nbSelStr;
+			characterNumber += commafyInt(nbSel).c_str();
 			characterNumber += nbSelLabel1;
-			characterNumber += nbSelByteStr;
+			characterNumber += commafyInt(nbSelByte).c_str();
 			characterNumber += nbSelLabel2;
-			characterNumber += nbRangeStr;
+			characterNumber += commafyInt(nbRange).c_str();
 			characterNumber += nbRangeLabel;
 			characterNumber += TEXT("\r");
 


### PR DESCRIPTION
Fixes #1329. This adds a thousands separator to the Summary window and the Statusbar. When the numbers are more then a few digits it is very hard to read. Especially with 64bit presumably going to handle larger files, this is very user friendly. 

Status bar before:
![statusbar_before](https://cloud.githubusercontent.com/assets/3694843/16969903/5c58a34a-4de6-11e6-8461-f1de02159dff.PNG)

Status bar after:
![statusbar_after](https://cloud.githubusercontent.com/assets/3694843/16969906/615f7d78-4de6-11e6-8f04-61db0af5b45c.PNG)

Summary window before:
![summary_before](https://cloud.githubusercontent.com/assets/3694843/16969908/665ff76c-4de6-11e6-93f0-0f70172fc5d5.png)

Summary window after:
![summary_after](https://cloud.githubusercontent.com/assets/3694843/16969909/6b39c2b8-4de6-11e6-89e5-5fc696cf9077.png)

Before merging I would like a bit of feed back. First of all, the separator is based on locale, and for my locale it uses a comma, for others it may use an apostrophe (or nothing at all). I'd be curious how other locales handle this exactly. (If need be I think it can be forced to use a particular character.)

Also, I'm no expert for ensuring 64bit compatibility. In a few cases `static_cast<>()` is used which I'm not sure is applicable (I just kept it since it was already there). Also the `commafyInt()` function currently just takes a `size_t`. I'm not sure if it would be best to do something like make this a template function or something.