### PR TITLE
Fix access violation in styler dialog

### DIFF
--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
@@ -162,7 +162,7 @@ private :
 		auto styleIndex = ::SendDlgItemMessage(_hSelf, IDC_STYLES_LIST, LB_GETCURSEL, 0, 0);
 		if (styleIndex == LB_ERR) styleIndex = 0;
 
-        if (_currentLexerIndex == 0)
+        if (_currentLexerIndex <= 0)
 		{
             return _globalStyles.getStyler(styleIndex);
 		}


### PR DESCRIPTION
The `_lexerStylerArray` is initially accessed outside the boundaries. This leads to crashes on x64 builds when opening the styler dialog.