### PR TITLE
DONOT include 32bit shell dll into 64bit installer

### DIFF
--- a/PowerEditor/installer/nsisInclude/binariesComponents.nsh
+++ b/PowerEditor/installer/nsisInclude/binariesComponents.nsh
@@ -29,11 +29,20 @@
 ${MementoSection} "Context Menu Entry" explorerContextMenu
 	SetOverwrite try
 	SetOutPath "$INSTDIR\"
-	${If} ${RunningX64}
+	
+	; There is no need to keep x86 NppShell_06.dll in 64 bit installer
+	; But in 32bit installer both the Dlls are required
+	; 	As user can install 32bit npp version on x64 bit machine, that time x64 bit NppShell is required.
+	
+	!ifdef ARCH64
 		File /oname=$INSTDIR\NppShell_06.dll "..\bin\NppShell64_06.dll"
-	${Else}
-		File "..\bin\NppShell_06.dll"
-	${EndIf}
+	!else
+		${If} ${RunningX64}
+			File /oname=$INSTDIR\NppShell_06.dll "..\bin\NppShell64_06.dll"
+		${Else}
+			File "..\bin\NppShell_06.dll"
+		${EndIf}
+	!endif
 	
 	Exec 'regsvr32 /s "$INSTDIR\NppShell_06.dll"'
 ${MementoSectionEnd}


### PR DESCRIPTION
There is no need to keep x86 NppShell_06.dll in 64bit  installer.
Partial fix to #2408

![singleshelldll](https://cloud.githubusercontent.com/assets/14791461/19984103/e5a72194-a232-11e6-8fc1-0f4caf61c5c0.png)
