### PR TITLE
Completely clear bookmarks when they are toggled off

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -538,7 +538,7 @@ private:
 	{
 		if (lineno == -1)
 			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
-		if ( bookmarkPresent(lineno))
+		while (bookmarkPresent(lineno))
 			_pEditView->execute(SCI_MARKERDELETE, lineno, MARK_BOOKMARK);
 	}
 


### PR DESCRIPTION
It seems markers within Scintilla are not a true/false value but rather a counter. Closes #2366

Related [SciTE bug](https://sourceforge.net/p/scintilla/bugs/1617/)