### PR TITLE
Add possibility to customize ColourPopup's color palette

### DIFF
--- a/PowerEditor/installer/themes/Bespin.xml
+++ b/PowerEditor/installer/themes/Bespin.xml
@@ -782,4 +782,14 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" bgColor="8000FF" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Black board.xml
+++ b/PowerEditor/installer/themes/Black board.xml
@@ -780,4 +780,14 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Choco.xml
+++ b/PowerEditor/installer/themes/Choco.xml
@@ -780,4 +780,14 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Deep Black.xml
+++ b/PowerEditor/installer/themes/Deep Black.xml
@@ -751,4 +751,14 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" bgColor="8000FF" fontSize="10" fontStyle="0" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Hello Kitty.xml
+++ b/PowerEditor/installer/themes/Hello Kitty.xml
@@ -751,4 +751,14 @@ so your enhanced file can be included in Notepad++ future release.
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/HotFudgeSundae.xml
+++ b/PowerEditor/installer/themes/HotFudgeSundae.xml
@@ -916,4 +916,14 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" fontStyle="0" bgColor="80FF00" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="43250B" bgColor="D5BC93" fontStyle="0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Mono Industrial.xml
+++ b/PowerEditor/installer/themes/Mono Industrial.xml
@@ -780,4 +780,14 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Monokai.xml
+++ b/PowerEditor/installer/themes/Monokai.xml
@@ -780,4 +780,14 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/MossyLawn.xml
+++ b/PowerEditor/installer/themes/MossyLawn.xml
@@ -917,4 +917,14 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="012001" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="162504" bgColor="BBCF60" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Navajo.xml
+++ b/PowerEditor/installer/themes/Navajo.xml
@@ -914,4 +914,14 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="181880" bgColor="BA9C80" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Obsidian.xml
+++ b/PowerEditor/installer/themes/Obsidian.xml
@@ -781,4 +781,14 @@ Notepad++ Custom Style
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" bgColor="0080FF" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Plastic Code Wrap.xml
+++ b/PowerEditor/installer/themes/Plastic Code Wrap.xml
@@ -792,4 +792,14 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Ruby Blue.xml
+++ b/PowerEditor/installer/themes/Ruby Blue.xml
@@ -629,4 +629,14 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Solarized-light.xml
+++ b/PowerEditor/installer/themes/Solarized-light.xml
@@ -925,4 +925,14 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="073642" bgColor="93A1A1" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Solarized.xml
+++ b/PowerEditor/installer/themes/Solarized.xml
@@ -925,4 +925,14 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="EEE8D5" bgColor="586E75" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Twilight.xml
+++ b/PowerEditor/installer/themes/Twilight.xml
@@ -781,4 +781,14 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Vibrant Ink.xml
+++ b/PowerEditor/installer/themes/Vibrant Ink.xml
@@ -752,4 +752,14 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Zenburn.xml
+++ b/PowerEditor/installer/themes/Zenburn.xml
@@ -868,4 +868,14 @@ License:             Feel free to modify this style and re-release it. This styl
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="A3DCA3" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/khaki.xml
+++ b/PowerEditor/installer/themes/khaki.xml
@@ -915,4 +915,14 @@ Installation:
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="5f5f00" bgColor="d7d7af" />
 <!--        <WidgetStyle name="Inactive tabs" styleID="0" fgColor="ffffd7" bgColor="5f5f00" /> -->
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/vim Dark Blue.xml
+++ b/PowerEditor/installer/themes/vim Dark Blue.xml
@@ -745,6 +745,16 @@
         <WidgetStyle name="Unsaved change marker" styleID="0" bgColor="FF0000" />
         <WidgetStyle name="Saved change marker" styleID="0" bgColor="80FF00" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>
 
  	  	 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1710,6 +1710,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				if (nppgui._rememberLastSession && !nppgui._isCmdlineNosessionActivated)
 					saveSession(currentSession);
 
+				pNppParam->saveColorPalette(); // save theme color palette
+
 				// write settings on cloud if enabled, if the settings files don't exist
 				if (nppgui._cloudPath != TEXT("") && pNppParam->isCloudPathChanged())
 				{

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -541,6 +541,65 @@ private :
 };
 
 
+// Default color palette for ColourPopup dialog
+const std::vector<COLORREF> defaultColorPalette {
+	RGB(  0,   0,   0), RGB( 64,   0,   0), RGB(128,   0,   0), RGB(128,  64,  64), RGB(255,   0,   0), RGB(255, 128, 128),
+	RGB(255, 255, 128), RGB(255, 255,   0), RGB(255, 128,  64), RGB(255, 128,   0), RGB(128,  64,   0), RGB(128, 128,   0),
+	RGB(128, 128,  64), RGB(  0,  64,   0), RGB(  0, 128,   0), RGB(  0, 255,   0), RGB(128, 255,   0), RGB(128, 255, 128),
+	RGB(  0, 255, 128), RGB(  0, 255,  64), RGB(  0, 128, 128), RGB(  0, 128,  64), RGB(  0,  64,  64), RGB(128, 128, 128),
+	RGB( 64, 128, 128), RGB(  0,   0, 128), RGB(  0,   0, 255), RGB(  0,  64, 128), RGB(  0, 255, 255), RGB(128, 255, 255),
+	RGB(  0, 128, 255), RGB(  0, 128, 192), RGB(128, 128, 255), RGB(  0,   0, 160), RGB(  0,   0,  64), RGB(192, 192, 192),
+	RGB( 64,   0,  64), RGB( 64,   0,  64), RGB(128,   0, 128), RGB(128,   0,  64), RGB(128, 128, 192), RGB(255, 128, 192),
+	RGB(255, 128, 255), RGB(255,   0, 255), RGB(255,   0, 128), RGB(128,   0, 255), RGB( 64,   0, 128), RGB(255, 255, 255),
+};
+
+// Customizable theme color palette for ColourPopup dialog
+struct ThemeColorPalette
+{
+public:
+	void setDefaultColorPalette()
+	{
+		_colorPalette = defaultColorPalette;
+	}
+
+	void setColor(const size_t & index, const COLORREF & color, const bool & markDirty = true)
+	{
+		if (index < _colorPalette.size())
+		{
+			_colorPalette[index] = color & 0xFFFFFF;
+			if (markDirty)
+				_isDirty = true;
+		}
+	}
+
+	COLORREF getColor(const size_t & index) const
+	{
+		if (index < _colorPalette.size())
+			return _colorPalette[index];
+		return 0;
+	}
+
+	size_t getSize() const
+	{
+		return _colorPalette.size();
+	}
+
+	bool isDirty() const
+	{
+		return _isDirty;
+	}
+
+	void setSavePoint()
+	{
+		_isDirty = false;
+	}
+
+private:
+	bool _isDirty = false;
+	std::vector<COLORREF> _colorPalette = defaultColorPalette;
+};
+
+
 struct NewDocDefaultSettings final
 {
 	EolType _format = EolType::osdefault;
@@ -1339,6 +1398,10 @@ public:
 	StyleArray & getMiscStylerArray() {return _widgetStyleArray;};
 	GlobalOverride & getGlobalOverrideStyle() {return _nppGUI._globalOverride;};
 
+	ThemeColorPalette & getThemeColorPalette() { return _themeColorPalette; }
+	bool saveColorPalette();
+	bool loadColorPalette();
+
 	COLORREF getCurLineHilitingColour();
 	void setCurLineHilitingColour(COLORREF colour2Set);
 
@@ -1598,6 +1661,7 @@ private:
 	// All Styles (colours & fonts)
 	LexerStylerArray _lexerStylerArray;
 	StyleArray _widgetStyleArray;
+	ThemeColorPalette _themeColorPalette;
 
 	std::vector<generic_string> _fontlist;
 	std::vector<generic_string> _blacklist;

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPicker.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPicker.cpp
@@ -112,11 +112,8 @@ LRESULT ColourPicker::runProc(UINT Message, WPARAM wParam, LPARAM lParam)
 		case WM_LBUTTONDOWN:
 		{
 			RECT rc;
-			POINT p;
 			Window::getClientRect(rc);
-			::InflateRect(&rc, -2, -2);
-			p.x = rc.left;
-			p.y = rc.top + rc.bottom;
+			POINT p { rc.left, rc.bottom };
 			::ClientToScreen(_hSelf, &p);
 
 			if (!_pColourPopup)

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -893,4 +893,14 @@
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="0000FF" />
     </GlobalStyles>
+    <ColorPalette>
+        <Colors name="Set 1" color1="000000" color2="400000" color3="800000" color4="804040" color5="FF0000" color6="FF8080" />
+        <Colors name="Set 2" color1="FFFF80" color2="FFFF00" color3="FF8040" color4="FF8000" color5="804000" color6="808000" />
+        <Colors name="Set 3" color1="808040" color2="004000" color3="008000" color4="00FF00" color5="80FF00" color6="80FF80" />
+        <Colors name="Set 4" color1="00FF80" color2="00FF40" color3="008080" color4="008040" color5="004040" color6="808080" />
+        <Colors name="Set 5" color1="408080" color2="000080" color3="0000FF" color4="004080" color5="00FFFF" color6="80FFFF" />
+        <Colors name="Set 6" color1="0080FF" color2="0080C0" color3="8080FF" color4="0000A0" color5="000040" color6="C0C0C0" />
+        <Colors name="Set 7" color1="400040" color2="400040" color3="800080" color4="800040" color5="8080C0" color6="FF80C0" />
+        <Colors name="Set 8" color1="FF80FF" color2="FF00FF" color3="FF0080" color4="8000FF" color5="400080" color6="FFFFFF" />
+    </ColorPalette>
 </NotepadPlus>


### PR DESCRIPTION
This adds the possibility to customize the color palette used by the ColourPopup dialog. Customization can be done by right clicking in the list box. The color palette will be saved and loaded per theme, so every theme can have its own palette.
