### PR TITLE
Allow drag n drop at High Integrity Level

### DIFF
--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -475,7 +475,11 @@ DEVOMER*/
 					MESSAGEFILTERFUNC func = (MESSAGEFILTERFUNC)::GetProcAddress( hDll, "ChangeWindowMessageFilter" );
 
 					if (func)
+					{
 						func(WM_COPYDATA, MSGFLT_ADD);
+						func(WM_DROPFILES, MSGFLT_ADD);
+						func(0x0049, MSGFLT_ADD);
+					}
 				}
 				else
 				{
@@ -485,7 +489,11 @@ DEVOMER*/
 					MESSAGEFILTERFUNCEX func = (MESSAGEFILTERFUNCEX)::GetProcAddress( hDll, "ChangeWindowMessageFilterEx" );
 
 					if (func)
-						func(notepad_plus_plus.getHSelf(), WM_COPYDATA, MSGFLT_ALLOW, NULL );
+					{
+						func(notepad_plus_plus.getHSelf(), WM_COPYDATA, MSGFLT_ALLOW, NULL);
+						func(notepad_plus_plus.getHSelf(), WM_DROPFILES, MSGFLT_ALLOW, NULL);
+						func(notepad_plus_plus.getHSelf(), 0x0049, MSGFLT_ALLOW, NULL);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Not sure whether a PR is correct way to discuss a issue/solution, but wanted to discuss an issue about drag n drop. Many issues have been reported that drag n drop is not working. In most of the cases, explorer integrity is lower then Notepad++ integrity.

Now in Win10 default integrity level of explorer is lower (non-elevated) and there are many cases when Notepad++ may be running as elevated process.
- case 1: right after installation (it is fixed in one of my PR)
- case 2: If saving a file fails then Npp is relaunched in admin mode
- case 3: user may launch in admin launch
So in all these cases, NPP will not able to support drag n drop.

As per MSDN and related blogs/articles, drag n drop is not supported if processes integrity level is different. It is blocked by User Interface Privilege Isolation (UIPI). So we can bypass UIPI for certain messages using ChangeWindowMessageFilter/ChangeWindowMessageFilterEX.

I see, there already exists a code to open a file which comes from context menu of Lower Integrity Level explorer while npp is running at higher integrity level. So we should handle drag n drop in same fashion, shouldn't we.

 ``` C++
// Tell UAC that lower integrity processes are allowed to send WM_COPYDATA messages to this process (or window)
// This allows opening new files to already opened elevated Notepad++ process via explorer context menu.
if (ver >= WV_VISTA || ver == WV_UNKNOWN)
{
	HMODULE hDll = GetModuleHandle(TEXT("user32.dll"));
	if (hDll)
	{
		// According to MSDN ChangeWindowMessageFilter may not be supported in future versions of Windows,
		// that is why we use ChangeWindowMessageFilterEx if it is available (windows version >= Win7).
		if (pNppParameters->getWinVersion() == WV_VISTA)
		{
			typedef BOOL(WINAPI *MESSAGEFILTERFUNC)(UINT message, DWORD dwFlag);
			const DWORD MSGFLT_ADD = 1;

			MESSAGEFILTERFUNC func = (MESSAGEFILTERFUNC)::GetProcAddress(hDll, "ChangeWindowMessageFilter");

			if (func)
				func(WM_COPYDATA, MSGFLT_ADD);
		}
		else
		{
			typedef BOOL(WINAPI *MESSAGEFILTERFUNCEX)(HWND hWnd, UINT message, DWORD action, VOID* pChangeFilterStruct);
			const DWORD MSGFLT_ALLOW = 1;

			MESSAGEFILTERFUNCEX func = (MESSAGEFILTERFUNCEX)::GetProcAddress(hDll, "ChangeWindowMessageFilterEx");

			if (func)
				func(notepad_plus_plus.getHSelf(), WM_COPYDATA, MSGFLT_ALLOW, NULL);
		}
	}
}
```

This way we can process WM_DROPFILES message as well. So with updated code (present in this PR) npp works exact same as non-elevated except one point. Still drag n drop is not allowed on scintilla edit view (editable portion).

I couldn't find way to handle it. If someone has any idea, it can be improved.
Also I'm not sure about undocumented message 0x0049, but without it given solution does not work. 

![nppdragndrop](https://cloud.githubusercontent.com/assets/14791461/21161685/a56c3f8c-c1af-11e6-809c-dabc8b7eb3ee.gif)


