### PR TITLE
Correctly identify when a macro is playing

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -45,6 +45,7 @@ void Notepad_plus::macroPlayback(Macro macro)
 {
 	LongRunningOperation op;
 
+	_playingBackMacro = true;
 	_pEditView->execute(SCI_BEGINUNDOACTION);
 
 	for (Macro::iterator step = macro.begin(); step != macro.end(); ++step)
@@ -56,6 +57,7 @@ void Notepad_plus::macroPlayback(Macro macro)
 	}
 
 	_pEditView->execute(SCI_ENDUNDOACTION);
+	_playingBackMacro = false;
 }
 
 void Notepad_plus::command(int id)
@@ -860,9 +862,7 @@ void Notepad_plus::command(int id)
 		case IDM_MACRO_PLAYBACKRECORDEDMACRO:
 			if (!_recordingMacro) // if we're not currently recording, then playback the recorded keystrokes
 			{
-				_playingBackMacro = true;
 				macroPlayback(_macro);
-				_playingBackMacro = false;
 			}
 			break;
 


### PR DESCRIPTION
In certain cases (e.g. running the current macro until the end of file) auto-completion and auto-indentation was not getting turned off, causing certain commands to get interpreted incorrectly. Closes #2553, Closes #2545