### PR TITLE
Enhance Load/Save Session Feature

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -916,8 +916,9 @@
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.\rAre you sure to open them?"/>
-			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,\ror on a folder needed privilege right for writting access.\rYour settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
+			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,\ror on a folder needed privilege right for writing access.\rYour settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
 			<FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
+	    <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Clipboard History"/>

--- a/PowerEditor/installer/nativeLang/hindi.xml
+++ b/PowerEditor/installer/nativeLang/hindi.xml
@@ -933,6 +933,7 @@
       <NbFileToOpenImportantWarning title="खोलने के लिए फ़ाइलों की राशि बहुत बड़ी है" message="$INT_REPLACE$ फ़ाइलों खुलने ही वाली हैं। आप उन्हें खोलने के लिए सुनिश्चित कर रहे हैं?"/>
       <SettingsOnCloudError title="क्लाउड (cloud) की सेटिंग्स" message="ऐसा लगता है कि क्लाउड (cloud) का सेटिंग पाथ रीड ओनली है या फिर आवश्यक फोल्डर पर राइट एक्सेस (write access) चाहिए। आपकी क्लाउड (cloud) की सेटिंग्स को रद्द कर दिया जायेगा। कृप्या प्रैफरेंसेज डायलॉग (preferences dialog) से एक सुसंगत (coherent ) मूल्य रीसेट करें।"/>
       <FilePathNotFoundWarning title="फाइल खोलें" message="आप जिस फ़ाइल को खोलने की कोशिश कर रहे हैं, वह मौजूद नहीं है।"/>
+      <SessionFileInvalidError title="सत्र लोड नहीं किया जा सका" message="सत्र फ़ाइल या तो अनुपयोगी है या मान्य नहीं है।"/>
     </MessageBox>
     <ClipboardHistory>
       <PanelTitle name="क्लिपबोर्ड हिस्ट्री"/>

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1769,7 +1769,6 @@ bool Notepad_plus::fileLoadSession(const TCHAR *fn)
 	if (fn == NULL)
 	{
 		FileDialog fDlg(_pPublicInterface->getHSelf(), _pPublicInterface->getHinst());
-		fDlg.setExtFilter(TEXT("All types"), TEXT(".*"), NULL);
 		const TCHAR *ext = NppParameters::getInstance()->getNppGUI()._definedSessionExt.c_str();
 		generic_string sessionExt = TEXT("");
 		if (*ext != '\0')
@@ -1779,6 +1778,7 @@ bool Notepad_plus::fileLoadSession(const TCHAR *fn)
 			sessionExt += ext;
 			fDlg.setExtFilter(TEXT("Session file"), sessionExt.c_str(), NULL);
 		}
+		fDlg.setExtFilter(TEXT("All types"), TEXT(".*"), NULL);
 		sessionFileName = fDlg.doOpenSingleFileDlg();
 	}
 	else
@@ -1810,6 +1810,7 @@ bool Notepad_plus::fileLoadSession(const TCHAR *fn)
 			args += sessionFileName;
 			args += TEXT("\"");
 			::ShellExecute(_pPublicInterface->getHSelf(), TEXT("open"), nppFullPath, args.c_str(), TEXT("."), SW_SHOW);
+			result = true;
 		}
 		else
 		{
@@ -1823,6 +1824,14 @@ bool Notepad_plus::fileLoadSession(const TCHAR *fn)
 			}
 			if (!isAllSuccessful)
 				(NppParameters::getInstance())->writeSession(session2Load, sessionFileName);
+		}
+		if (result == false)
+		{
+			_nativeLangSpeaker.messageBox("SessionFileInvalidError",
+				NULL,
+				TEXT("Session file is either corrupted or not valid."),
+				TEXT("Could not Load Session"),
+				MB_OK);
 		}
 	}
 	return result;
@@ -1857,7 +1866,6 @@ const TCHAR * Notepad_plus::fileSaveSession(size_t nbFile, TCHAR ** fileNames)
 	FileDialog fDlg(_pPublicInterface->getHSelf(), _pPublicInterface->getHinst());
 	const TCHAR *ext = NppParameters::getInstance()->getNppGUI()._definedSessionExt.c_str();
 
-	fDlg.setExtFilter(TEXT("All types"), TEXT(".*"), NULL);
 	generic_string sessionExt = TEXT("");
 	if (*ext != '\0')
 	{
@@ -1866,6 +1874,7 @@ const TCHAR * Notepad_plus::fileSaveSession(size_t nbFile, TCHAR ** fileNames)
 		sessionExt += ext;
 		fDlg.setExtFilter(TEXT("Session file"), sessionExt.c_str(), NULL);
 	}
+	fDlg.setExtFilter(TEXT("All types"), TEXT(".*"), NULL);
 	sessionFileName = fDlg.doSaveDlg();
 
 	return fileSaveSession(nbFile, fileNames, sessionFileName);

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -183,7 +183,7 @@ TCHAR* FileDialog::doOpenSingleFileDlg()
 	} catch(std::exception e) {
 		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 	} catch(...) {
-		::MessageBox(NULL, TEXT("GetSaveFileName crashes!!!"), TEXT(""), MB_OK);
+		::MessageBox(NULL, TEXT("doOpenSingleFileDlg crashes!!!"), TEXT(""), MB_OK);
 	}
 
 	::SetCurrentDirectory(dir); 


### PR DESCRIPTION
Change log:
1. English.xml => Corrected typo (writting->writing) and added new message for session load failure.
2. Hindi.xml => Added new localization message w.r.t English.xml
3. NppIO.cpp =>
         1. If any session ext is set, then give preference to session ext instead of "All Types (* . *). This is applicable for both save/load session methods.
          2. Show error message when user tries to load wrong session file (e.g. any text file which is not a valid session file)
4. FileDialog.cpp => Changed messagebox content to show proper method name.

![image](https://cloud.githubusercontent.com/assets/14791461/23092897/cf36e374-f5fa-11e6-8108-e6d068201749.png)


