### PR TITLE
Include version info in Installer

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -45,6 +45,17 @@ OutFile ".\build\npp.${APPVERSION}.Installer.x64.exe"
 !else
 OutFile ".\build\npp.${APPVERSION}.Installer.exe"
 !endif
+
+; ------------------------------------------------------------------------
+;Version Information
+   VIProductVersion "${Version}"
+   VIAddVersionKey  "ProductName" 	"${APPNAME}"
+   VIAddVersionKey  "CompanyName" 	"${CompanyName}"
+   VIAddVersionKey  "LegalCopyright" 	"${LegalCopyright}"
+   VIAddVersionKey  "FileDescription" 	"${Description}"
+   VIAddVersionKey  "FileVersion" 	"${Version}"
+   VIAddVersionKey  "ProductVersion" 	"${ProdVer}"
+; ------------------------------------------------------------------------
  
 ; Insert CheckIfRunning function as an installer and uninstaller function.
 !insertmacro CheckIfRunning ""

--- a/PowerEditor/installer/nsisInclude/gobalDef.nsh
+++ b/PowerEditor/installer/nsisInclude/gobalDef.nsh
@@ -34,6 +34,12 @@
 !define VERSION_MAJOR 7
 !define VERSION_MINOR 0
 
+!define CompanyName		"Don HO don.h@free.fr"
+!define Description		"Notepad++ : a free (GNU) source code editor"
+!define Version 		"7.0.0.0"
+!define ProdVer 		"${VERSION_MAJOR}.${VERSION_MINOR}"
+!define LegalCopyright 	"Copyleft 1998-2016 by Don HO"
+
 !define APPWEBSITE "http://notepad-plus-plus.org/"
 
 !define UNINSTALL_REG_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"


### PR DESCRIPTION
As of now, there is no version info available on the detail section of installer properties.
It is good to have version info.

![file_info](https://cloud.githubusercontent.com/assets/14791461/18883249/167c7b0c-8500-11e6-8f19-80e4f037dade.png)
