### PR TITLE
Sort plugin menu by plugin name

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -80,6 +80,7 @@ struct PluginInfo
 	FuncItem *_funcItems = NULL;
 	int _nbFuncItem = 0;
 	generic_string _moduleName;
+	generic_string _funcName;
 };
 
 class PluginsManager


### PR DESCRIPTION
Currently plugins are in order of the *file* name (which is not always the same as its menu item). This sorts them based on the name that shows up in the menu. 