### PR TITLE
Show OS name properly on Debug Info

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -45,7 +45,7 @@ enum LangType {L_TEXT, L_PHP , L_C, L_CPP, L_CS, L_OBJC, L_JAVA, L_RC,\
 			   // The end of enumated language type, so it should be always at the end
 			   L_EXTERNAL};
 
-enum winVer{ WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV_S2003, WV_XPX64, WV_VISTA, WV_WIN7, WV_WIN8, WV_WIN81, WV_WIN10};
+enum winVer{ WV_UNKNOWN, WV_WIN32S, WV_95, WV_98, WV_ME, WV_NT, WV_W2K, WV_XP, WV_S2003, WV_XPX64, WV_SHOME, WV_S2003R2, WV_VISTA, WV_S2008, WV_S2008R2, WV_WIN7, WV_S2012, WV_WIN8, WV_S2012R2, WV_WIN81, WV_S2016, WV_WIN10};
 enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -789,25 +789,55 @@ winVer NppParameters::getWindowsVersion()
 		case VER_PLATFORM_WIN32_NT:
 		{
 			if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0)
-				return WV_WIN10;
+			{
+				if (osvi.wProductType != VER_NT_WORKSTATION)
+					return WV_S2016;
+				else
+					return WV_WIN10;
+			}
 
 			if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3)
-				return WV_WIN81;
+			{
+				if (osvi.wProductType != VER_NT_WORKSTATION)
+					return WV_S2012R2;
+				else
+					return WV_WIN81;
+			}
 
 			if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 2)
-				return WV_WIN8;
+			{
+				if (osvi.wProductType != VER_NT_WORKSTATION)
+					return WV_S2012;
+				else
+					return WV_WIN8;
+			}
 
 			if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 1)
-				return WV_WIN7;
+			{
+				if (osvi.wProductType != VER_NT_WORKSTATION)
+					return WV_S2008R2;
+				else
+					return WV_WIN7;
+			}
 
 			if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 0)
-				return WV_VISTA;
+			{
+				if (osvi.wProductType != VER_NT_WORKSTATION)
+					return WV_S2008;
+				else
+					return WV_VISTA;
+			}
 
 			if (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 2)
 			{
-				if (osvi.wProductType == VER_NT_WORKSTATION && si.wProcessorArchitecture==PROCESSOR_ARCHITECTURE_AMD64)
+				if (GetSystemMetrics(SM_SERVERR2))
+					return WV_S2003R2;
+				if (osvi.wSuiteMask & VER_SUITE_WH_SERVER)
+					return WV_SHOME;
+				if (osvi.wProductType == VER_NT_WORKSTATION && si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
 					return WV_XPX64;
-				return WV_S2003;
+				else
+					return WV_S2003;
 			}
 
 			if (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 1)
@@ -5904,11 +5934,18 @@ generic_string NppParameters:: getWinVersionStr() const
 		case WV_W2K: return TEXT("Windows 2000");
 		case WV_XP: return TEXT("Windows XP");
 		case WV_S2003: return TEXT("Windows Server 2003");
-		case WV_XPX64: return TEXT("Windows XP 64 bits");
+		case WV_XPX64: return TEXT("Windows XP");			// bit info is taken care seperately
+		case WV_SHOME: return TEXT("Windows Home Server");
+		case WV_S2003R2: return TEXT("Windows Server 2003 R2");
 		case WV_VISTA: return TEXT("Windows Vista");
+		case WV_S2008: return TEXT("Windows Server 2008");
+		case WV_S2008R2: return TEXT("Windows Server 2008 R2");
 		case WV_WIN7: return TEXT("Windows 7");
+		case WV_S2012: return TEXT("Windows Server 2012");
 		case WV_WIN8: return TEXT("Windows 8");
+		case WV_S2012R2: return TEXT("Windows Server 2012 R2");
 		case WV_WIN81: return TEXT("Windows 8.1");
+		case WV_S2016: return TEXT("Windows Server 2016");
 		case WV_WIN10: return TEXT("Windows 10");
 		default: /*case WV_UNKNOWN:*/ return TEXT("Windows unknown version");
 	}


### PR DESCRIPTION
Fix for #2976  There is no check to handle server name.

Fix is submitted to show OS name only. However, user reported issue saying show build number and OS flavor etc. As this info is meant for Notepad++ Dev Team to investigate the issue further. I think there is no point to show build number or flavor such Home/Professional/Enterprise Edition etc.

Let me know if those info is needed. I will be happy to update the PR.

PR is updated using [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724833(v=vs.85).aspx)