### PR TITLE
CallTip text uses start/stop/separator settings

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -26,7 +26,6 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <algorithm>
 #include <stdexcept>
-#include <sstream>
 #include <shlwapi.h>
 #include <shlobj.h>
 #include <uxtheme.h>
@@ -38,7 +37,6 @@
 
 WcharMbcsConvertor* WcharMbcsConvertor::_pSelf = new WcharMbcsConvertor;
 
-typedef std::basic_stringstream<TCHAR> generic_stringstream;
 
 
 

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -27,6 +27,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <sstream>
 #include <windows.h>
 #include <iso646.h>
 #include <cstdint>
@@ -65,6 +66,7 @@ const bool dirDown = false;
 #define COPYDATA_FILENAMES COPYDATA_FILENAMESW
 
 typedef std::basic_string<TCHAR> generic_string;
+typedef std::basic_stringstream<TCHAR> generic_stringstream;
 
 generic_string folderBrowser(HWND parent, const generic_string & title = TEXT(""), int outputCtrlID = 0, const TCHAR *defaultStr = NULL);
 generic_string getFolderName(HWND parent, const TCHAR *defaultDir = NULL);


### PR DESCRIPTION
Closes #2274. The calltip text uses the environment parameters to build the string.

I manually modified the API file for C so that used  `startFunc="[" stopFunc="]" paramSeparator=":"`

Before: 
![before](https://cloud.githubusercontent.com/assets/3694843/18478498/86d9da78-799f-11e6-8428-cf36a3452af5.png)

Before (with a description as well):
![before_wdescr](https://cloud.githubusercontent.com/assets/3694843/18478511/8fd75efc-799f-11e6-8fb1-934833b808a5.png)

After:
![after](https://cloud.githubusercontent.com/assets/3694843/18478517/93b86ff2-799f-11e6-93b0-e40bf03de32a.png)

After (with a description as well):
![after_wdescr](https://cloud.githubusercontent.com/assets/3694843/18478526/9aefb9b0-799f-11e6-81e8-0c3225148420.png)



