### PR TITLE
- Added call to update full "File" menu when emptying recent files history (Fixed #2399)

### DIFF
--- a/PowerEditor/src/lastRecentFileList.cpp
+++ b/PowerEditor/src/lastRecentFileList.cpp
@@ -149,6 +149,7 @@ void LastRecentFileList::updateMenu()
 			// Remove the last left separator from the submenu
 			::RemoveMenu(_hMenu, 0, MF_BYPOSITION);
 		}
+		_pAccelerator->updateFullMenu();
 	}
 
 	//Remove all menu items


### PR DESCRIPTION
I attempted a fix for issue #2399 by having it update the full menu when the size of the list is 0, so that it will resize to it's original width.
