### PR TITLE
addition and correction for english.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -121,10 +121,10 @@
                     <Item id="42070" name="Sentence case (blend)"/>
                     <Item id="42071" name="iNVERT cASE"/>
                     <Item id="42072" name="ranDOm CasE"/>
-                    <Item id="42073" name="Open File"/>
-                    <Item id="42074" name="Open Containing Folder in Explorer"/>
-                    <Item id="42075" name="Search on Internet"/>
-                    <Item id="42076" name="Change Search Engine..."/>
+					<Item id="42073" name="Open File"/>
+					<Item id="42074" name="Open Containing Folder in Explorer"/>
+					<Item id="42075" name="Search on Internet"/>
+					<Item id="42076" name="Change Search Engine..."/>
                     <Item id="42018" name="&amp;Start Recording"/>
                     <Item id="42019" name="&amp;Stop Recording"/>
                     <Item id="42021" name="&amp;Playback"/>
@@ -213,7 +213,7 @@
                     <Item id="43047" name="Previous Search Result"/>
                     <Item id="43048" name="Select and Find Next"/>
                     <Item id="43049" name="Select and Find Previous"/>
-                    <Item id="43054" name="Mark..."/>
+					<Item id="43054" name="Mark..."/>
                     <Item id="44009" name="Post-It"/>
                     <Item id="44010" name="Fold All"/>
                     <Item id="44019" name="Show All Characters"/>
@@ -298,7 +298,7 @@
                     <Item id="47001" name="Notepad++ Home"/>
                     <Item id="47002" name="Notepad++ Project Page"/>
                     <Item id="47003" name="Online Documentation"/>
-                    <Item id="47004" name="Notepad++ Community (Forum)"/>
+					<Item id="47004" name="Notepad++ Community (Forum)"/>
                     <Item id="47011" name="Live Support"/>
                     <Item id="47012" name="Debug Info..."/>
                     <Item id="47005" name="Get More Plugins"/>
@@ -493,7 +493,7 @@
                     <Item id="25026" name="Operator 1"/>
                     <Item id="25027" name="Operator 2"/>
                     <Item id="25028" name="Numbers"/>
-                    <Item id="1" name="OK"/>
+					<Item id="1" name="OK"/>
                     <Item id="2" name="Cancel"/>
                 </StylerDialog>
                 <Folder title="Folder &amp;&amp; Default">
@@ -681,7 +681,7 @@
                     <Item id="6212" name="Line mode"/>
                     <Item id="6213" name="Background mode"/>
                     <Item id="6214" name="Enable current line highlighting"/>
-                    <Item id="6215" name="Enable smooth font"/>
+					<Item id="6215" name="Enable smooth font"/>
                     <Item id="6231" name="Border Width"/>
                     <Item id="6235" name="No edge"/>
                     <Item id="6236" name="Enable scrolling beyond last line"/>
@@ -720,7 +720,7 @@
                     <Item id="6506" name="Disabled items"/>
                     <Item id="6507" name="Make language menu compact"/>
                     <Item id="6508" name="Language Menu"/>
-                    <Item id="6301" name="Tab Settings"/>
+					<Item id="6301" name="Tab Settings"/>
                     <Item id="6302" name="Replace by space"/>
                     <Item id="6303" name="Tab size: "/>
                     <Item id="6510" name="Use default value"/>
@@ -729,9 +729,9 @@
                 <Highlighting title="Highlighting">
                     <Item id="6333" name="Smart Highlighting"/>
                     <Item id="6326" name="Enable smart highlighting"/>
-                    <Item id="6332" name="Match case"/>
-                    <Item id="6338" name="Match whole word only"/>
-                    <Item id="6339" name="Use Find dialog settings"/>
+					<Item id="6332" name="Match case"/>
+					<Item id="6338" name="Match whole word only"/>
+					<Item id="6339" name="Use Find dialog settings"/>
                     <Item id="6329" name="Highlight Matching Tags"/>
                     <Item id="6327" name="Enable"/>
                     <Item id="6328" name="Highlight tag attributes"/>
@@ -834,7 +834,7 @@
                     <Item id="6263" name="No Cloud"/>
                     <Item id="6267" name="Set your cloud location path here:"/>
                 </Cloud>
-
+				
                 <SearchEngine title="Search Engine">
                     <Item id="6271" name="Search Engine (for command &quot;Search on Internet&quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
@@ -932,7 +932,7 @@ Are you sure to open them?"/>
 "It seems the path of settings on cloud is set on a read only drive,
 or on a folder needed privilege right for writting access.
 Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
-            <FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
+			<FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
 
             <!-- $STR_REPLACE$ is a place holder, don't translate it -->
             <SortingError title="Sorting Error" message="Unable to perform numeric sort due to line $STR_REPLACE$."/>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -121,10 +121,10 @@
                     <Item id="42070" name="Sentence case (blend)"/>
                     <Item id="42071" name="iNVERT cASE"/>
                     <Item id="42072" name="ranDOm CasE"/>
-					<Item id="42073" name="Open File"/>
-					<Item id="42074" name="Open Containing Folder in Explorer"/>
-					<Item id="42075" name="Search on Internet"/>
-					<Item id="42076" name="Change Search Engine..."/>
+                    <Item id="42073" name="Open File"/>
+                    <Item id="42074" name="Open Containing Folder in Explorer"/>
+                    <Item id="42075" name="Search on Internet"/>
+                    <Item id="42076" name="Change Search Engine..."/>
                     <Item id="42018" name="&amp;Start Recording"/>
                     <Item id="42019" name="&amp;Stop Recording"/>
                     <Item id="42021" name="&amp;Playback"/>
@@ -213,7 +213,7 @@
                     <Item id="43047" name="Previous Search Result"/>
                     <Item id="43048" name="Select and Find Next"/>
                     <Item id="43049" name="Select and Find Previous"/>
-					<Item id="43054" name="Mark..."/>
+                    <Item id="43054" name="Mark..."/>
                     <Item id="44009" name="Post-It"/>
                     <Item id="44010" name="Fold All"/>
                     <Item id="44019" name="Show All Characters"/>
@@ -273,6 +273,23 @@
                     <Item id="10003" name="Move to New Instance"/>
                     <Item id="10004" name="Open in New Instance"/>
 
+                    <Item id="45060" name="Big5 (Traditional)"/>
+                    <Item id="45061" name="GB2312 (Simplified)"/>
+                    <Item id="45054" name="OEM 861 : Icelandic"/>
+                    <Item id="45057" name="OEM 865 : Nordic"/>
+                    <Item id="45053" name="OEM 860 : Portuguese"/>
+                    <Item id="45056" name="OEM 863 : French"/>
+
+                    <Item id="46033" name="Assembly"/>
+                    <Item id="46022" name="Batch"/>
+                    <Item id="46026" name="Fortran (free form)"/>
+                    <Item id="46019" name="INI file"/>
+                    <Item id="46015" name="MS-DOS Style"/>
+                    <Item id="46016" name="Normal Text"/>
+                    <Item id="46017" name="Resource file"/>
+                    <Item id="46027" name="Shell"/>
+                    <Item id="46058" name="Fortran (fixed form)"/>
+
                     <Item id="46001" name="Style Configurator..."/>
                     <Item id="46150" name="Define your language..."/>
                     <Item id="46080" name="User-Defined"/>
@@ -281,7 +298,7 @@
                     <Item id="47001" name="Notepad++ Home"/>
                     <Item id="47002" name="Notepad++ Project Page"/>
                     <Item id="47003" name="Online Documentation"/>
-					<Item id="47004" name="Notepad++ Community (Forum)"/>
+                    <Item id="47004" name="Notepad++ Community (Forum)"/>
                     <Item id="47011" name="Live Support"/>
                     <Item id="47012" name="Debug Info..."/>
                     <Item id="47005" name="Get More Plugins"/>
@@ -476,7 +493,7 @@
                     <Item id="25026" name="Operator 1"/>
                     <Item id="25027" name="Operator 2"/>
                     <Item id="25028" name="Numbers"/>
-					<Item id="1" name="OK"/>
+                    <Item id="1" name="OK"/>
                     <Item id="2" name="Cancel"/>
                 </StylerDialog>
                 <Folder title="Folder &amp;&amp; Default">
@@ -664,7 +681,7 @@
                     <Item id="6212" name="Line mode"/>
                     <Item id="6213" name="Background mode"/>
                     <Item id="6214" name="Enable current line highlighting"/>
-					<Item id="6215" name="Enable smooth font"/>
+                    <Item id="6215" name="Enable smooth font"/>
                     <Item id="6231" name="Border Width"/>
                     <Item id="6235" name="No edge"/>
                     <Item id="6236" name="Enable scrolling beyond last line"/>
@@ -703,7 +720,7 @@
                     <Item id="6506" name="Disabled items"/>
                     <Item id="6507" name="Make language menu compact"/>
                     <Item id="6508" name="Language Menu"/>
-					<Item id="6301" name="Tab Settings"/>
+                    <Item id="6301" name="Tab Settings"/>
                     <Item id="6302" name="Replace by space"/>
                     <Item id="6303" name="Tab size: "/>
                     <Item id="6510" name="Use default value"/>
@@ -712,9 +729,9 @@
                 <Highlighting title="Highlighting">
                     <Item id="6333" name="Smart Highlighting"/>
                     <Item id="6326" name="Enable smart highlighting"/>
-					<Item id="6332" name="Match case"/>
-					<Item id="6338" name="Match whole word only"/>
-					<Item id="6339" name="Use Find dialog settings"/>
+                    <Item id="6332" name="Match case"/>
+                    <Item id="6338" name="Match whole word only"/>
+                    <Item id="6339" name="Use Find dialog settings"/>
                     <Item id="6329" name="Highlight Matching Tags"/>
                     <Item id="6327" name="Enable"/>
                     <Item id="6328" name="Highlight tag attributes"/>
@@ -817,7 +834,7 @@
                     <Item id="6263" name="No Cloud"/>
                     <Item id="6267" name="Set your cloud location path here:"/>
                 </Cloud>
-				
+
                 <SearchEngine title="Search Engine">
                     <Item id="6271" name="Search Engine (for command &quot;Search on Internet&quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
@@ -882,20 +899,51 @@
             </ColumnEditor>
         </Dialog>
         <MessageBox>
-            <ContextMenuXmlEditWarning title="Editing contextMenu" message="Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.\rYou have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
-            <NppHelpAbsentWarning title="File does not exist" message="\rdoesn't exist. Please download it on Notepad++ site."/>
-            <SaveCurrentModifWarning title="Save Current Modification" message="You should save the current modification.\rAll the saved modifications can not be undone.\r\rContinue?"/>
-            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message="You should save the current modification.\rAll the saved modifications can not be undone.\r\rContinue?"/>
+            <!-- Line feed code "\r" doesn't work here. Just start a new line, instead of "\r". -->
+            <ContextMenuXmlEditWarning title="Editing contextMenu" message=
+"Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.
+You have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
+            <NppHelpAbsentWarning title="File does not exist" message=
+"
+doesn't exist. Please download it on Notepad++ site."/>
+            <SaveCurrentModifWarning title="Save Current Modification" message=
+"You should save the current modification.
+All the saved modifications can not be undone.
+
+Continue?"/>
+            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message=
+"You should save the current modification.
+All the saved modifications can not be undone.
+
+Continue?"/>
             <CannotMoveDoc title="Move to new Notepad++ Instance" message="Document is modified, save it then try again."/>
             <DocReloadWarning title="Reload" message="Are you sure you want to reload the current file and lose the changes made in Notepad++?"/>
             <FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
             <FileAlreadyOpenedInNpp title="" message="The file is already opened in the Notepad++."/>
             <DeleteFileFailed title="Delete File" message="Delete File failed"/>
+            <!-- &quot; means double-quotation (") -->
+            <ColumnModeTip title="Column Mode Tip" message="Please use &quot;ALT+Mouse Selection&quot; or &quot;Alt+Shift+Arrow key&quot; to switch to column mode."/>
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.\rAre you sure to open them?"/>
-			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,\ror on a folder needed privilege right for writting access.\rYour settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
-			<FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
+            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message=
+"$INT_REPLACE$ files are about to be opened.
+Are you sure to open them?"/>
+            <SettingsOnCloudError title="Settings on Cloud" message=
+"It seems the path of settings on cloud is set on a read only drive,
+or on a folder needed privilege right for writting access.
+Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
+            <FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
+
+            <!-- $STR_REPLACE$ is a place holder, don't translate it -->
+            <SortingError title="Sorting Error" message="Unable to perform numeric sort due to line $STR_REPLACE$."/>
+            <BufferInvalidWarning title="Save failed" message="Cannot save: Buffer is invalid."/>
+            <OpenInAdminMode title="Save failed" message=
+"The file cannot be saved and it may be protected.
+Do you want to launch Notepad++ in Administrator mode?"/>
+            <OpenInAdminModeFailed title="Open in Administrator mode failed" message="Notepad++ cannot be opened in Administrator mode."/>
+            <OpenInAdminModeWithoutCloseCurrent title="Save failed" message=
+"The file cannot be saved and it may be protected.
+Do you want to launch Notepad++ in Administrator mode?"/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Clipboard History"/>


### PR DESCRIPTION
* add encodings which includes language name or annotation.
* add languages which might be translatable.
* add template texts to MessageBox section. These texts are used with
_nativeLangSpeaker.messageBox().
* correct wrongly used "\r", which is escaped by xml parser and does not
work as a line-feed code.
* change tabs to spaces.