### PR TITLE
Fixed uinstaller issues

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -100,7 +100,7 @@ Function .onInit
 		
 		; check if 32-bit version has been installed if yes, ask user to remove it
 		IfFileExists $PROGRAMFILES\${APPNAME}\notepad++.exe 0 noDelete32
-		MessageBox MB_YESNO "You're installing 64-bit version. 32-bit version has been installed. Remove it?$\n(Your custom config files will be kept)" /SD IDYES IDYES doDelete32 IDNO noDelete32 ;IDYES remove
+		MessageBox MB_YESNO "You are trying to install 64-bit version while 32-bit version is already installed. Would you like to remove Notepad++ 32 bit version before proceeding further?$\n(Your custom config files will be kept)" /SD IDYES IDYES doDelete32 IDNO noDelete32 ;IDYES remove
 doDelete32:
 		StrCpy $diffArchDir2Remove $PROGRAMFILES\${APPNAME}
 noDelete32:
@@ -113,7 +113,7 @@ noDelete32:
 	${If} ${RunningX64}
 		; check if 64-bit version has been installed if yes, ask user to remove it
 		IfFileExists $PROGRAMFILES64\${APPNAME}\notepad++.exe 0 noDelete64
-		MessageBox MB_YESNO "You're installing 32-bit version. 64-bit version has been installed. Remove it?$\n(Your custom config files will be kept)"  /SD IDYES IDYES doDelete64 IDNO noDelete64
+		MessageBox MB_YESNO "You are trying to install 32-bit version while 64-bit version is already installed. Would you like to remove Notepad++ 64 bit version before proceeding further?$\n(Your custom config files will be kept)"  /SD IDYES IDYES doDelete64 IDNO noDelete64
 doDelete64:
 		StrCpy $diffArchDir2Remove $PROGRAMFILES64\${APPNAME}
 noDelete64:

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -27,8 +27,10 @@
 
 Var themesParentPath
 Var doLocalConf
+Var keepUserData
 Function un.onInit
-  	; determinate theme path for uninstall themes
+	StrCpy $keepUserData "false"	; default value(It is must, otherwise few files such as shortcuts.xml, contextMenu.xml etc, will not be removed when $INSTDIR\doLocalConf.xml is not avaliable.)
+	; determinate theme path for uninstall themes
 	StrCpy $themesParentPath "$APPDATA\${APPNAME}"
 	StrCpy $doLocalConf "false"
 	IfFileExists $INSTDIR\doLocalConf.xml doesExist noneExist
@@ -37,6 +39,21 @@ doesExist:
 	StrCpy $doLocalConf "true"
 noneExist:
 	;MessageBox MB_OK "doLocalConf == $doLocalConf"
+FunctionEnd
+
+Function un.onUninstSuccess
+	; make sure all the empty folders are deleted on successful uninstall
+	; These folders will be deleted only if they are emtpy
+	RMDir "$INSTDIR\localization\"
+	RMDir "$INSTDIR\plugins\APIs\"
+	RMDir "$INSTDIR\plugins\disabled\"
+	RMDir "$INSTDIR\plugins\"
+	RMDir "$INSTDIR\updater\"
+	RMDir "$INSTDIR\"
+
+	RMDir "$APPDATA\${APPNAME}\plugins\"
+	RMDir "$themesParentPath\themes\"	; if files are kept because of $keepUserData, this will not be deleted
+	RMDir "$themesParentPath\"
 FunctionEnd
 
 
@@ -116,7 +133,6 @@ Section un.UserManual
 SectionEnd
 
 
-Var keepUserData
 Function un.doYouReallyWantToKeepData
 	StrCpy $keepUserData "false"
 	MessageBox MB_YESNO "Would you like to keep your custom settings?" /SD IDNO IDYES skipRemoveUserData IDNO removeUserData
@@ -247,9 +263,9 @@ Section Uninstall
 		Delete "$APPDATA\${APPNAME}\insertExt.ini"
 	
 		RMDir /r "$APPDATA\${APPNAME}\plugins\"
-		RMDir "$APPDATA\${APPNAME}\backup\"
-		RMDir "$APPDATA\${APPNAME}\themes\"
-		RMDir "$APPDATA\${APPNAME}"
+		RMDir /r "$APPDATA\${APPNAME}\backup\"	; Remove backup folder recursively if not empty
+		RMDir "$APPDATA\${APPNAME}\themes\"	; has no effect as not empty at this momenet, but it is taken care at un.onUninstSuccess
+		RMDir "$APPDATA\${APPNAME}"		; has no effect as not empty at this momenet, but it is taken care at un.onUninstSuccess
 		
 		StrCmp $1 "Admin" 0 +2
 			SetShellVarContext all ; make context for all user


### PR DESCRIPTION
- Few files and folders are not deleted during uninstallation.
From InstallDir

1. Folder "localization" is not removed even all the files are removed from this folder.
2. Folder "pluging\APIs" is not removed even all the files are removed from this folder.
3. Three files are not removed (contextMenu.xml, functionList.xml and shortcuts.xml). There might be more files.
From "%appdata%\Notepad"
1. Bakcup folder (form %appdata%\Notepad++) is not removed if backup folder is not empty.
2. Folder "themes" is not removed even all the files are removed.
3. Because of above two items, parent folder ("%appdata%\Notepad") is also not removed.

- Rephrase user message when user tries to install 64 bit while 32 is already installed (vice versa).
