### PR TITLE
Fixed issues: #1200, #1714, #2125 and #2854

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -200,7 +200,7 @@ public:
 	bool doBlockComment(comment_mode currCommentMode);
 	bool doStreamComment();
 	//--FLS: undoStreamComment: New function unDoStreamComment()
-	bool undoStreamComment();
+	bool undoStreamComment(bool tryBlockComment = true);
 
 	bool addCurrentMacro();
 	void macroPlayback(Macro);


### PR DESCRIPTION
Fixed block uncomment in undoStreamComment func, new argument tryBlockComment is to avoid loop call.
Fixed typo in doStreamComment func.