### PR TITLE
Check plugin architecture before loading

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -27,14 +27,22 @@
 
 
 #include <shlwapi.h>
+#include <DbgHelp.h>
 #include "PluginsManager.h"
 #include "resource.h"
 
 using namespace std;
 
-const TCHAR * USERMSG = TEXT("This plugin is not compatible with current version of Notepad++.\n\n\
-Do you want to remove this plugin from plugins directory to prevent this message from the next launch time?");
+const TCHAR * USERMSG = TEXT(" is not compatible with the current version of Notepad++.\n\n\
+Do you want to remove this plugin from the plugins directory to prevent this message from the next launch?");
 
+#ifdef _WIN64
+#define ARCH_TYPE IMAGE_FILE_MACHINE_AMD64
+const TCHAR *ARCH_ERR_MSG = TEXT("Cannot load 32-bit plugin.");
+#else
+#define ARCH_TYPE IMAGE_FILE_MACHINE_I386
+const TCHAR *ARCH_ERR_MSG = TEXT("Cannot load 64-bit plugin.");
+#endif
 
 
 
@@ -81,6 +89,44 @@ static std::wstring GetLastErrorAsString()
     return message;
 }
 
+static WORD GetBinaryArchitectureType(const TCHAR *filePath)
+{
+	WORD machine_type = IMAGE_FILE_MACHINE_UNKNOWN;
+	HANDLE hMapping = NULL;
+	LPVOID addrHeader = NULL;
+
+	HANDLE hFile = CreateFile(filePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_READONLY, NULL);
+	if (hFile == INVALID_HANDLE_VALUE)
+		goto cleanup;
+
+	hMapping = CreateFileMapping(hFile, NULL, PAGE_READONLY | SEC_IMAGE, 0, 0, NULL);
+	if (hMapping == NULL)
+		goto cleanup;
+
+	addrHeader = MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, 0);
+	if (addrHeader == NULL)
+		goto cleanup; // couldn't memory map the file
+
+	PIMAGE_NT_HEADERS peHdr = ImageNtHeader(addrHeader);
+	if (peHdr == NULL)
+		goto cleanup; // couldn't read the header
+
+	// Found the binary and architecture type
+	machine_type = peHdr->FileHeader.Machine;
+
+cleanup: // release all of our handles
+	if (addrHeader != NULL)
+		UnmapViewOfFile(addrHeader);
+
+	if (hMapping != NULL)
+		CloseHandle(hMapping);
+
+	if (hFile != INVALID_HANDLE_VALUE)
+		CloseHandle(hFile);
+
+	return machine_type;
+}
+
 int PluginsManager::loadPlugin(const TCHAR *pluginFilePath, vector<generic_string> & dll2Remove)
 {
 	const TCHAR *pluginFileName = ::PathFindFileName(pluginFilePath);
@@ -93,6 +139,9 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath, vector<generic_strin
 	try
 	{
 		pi->_moduleName = PathFindFileName(pluginFilePath);
+
+		if (GetBinaryArchitectureType(pluginFilePath) != ARCH_TYPE)
+			throw generic_string(ARCH_ERR_MSG);
 
 	    pi->_hLib = ::LoadLibrary(pluginFilePath);
         if (!pi->_hLib)
@@ -228,6 +277,7 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath, vector<generic_strin
 	catch (generic_string s)
 	{
 		s += TEXT("\n\n");
+		s += pluginFileName;
 		s += USERMSG;
 		if (::MessageBox(NULL, s.c_str(), pluginFilePath, MB_YESNO) == IDYES)
 		{
@@ -240,6 +290,7 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath, vector<generic_strin
 	{
 		generic_string msg = TEXT("Failed to load");
 		msg += TEXT("\n\n");
+		msg += pluginFileName;
 		msg += USERMSG;
 		if (::MessageBox(NULL, msg.c_str(), pluginFilePath, MB_YESNO) == IDYES)
 		{

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -107,7 +107,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/fixed:no %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>
@@ -142,7 +142,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/fixed:no %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>
@@ -182,7 +182,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>
@@ -231,7 +231,7 @@ copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>

--- a/PowerEditor/visual.net/notepadPlus.vs2015.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vs2015.vcxproj
@@ -108,7 +108,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/fixed:no %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>
@@ -144,7 +144,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/fixed:no %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>
@@ -185,7 +185,7 @@
       <DisableSpecificWarnings>4091;4456;4457;4459</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>
@@ -236,7 +236,7 @@ copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
       <DisableSpecificWarnings>4091;4456;4457;4459</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>


### PR DESCRIPTION
Previously attempting to load a DLL that does not match the current Notepad++ architecture would give:

![before](https://cloud.githubusercontent.com/assets/3694843/18859226/29b3d10e-8440-11e6-9c94-47a1fc0a35e0.png)

Now it checks the plugin to see if it is 32 or 64-bit and provides a better error message. I also slightly tweaked the strings, and added the plugin name to the message, since the full path at the top can cut of the actual plugin name.

Notepad++ 32-bit attempting to load a 64-bit plugin:

![32load64](https://cloud.githubusercontent.com/assets/3694843/18859253/6d22e696-8440-11e6-856f-4006fcd25ea6.png)

Notepad++ 64-bit attempting to load a 32-bit plugin:

![64load32](https://cloud.githubusercontent.com/assets/3694843/18859258/7bf17818-8440-11e6-8395-d38b0e078f5c.png)

The code is derived from [here](https://github.com/markedup-mobi/crt-detector/blob/30f1053c1779cd97d2f5f42d9fed518573c94550/VCRuntimeDetector/VCDetector.cpp#L118). I'm normally not a fan of using `goto` but the code is still very readable. If there is a huge objection to using `goto` I can update the PR.

**NOTE:** I have not tested this with VS2015 as I do not have access to it. I'd appreciate if anyone can check out this PR and confirm it works for VS2015.