### PR TITLE
Unicode installer

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -32,6 +32,7 @@
 !include "nsDialogs.nsh" ; allows creation of custom pages in the installer
 !include "Memento.nsh"   ; remember user selections in the installer across runs
 
+Unicode true			; Generate a Unicode installer. It can only be used outside of sections and functions and before any data is compressed.
 SetCompressor /SOLID lzma	; This reduces installer size by approx 30~35%
 ;SetCompressor /FINAL lzma	; This reduces installer size by approx 15~18%
 


### PR DESCRIPTION
Fixed issue #2568 
Something went wrong while breaking nppSetup.nsi (6.9.2 to 7.0) to multiple files.
The easiest way to fix this is make installer Unicode by specifying Unicode as true. **But this will work if script is complied using NSIS v3.0 and I'm assuming npp setup is being created using NSIS v3.0**
Refer below URLs for details -
[Unicode installer](http://nsis.sourceforge.net/Docs/Chapter1.html#intro-unicode)
[How to make Unicode Installer](http://nsis.sourceforge.net/Docs/Chapter4.html#aunicodetarget)

![uncodeinstaller](https://cloud.githubusercontent.com/assets/14791461/20279348/47615064-aace-11e6-9ebe-8a048111ad57.png)


 