### PR TITLE
fixing the mouse wheel to task list scroll bug (#2828)

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2805,17 +2805,19 @@ void Notepad_plus::command(int id)
 			if (nbDoc > 1)
 			{
 				bool direction = (id == IDC_NEXT_DOC)?dirDown:dirUp;
-
 				if (!doTaskList)
 				{
 					activateNextDoc(direction);
 				}
 				else
 				{
-					TaskListDlg tld;
-					HIMAGELIST hImgLst = _docTabIconList.getHandle();
-					tld.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst, direction);
-					tld.doDialog();
+					if (TaskListDlg::_instanceCount == 0)
+					{
+						TaskListDlg tld;
+						HIMAGELIST hImgLst = _docTabIconList.getHandle();
+						tld.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst, direction);
+						tld.doDialog();
+					}
 				}
 			}
 			_linkTriggered = true;

--- a/PowerEditor/src/WinControls/TaskList/TaskList.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.cpp
@@ -88,6 +88,7 @@ void TaskList::init(HINSTANCE hInst, HWND parent, HIMAGELIST hImaLst, int nbItem
 
 	ListView_SetItemState(_hSelf, _currentIndex, LVIS_SELECTED|LVIS_FOCUSED, LVIS_SELECTED|LVIS_FOCUSED);
 	ListView_SetBkColor(_hSelf, lightYellow);
+
 }
 
 void TaskList::destroy()
@@ -127,6 +128,11 @@ RECT TaskList::adjustSize()
 	ListView_SetColumnWidth(_hSelf, 0, _rc.right);
 	::SendMessage(_hSelf, WM_SETFONT, reinterpret_cast<WPARAM>(_hFont), 0);
 
+	//if the tasklist exceeds the height of the display, leave some space at the bottom
+	if (_rc.bottom > ::GetSystemMetrics(SM_CYSCREEN) - 120)
+	{
+		_rc.bottom = ::GetSystemMetrics(SM_CYSCREEN) - 120;
+	}
 	reSizeTo(_rc);
 
 	// Task List's border is 1px smaller than ::GetSystemMetrics(SM_CYFRAME) returns
@@ -205,18 +211,19 @@ LRESULT TaskList::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 			else
 			{
 				int32_t selected = (_currentIndex + 1) > (_nbItem - 1) ? 0 : (_currentIndex + 1);
-				ListView_SetItemState(_hSelf, _currentIndex, 0, LVIS_SELECTED|LVIS_FOCUSED);
+				ListView_SetItemState(_hSelf, _currentIndex, 0, LVIS_SELECTED|LVIS_FOCUSED);				
 				// tells what item(s) to be repainted
 				ListView_RedrawItems(_hSelf, _currentIndex, _currentIndex);
 				// repaint item(s)
 				UpdateWindow(_hSelf); 
 				ListView_SetItemState(_hSelf, selected, LVIS_SELECTED|LVIS_FOCUSED, LVIS_SELECTED|LVIS_FOCUSED);
 				// tells what item(s) to be repainted
-				ListView_RedrawItems(_hSelf, selected, selected);
+				ListView_RedrawItems(_hSelf, selected, selected);				
 				// repaint item(s)
-				UpdateWindow(_hSelf);              
+				UpdateWindow(_hSelf);
 				_currentIndex = selected;
 			}
+			ListView_EnsureVisible(_hSelf, _currentIndex, true);
 			return TRUE;
 		}
 
@@ -267,6 +274,7 @@ LRESULT TaskList::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 						UpdateWindow(_hSelf);              
 						_currentIndex = selected;
 					}
+					ListView_EnsureVisible(_hSelf, _currentIndex, true);
 				}
 				else
 				{

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -31,13 +31,25 @@
 #include "Parameters.h"
 #include "resource.h"
 
+int TaskListDlg::_instanceCount = 0;
+
 LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam)
 {
 	if ((nCode >= 0) && (wParam == WM_RBUTTONUP))
     {
 		::PostMessage(hWndServer, WM_RBUTTONUP, 0, 0);
     }        
-	
+	if ((nCode >= 0) && (wParam == WM_MOUSEWHEEL))
+	{
+		MSLLHOOKSTRUCT* pMD = (MSLLHOOKSTRUCT*)lParam;		
+		RECT rCtrl;
+		GetWindowRect(hWndServer, &rCtrl);
+		//to avoid duplicate messages, only send this message to the list control if it comes from outside the control window. if the message occurs whilst the mouse is inside the control, the control will have receive the mouse wheel message itself
+		if (false == PtInRect(&rCtrl, pMD->pt))
+		{
+			::PostMessage(hWndServer, WM_MOUSEWHEEL, (WPARAM)pMD->mouseData, MAKELPARAM(pMD->pt.x,pMD->pt.y));
+		}
+	}
 	return ::CallNextHookEx(hook, nCode, wParam, lParam);
 }
 
@@ -93,6 +105,7 @@ INT_PTR CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lP
 		{
 			_taskList.destroy();
 			::UnhookWindowsHookEx(_hHooker);
+			_instanceCount--;
 			return TRUE;
 		}
 
@@ -103,6 +116,11 @@ INT_PTR CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lP
 			return TRUE;
 		}
 		
+		case WM_MOUSEWHEEL:
+		{
+			::SendMessage(_taskList.getHSelf(), WM_MOUSEWHEEL, wParam, lParam);
+			return TRUE;
+		}
 
 		case WM_DRAWITEM :
 		{

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -61,7 +61,7 @@ static LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam);
 class TaskListDlg : public StaticDialog
 {
 public :	
-        TaskListDlg() : StaticDialog() {};
+		TaskListDlg() : StaticDialog() { _instanceCount++; };
 		void init(HINSTANCE hInst, HWND parent, HIMAGELIST hImgLst, bool dir) {
             Window::init(hInst, parent);
 			_hImalist = hImgLst;
@@ -81,5 +81,7 @@ private :
 	HHOOK _hHooker = nullptr;
 
 	void drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct);
+public:
+	static int _instanceCount;
 };
 


### PR DESCRIPTION
Sorts out the following:

1. Crash caused by scroll wheel + RMB selecting document in task list dialog
2. Direction of the scrolling in response to the mouse wheel that was present in previous patch attempts
3. Ensures that the item selected in the task list using either the mouse wheel or Ctrl + TAB is visible. This appears to be an unreported bug where a large number of files causes the task list to overflow the display height and hidden items are never shown even when selected.  

@SinghRajenM the dialog is always destroyed when the user selects a file in the task list and re-created, so I'm not sure if I'm misunderstanding what you were saying but I can't see any issue with direction being only set once in this latest patch.