### PR TITLE
Fixed crash issue: #2820

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2765,6 +2765,11 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 {
 	assert(repeat > 0);
 
+	// If there is no column mode info available, no need to do anything
+	// If required a message can be shown to user, that select column properly or something similar
+	// It is just a double check as taken in callee method (in case this method is called from multiple places)
+	if (cmi.size() <= 0)
+		return;
 	// 0000 00 00 : Dec BASE_10
 	// 0000 00 01 : Hex BASE_16
 	// 0000 00 10 : Oct BASE_08

--- a/PowerEditor/src/ScitillaComponent/columnEditor.cpp
+++ b/PowerEditor/src/ScitillaComponent/columnEditor.cpp
@@ -158,10 +158,16 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 						if ((*_ppEditView)->execute(SCI_SELECTIONISRECTANGLE) || (*_ppEditView)->execute(SCI_GETSELECTIONS) > 1)
 						{
 							ColumnModeInfos colInfos = (*_ppEditView)->getColumnModeSelectInfo();
-							std::sort(colInfos.begin(), colInfos.end(), SortInPositionOrder());
-							(*_ppEditView)->columnReplace(colInfos, initialNumber, increaseNumber, repeat, format);
-							std::sort(colInfos.begin(), colInfos.end(), SortInSelectOrder());
-							(*_ppEditView)->setMultiSelections(colInfos);
+
+							// If there is no column mode info available, no need to do anything
+							// If required a message can be shown to user, that select column properly or something similar
+							if (colInfos.size() > 0)
+							{
+								std::sort(colInfos.begin(), colInfos.end(), SortInPositionOrder());
+								(*_ppEditView)->columnReplace(colInfos, initialNumber, increaseNumber, repeat, format);
+								std::sort(colInfos.begin(), colInfos.end(), SortInSelectOrder());
+								(*_ppEditView)->setMultiSelections(colInfos);
+							}
 						}
 						else
 						{


### PR DESCRIPTION
Fixed issue #2820 
If empty column(s) is/are selected in column mode, then NPP should not crash.