### PR TITLE
Add Support Highlight for 3.5.0+ Syntax.

### DIFF
--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -204,7 +204,7 @@
         <Language name="props" ext="properties" commentLine=";">
         </Language>
         <Language name="python" ext="py pyw" commentLine="#">
-            <Keywords name="instre1">and as assert break class continue def del elif else except exec False finally for from global if import in is lambda None not or pass print raise return True try while with yield</Keywords>
+            <Keywords name="instre1">and as assert break class continue def del elif else except exec False finally for from global if import in is lambda None not or pass print raise return True try while with yield async await</Keywords>
         </Language>
         <Language name="r" ext="r s splus" commentLine="#">
             <Keywords name="instre1">if else repeat while function for in next break TRUE FALSE NULL NA Inf NaN</Keywords>


### PR DESCRIPTION
This adds in highlighting for Python 3.5.0+ users who uses ``async def`` and ``await``s for coroutines.

These keywords are also planned to change in 3.6.0 as well with PEP-530.

http://www.python.org/dev/peps/pep-0530

This fixes #2640.

Note: this only adds in to 1 line the following keywords to the python setting:
``async``
``await``