### PR TITLE
Update for Python Lexer : add detect "end of line where string is not…

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -742,6 +742,7 @@ protected:
 
 	void setPythonLexer() {
 		setLexer(SCLEX_PYTHON, L_PYTHON, LIST_0 | LIST_1);
+		execute(SCI_STYLESETEOLFILLED, SCE_P_STRINGEOL, true);
 	};
 
 	void setBatchLexer() {

--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -205,6 +205,7 @@
         </Language>
         <Language name="python" ext="py pyw" commentLine="#">
             <Keywords name="instre1">and as assert break class continue def del elif else except exec False finally for from global if import in is lambda None not or pass print raise return True try while with yield</Keywords>
+            <Keywords name="instre2"></Keywords>
         </Language>
         <Language name="r" ext="r s splus" commentLine="#">
             <Keywords name="instre1">if else repeat while function for in next break TRUE FALSE NULL NA Inf NaN</Keywords>

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -656,6 +656,8 @@
             <WordsStyle name="OPERATOR" styleID="10" fgColor="000080" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING NOT CLOSED" styleID="13" fgColor="000000" bgColor="E0C0E0" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER DEFINED" styleID="14" fgColor="407090" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
             <WordsStyle name="DECORATOR" styleID="15" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="2" fontSize="" />
         </LexerType>
         <LexerType name="r" desc="R" ext="">


### PR DESCRIPTION
Update for Python Lexer : add detect "end of line where string is not… closed" and "user defined keyword" already included in scintilla Python lexer

Close issue #2584

### 1. End of line where string is not… closed 
**before**
![pythonlexer_before](https://cloud.githubusercontent.com/assets/12849364/20454291/8c16987e-ae3c-11e6-88ce-ed6648c86b7a.jpg)
**activate partially** (stylers.model.xml, without eolfilled):
![pythonlexer_partial](https://cloud.githubusercontent.com/assets/12849364/20454300/e59eca92-ae3c-11e6-89d1-ff4be3e01ba5.jpg)
**fully activated** (stylers.model.xml + enable eolfilled in ScintillaEditView.h):
![pythonlexer_after](https://cloud.githubusercontent.com/assets/12849364/20454319/6f5fe0b8-ae3d-11e6-8325-fc818b13c0f3.jpg)

### 2. User defined keyword
sample
![pythonlexer_userdefinedkeyword](https://cloud.githubusercontent.com/assets/12849364/20454330/c52348f0-ae3d-11e6-9d91-d0720bb4932b.jpg)



Sources : 
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/scintilla/lexers/LexPython.cxx
https://sourceforge.net/p/scintilla/scite/ci/default/tree/src/python.properties


