### PR TITLE
Reduce the installer size by 30~35%

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -32,6 +32,8 @@
 !include "nsDialogs.nsh" ; allows creation of custom pages in the installer
 !include "Memento.nsh"   ; remember user selections in the installer across runs
 
+SetCompressor /SOLID lzma	; This reduces installer size by approx 30~35%
+;SetCompressor /FINAL lzma	; This reduces installer size by approx 15~18%,
 
 ; Define the application name
 !define APPNAME "Notepad++"


### PR DESCRIPTION
As of now npp installer is not using any compression to reduce the installer size. I don't know if there is any history behind not using any compression algorithm.

But I noticed a reasonable difference after using /SOLID lzma compression technique. It reduces the installer size by 30~35%.
If we use /FINAL lzma, it is improved by 15~18%.