### PR TITLE
iface docu correction of bufferID

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -214,7 +214,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// returned value : TRUE if tab bar is hidden, otherwise FALSE
 
 	#define NPPM_GETPOSFROMBUFFERID (NPPMSG + 57)
-	// INT NPPM_GETPOSFROMBUFFERID(INT bufferID, INT priorityView)
+	// INT NPPM_GETPOSFROMBUFFERID(UINT_PTR bufferID, INT priorityView)
 	// Return VIEW|INDEX from a buffer ID. -1 if the bufferID non existing
 	// if priorityView set to SUB_VIEW, then SUB_VIEW will be search firstly
 	//
@@ -224,11 +224,11 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	//  SUB_VIEW  1
 
 	#define NPPM_GETFULLPATHFROMBUFFERID (NPPMSG + 58)
-	// INT NPPM_GETFULLPATHFROMBUFFERID(INT bufferID, TCHAR *fullFilePath)
+	// INT NPPM_GETFULLPATHFROMBUFFERID(UINT_PTR bufferID, TCHAR *fullFilePath)
 	// Get full path file name from a bufferID.
 	// Return -1 if the bufferID non existing, otherwise the number of TCHAR copied/to copy
 	// User should call it with fullFilePath be NULL to get the number of TCHAR (not including the nul character),
-	// allocate fullFilePath with the return values + 1, then call it again to get  full path file name
+	// allocate fullFilePath with the return values + 1, then call it again to get full path file name
 
 	#define NPPM_GETBUFFERIDFROMPOS (NPPMSG + 59)
 	// LRESULT NPPM_GETBUFFERIDFROMPOS(INT index, INT iView)
@@ -241,20 +241,20 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// Returns active Buffer
 
 	#define NPPM_RELOADBUFFERID (NPPMSG + 61)
-	// VOID NPPM_RELOADBUFFERID(0, 0)
+	// VOID NPPM_RELOADBUFFERID(UINT_PTR bufferID, BOOL alert)
 	// Reloads Buffer
 	// wParam: Buffer to reload
 	// lParam: 0 if no alert, else alert
 
 
 	#define NPPM_GETBUFFERLANGTYPE (NPPMSG + 64)
-	// INT NPPM_GETBUFFERLANGTYPE(INT bufferID, 0)
+	// INT NPPM_GETBUFFERLANGTYPE(UINT_PTR bufferID, 0)
 	// wParam: BufferID to get LangType from
 	// lParam: 0
 	// Returns as int, see LangType. -1 on error
 
 	#define NPPM_SETBUFFERLANGTYPE (NPPMSG + 65)
-	// BOOL NPPM_SETBUFFERLANGTYPE(INT bufferID, INT langType)
+	// BOOL NPPM_SETBUFFERLANGTYPE(UINT_PTR bufferID, INT langType)
 	// wParam: BufferID to set LangType of
 	// lParam: LangType
 	// Returns TRUE on success, FALSE otherwise
@@ -262,13 +262,13 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// L_USER and L_EXTERNAL are not supported
 
 	#define NPPM_GETBUFFERENCODING (NPPMSG + 66)
-	// INT NPPM_GETBUFFERENCODING(INT bufferID, 0)
+	// INT NPPM_GETBUFFERENCODING(UINT_PTR bufferID, 0)
 	// wParam: BufferID to get encoding from
 	// lParam: 0
 	// returns as int, see UniMode. -1 on error
 
 	#define NPPM_SETBUFFERENCODING (NPPMSG + 67)
-	// BOOL NPPM_SETBUFFERENCODING(INT bufferID, INT encoding)
+	// BOOL NPPM_SETBUFFERENCODING(UINT_PTR bufferID, INT encoding)
 	// wParam: BufferID to set encoding of
 	// lParam: encoding
 	// Returns TRUE on success, FALSE otherwise
@@ -276,29 +276,18 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// Can only be done on new, unedited files
 
 	#define NPPM_GETBUFFERFORMAT (NPPMSG + 68)
-	// INT NPPM_GETBUFFERFORMAT(INT bufferID, 0)
-	// wParam: BufferID to get format from
+	// INT NPPM_GETBUFFERFORMAT(UINT_PTR bufferID, 0)
+	// wParam: BufferID to get EolType format from
 	// lParam: 0
-	// returns as int, see formatType. -1 on error
+	// returns as int, see EolType format. -1 on error
 
 	#define NPPM_SETBUFFERFORMAT (NPPMSG + 69)
-	// BOOL NPPM_SETBUFFERFORMAT(INT bufferID, INT format)
-	// wParam: BufferID to set format of
+	// BOOL NPPM_SETBUFFERFORMAT(UINT_PTR bufferID, INT format)
+	// wParam: BufferID to set EolType format of
 	// lParam: format
 	// Returns TRUE on success, FALSE otherwise
-	// use int, see formatType
+	// use int, see EolType format
 
-/*
-	#define NPPM_ADDREBAR (NPPMSG + 57)
-	// BOOL NPPM_ADDREBAR(0, REBARBANDINFO *)
-	// Returns assigned ID in wID value of struct pointer
-	#define NPPM_UPDATEREBAR (NPPMSG + 58)
-	// BOOL NPPM_ADDREBAR(INT ID, REBARBANDINFO *)
-	//Use ID assigned with NPPM_ADDREBAR
-	#define NPPM_REMOVEREBAR (NPPMSG + 59)
-	// BOOL NPPM_ADDREBAR(INT ID, 0)
-	//Use ID assigned with NPPM_ADDREBAR
-*/
 
 	#define NPPM_HIDETOOLBAR (NPPMSG + 70)
 	// BOOL NPPM_HIDETOOLBAR(0, BOOL hideOrNot)
@@ -334,7 +323,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// BOOL NPPM_GETSHORTCUTBYCMDID(int cmdID, ShortcutKey *sk)
 	// get your plugin command current mapped shortcut into sk via cmdID
 	// You may need it after getting NPPN_READY notification
-	// returned value : TRUE if this function call is successful and shorcut is enable, otherwise FALSE
+	// returned value : TRUE if this function call is successful and shortcut is enable, otherwise FALSE
 
 	#define NPPM_DOOPEN (NPPMSG + 77)
 	// BOOL NPPM_DOOPEN(0, const TCHAR *fullPathName2Open)
@@ -346,7 +335,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 
     #define NPPM_GETCURRENTNATIVELANGENCODING (NPPMSG + 79)
 	// INT NPPM_GETCURRENTNATIVELANGENCODING(0, 0)
-	// returned value : the current native language enconding
+	// returned value : the current native language encoding
 
     #define NPPM_ALLOCATESUPPORTED   (NPPMSG + 80)
     // returns TRUE if NPPM_ALLOCATECMDID is supported
@@ -365,7 +354,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 
 	#define NPPM_GETLANGUAGENAME  (NPPMSG + 83)
 	// INT NPPM_GETLANGUAGENAME(int langType, TCHAR *langName)
-	// Get programing language name from the given language type (LangType)
+	// Get programming language name from the given language type (LangType)
 	// Return value is the number of copied character / number of character to copy (\0 is not included)
 	// You should call this function 2 times - the first time you pass langName as NULL to get the number of characters to copy.
     // You allocate a buffer of the length of (the number of characters + 1) then call NPPM_GETLANGUAGENAME function the 2nd time
@@ -373,7 +362,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 
 	#define NPPM_GETLANGUAGEDESC  (NPPMSG + 84)
 	// INT NPPM_GETLANGUAGEDESC(int langType, TCHAR *langDesc)
-	// Get programing language short description from the given language type (LangType)
+	// Get programming language short description from the given language type (LangType)
 	// Return value is the number of copied character / number of character to copy (\0 is not included)
 	// You should call this function 2 times - the first time you pass langDesc as NULL to get the number of characters to copy.
     // You allocate a buffer of the length of (the number of characters + 1) then call NPPM_GETLANGUAGEDESC function the 2nd time
@@ -547,10 +536,10 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	//scnNotification->nmhdr.hwndFrom = bufferID;
 	//scnNotification->nmhdr.idFrom = docStatus;
 		// where bufferID is BufferID
-		//       docStatus can be combined by DOCSTAUS_READONLY and DOCSTAUS_BUFFERDIRTY
+		//       docStatus can be combined by DOCSTATUS_READONLY and DOCSTATUS_BUFFERDIRTY
 
-		#define DOCSTAUS_READONLY 1
-		#define DOCSTAUS_BUFFERDIRTY 2
+		#define DOCSTATUS_READONLY 1
+		#define DOCSTATUS_BUFFERDIRTY 2
 
 	#define NPPN_DOCORDERCHANGED (NPPN_FIRST + 17)  // To notify plugins that document order is changed
 	//scnNotification->nmhdr.code = NPPN_DOCORDERCHANGED;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5081,7 +5081,7 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 		// To notify plugins ro status is changed
 		SCNotification scnN;
 		scnN.nmhdr.hwndFrom = (void *)buffer->getID();
-		scnN.nmhdr.idFrom = (uptr_t)  ((isSysReadOnly || isUserReadOnly? DOCSTAUS_READONLY : 0) | (isDirty ? DOCSTAUS_BUFFERDIRTY : 0));
+		scnN.nmhdr.idFrom = (uptr_t)  ((isSysReadOnly || isUserReadOnly? DOCSTATUS_READONLY : 0) | (isDirty ? DOCSTATUS_BUFFERDIRTY : 0));
 		scnN.nmhdr.code = NPPN_READONLYCHANGED;
 		_pluginsManager.notify(&scnN);
 


### PR DESCRIPTION
- corrections for interface of bufferID, as x64 requires usage of UINT_PTR aka WPARAM instead of INT
- used new EolType instead of formatType
- removed commented NPPM_ADDREBAR, NPPM_UPDATEREBAR, NPPM_REMOVEREBAR not available in n++ code
- corrected typos