### PR TITLE
Remove post installation leftover files from temp

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -86,6 +86,7 @@ page Custom ExtraOptions
 
 Function .onInit
 
+	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
 	Call preventInstallInWin9x
 		
  !insertmacro MUI_LANGDLL_DISPLAY

--- a/PowerEditor/installer/nsisInclude/langs.nsh
+++ b/PowerEditor/installer/nsisInclude/langs.nsh
@@ -117,256 +117,256 @@ LangString langFileName ${LANG_ESTONIAN} "estonian.xml"
 SectionGroup "Localization" localization
 	SetOverwrite on
 	${MementoUnselectedSection} "Afrikaans" afrikaans
-		CopyFiles "$TEMP\nppLocalization\afrikaans.xml" "$INSTDIR\localization\afrikaans.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\afrikaans.xml" "$INSTDIR\localization\afrikaans.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Albanian" albanian
-		CopyFiles "$TEMP\nppLocalization\albanian.xml" "$INSTDIR\localization\albanian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\albanian.xml" "$INSTDIR\localization\albanian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Arabic" arabic
-		CopyFiles "$TEMP\nppLocalization\arabic.xml" "$INSTDIR\localization\arabic.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\arabic.xml" "$INSTDIR\localization\arabic.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Aragonese" aragonese
-		CopyFiles "$TEMP\nppLocalization\aragonese.xml" "$INSTDIR\localization\aragonese.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\aragonese.xml" "$INSTDIR\localization\aragonese.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Aranese" aranese
-		CopyFiles "$TEMP\nppLocalization\aranese.xml" "$INSTDIR\localization\aranese.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\aranese.xml" "$INSTDIR\localization\aranese.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Azerbaijani" azerbaijani
-		CopyFiles "$TEMP\nppLocalization\azerbaijani.xml" "$INSTDIR\localization\azerbaijani.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\azerbaijani.xml" "$INSTDIR\localization\azerbaijani.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Basque" basque
-		CopyFiles "$TEMP\nppLocalization\basque.xml" "$INSTDIR\localization\basque.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\basque.xml" "$INSTDIR\localization\basque.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Belarusian" belarusian
-		CopyFiles "$TEMP\nppLocalization\belarusian.xml" "$INSTDIR\localization\belarusian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\belarusian.xml" "$INSTDIR\localization\belarusian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Bengali" bengali
-		CopyFiles "$TEMP\nppLocalization\bengali.xml" "$INSTDIR\localization\bengali.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\bengali.xml" "$INSTDIR\localization\bengali.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Bosnian" bosnian
-		CopyFiles "$TEMP\nppLocalization\bosnian.xml" "$INSTDIR\localization\bosnian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\bosnian.xml" "$INSTDIR\localization\bosnian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Brazilian Portuguese" brazilian_portuguese
-		CopyFiles "$TEMP\nppLocalization\brazilian_portuguese.xml" "$INSTDIR\localization\brazilian_portuguese.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\brazilian_portuguese.xml" "$INSTDIR\localization\brazilian_portuguese.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Bulgarian" bulgarian
-		CopyFiles "$TEMP\nppLocalization\bulgarian.xml" "$INSTDIR\localization\bulgarian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\bulgarian.xml" "$INSTDIR\localization\bulgarian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Catalan" catalan
-		CopyFiles "$TEMP\nppLocalization\catalan.xml" "$INSTDIR\localization\catalan.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\catalan.xml" "$INSTDIR\localization\catalan.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Chinese (Traditional)" chineseTraditional
-		CopyFiles "$TEMP\nppLocalization\chinese.xml" "$INSTDIR\localization\chinese.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\chinese.xml" "$INSTDIR\localization\chinese.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Chinese (Simplified)" chineseSimplified
-		CopyFiles "$TEMP\nppLocalization\chineseSimplified.xml" "$INSTDIR\localization\chineseSimplified.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\chineseSimplified.xml" "$INSTDIR\localization\chineseSimplified.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Croatian" croatian
-		CopyFiles "$TEMP\nppLocalization\croatian.xml" "$INSTDIR\localization\croatian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\croatian.xml" "$INSTDIR\localization\croatian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Czech" czech
-		CopyFiles "$TEMP\nppLocalization\czech.xml" "$INSTDIR\localization\czech.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\czech.xml" "$INSTDIR\localization\czech.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Danish" danish
-		CopyFiles "$TEMP\nppLocalization\danish.xml" "$INSTDIR\localization\danish.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\danish.xml" "$INSTDIR\localization\danish.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Dutch" dutch
-		CopyFiles "$TEMP\nppLocalization\dutch.xml" "$INSTDIR\localization\dutch.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\dutch.xml" "$INSTDIR\localization\dutch.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "English (Customizable)" english_customizable
-		CopyFiles "$TEMP\nppLocalization\english_customizable.xml" "$INSTDIR\localization\english_customizable.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\english_customizable.xml" "$INSTDIR\localization\english_customizable.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Esperanto" esperanto
-		CopyFiles "$TEMP\nppLocalization\esperanto.xml" "$INSTDIR\localization\esperanto.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\esperanto.xml" "$INSTDIR\localization\esperanto.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Estonian" estonian
-		CopyFiles "$TEMP\nppLocalization\estonian.xml" "$INSTDIR\localization\estonian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\estonian.xml" "$INSTDIR\localization\estonian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Extremaduran" extremaduran
-		CopyFiles "$TEMP\nppLocalization\extremaduran.xml" "$INSTDIR\localization\extremaduran.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\extremaduran.xml" "$INSTDIR\localization\extremaduran.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Farsi" farsi
-		CopyFiles "$TEMP\nppLocalization\farsi.xml" "$INSTDIR\localization\farsi.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\farsi.xml" "$INSTDIR\localization\farsi.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Finnish" finnish
-		CopyFiles "$TEMP\nppLocalization\finnish.xml" "$INSTDIR\localization\finnish.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\finnish.xml" "$INSTDIR\localization\finnish.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Friulian" friulian
-		CopyFiles "$TEMP\nppLocalization\friulian.xml" "$INSTDIR\localization\friulian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\friulian.xml" "$INSTDIR\localization\friulian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "French" french 
-		CopyFiles "$TEMP\nppLocalization\french.xml" "$INSTDIR\localization\french.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\french.xml" "$INSTDIR\localization\french.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Galician" galician
-		CopyFiles "$TEMP\nppLocalization\galician.xml" "$INSTDIR\localization\galician.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\galician.xml" "$INSTDIR\localization\galician.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Georgian" georgian
-		CopyFiles "$TEMP\nppLocalization\georgian.xml" "$INSTDIR\localization\georgian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\georgian.xml" "$INSTDIR\localization\georgian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "German" german
-		CopyFiles "$TEMP\nppLocalization\german.xml" "$INSTDIR\localization\german.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\german.xml" "$INSTDIR\localization\german.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Greek" greek
-		CopyFiles "$TEMP\nppLocalization\greek.xml" "$INSTDIR\localization\greek.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\greek.xml" "$INSTDIR\localization\greek.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Gujarati" gujarati
-		CopyFiles "$TEMP\nppLocalization\gujarati.xml" "$INSTDIR\localization\gujarati.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\gujarati.xml" "$INSTDIR\localization\gujarati.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Hebrew" hebrew
-		CopyFiles "$TEMP\nppLocalization\hebrew.xml" "$INSTDIR\localization\hebrew.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\hebrew.xml" "$INSTDIR\localization\hebrew.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Hindi" hindi
-		CopyFiles "$TEMP\nppLocalization\hindi.xml" "$INSTDIR\localization\hindi.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\hindi.xml" "$INSTDIR\localization\hindi.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Hungarian" hungarian
-		CopyFiles "$TEMP\nppLocalization\hungarian.xml" "$INSTDIR\localization\hungarian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\hungarian.xml" "$INSTDIR\localization\hungarian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Hungarian (ANSI)" hungarianA
-		CopyFiles "$TEMP\nppLocalization\hungarianA.xml" "$INSTDIR\localization\hungarianA.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\hungarianA.xml" "$INSTDIR\localization\hungarianA.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Indonesian" indonesian
-		CopyFiles "$TEMP\nppLocalization\indonesian.xml" "$INSTDIR\localization\indonesian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\indonesian.xml" "$INSTDIR\localization\indonesian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Italian" italian
-		CopyFiles "$TEMP\nppLocalization\italian.xml" "$INSTDIR\localization\italian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\italian.xml" "$INSTDIR\localization\italian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Japanese" japanese
-		CopyFiles "$TEMP\nppLocalization\japanese.xml" "$INSTDIR\localization\japanese.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\japanese.xml" "$INSTDIR\localization\japanese.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Kazakh" kazakh
-		CopyFiles "$TEMP\nppLocalization\kazakh.xml" "$INSTDIR\localization\kazakh.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\kazakh.xml" "$INSTDIR\localization\kazakh.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Korean" korean
-		CopyFiles "$TEMP\nppLocalization\korean.xml" "$INSTDIR\localization\korean.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\korean.xml" "$INSTDIR\localization\korean.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Kyrgyz" kyrgyz
-		CopyFiles "$TEMP\nppLocalization\kyrgyz.xml" "$INSTDIR\localization\kyrgyz.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\kyrgyz.xml" "$INSTDIR\localization\kyrgyz.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Latvian" latvian
-		CopyFiles "$TEMP\nppLocalization\latvian.xml" "$INSTDIR\localization\latvian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\latvian.xml" "$INSTDIR\localization\latvian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Ligurian" ligurian
-		CopyFiles "$TEMP\nppLocalization\ligurian.xml" "$INSTDIR\localization\ligurian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\ligurian.xml" "$INSTDIR\localization\ligurian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Lithuanian" lithuanian
-		CopyFiles "$TEMP\nppLocalization\lithuanian.xml" "$INSTDIR\localization\lithuanian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\lithuanian.xml" "$INSTDIR\localization\lithuanian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Luxembourgish" luxembourgish
-		CopyFiles "$TEMP\nppLocalization\luxembourgish.xml" "$INSTDIR\localization\luxembourgish.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\luxembourgish.xml" "$INSTDIR\localization\luxembourgish.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Macedonian" macedonian
-		CopyFiles "$TEMP\nppLocalization\macedonian.xml" "$INSTDIR\localization\macedonian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\macedonian.xml" "$INSTDIR\localization\macedonian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Malay" malay
-		CopyFiles "$TEMP\nppLocalization\malay.xml" "$INSTDIR\localization\malay.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\malay.xml" "$INSTDIR\localization\malay.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Marathi" marathi
-		CopyFiles "$TEMP\nppLocalization\marathi.xml" "$INSTDIR\localization\marathi.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\marathi.xml" "$INSTDIR\localization\marathi.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Mongolian" mongolian
-		CopyFiles "$TEMP\nppLocalization\mongolian.xml" "$INSTDIR\localization\mongolian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\mongolian.xml" "$INSTDIR\localization\mongolian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Norwegian" norwegian
-		CopyFiles "$TEMP\nppLocalization\norwegian.xml" "$INSTDIR\localization\norwegian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\norwegian.xml" "$INSTDIR\localization\norwegian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Nynorsk" nynorsk
-		CopyFiles "$TEMP\nppLocalization\nynorsk.xml" "$INSTDIR\localization\nynorsk.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\nynorsk.xml" "$INSTDIR\localization\nynorsk.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Occitan" occitan
-		CopyFiles "$TEMP\nppLocalization\occitan.xml" "$INSTDIR\localization\occitan.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\occitan.xml" "$INSTDIR\localization\occitan.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Polish" polish
-		CopyFiles "$TEMP\nppLocalization\polish.xml" "$INSTDIR\localization\polish.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\polish.xml" "$INSTDIR\localization\polish.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Portuguese" portuguese
-		CopyFiles "$TEMP\nppLocalization\portuguese.xml" "$INSTDIR\localization\portuguese.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\portuguese.xml" "$INSTDIR\localization\portuguese.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Punjabi" punjabi
-		CopyFiles "$TEMP\nppLocalization\punjabi.xml" "$INSTDIR\localization\punjabi.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\punjabi.xml" "$INSTDIR\localization\punjabi.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Kannada" kannada
-		CopyFiles "$TEMP\nppLocalization\kannada.xml" "$INSTDIR\localization\kannada.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\kannada.xml" "$INSTDIR\localization\kannada.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Romanian" romanian
-		CopyFiles "$TEMP\nppLocalization\romanian.xml" "$INSTDIR\localization\romanian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\romanian.xml" "$INSTDIR\localization\romanian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Russian" russian
-		CopyFiles "$TEMP\nppLocalization\russian.xml" "$INSTDIR\localization\russian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\russian.xml" "$INSTDIR\localization\russian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Samogitian" samogitian
-		CopyFiles "$TEMP\nppLocalization\samogitian.xml" "$INSTDIR\localization\samogitian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\samogitian.xml" "$INSTDIR\localization\samogitian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Sardinian" sardinian
-		CopyFiles "$TEMP\nppLocalization\sardinian.xml" "$INSTDIR\localization\sardinian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\sardinian.xml" "$INSTDIR\localization\sardinian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Serbian" serbian
-		CopyFiles "$TEMP\nppLocalization\serbian.xml" "$INSTDIR\localization\serbian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\serbian.xml" "$INSTDIR\localization\serbian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Serbian (Cyrillic)" serbianCyrillic
-		CopyFiles "$TEMP\nppLocalization\serbianCyrillic.xml" "$INSTDIR\localization\serbianCyrillic.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\serbianCyrillic.xml" "$INSTDIR\localization\serbianCyrillic.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Sinhala" sinhala
-		CopyFiles "$TEMP\nppLocalization\sinhala.xml" "$INSTDIR\localization\sinhala.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\sinhala.xml" "$INSTDIR\localization\sinhala.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Slovak" slovak
-		CopyFiles "$TEMP\nppLocalization\slovak.xml" "$INSTDIR\localization\slovak.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\slovak.xml" "$INSTDIR\localization\slovak.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Slovak (ANSI)" slovakA
-		CopyFiles "$TEMP\nppLocalization\slovakA.xml" "$INSTDIR\localization\slovakA.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\slovakA.xml" "$INSTDIR\localization\slovakA.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Slovenian" slovenian
-		CopyFiles "$TEMP\nppLocalization\slovenian.xml" "$INSTDIR\localization\slovenian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\slovenian.xml" "$INSTDIR\localization\slovenian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Spanish" spanish
-		CopyFiles "$TEMP\nppLocalization\spanish.xml" "$INSTDIR\localization\spanish.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\spanish.xml" "$INSTDIR\localization\spanish.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Spanish_ar" spanish_ar
-		CopyFiles "$TEMP\nppLocalization\spanish_ar.xml" "$INSTDIR\localization\spanish_ar.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\spanish_ar.xml" "$INSTDIR\localization\spanish_ar.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Swedish" swedish
-		CopyFiles "$TEMP\nppLocalization\swedish.xml" "$INSTDIR\localization\swedish.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\swedish.xml" "$INSTDIR\localization\swedish.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Tagalog" tagalog
-		CopyFiles "$TEMP\nppLocalization\tagalog.xml" "$INSTDIR\localization\tagalog.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\tagalog.xml" "$INSTDIR\localization\tagalog.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Tajik" tajik
-		CopyFiles "$TEMP\nppLocalization\tajikCyrillic.xml" "$INSTDIR\localization\tajikCyrillic.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\tajikCyrillic.xml" "$INSTDIR\localization\tajikCyrillic.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Tamil" tamil
-		CopyFiles "$TEMP\nppLocalization\tamil.xml" "$INSTDIR\localization\tamil.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\tamil.xml" "$INSTDIR\localization\tamil.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Tatar" tatar
-		CopyFiles "$TEMP\nppLocalization\tatar.xml" "$INSTDIR\localization\tatar.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\tatar.xml" "$INSTDIR\localization\tatar.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Telugu" telugu
-		CopyFiles "$TEMP\nppLocalization\telugu.xml" "$INSTDIR\localization\telugu.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\telugu.xml" "$INSTDIR\localization\telugu.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Thai" thai
-		CopyFiles "$TEMP\nppLocalization\thai.xml" "$INSTDIR\localization\thai.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\thai.xml" "$INSTDIR\localization\thai.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Turkish" turkish
-		CopyFiles "$TEMP\nppLocalization\turkish.xml" "$INSTDIR\localization\turkish.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\turkish.xml" "$INSTDIR\localization\turkish.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Ukrainian" ukrainian
-		CopyFiles "$TEMP\nppLocalization\ukrainian.xml" "$INSTDIR\localization\ukrainian.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\ukrainian.xml" "$INSTDIR\localization\ukrainian.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Urdu" urdu
-		CopyFiles "$TEMP\nppLocalization\urdu.xml" "$INSTDIR\localization\urdu.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\urdu.xml" "$INSTDIR\localization\urdu.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Uyghur" uyghur
-		CopyFiles "$TEMP\nppLocalization\uyghur.xml" "$INSTDIR\localization\uyghur.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\uyghur.xml" "$INSTDIR\localization\uyghur.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Uzbek" uzbek
-		CopyFiles "$TEMP\nppLocalization\uzbek.xml" "$INSTDIR\localization\uzbek.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\uzbek.xml" "$INSTDIR\localization\uzbek.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Uzbek (Cyrillic)" uzbekCyrillic
-		CopyFiles "$TEMP\nppLocalization\uzbekCyrillic.xml" "$INSTDIR\localization\uzbekCyrillic.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\uzbekCyrillic.xml" "$INSTDIR\localization\uzbekCyrillic.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Vietnamese" vietnamese
-		CopyFiles "$TEMP\nppLocalization\vietnamese.xml" "$INSTDIR\localization\vietnamese.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\vietnamese.xml" "$INSTDIR\localization\vietnamese.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Welsh" welsh
-		CopyFiles "$TEMP\nppLocalization\welsh.xml" "$INSTDIR\localization\welsh.xml"
+		CopyFiles "$PLUGINSDIR\nppLocalization\welsh.xml" "$INSTDIR\localization\welsh.xml"
 	${MementoSectionEnd}
 SectionGroupEnd
 

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -25,7 +25,7 @@ FunctionEnd
 	
 Function copyCommonFiles
 	SetOverwrite on
-	SetOutPath "$TEMP\"
+	SetOutPath "$PLUGINSDIR\"
 	File "langsModel.xml"
 	File "configModel.xml"
 	File "stylesGlobalModel.xml"
@@ -73,7 +73,7 @@ Function copyCommonFiles
 
 	; Copy all the language files to the temp directory
 	; than make them installed via option
-	SetOutPath "$TEMP\nppLocalization\"
+	SetOutPath "$PLUGINSDIR\nppLocalization\"
 	File ".\nativeLang\"
 
 	IfFileExists "$UPDATE_PATH\nativeLang.xml" 0 +2
@@ -83,8 +83,8 @@ Function copyCommonFiles
 		Delete "$INSTDIR\nativeLang.xml"
 
 	StrCmp $LANGUAGE ${LANG_ENGLISH} +3 0
-	CopyFiles "$TEMP\nppLocalization\$(langFileName)" "$UPDATE_PATH\nativeLang.xml"
-	CopyFiles "$TEMP\nppLocalization\$(langFileName)" "$INSTDIR\localization\$(langFileName)"
+	CopyFiles "$PLUGINSDIR\nppLocalization\$(langFileName)" "$UPDATE_PATH\nativeLang.xml"
+	CopyFiles "$PLUGINSDIR\nppLocalization\$(langFileName)" "$INSTDIR\localization\$(langFileName)"
 FunctionEnd
 
 	
@@ -260,10 +260,10 @@ FunctionEnd
 
 Function changeIconOption
 	${If} $isOldIconChecked == ${BST_CHECKED}
-		SetOutPath "$TEMP\"
+		SetOutPath "$PLUGINSDIR\"
 		File "..\misc\vistaIconTool\changeIcon.exe"
 		File "..\src\icons\npp.ico"
-		nsExec::ExecToStack '"$TEMP\changeIcon.exe" "$TEMP\npp.ico" "$INSTDIR\notepad++.exe" 100 1033'
+		nsExec::ExecToStack '"$PLUGINSDIR\changeIcon.exe" "$PLUGINSDIR\npp.ico" "$INSTDIR\notepad++.exe" 100 1033'
 	${EndIf}
 FunctionEnd
 


### PR DESCRIPTION
Current Notepad++ installer just leaves almost all the files (used in installation) in the %temp% folder. I feel that Notepad++ should remove these files post installation.
Use $PLUGINSDIR instead of $TEMP. The $PLUGINSDIR keyword points to the temp dir created by the InitPluginsDir macro, usually %temp%\nsXXX.tmp. This directory (%temp%\nsXXX.tmp) is removed once installation is over.