### PR TITLE
Add thousands separator for FindReplace dialog

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1102,7 +1102,7 @@ bool Notepad_plus::replaceInOpenedFiles() {
 		if (nbTotal)
 			enableCommand(IDM_FILE_SAVEALL, true, MENU | TOOLBAR);
 		TCHAR result[64];
-		wsprintf(result, TEXT("Replace in Opened Files: %d occurrences replaced."), nbTotal);
+		wsprintf(result, TEXT("Replace in Opened Files: %s occurrences replaced."), commafyInt(nbTotal).c_str());
 		_findReplaceDlg.setStatusbarMessage(result, FSMessage);
 	}
 	return true;
@@ -1533,7 +1533,7 @@ bool Notepad_plus::replaceInFiles()
 	_pEditView = pOldView;
 
 	TCHAR msg[128];
-	wsprintf(msg, TEXT("Replace in Files: %d occurrences replaced"), nbTotal);
+	wsprintf(msg, TEXT("Replace in Files: %s occurrences replaced"), commafyInt(nbTotal).c_str());
 	_findReplaceDlg.setStatusbarMessage(msg, FSMessage);
 
 	return true;

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -1008,7 +1008,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 							if(nbReplaced == 1)
 								wsprintf(moreInfo, TEXT("Replace All: %d occurrence was replaced."), nbReplaced);
 							else
-								wsprintf(moreInfo, TEXT("Replace All: %d occurrences were replaced."), nbReplaced);
+								wsprintf(moreInfo, TEXT("Replace All: %s occurrences were replaced."), commafyInt(nbReplaced).c_str());
 							result = moreInfo;
 						}
 						setStatusbarMessage(result, FSMessage);
@@ -1038,7 +1038,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 							if (nbCounted == 1)
 								wsprintf(moreInfo, TEXT("Count: %d match."), nbCounted);
 							else
-								wsprintf(moreInfo, TEXT("Count: %d matches."), nbCounted);
+								wsprintf(moreInfo, TEXT("Count: %s matches."), commafyInt(nbCounted).c_str());
 							result = moreInfo;
 						}
 						if (isMacroRecording) saveInMacro(wParam, FR_OP_FIND);
@@ -1071,7 +1071,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 							if(nbMarked == 1)
 								wsprintf(moreInfo, TEXT("Mark: %d match."), nbMarked);
 							else
-								wsprintf(moreInfo, TEXT("Mark: %d matches."), nbMarked);
+								wsprintf(moreInfo, TEXT("Mark: %s matches."), commafyInt(nbMarked).c_str());
 							result = moreInfo;
 						}
 						setStatusbarMessage(result, FSMessage);
@@ -2015,7 +2015,7 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		if(_findAllResult == 1)
 			wsprintf(_findAllResultStr, TEXT("1 hit"));
 		else
-			wsprintf(_findAllResultStr, TEXT("%d hits"), _findAllResult);
+			wsprintf(_findAllResultStr, TEXT("%s hits"), commafyInt(_findAllResult).c_str());
 		if (_findAllResult) 
 		{
 			focusOnFinder();
@@ -2409,7 +2409,7 @@ void FindReplaceDlg::execSavedCommand(int cmd, int intValue, generic_string stri
 						if (nbReplaced == 1)
 							wsprintf(moreInfo, TEXT("Replace All: %d occurrence was replaced."), nbReplaced);
 						else
-							wsprintf(moreInfo, TEXT("Replace All: %d occurrences were replaced."), nbReplaced);
+							wsprintf(moreInfo, TEXT("Replace All: %s occurrences were replaced."), commafyInt(nbReplaced).c_str());
 						result = moreInfo;
 					}
 					
@@ -2429,7 +2429,7 @@ void FindReplaceDlg::execSavedCommand(int cmd, int intValue, generic_string stri
 						if (nbCounted == 1)
 							wsprintf(moreInfo, TEXT("Count: %d match."), nbCounted);
 						else
-							wsprintf(moreInfo, TEXT("Count: %d matches."), nbCounted);
+							wsprintf(moreInfo, TEXT("Count: %s matches."), commafyInt(nbCounted).c_str());
 						result = moreInfo;
 					}
 					setStatusbarMessage(result, FSMessage);
@@ -2452,7 +2452,7 @@ void FindReplaceDlg::execSavedCommand(int cmd, int intValue, generic_string stri
 						if (nbMarked <= 1)
 							wsprintf(moreInfo, TEXT("%d match."), nbMarked);
 						else
-							wsprintf(moreInfo, TEXT("%d matches."), nbMarked);
+							wsprintf(moreInfo, TEXT("%s matches."), commafyInt(nbMarked).c_str());
 						result = moreInfo;
 					}
 
@@ -3256,7 +3256,7 @@ void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted)
 	else if (nbCounted == 1)
 		wsprintf(findCount, TEXT("%d match."), nbCounted);
 	else
-		wsprintf(findCount, TEXT("%d matches."), nbCounted);
+		wsprintf(findCount, TEXT("%s matches."), commafyInt(nbCounted).c_str());
 
 	if (iStatus<0 || iStatus >= sizeof(findStatus)/sizeof(findStatus[0]))
 		return; // out of range


### PR DESCRIPTION
Continuation of PR #2103. Adds thousands separator for results related to find/replace. Some examples:

![1](https://cloud.githubusercontent.com/assets/3694843/17270538/c53fc682-5632-11e6-825b-e61f6d33b7e7.png)
![2](https://cloud.githubusercontent.com/assets/3694843/17270536/c53d030c-5632-11e6-9724-4d75c3d7604c.png)
![3](https://cloud.githubusercontent.com/assets/3694843/17270537/c53e6486-5632-11e6-889c-543cfbf12fdb.png)
![4](https://cloud.githubusercontent.com/assets/3694843/17270539/c53fea86-5632-11e6-8fef-dbfe9c240eb5.png)
![capture](https://cloud.githubusercontent.com/assets/3694843/17270540/c540cbc2-5632-11e6-824e-b26e2bad58e7.PNG)
