### PR TITLE
Retain the caret position between document move

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3537,6 +3537,17 @@ void Notepad_plus::docGotoAnotherEditView(FileTransferMode mode)
 	}
 	else	//open the document, also copying the position
 	{
+		// If both the views are visible then first save the position of non-edit view
+		// So that moving document between views does not lose caret position
+		// How it works =>
+		//		non-edit view becomes edit view as document from edit view is sent to non edit view
+		//		restoreCurrentPos is called on non-edit view, which will restore the position of
+		//		active document/tab on non-edit view  (whatever position we set in below if condition)
+		if (_pEditView->isVisible() && _pNonEditView->isVisible())
+		{
+			_pNonEditView->saveCurrentPos();
+		}
+
 		loadBufferIntoView(current, viewToGo);
 		Buffer *buf = MainFileManager->getBufferByID(current);
 		_pEditView->saveCurrentPos();	//allow copying of position


### PR DESCRIPTION
Document position (including caret position) is lost when document is between views.

Scenario:
1. Open two documents (say A.txt and B.txt) in N++. I assume caret position for both the document is at beginning. 
2. Now move B to other view.
3. Change caret positions of both A and B. To make is easier, move caret to EOF for both files.
4. Now move B again to other view (which is nothing but main view)

Observe document position of A. Caret of A is moved to beginning of document.

Fixes issue:
1. NPP -> #2541 
2. Compare plugin -> [Issue 66](https://github.com/pnedev/compare-plugin/issues/66)
