### PR TITLE
Improve Folder Browse And Save Dialog

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -180,7 +180,7 @@ generic_string folderBrowser(HWND parent, const generic_string & title, int outp
 		TCHAR szDisplayName[MAX_PATH];
 		info.pszDisplayName = szDisplayName;
 		info.lpszTitle = title.c_str();
-		info.ulFlags = 0;
+		info.ulFlags = BIF_USENEWUI | BIF_NONEWFOLDERBUTTON;
 		info.lpfn = BrowseCallbackProc;
 
 		TCHAR directory[MAX_PATH];

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -174,6 +174,11 @@ Notepad_plus::Notepad_plus()
 		is_admin = false;
 
 	_isAdministrator = is_admin ? true : false;
+
+	// Enable new style save dialog.
+	if (ver >= WV_VISTA) {
+		(NppParameters::getInstance())->setUseNewStyleSaveDlg(true);
+	}
 }
 
 Notepad_plus::~Notepad_plus()


### PR DESCRIPTION
**Folder Browse & Save Dialog**
Enable the new user interface for `Folder Browse Dialog` including the edit box and enable Vista style for `Save Dialog`.

![Folder Browse And Save Dialog](http://i1297.photobucket.com/albums/ag34/MotazNew/Folder_And_Save_Dialog_zpsyzrnz6yz.jpg)