### PR TITLE
Updated uninstaller information

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -31,6 +31,7 @@
 !include "MUI.nsh"       ; Modern UI
 !include "nsDialogs.nsh" ; allows creation of custom pages in the installer
 !include "Memento.nsh"   ; remember user selections in the installer across runs
+!include "FileFunc.nsh"
 
 SetCompressor /SOLID lzma	; This reduces installer size by approx 30~35%
 ;SetCompressor /FINAL lzma	; This reduces installer size by approx 15~18%

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -134,14 +134,22 @@ Function writeInstallInfoInRegistry
 		WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayName" "${APPNAME} (32-bit x86)"
 	!endif
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "Publisher" "Notepad++ Team"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "VersionMajor" "${VERSION_MAJOR}"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "VersionMinor" "${VERSION_MINOR}"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "MajorVersion" "${VERSION_MAJOR}"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "MinorVersion" "${VERSION_MINOR}"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "UninstallString" "$INSTDIR\uninstall.exe"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayIcon" "$INSTDIR\notepad++.exe"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayVersion" "${APPVERSION}"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "URLInfoAbout" "${APPWEBSITE}"
+	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "VersionMajor" ${VERSION_MAJOR}
+	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "VersionMinor" ${VERSION_MINOR}
+	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "NoModify" 1
+	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "NoRepair" 1
+	
+	${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+	IfErrors +3 0
+	IntFmt $0 "0x%08X" $0
+	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "EstimatedSize" "$0"
+	
 	WriteUninstaller "$INSTDIR\uninstall.exe"
 FunctionEnd
 


### PR DESCRIPTION
 - Use DWORD instead of string for Minor and major version
     As per [nsis documentation](http://nsis.sourceforge.net/Add_uninstall_information_to_Add/Remove_Programs), VersionMajor and VersionMinor should be DWORD.
 - Show only "Uninstall" instead of "Uninstall/Change". Refer the screenshot.
    Currently npp installer does not support modify/repair feature. It is better to show only "Uninstall" in  "Program and Features". As per [nsis documentation](http://nsis.sourceforge.net/Add_uninstall_information_to_Add/Remove_Programs), If both NoModify and NoRepair are set to 1, the button displays "Remove" instead of "Modify/Remove".
 - Write installed size as well which will be shown in "Program and Features". Refer the screenshot.
 As per [nsis documentation](http://nsis.sourceforge.net/Add_uninstall_information_to_Add/Remove_Programs), It's strongly recommended to include an EstimatedSize field in unninstall entry. Moreover it is nice to show total installation size.

![uninstallerinfo](https://cloud.githubusercontent.com/assets/14791461/20436142/fbe2537c-add4-11e6-9586-8e0ad18e64e4.png)
