### PR TITLE
No notification if ShellExecute fails (Fixed#2179)

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -182,3 +182,8 @@ generic_string stringTakeWhileAdmissable(const generic_string& input, const gene
 double stodLocale(const generic_string& str, _locale_t loc, size_t* idx = NULL);
 
 bool str2Clipboard(const generic_string &str2cpy, HWND hwnd);
+
+std::wstring GetLastErrorAsString(DWORD errorCode = 0);
+
+generic_string intToString(int val);
+generic_string uintToString(unsigned int val);


### PR DESCRIPTION
If ShellExecute fails to execute command as if required software is not installed, then there is no notification to user.
This happens specially from "Run" menu (e.g. user clicks on Launch in Chrome while Chrome is not installed).

Accommodated reviews and prepared new PR. Original PR is #2181 and #2190.

![shellexecute_failled](https://cloud.githubusercontent.com/assets/14791461/18717144/a991c4ce-803c-11e6-8c7d-ae011623eb65.png)
