### PR TITLE
Added new (>r2008) MATLAB keywords, as returned by MATLAB iskeyword()

### DIFF
--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -147,7 +147,7 @@
         <Language name="makefile" ext="mak" commentLine="#">
         </Language>
         <Language name="matlab" ext="m" commentLine="%" commentStart="" commentEnd="">
-            <Keywords name="instre1">break case catch continue else elseif end for function global if otherwise persistent return switch try while</Keywords>
+            <Keywords name="instre1">break case catch classdef continue else elseif end for function global if otherwise parfor persistent return switch try while</Keywords>
         </Language>
         <Language name="nfo" ext="nfo">
         </Language>


### PR DESCRIPTION
At least since 2008, several new keywords have been added to the MATLAB language. There are several other conditional keywords ('methods' and 'properties', to name two) that I have not added here. Instead, I'm sticking to the results of the iskeyword() built-in MATLAB method.