### PR TITLE
Fix double click after double clicking hotspot

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -383,7 +383,6 @@ private:
 
 	// For hotspot
 	bool _linkTriggered = true;
-	bool _isHotspotDblClicked = false;
 	bool _isFolding = false;
 
 	//For Dynamic selection highlight

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -691,13 +691,6 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					}
 				}
 			}
-			else if (_isHotspotDblClicked)
-			{
-				auto pos = notifyView->execute(SCI_GETCURRENTPOS);
-				notifyView->execute(SCI_SETCURRENTPOS, pos);
-				notifyView->execute(SCI_SETANCHOR, pos);
-				_isHotspotDblClicked = false;
-			}
 
 			break;
 		}
@@ -932,10 +925,13 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					currentWord[lastCharIndex] = '\0';
 
 				::ShellExecute(_pPublicInterface->getHSelf(), TEXT("open"), currentWord, NULL, NULL, SW_SHOW);
-				_isHotspotDblClicked = true;
 
 				// Re-set the previous wordChar list
 				notifyView->execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>(wordChars));
+
+				// Select the entire link
+				notifyView->execute(SCI_SETANCHOR, startPos);
+				notifyView->execute(SCI_SETCURRENTPOS, endPos);
 			}
 
 			delete[] wordChars;


### PR DESCRIPTION
Closes #2547. 

From [this section of code](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/scintilla/src/Editor.cxx#L4210-L4214) it shows that the double click notification comes before the hotspot double click notification, so there is no need to store a flag for the next time `SCN_DOUBLECLICK` occurs.

