### PR TITLE
Fixing the mouse wheel to task list scroll bug (#2828), task list sizing and visible items

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2805,17 +2805,19 @@ void Notepad_plus::command(int id)
 			if (nbDoc > 1)
 			{
 				bool direction = (id == IDC_NEXT_DOC)?dirDown:dirUp;
-
 				if (!doTaskList)
 				{
 					activateNextDoc(direction);
 				}
 				else
 				{
-					TaskListDlg tld;
-					HIMAGELIST hImgLst = _docTabIconList.getHandle();
-					tld.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst, direction);
-					tld.doDialog();
+					if (TaskListDlg::_instanceCount == 0)
+					{
+						TaskListDlg tld;
+						HIMAGELIST hImgLst = _docTabIconList.getHandle();
+						tld.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst, direction);
+						tld.doDialog();
+					}
 				}
 			}
 			_linkTriggered = true;

--- a/PowerEditor/src/WinControls/TaskList/TaskList.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.cpp
@@ -88,6 +88,7 @@ void TaskList::init(HINSTANCE hInst, HWND parent, HIMAGELIST hImaLst, int nbItem
 
 	ListView_SetItemState(_hSelf, _currentIndex, LVIS_SELECTED|LVIS_FOCUSED, LVIS_SELECTED|LVIS_FOCUSED);
 	ListView_SetBkColor(_hSelf, lightYellow);
+
 }
 
 void TaskList::destroy()
@@ -127,6 +128,11 @@ RECT TaskList::adjustSize()
 	ListView_SetColumnWidth(_hSelf, 0, _rc.right);
 	::SendMessage(_hSelf, WM_SETFONT, reinterpret_cast<WPARAM>(_hFont), 0);
 
+	//if the tasklist exceeds the height of the display, leave some space at the bottom
+	if (_rc.bottom > ::GetSystemMetrics(SM_CYSCREEN) - 120)
+	{
+		_rc.bottom = ::GetSystemMetrics(SM_CYSCREEN) - 120;
+	}
 	reSizeTo(_rc);
 
 	// Task List's border is 1px smaller than ::GetSystemMetrics(SM_CYFRAME) returns
@@ -205,18 +211,19 @@ LRESULT TaskList::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 			else
 			{
 				int32_t selected = (_currentIndex + 1) > (_nbItem - 1) ? 0 : (_currentIndex + 1);
-				ListView_SetItemState(_hSelf, _currentIndex, 0, LVIS_SELECTED|LVIS_FOCUSED);
+				ListView_SetItemState(_hSelf, _currentIndex, 0, LVIS_SELECTED|LVIS_FOCUSED);				
 				// tells what item(s) to be repainted
 				ListView_RedrawItems(_hSelf, _currentIndex, _currentIndex);
 				// repaint item(s)
 				UpdateWindow(_hSelf); 
 				ListView_SetItemState(_hSelf, selected, LVIS_SELECTED|LVIS_FOCUSED, LVIS_SELECTED|LVIS_FOCUSED);
 				// tells what item(s) to be repainted
-				ListView_RedrawItems(_hSelf, selected, selected);
+				ListView_RedrawItems(_hSelf, selected, selected);				
 				// repaint item(s)
-				UpdateWindow(_hSelf);              
+				UpdateWindow(_hSelf);
 				_currentIndex = selected;
 			}
+			ListView_EnsureVisible(_hSelf, _currentIndex, true);
 			return TRUE;
 		}
 
@@ -267,6 +274,7 @@ LRESULT TaskList::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 						UpdateWindow(_hSelf);              
 						_currentIndex = selected;
 					}
+					ListView_EnsureVisible(_hSelf, _currentIndex, true);
 				}
 				else
 				{

--- a/PowerEditor/src/WinControls/TaskList/TaskList.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.cpp
@@ -88,7 +88,6 @@ void TaskList::init(HINSTANCE hInst, HWND parent, HIMAGELIST hImaLst, int nbItem
 
 	ListView_SetItemState(_hSelf, _currentIndex, LVIS_SELECTED|LVIS_FOCUSED, LVIS_SELECTED|LVIS_FOCUSED);
 	ListView_SetBkColor(_hSelf, lightYellow);
-
 }
 
 void TaskList::destroy()
@@ -211,14 +210,14 @@ LRESULT TaskList::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 			else
 			{
 				int32_t selected = (_currentIndex + 1) > (_nbItem - 1) ? 0 : (_currentIndex + 1);
-				ListView_SetItemState(_hSelf, _currentIndex, 0, LVIS_SELECTED|LVIS_FOCUSED);				
+				ListView_SetItemState(_hSelf, _currentIndex, 0, LVIS_SELECTED|LVIS_FOCUSED);
 				// tells what item(s) to be repainted
 				ListView_RedrawItems(_hSelf, _currentIndex, _currentIndex);
 				// repaint item(s)
 				UpdateWindow(_hSelf); 
 				ListView_SetItemState(_hSelf, selected, LVIS_SELECTED|LVIS_FOCUSED, LVIS_SELECTED|LVIS_FOCUSED);
 				// tells what item(s) to be repainted
-				ListView_RedrawItems(_hSelf, selected, selected);				
+				ListView_RedrawItems(_hSelf, selected, selected);
 				// repaint item(s)
 				UpdateWindow(_hSelf);
 				_currentIndex = selected;

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -31,13 +31,25 @@
 #include "Parameters.h"
 #include "resource.h"
 
+int TaskListDlg::_instanceCount = 0;
+
 LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam)
 {
 	if ((nCode >= 0) && (wParam == WM_RBUTTONUP))
     {
 		::PostMessage(hWndServer, WM_RBUTTONUP, 0, 0);
     }        
-	
+	if ((nCode >= 0) && (wParam == WM_MOUSEWHEEL))
+	{
+		MSLLHOOKSTRUCT* pMD = (MSLLHOOKSTRUCT*)lParam;		
+		RECT rCtrl;
+		GetWindowRect(hWndServer, &rCtrl);
+		//to avoid duplicate messages, only send this message to the list control if it comes from outside the control window. if the message occurs whilst the mouse is inside the control, the control will have receive the mouse wheel message itself
+		if (false == PtInRect(&rCtrl, pMD->pt))
+		{
+			::PostMessage(hWndServer, WM_MOUSEWHEEL, (WPARAM)pMD->mouseData, MAKELPARAM(pMD->pt.x,pMD->pt.y));
+		}
+	}
 	return ::CallNextHookEx(hook, nCode, wParam, lParam);
 }
 
@@ -93,6 +105,7 @@ INT_PTR CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lP
 		{
 			_taskList.destroy();
 			::UnhookWindowsHookEx(_hHooker);
+			_instanceCount--;
 			return TRUE;
 		}
 
@@ -103,6 +116,11 @@ INT_PTR CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lP
 			return TRUE;
 		}
 		
+		case WM_MOUSEWHEEL:
+		{
+			::SendMessage(_taskList.getHSelf(), WM_MOUSEWHEEL, wParam, lParam);
+			return TRUE;
+		}
 
 		case WM_DRAWITEM :
 		{

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -38,16 +38,16 @@ LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam)
 	if ((nCode >= 0) && (wParam == WM_RBUTTONUP))
     {
 		::PostMessage(hWndServer, WM_RBUTTONUP, 0, 0);
-    }        
-	if ((nCode >= 0) && (wParam == WM_MOUSEWHEEL))
+    } 
+	if ((nCode >= 0) && (wParam == WM_MOUSEWHEEL) && windowsVersion== WV_WIN10)
 	{
-		MSLLHOOKSTRUCT* pMD = (MSLLHOOKSTRUCT*)lParam;		
+		MSLLHOOKSTRUCT* pMD = (MSLLHOOKSTRUCT*)lParam;
 		RECT rCtrl;
 		GetWindowRect(hWndServer, &rCtrl);
 		//to avoid duplicate messages, only send this message to the list control if it comes from outside the control window. if the message occurs whilst the mouse is inside the control, the control will have receive the mouse wheel message itself
 		if (false == PtInRect(&rCtrl, pMD->pt))
 		{
-			::PostMessage(hWndServer, WM_MOUSEWHEEL, (WPARAM)pMD->mouseData, MAKELPARAM(pMD->pt.x,pMD->pt.y));
+			::PostMessage(hWndServer, WM_MOUSEWHEEL, (WPARAM)pMD->mouseData, MAKELPARAM(pMD->pt.x, pMD->pt.y));
 		}
 	}
 	return ::CallNextHookEx(hook, nCode, wParam, lParam);
@@ -92,6 +92,7 @@ INT_PTR CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lP
 
 			_taskList.display(true);
 			hWndServer = _hSelf;
+			windowsVersion = NppParameters::getInstance()->getWinVersion();
 
 #ifndef WH_MOUSE_LL
 #define WH_MOUSE_LL 14

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -55,12 +55,13 @@ struct TaskListInfo {
 
 static HWND hWndServer = NULL;
 static HHOOK hook = NULL;
+static winVer windowsVersion = WV_UNKNOWN;
 
 static LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam);
 
 class TaskListDlg : public StaticDialog
 {
-public :	
+public :
 		TaskListDlg() : StaticDialog() { _instanceCount++; };
 		void init(HINSTANCE hInst, HWND parent, HIMAGELIST hImgLst, bool dir) {
             Window::init(hInst, parent);

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -61,7 +61,7 @@ static LRESULT CALLBACK hookProc(UINT nCode, WPARAM wParam, LPARAM lParam);
 class TaskListDlg : public StaticDialog
 {
 public :	
-        TaskListDlg() : StaticDialog() {};
+		TaskListDlg() : StaticDialog() { _instanceCount++; };
 		void init(HINSTANCE hInst, HWND parent, HIMAGELIST hImgLst, bool dir) {
             Window::init(hInst, parent);
 			_hImalist = hImgLst;
@@ -81,5 +81,7 @@ private :
 	HHOOK _hHooker = nullptr;
 
 	void drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct);
+public:
+	static int _instanceCount;
 };
 


### PR DESCRIPTION
This should do it now. Fixes the crash that occurs when a user holds down RMB and uses mouse wheel to scroll through document list. Also fixes the document list window size to prevent display overflow and ensures that the selected document item is visible. The patch includes an os version check and only forwards the mouse wheel messages on windows 10 to prevent duplicates getting through. I've tested on Win7, Win 7 embedded, Win 8.1 and Win 10.