### PR TITLE
Make folding style visible

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2304,23 +2304,8 @@ void ScintillaEditView::performGlobalStyles()
 	execute(SCI_SETFOLDMARGINCOLOUR, true, foldMarginColor);
 	execute(SCI_SETFOLDMARGINHICOLOUR, true, foldMarginHiColor);
 
-	COLORREF foldfgColor = white;
-	COLORREF foldbgColor = grey;
-	i = stylers.getStylerIndexByName(TEXT("Fold"));
-	if (i != -1)
-	{
-		Style & style = stylers.getStyler(i);
-		foldfgColor = style._bgColor;
-		foldbgColor = style._fgColor;
-	}
-
-	COLORREF activeFoldFgColor = red;
-	i = stylers.getStylerIndexByName(TEXT("Fold active"));
-	if (i != -1)
-	{
-		Style & style = stylers.getStyler(i);
-		activeFoldFgColor = style._fgColor;
-	}
+	COLORREF foldfgColor = white, foldbgColor = grey, activeFoldFgColor = red;
+	getFoldColor(foldfgColor, foldbgColor, activeFoldFgColor);
 
 	ScintillaViewParams & svp = (ScintillaViewParams &)_pParameter->getSVP();
 	for (int j = 0 ; j < NB_FOLDER_STATE ; ++j)
@@ -3328,4 +3313,24 @@ void ScintillaEditView::setBorderEdge(bool doWithBorderEdge)
 
 	::SetWindowLongPtr(_hSelf, GWL_EXSTYLE, exStyle);
 	::SetWindowPos(_hSelf, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+}
+
+void ScintillaEditView::getFoldColor(COLORREF& fgColor, COLORREF& bgColor, COLORREF& activeFgColor)
+{
+	StyleArray & stylers = _pParameter->getMiscStylerArray();
+
+	int i = stylers.getStylerIndexByName(TEXT("Fold"));
+	if (i != -1)
+	{
+		Style & style = stylers.getStyler(i);
+		fgColor = style._bgColor;
+		bgColor = style._fgColor;
+	}
+
+	i = stylers.getStylerIndexByName(TEXT("Fold active"));
+	if (i != -1)
+	{
+		Style & style = stylers.getStyler(i);
+		activeFgColor = style._fgColor;
+	}
 }

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -265,8 +265,6 @@ public:
 
 	void saveCurrentPos();
 	void restoreCurrentPos();
-	void saveCurrentFold();
-	void restoreCurrentFold();
 
 	void beginOrEndSelect();
 	bool beginEndSelectedIsStarted() const {
@@ -346,8 +344,12 @@ public:
 		{
 			display = true;
 		}
+
+		COLORREF foldfgColor = white, foldbgColor = grey, activeFoldFgColor = red;
+		getFoldColor(foldfgColor, foldbgColor, activeFoldFgColor);
+
 		for (int i = 0 ; i < NB_FOLDER_STATE ; ++i)
-			defineMarker(_markersArray[FOLDER_TYPE][i], _markersArray[style][i], white, grey, white);
+			defineMarker(_markersArray[FOLDER_TYPE][i], _markersArray[style][i], foldfgColor, foldbgColor, activeFoldFgColor);
 		showMargin(ScintillaEditView::_SC_MARGE_FOLDER, display);
     };
 
@@ -928,5 +930,6 @@ protected:
 
 	std::pair<int, int> getWordRange();
 	bool expandWordSelection();
+	void getFoldColor(COLORREF& fgColor, COLORREF& bgColor, COLORREF& activeFgColor);
 };
 


### PR DESCRIPTION
Fixed issue #2948 
Instead of gray and while colors, ask styler to provide color. If styler does not provide then only use gray and while. 
To make review easier => same piece of code is used in method 
```C++
void ScintillaEditView::performGlobalStyles()
```
Also marked two methods as deleted which were not used (rather I'd say not defined).

**Before**
![foldingstylebefore](https://cloud.githubusercontent.com/assets/14791461/23276895/fb04064a-fa31-11e6-91fe-f11e68d37d99.gif)

**After**
![foldingstyleafter](https://cloud.githubusercontent.com/assets/14791461/23276896/fb0e474a-fa31-11e6-8dec-74ea7dfbe480.gif)

