### PR TITLE
Fix for issue #2828 Crashes if you hold right mousebutton and scroll a couple of times

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2812,10 +2812,13 @@ void Notepad_plus::command(int id)
 				}
 				else
 				{
-					TaskListDlg tld;
-					HIMAGELIST hImgLst = _docTabIconList.getHandle();
-					tld.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst, direction);
-					tld.doDialog();
+					if (TaskListDlg::_instanceCount == 0)
+					{
+						TaskListDlg tld;
+						HIMAGELIST hImgLst = _docTabIconList.getHandle();
+						tld.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst, direction);
+						tld.doDialog();
+					}
 				}
 			}
 			_linkTriggered = true;

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -31,6 +31,8 @@
 #include "Parameters.h"
 #include "resource.h"
 
+int TaskListDlg::_instanceCount = 0;
+
 LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam)
 {
 	if ((nCode >= 0) && (wParam == WM_RBUTTONUP))
@@ -93,6 +95,7 @@ INT_PTR CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lP
 		{
 			_taskList.destroy();
 			::UnhookWindowsHookEx(_hHooker);
+			_instanceCount--;
 			return TRUE;
 		}
 

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -61,7 +61,7 @@ static LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam);
 class TaskListDlg : public StaticDialog
 {
 public :	
-        TaskListDlg() : StaticDialog() {};
+		TaskListDlg() : StaticDialog() { _instanceCount++; };
 		void init(HINSTANCE hInst, HWND parent, HIMAGELIST hImgLst, bool dir) {
             Window::init(hInst, parent);
 			_hImalist = hImgLst;
@@ -81,5 +81,7 @@ private :
 	HHOOK _hHooker = nullptr;
 
 	void drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct);
+public:
+	static int _instanceCount;
 };
 


### PR DESCRIPTION
The application crashes when the user clicks the right mouse button and then scrolls back and forth between the list of files. The problem is caused by additional mouse wheel messages landing in the message queue before the dialog window has been completely initialized and is able to handle messages. As a result the main application window creates multiple TaskListDlg's which eventually leads to a stack overflow. The fix uses a static member variable in TaskListDlg to track the number of instances. This allows the main application window to check the static variable and only create the dialog window if there are no instances. This fix should then also address issues #1619, #2603 and #607 however this has to be confirmed.