### PR TITLE
Launch N++ with same privileges as explorer

### DIFF
--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -26,7 +26,22 @@
 ; Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 Function LaunchNpp
-  Exec '"$INSTDIR\notepad++.exe" "$INSTDIR\change.log" '
+  ;Exec '"$INSTDIR\notepad++.exe" "$INSTDIR\change.log" '
+
+  ; create shortcut in temp with to launch as argument
+  CreateShortCut "$TEMP\notepad++.lnk" "$INSTDIR\notepad++.exe" "$INSTDIR\change.log"
+
+  ; Launch Notepad++ with same elevation as explorer
+  ; It will solve the drag an drop issue if explorer is running with lower privilege
+  Exec '"$WINDIR\explorer.exe" "$TEMP\notepad++.lnk"'
+
+  ; Caution : Please DONOT delete $TEMP\notepad++.lnk right after Exec command
+  ; In slower system it may take some time to open N++ while Exec command exist quickly
+  ; Also putting sleep does not make sense here as
+  ; 	- DONOT know how much to wait
+  ;		- Keeps installer UI open wait time period
+  ;		- If wait time is more, installer UI may become irresponsive
+
 FunctionEnd
 
 ; Check if Notepad++ is running


### PR DESCRIPTION
Fixes: #2641, #159, #556

Known Pending Action Item:
A shortcut is created in %temp% which should be deleted. But I didn't find way to handle it.
However, we can check for "nppInstance" mutex in a loop, but again keeping installer open (that too on finish page->finish page) for some more time (until N++ launched) is not good idea. Let me know if checking mutex if fine, I will update PR.