### PR TITLE
Copy encoding fixes from loadFile() to reloadBuffer()

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -689,13 +689,21 @@ bool FileManager::reloadBuffer(BufferID id)
 
 	if (res)
 	{
+		NppParameters *pNppParamInst = NppParameters::getInstance();
+		const NewDocDefaultSettings & ndds = (pNppParamInst->getNppGUI()).getNewDocDefaultSettings();
+
 		if (encoding == -1)
 		{
-			buf->setUnicodeMode(UnicodeConvertor.getEncoding());
+			UniMode um = UnicodeConvertor.getEncoding();
+			if (um == uni7Bit)
+				um = (ndds._openAnsiAsUtf8) ? uniCookie : uni8Bit;
+
+			buf->setUnicodeMode(um);
 		}
-		else
+		else // encoding != -1
 		{
-			buf->setEncoding(encoding);
+			// Test if encoding is set to UTF8 w/o BOM (usually for utf8 indicator of xml or html)
+			buf->setEncoding((encoding == SC_CP_UTF8)?-1:encoding);
 			buf->setUnicodeMode(uniCookie);
 		}
 	}


### PR DESCRIPTION
(noticed this while investigating #1874)

Copy some code from `FileManager::loadFile` to `reloadBuffer`, to fix two bugs also when reloading file from disk. I think the bug 1 is quite important, as it affects "reload from disk" in a very common scenario (ANSI-only content, but force-detected as UTF-8 without BOM).

Bug 1:
1. The settings "New Document > UTF-8 + Apply to opened ANSI files" should be checked.
2. Create a file with only ANSI content (e.g. "aaa"). Save this file in ANSI. Close the file.
3. Open the file. It should be detected as UTF-8 (without BOM).
4. Execute menu command "Reload from Disk". The file is now detected as ANSI. Expected: should be detected as UTF-8.

Bug 2:
1. Create a file with this exact content:
    `<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> ééé`
2. Save it in ANSI and with a `.html` extension. Close the file.
3. Open the file. It should be detected as UTF-8 (and display garbage but that's "expected").
4. Execute command "Reload from Disk". The file is now detected as Windows-1255. Expected: should be detected as UTF-8.

<br>By the way, maybe we should drop the `getHtmlXmlEncoding` method. For instance look at the HTML regexes, they are outdated (no html5), not flexible and in most cases wouldn't match. Also, I think this method does more harm than good. These &lt;meta&gt; tags don't determine the file encoding, but the *expected* file encoding.