### PR TITLE
Improve Installer

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -115,6 +115,10 @@ Var UPDATE_PATH
 
 !include "nsisInclude\mainSectionFuncs.nsh"
 
+; Insert removeOldContexMenu function as an installer and uninstaller function.
+!insertmacro removeOldContexMenu ""
+!insertmacro removeOldContexMenu "un."
+
 Section -"Notepad++" mainSection
 
 	Call setPathAndOptions

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -215,7 +215,7 @@ Function removeUnstablePlugins
 		Rename "$INSTDIR\plugins\NppQCP.dll" "$INSTDIR\plugins\disabled\NppQCP.dll"
 		Delete "$INSTDIR\plugins\NppQCP.dll"
 		
-	IfFileExists "$INSTDIR\plugins\DSpellCheck.dll" 0 +11
+	IfFileExists "$INSTDIR\plugins\DSpellCheck.dll" 0 donothing
 		MessageBox MB_YESNOCANCEL "Due to the stability issue, DSpellCheck.dll will be moved to the directory $\"disabled$\".$\nChoose Cancel to keep it for this installation.$\nChoose No to keep it forever." /SD IDYES IDNO never IDCANCEL donothing ;IDYES remove
 		Rename "$INSTDIR\plugins\DSpellCheck.dll" "$INSTDIR\plugins\disabled\DSpellCheck.dll"
 		Delete "$INSTDIR\plugins\DSpellCheck.dll"
@@ -226,36 +226,38 @@ Function removeUnstablePlugins
 	donothing:
 FunctionEnd
 
-Function removeOldContextMenu
+!macro removeOldContexMenu un
+Function ${un}removeOldContextMenu
    ; Context Menu Management : removing old version of Context Menu module
-	IfFileExists "$INSTDIR\nppcm.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\nppcm.dll"'
+    IfFileExists "$INSTDIR\nppcm.dll" 0 +3
+		ExecWait 'regsvr32 /u /s "$INSTDIR\nppcm.dll"'
 		Delete "$INSTDIR\nppcm.dll"
         
     IfFileExists "$INSTDIR\NppShell.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell.dll"'
+		ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell.dll"'
 		Delete "$INSTDIR\NppShell.dll"
 		
     IfFileExists "$INSTDIR\NppShell_01.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
+		ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
 		Delete "$INSTDIR\NppShell_01.dll"
         
     IfFileExists "$INSTDIR\NppShell_02.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
+		ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
 		Delete "$INSTDIR\NppShell_02.dll"
 		
     IfFileExists "$INSTDIR\NppShell_03.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
+		ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
 		Delete "$INSTDIR\NppShell_03.dll"
 		
-	IfFileExists "$INSTDIR\NppShell_04.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
+    IfFileExists "$INSTDIR\NppShell_04.dll" 0 +3
+		ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
 		Delete "$INSTDIR\NppShell_04.dll"
 		
-	IfFileExists "$INSTDIR\NppShell_05.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
+    IfFileExists "$INSTDIR\NppShell_05.dll" 0 +3
+		ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
 		Delete "$INSTDIR\NppShell_05.dll"
 FunctionEnd
+!macroend
 
 Function shortcutLinkManagement
 	; remove all the npp shortcuts from current user

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -26,18 +26,13 @@
 ; Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 Section un.explorerContextMenu
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_06.dll"'
-	Delete "$INSTDIR\NppShell_01.dll"
-	Delete "$INSTDIR\NppShell_02.dll"
-	Delete "$INSTDIR\NppShell_03.dll"
-	Delete "$INSTDIR\NppShell_04.dll"
-	Delete "$INSTDIR\NppShell_05.dll"
-	Delete "$INSTDIR\NppShell_06.dll"
+	; Removing old contextMenu is not required as it is taken care the time of installation
+	; But just to play safe, Call removeOldContextMenu	
+	Call un.removeOldContextMenu
+	
+	IfFileExists "$INSTDIR\NppShell_06.dll" 0 +3
+		ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_06.dll"'
+		Delete "$INSTDIR\NppShell_06.dll"
 SectionEnd
 
 Section un.UnregisterFileExt
@@ -182,4 +177,15 @@ SectionEnd
 
 Function un.onInit
   ;!insertmacro MUI_UNGETLANGUAGE
+  ; *******************************************************
+	; This section is required, to delete only 64 bit portion of uninstaller
+	; Otherwise, if both the versions (32 and 64) are installed and user uninstalls 64 bit version
+	; Then 32 bit version can't be uninstalled (via control panel), as 32 bit registries were also deleted
+	; To avoid this, SetRegView 64 for 64bit installer, So only 64 bit uninstaller related registry will be deleted.
+	!ifdef ARCH64
+		${If} ${RunningX64}
+			SetRegView 64
+		${EndIf}
+ 	!endif
+  ; *******************************************************
 FunctionEnd


### PR DESCRIPTION
1. Remove only 64 bit uninstaller related registry while installing 64 bit Npp
2. Removed duplicate code for context menu
3. Use ExecWait instead of Exec to deregister the contextMenuDll

This change is specially for #1, consider a scenario where both the current versions (32 and 64) are installed and user uninstalls 64 bit version, then 32 bit version can't be uninstalled (via control panel), as 32 bit registries were also deleted. To avoid this, SetRegView 64 for 64bit uninstaller (similar to 64 bit installer), So only 64 bit uninstaller related registry will be deleted.

![uninstaller](https://cloud.githubusercontent.com/assets/14791461/18814873/24b05604-833d-11e6-8362-5770ee9b4c82.png)

	