### PR TITLE
No notification if ShellExecute fails

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -911,3 +911,24 @@ bool matchInList(const TCHAR *fileName, const std::vector<generic_string> & patt
 	return false;
 }
 
+generic_string GetLastErrorAsString(DWORD errorCode)
+{
+	generic_string errorMsg(_T(""));
+	// Get the error message, if any.
+	// If both error codes (passed error n GetLastError) are 0, then return empty
+	if (errorCode == 0)
+		errorCode = GetLastError();
+	if (errorCode == 0)
+		return errorMsg; //No error message has been recorded
+
+	LPWSTR messageBuffer = nullptr;
+	FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		nullptr, errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, nullptr);
+
+	errorMsg += messageBuffer;
+
+	//Free the buffer.
+	LocalFree(messageBuffer);
+
+	return errorMsg;
+}

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -182,3 +182,8 @@ generic_string stringTakeWhileAdmissable(const generic_string& input, const gene
 double stodLocale(const generic_string& str, _locale_t loc, size_t* idx = NULL);
 
 bool str2Clipboard(const generic_string &str2cpy, HWND hwnd);
+
+generic_string GetLastErrorAsString(DWORD errorCode = 0);
+
+generic_string intToString(int val);
+generic_string uintToString(unsigned int val);

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -71,25 +71,6 @@ bool PluginsManager::unloadPlugin(int index, HWND nppHandle)
     return true;
 }
 
-static std::wstring GetLastErrorAsString()
-{
-    //Get the error message, if any.
-    DWORD errorMessageID = ::GetLastError();
-    if (errorMessageID == 0)
-        return std::wstring(); //No error message has been recorded
-
-    LPWSTR messageBuffer = nullptr;
-    size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        nullptr, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, nullptr);
-
-    std::wstring message(messageBuffer, size);
-
-    //Free the buffer.
-    LocalFree(messageBuffer);
-
-    return message;
-}
-
 static WORD GetBinaryArchitectureType(const TCHAR *filePath)
 {
 	WORD machine_type = IMAGE_FILE_MACHINE_UNKNOWN;
@@ -147,9 +128,9 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath, vector<generic_strin
 	    pi->_hLib = ::LoadLibrary(pluginFilePath);
         if (!pi->_hLib)
         {
-            const std::wstring& lastErrorMsg = GetLastErrorAsString();
+			generic_string lastErrorMsg = GetLastErrorAsString();
             if (lastErrorMsg.empty())
-                throw generic_string(TEXT("Load Library is failed.\nMake \"Runtime Library\" setting of this project as \"Multi-threaded(/MT)\" may cure this problem."));
+                throw generic_string(TEXT("Load Library has failed.\nChanging the project's \"Runtime Library\" setting to \"Multi-threaded(/MT)\" might solve this problem."));
             else
                 throw generic_string(lastErrorMsg.c_str());
         }

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
@@ -195,6 +195,28 @@ HINSTANCE Command::run(HWND hWnd)
 	expandNppEnvironmentStrs(argsIntermediate, args2Exec, args2ExecLen, hWnd);
 
 	HINSTANCE res = ::ShellExecute(hWnd, TEXT("open"), cmd2Exec, args2Exec, TEXT("."), SW_SHOW);
+
+	// As per MSDN (https://msdn.microsoft.com/en-us/library/windows/desktop/bb762153(v=vs.85).aspx)
+	// If the function succeeds, it returns a value greater than 32.
+	// If the function fails, it returns an error value that indicates the cause of the failure.
+	int retResult = reinterpret_cast<int>(res);
+	if (retResult <= 32)
+	{
+		generic_string errorMsg;
+		errorMsg += GetLastErrorAsString(retResult);
+		errorMsg += TEXT("An attempt was made to execute the below command.");
+		errorMsg += TEXT("\n----------------------------------------------------------");
+		errorMsg += TEXT("\nCommand: ");
+		errorMsg += cmd2Exec;
+		errorMsg += TEXT("\nArguments: ");
+		errorMsg += args2Exec;
+		errorMsg += TEXT("\nError Code: ");
+		errorMsg += intToString(retResult);
+		errorMsg += TEXT("\n----------------------------------------------------------");
+
+		::MessageBox(hWnd, errorMsg.c_str(), TEXT("ShellExecute - ERROR"), MB_ICONINFORMATION | MB_APPLMODAL);
+	}
+
 	return res;
 }
 


### PR DESCRIPTION
If ShellExecute fails to execute command as if required software is not installed, then there is no notification to user.
This happens specially from "Run" menu (e.g. user clicks on Launch in Chrome while Chrome is not installed).

Few review comments also have been accommodated as per #2311 .

![image](https://cloud.githubusercontent.com/assets/14791461/20698526/a1756e50-b627-11e6-8196-1bd7c773e9c7.png)
