### PR TITLE
Fixed uinstaller issues

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -101,7 +101,7 @@ Function .onInit
 		
 		; check if 32-bit version has been installed if yes, ask user to remove it
 		IfFileExists $PROGRAMFILES\${APPNAME}\notepad++.exe 0 noDelete32
-		MessageBox MB_YESNO "You're installing 64-bit version. 32-bit version has been installed. Remove it?$\n(Your custom config files will be kept)" /SD IDYES IDYES doDelete32 IDNO noDelete32 ;IDYES remove
+		MessageBox MB_YESNO "You are trying to install 64-bit version while 32-bit version is already installed. Would you like to remove Notepad++ 32 bit version?$\n(Your custom config files will be kept)" /SD IDYES IDYES doDelete32 IDNO noDelete32 ;IDYES remove
 doDelete32:
 		StrCpy $diffArchDir2Remove $PROGRAMFILES\${APPNAME}
 noDelete32:
@@ -114,7 +114,7 @@ noDelete32:
 	${If} ${RunningX64}
 		; check if 64-bit version has been installed if yes, ask user to remove it
 		IfFileExists $PROGRAMFILES64\${APPNAME}\notepad++.exe 0 noDelete64
-		MessageBox MB_YESNO "You're installing 32-bit version. 64-bit version has been installed. Remove it?$\n(Your custom config files will be kept)"  /SD IDYES IDYES doDelete64 IDNO noDelete64
+		MessageBox MB_YESNO "You are trying to install 32-bit version while 64-bit version is already installed. Would you like to remove Notepad++ 64 bit version?$\n(Your custom config files will be kept)"  /SD IDYES IDYES doDelete64 IDNO noDelete64
 doDelete64:
 		StrCpy $diffArchDir2Remove $PROGRAMFILES64\${APPNAME}
 noDelete64:

--- a/PowerEditor/installer/nsisInclude/autoCompletion.nsh
+++ b/PowerEditor/installer/nsisInclude/autoCompletion.nsh
@@ -215,5 +215,10 @@ SectionGroup un.autoCompletionComponent
 	
 	Section un.CMAKE
 		Delete "$INSTDIR\plugins\APIs\cmake.xml"
-	SectionEnd	
+	SectionEnd
+	
+	Section un.RemovePluginAPIDir
+		; As if all the files are deleted remove current dir
+		RMDir "$INSTDIR\plugins\APIs\"
+	SectionEnd
 SectionGroupEnd

--- a/PowerEditor/installer/nsisInclude/binariesComponents.nsh
+++ b/PowerEditor/installer/nsisInclude/binariesComponents.nsh
@@ -116,7 +116,12 @@ SectionGroup un.Plugins
 		Delete "$INSTDIR\plugins\PluginManager.dll"
 		Delete "$INSTDIR\updater\gpup.exe"
 		RMDir "$INSTDIR\updater\"
-	SectionEnd	
+	SectionEnd
+	
+	Section un.RemovePluginDir
+		; As if all the files are deleted remove current dir
+		RMDir "$INSTDIR\plugins\"
+	SectionEnd
 
 SectionGroupEnd
 

--- a/PowerEditor/installer/nsisInclude/langs.nsh
+++ b/PowerEditor/installer/nsisInclude/langs.nsh
@@ -399,7 +399,7 @@ SectionGroup "Localization" localization
 SectionGroupEnd
 
 SectionGroup un.localization
-	SetOverwrite on
+
 	Section un.afrikaans
 		Delete "$INSTDIR\localization\afrikaans.xml"
 	SectionEnd
@@ -499,7 +499,7 @@ SectionGroup un.localization
 	Section un.hebrew
 		Delete "$INSTDIR\localization\hebrew.xml"
 	SectionEnd
-		Section un.hindi
+	Section un.hindi
 		Delete "$INSTDIR\localization\hindi.xml"
 	SectionEnd
 	Section un.hungarian
@@ -651,5 +651,10 @@ SectionGroup un.localization
 	SectionEnd
 	Section un.welsh
 		Delete "$INSTDIR\localization\welsh.xml"
+	SectionEnd
+	
+	Section un.RemoveLocalizationDir
+		; As if all the files are deleted remove current dir
+		RMDir "$INSTDIR\localization\"
 	SectionEnd
 SectionGroupEnd

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -216,7 +216,7 @@ Function removeUnstablePlugins
 		Rename "$INSTDIR\plugins\NppQCP.dll" "$INSTDIR\plugins\disabled\NppQCP.dll"
 		Delete "$INSTDIR\plugins\NppQCP.dll"
 		
-	IfFileExists "$INSTDIR\plugins\DSpellCheck.dll" 0 +11
+	IfFileExists "$INSTDIR\plugins\DSpellCheck.dll" 0 donothing
 		MessageBox MB_YESNOCANCEL "Due to the stability issue, DSpellCheck.dll will be moved to the directory $\"disabled$\".$\nChoose Cancel to keep it for this installation.$\nChoose No to keep it forever." /SD IDYES IDNO never IDCANCEL donothing ;IDYES remove
 		Rename "$INSTDIR\plugins\DSpellCheck.dll" "$INSTDIR\plugins\disabled\DSpellCheck.dll"
 		Delete "$INSTDIR\plugins\DSpellCheck.dll"

--- a/PowerEditor/installer/nsisInclude/themes.nsh
+++ b/PowerEditor/installer/nsisInclude/themes.nsh
@@ -254,4 +254,10 @@ SectionGroup un.Themes
 	${endIf}
 	SectionEnd
 	
+	Section un.RemoveThemesDir
+		; As if all the files are deleted remove current dir
+		; if files are kept because of $keepUserData, current dir will not be deleted
+		RMDir "$themesParentPath\themes\"
+		RMDir "$themesParentPath\"
+	SectionEnd
 SectionGroupEnd

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -27,8 +27,10 @@
 
 Var themesParentPath
 Var doLocalConf
+Var keepUserData
 Function un.onInit
-  	; determinate theme path for uninstall themes
+  	StrCpy $keepUserData "false"	; default value(It is must, otherwise few files such as shortcuts.xml, contextMenu.xml etc, will not be removed when $INSTDIR\doLocalConf.xml is not avaliable.)
+	; determinate theme path for uninstall themes
 	StrCpy $themesParentPath "$APPDATA\${APPNAME}"
 	StrCpy $doLocalConf "false"
 	IfFileExists $INSTDIR\doLocalConf.xml doesExist noneExist
@@ -116,7 +118,6 @@ Section un.UserManual
 SectionEnd
 
 
-Var keepUserData
 Function un.doYouReallyWantToKeepData
 	StrCpy $keepUserData "false"
 	MessageBox MB_YESNO "Would you like to keep your custom settings?" IDYES skipRemoveUserData IDNO removeUserData
@@ -247,9 +248,9 @@ Section Uninstall
 		Delete "$APPDATA\${APPNAME}\insertExt.ini"
 	
 		RMDir /r "$APPDATA\${APPNAME}\plugins\"
-		RMDir "$APPDATA\${APPNAME}\backup\"
-		RMDir "$APPDATA\${APPNAME}\themes\"
-		RMDir "$APPDATA\${APPNAME}"
+		RMDir /r "$APPDATA\${APPNAME}\backup\"
+		RMDir "$APPDATA\${APPNAME}\themes\"	; has no effect as not empty at this momenet, but it is taken care in themes.nsh
+		RMDir "$APPDATA\${APPNAME}"		; has no effect as not empty at this momenet, but it is taken care in themes.nsh
 		
 		StrCmp $1 "Admin" 0 +2
 			SetShellVarContext all ; make context for all user


### PR DESCRIPTION
Few folders and files are not cleared.
From InstallDir
	1. Folder "localization" is not removed even all the files are removed.
	2. Folder "pluging\APIs" is not removed even all the files are removed.
	3. Three files are not removed (contextMenu.xml, functionList.xml and shortcuts.xml). There might be more files.
From "%appdata%\Notepad"
	1. Bakcup folder (%appdata%) is not removed if backup folder is not empty.
	2. Folder "themes" is not removed even all the files are removed.
	3. Because of above two items, parent folder ("%appdata%\Notepad") is also not removed.
	
Rephrase user message when user tries to install 64 bit while 32 is already installed (vice versa).