### PR TITLE
Shorten some properties of the executable

### DIFF
--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -47,8 +47,8 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE    "CompanyName",        "Don HO don.h@free.fr\0"
-            VALUE    "FileDescription",    "Notepad++ : a free (GNU) source code editor\0"
+            VALUE    "CompanyName",        "Don HO\0"
+            VALUE    "FileDescription",    "Notepad++\0"
             VALUE    "FileVersion",        VERSION_VALUE
             VALUE    "InternalName",       "npp.exe\0"
             VALUE    "LegalCopyright",     "Copyleft 1998-2016 by Don HO\0"


### PR DESCRIPTION
A long lasting nitpick!
"Notepad++ : a free (GNU) source code editor" appears in various locations (mainly "open with" menus and dialogs), whereas it should display the software name only.

![windows open with](https://cloud.githubusercontent.com/assets/544424/18866008/3fc5dc86-849e-11e6-9711-85b2b99604a1.png)
![firefox open with](https://cloud.githubusercontent.com/assets/544424/18866009/413933ba-849e-11e6-8ddd-98b348a65e7a.png)
