### PR TITLE
Added "Exclude Filters" to 'Find in Files' dialog

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -907,6 +907,25 @@ bool matchInList(const TCHAR *fileName, const std::vector<generic_string> & patt
 	return false;
 }
 
+bool matchInList(const TCHAR *fileName, const SearchPathFilter & pathFilter)
+{
+	for (const generic_string &includePattern : pathFilter._includePatterns)
+	{
+		if (PathMatchSpec(fileName, includePattern.c_str()))
+		{
+			for (const generic_string &excludePattern : pathFilter._excludePatterns)
+			{
+				if (PathMatchSpec(fileName, excludePattern.c_str()))
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+	return false;
+}
+
 generic_string GetLastErrorAsString(DWORD errorCode)
 {
 	generic_string errorMsg(_T(""));

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -68,6 +68,12 @@ const bool dirDown = false;
 typedef std::basic_string<TCHAR> generic_string;
 typedef std::basic_stringstream<TCHAR> generic_stringstream;
 
+struct SearchPathFilter final
+{
+	std::vector<generic_string> _includePatterns;
+	std::vector<generic_string> _excludePatterns;
+};
+
 generic_string folderBrowser(HWND parent, const generic_string & title = TEXT(""), int outputCtrlID = 0, const TCHAR *defaultStr = NULL);
 generic_string getFolderName(HWND parent, const TCHAR *defaultDir = NULL);
 
@@ -92,6 +98,8 @@ std::string getFileContent(const TCHAR *file2read);
 generic_string relativeFilePathToFullFilePath(const TCHAR *relativeFilePath);
 void writeFileContent(const TCHAR *file2write, const char *content2write);
 bool matchInList(const TCHAR *fileName, const std::vector<generic_string> & patterns);
+
+bool matchInList(const TCHAR * fileName, const SearchPathFilter & patterns);
 
 class WcharMbcsConvertor final
 {

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1382,7 +1382,7 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	_findReplaceDlg.processAll(ProcessReplaceAll, &env, true);
 }
 
-void Notepad_plus::getMatchedFileNames(const TCHAR *dir, const vector<generic_string> & patterns, vector<generic_string> & fileNames, bool isRecursive, bool isInHiddenDir)
+void Notepad_plus::getMatchedFileNames(const TCHAR *dir, const SearchPathFilter & patterns, vector<generic_string> & fileNames, bool isRecursive, bool isInHiddenDir)
 {
 	generic_string dirFilter(dir);
 	dirFilter += TEXT("*.*");
@@ -1452,6 +1452,16 @@ void Notepad_plus::getMatchedFileNames(const TCHAR *dir, const vector<generic_st
 	::FindClose(hFile);
 }
 
+void Notepad_plus::getSearchPathFilter(SearchPathFilter & patterns2Match)
+{
+	_findReplaceDlg.getPatterns(patterns2Match);
+	if (patterns2Match._includePatterns.size() == 0)
+	{
+		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
+		_findReplaceDlg.getPatterns(patterns2Match);
+	}
+}
+
 bool Notepad_plus::replaceInFiles()
 {
 	const TCHAR *dir2Search = _findReplaceDlg.getDir2Search();
@@ -1469,13 +1479,8 @@ bool Notepad_plus::replaceInFiles()
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 	Buffer * oldBuf = _invisibleEditView.getCurrentBuffer();	//for manually setting the buffer, so notifications can be handled properly
 
-	vector<generic_string> patterns2Match;
-	_findReplaceDlg.getPatterns(patterns2Match);
-	if (patterns2Match.size() == 0)
-	{
-		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
-		_findReplaceDlg.getPatterns(patterns2Match);
-	}
+	SearchPathFilter patterns2Match;
+	getSearchPathFilter(patterns2Match);
 	vector<generic_string> fileNames;
 
 	getMatchedFileNames(dir2Search, patterns2Match, fileNames, isRecursive, isInHiddenDir);
@@ -1555,13 +1560,8 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 	_pEditView = &_invisibleEditView;
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 
-	vector<generic_string> patterns2Match;
-	_findReplaceDlg.getPatterns(patterns2Match);
-	if (patterns2Match.size() == 0)
-	{
-		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
-		_findReplaceDlg.getPatterns(patterns2Match);
-	}
+	SearchPathFilter patterns2Match;
+	getSearchPathFilter(patterns2Match);
 
 	vector<generic_string> fileNames = findInFolderInfo->_pSourceFinder->getResultFilePaths();
 
@@ -1640,13 +1640,8 @@ bool Notepad_plus::findInFiles()
 	_pEditView = &_invisibleEditView;
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 
-	vector<generic_string> patterns2Match;
-	_findReplaceDlg.getPatterns(patterns2Match);
-	if (patterns2Match.size() == 0)
-	{
-		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
-		_findReplaceDlg.getPatterns(patterns2Match);
-	}
+	SearchPathFilter patterns2Match;
+	getSearchPathFilter(patterns2Match);
 
 	vector<generic_string> fileNames;
 	getMatchedFileNames(dir2Search, patterns2Match, fileNames, isRecursive, isInHiddenDir);

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -531,7 +531,8 @@ private:
 	bool findInOpenedFiles();
 	bool findInCurrentFile();
 
-	void getMatchedFileNames(const TCHAR *dir, const std::vector<generic_string> & patterns, std::vector<generic_string> & fileNames, bool isRecursive, bool isInHiddenDir);
+	void getMatchedFileNames(const TCHAR *dir, const SearchPathFilter & patterns, std::vector<generic_string> & fileNames, bool isRecursive, bool isInHiddenDir);
+	void getSearchPathFilter(SearchPathFilter& patterns2Match);
 	void doSynScorll(HWND hW);
 	void setWorkingDir(const TCHAR *dir);
 	bool str2Cliboard(const generic_string & str2cpy);

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -189,8 +189,8 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 		_notepad_plus_plus_core.loadCommandlineParams(cmdLine, cmdLineParams);
 
 	std::vector<generic_string> fileNames;
-	std::vector<generic_string> patterns;
-	patterns.push_back(TEXT("*.xml"));
+	SearchPathFilter patterns;
+	patterns._includePatterns.push_back(TEXT("*.xml"));
 
 	generic_string nppDir = pNppParams->getNppPath();
 

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -339,13 +339,13 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
         if (globbing || ::PathIsDirectory(fileName.c_str()))
         {
             vector<generic_string> fileNames;
-            vector<generic_string> patterns;
+            SearchPathFilter patterns;
             if (globbing)
             {
                 const TCHAR * substring = wcsrchr(fileName.c_str(), TCHAR('\\'));
                 size_t pos = substring - fileName.c_str();
 
-                patterns.push_back(substring + 1);
+                patterns._includePatterns.push_back(substring + 1);
                 generic_string dir(fileName.c_str(), pos + 1); // use char * to evoke:
                                                                // string (const char* s, size_t n);
                                                                // and avoid to call (if pass string) :
@@ -359,7 +359,7 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
                 if (fileName[fileName.size() - 1] != '\\')
                     fileNameStr += TEXT("\\");
 
-                patterns.push_back(TEXT("*"));
+                patterns._includePatterns.push_back(TEXT("*"));
                 getMatchedFileNames(fileNameStr.c_str(), patterns, fileNames, true, false);
             }
 

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -268,7 +268,7 @@ public :
 	};
 	const TCHAR * getDir2Search() const {return _env->_directory.c_str();};
 
-	void getPatterns(std::vector<generic_string> & patternVect);
+	void getPatterns(SearchPathFilter& filter);
 
 	void launchFindInFilesDlg() {
 		doDialog(FINDINFILES_DLG);
@@ -335,6 +335,7 @@ public :
 	bool removeFinder(Finder *finder2remove);
 
 protected :
+	void fillSearchOptions();
 	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	static LONG_PTR originalFinderProc;
 


### PR DESCRIPTION
PR allows to provide patterns to exclude from search. Exclude patterns can be provided after "|" separator:
[Include Filters] | [Exclude Filters]

For instance the following Filters:
\*.\* | *.dll; *.exe; *.pdb

Will search in all files except *.dll, *.exe and *.pdb files.