### PR TITLE
Go to correct position after word completion

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -342,8 +342,8 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 
 	if (wordArray.size() == 1 && autoInsert)
 	{
-		_pEditView->replaceTargetRegExMode(wordArray[0].c_str(), startPos, curPos);
-		_pEditView->execute(SCI_GOTOPOS, startPos + wordArray[0].length());
+		int replacedLength = _pEditView->replaceTargetRegExMode(wordArray[0].c_str(), startPos, curPos);
+		_pEditView->execute(SCI_GOTOPOS, startPos + replacedLength);
 		return true;
 	}
 


### PR DESCRIPTION
Closes #2675. In the case where there was only 1 word to auto-complete, the cursor's position could be incorrect.