### PR TITLE
Delete Shell Extension dll more effectively

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -132,6 +132,9 @@ FunctionEnd
 
 
 !include "nsisInclude\mainSectionFuncs.nsh"
+; Insert removeOldContexMenu function as an installer and uninstaller function.
+!insertmacro removeOldContexMenu ""
+!insertmacro removeOldContexMenu "un."
 
 Section -"Notepad++" mainSection
 

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -216,7 +216,7 @@ Function removeUnstablePlugins
 		Rename "$INSTDIR\plugins\NppQCP.dll" "$INSTDIR\plugins\disabled\NppQCP.dll"
 		Delete "$INSTDIR\plugins\NppQCP.dll"
 		
-	IfFileExists "$INSTDIR\plugins\DSpellCheck.dll" 0 +11
+	IfFileExists "$INSTDIR\plugins\DSpellCheck.dll" 0 donothing
 		MessageBox MB_YESNOCANCEL "Due to the stability issue, DSpellCheck.dll will be moved to the directory $\"disabled$\".$\nChoose Cancel to keep it for this installation.$\nChoose No to keep it forever." /SD IDYES IDNO never IDCANCEL donothing ;IDYES remove
 		Rename "$INSTDIR\plugins\DSpellCheck.dll" "$INSTDIR\plugins\disabled\DSpellCheck.dll"
 		Delete "$INSTDIR\plugins\DSpellCheck.dll"
@@ -227,36 +227,42 @@ Function removeUnstablePlugins
 	donothing:
 FunctionEnd
 
-Function removeOldContextMenu
-   ; Context Menu Management : removing old version of Context Menu module
-	IfFileExists "$INSTDIR\nppcm.dll" 0 +3
+!macro removeOldContexMenu un
+Function ${un}removeOldContextMenu
+	; Context Menu Management : removing old version of Context Menu module
+
+	; First try to unregister the Dlls.
+	IfFileExists "$INSTDIR\nppcm.dll" 0 +2
 		Exec 'regsvr32 /u /s "$INSTDIR\nppcm.dll"'
-		Delete "$INSTDIR\nppcm.dll"
-        
-    IfFileExists "$INSTDIR\NppShell.dll" 0 +3
+		
+	IfFileExists "$INSTDIR\NppShell.dll" 0 +2
 		Exec 'regsvr32 /u /s "$INSTDIR\NppShell.dll"'
-		Delete "$INSTDIR\NppShell.dll"
 		
-    IfFileExists "$INSTDIR\NppShell_01.dll" 0 +3
+	IfFileExists "$INSTDIR\NppShell_01.dll" 0 +2
 		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
-		Delete "$INSTDIR\NppShell_01.dll"
-        
-    IfFileExists "$INSTDIR\NppShell_02.dll" 0 +3
+		
+	IfFileExists "$INSTDIR\NppShell_02.dll" 0 +2
 		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
-		Delete "$INSTDIR\NppShell_02.dll"
-		
-    IfFileExists "$INSTDIR\NppShell_03.dll" 0 +3
+
+	IfFileExists "$INSTDIR\NppShell_03.dll" 0 +2
 		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
-		Delete "$INSTDIR\NppShell_03.dll"
-		
-	IfFileExists "$INSTDIR\NppShell_04.dll" 0 +3
+
+	IfFileExists "$INSTDIR\NppShell_04.dll" 0 +2
 		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
-		Delete "$INSTDIR\NppShell_04.dll"
-		
-	IfFileExists "$INSTDIR\NppShell_05.dll" 0 +3
+
+	IfFileExists "$INSTDIR\NppShell_05.dll" 0 +2
 		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
-		Delete "$INSTDIR\NppShell_05.dll"
+
+   ; Now try to delete the file. If file is locked in explorer.exe, then move to %temp
+   ${safeFileDelete} "$INSTDIR" "nppcm.dll"
+   ${safeFileDelete} "$INSTDIR" "NppShell.dll"
+   ${safeFileDelete} "$INSTDIR" "NppShell_01.dll"
+   ${safeFileDelete} "$INSTDIR" "NppShell_02.dll"
+   ${safeFileDelete} "$INSTDIR" "NppShell_03.dll"
+   ${safeFileDelete} "$INSTDIR" "NppShell_04.dll"
+   ${safeFileDelete} "$INSTDIR" "NppShell_05.dll"
 FunctionEnd
+!macroend
 
 Function shortcutLinkManagement
 	; remove all the npp shortcuts from current user

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -145,3 +145,39 @@ Function writeInstallInfoInRegistry
 	WriteUninstaller "$INSTDIR\uninstall.exe"
 FunctionEnd
 
+Var count	; Though, there is no need to declare variable. It can be handled using register variables
+Var tempFile	; but people criticise that, so let's have variable here :(
+		
+!macro safeFileDelete filePath fileName
+
+	/*
+	Author: Rajendra Singh (singh.rajen15@gmail.com)
+	Usage:  
+		Syntax: ${safeFileDelete} "FilePath (without trailing slash)" "FileName"
+		Example: ${safeFileDelete} "C:\Users\Prince\Desktop\Installer" "Test.exe"
+	Description:
+		This macro tries to delete the file safely. First it will try to delete the file directly using API 'Delete'.
+		If this API fails due to any reason (e.g. file is in use), then move the file in %temp% folder.
+		To Move file API 'Rename' is used. Refer http://nsis.sourceforge.net/Docs/Chapter4.html for details.
+		API 'Rename' is more or less similar to Win API 'MoveFile' or 'MoveFileEx'.
+		After moving file to temp, hand over the file to OS by putting in pending items, so file will be deleted on next reboot
+	*/
+	
+	!define ID ${__LINE__}						; Use Line to avoid label duplication
+	IfFileExists ${filePath}\${fileName} 0 NotExistOrDeleted${ID}	; Check if file exists or not. If file does not exist, then exit
+	ClearErrors														; Before trying to delete clear previous error
+	Delete ${filePath}\${fileName}					; Try to delete the file directly
+	IfErrors 0 NotExistOrDeleted${ID}				; Check if file deleted or not (if file not deleted error flag will be set)
+		${ForEach} $count 1 20 + 1				; Loop to find suitable name in %temp% folder, I feel 20 iteration is enough (as user will not unistall npp 20 times in a day without restart)
+			StrCpy $tempFile "$TEMP\$count_${fileName}"	; get the temp name of a file
+			IfFileExists $tempFile +2 
+				${Break}
+		${Next}
+	Rename "${filePath}\${fileName}" "$tempFile"			; Move the file to %temp% .API 'Rename' fails if same file exists in the dest folder. This is avoided in above for loop
+	Delete /REBOOTOK $tempFile					; Ask OS to delete the file on next reboot
+	
+	NotExistOrDeleted${ID}:
+	!undef ID
+
+!macroend
+!define safeFileDelete "!insertmacro safeFileDelete"

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -41,18 +41,15 @@ FunctionEnd
 
 
 Section un.explorerContextMenu
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
+	; Removing old contextMenu is not required as it is taken care the time of installation
+	; But just to play safe, Call removeOldContextMenu
+	Call un.removeOldContextMenu
+	
+	; First try to unregister the Dlls
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_06.dll"'
-	Delete "$INSTDIR\NppShell_01.dll"
-	Delete "$INSTDIR\NppShell_02.dll"
-	Delete "$INSTDIR\NppShell_03.dll"
-	Delete "$INSTDIR\NppShell_04.dll"
-	Delete "$INSTDIR\NppShell_05.dll"
-	Delete "$INSTDIR\NppShell_06.dll"
+	
+	; Now try to delete the file. If files are locked in explorer.exe, then move to %temp
+	${safeFileDelete} "$INSTDIR" "NppShell_06.dll"
 SectionEnd
 
 Section un.UnregisterFileExt


### PR DESCRIPTION
Delete Npp Shell Extension dll more effectively
Fix issue #2404 
As soon Npp shell dll is loaded (right click on any file). It is locked inside the explorer.exe. Therefore, uninstaller/installer could not delete/replace the npp shell dll.
**Concept to resolve the issue is: move the locked dll to temp dir and delete that file on next reboot.**
