### PR TITLE
Clear app registry key while switching from 32bit to 64 bit and vice versa

### DIFF
--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -150,7 +150,7 @@ FunctionEnd
 	SetRegView 64
 !endif
 	DeleteRegKey HKLM "${UNINSTALL_REG_KEY}"
-	;DeleteRegKey HKLM "SOFTWARE\${APPNAME}"
+	DeleteRegKey HKLM "SOFTWARE\${APPNAME}"
 	;DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\notepad++.exe"
 !ifdef ARCH64
 	SetRegView 64


### PR DESCRIPTION
While analyzing an issue, I found that while upgrading/downgrading from/to 32 bit version to/from 64 bit version, app registry key is not cleared. Therefore, on final uninstall of N++, this key is not being deleted. It remains floating.

When switching from 32 bit version to 64 bit version
**HKLM/Software/Wow6432Node/Notepad++** should be removed while switching from 64bit to 32 bit version 
**HKLM/Software/Notepad++** should be removed.

However, it can be seen that related piece of code is commented. I'm not sure what was the reason. If there is any reason behind this, I'm eager to know it.
