### PR TITLE
Display MRU list properly on seconday display

### DIFF
--- a/PowerEditor/src/WinControls/TaskList/TaskList.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.cpp
@@ -127,10 +127,11 @@ RECT TaskList::adjustSize()
 	ListView_SetColumnWidth(_hSelf, 0, _rc.right);
 	::SendMessage(_hSelf, WM_SETFONT, reinterpret_cast<WPARAM>(_hFont), 0);
 
-	//if the tasklist exceeds the height of the display, leave some space at the bottom
-	if (_rc.bottom > ::GetSystemMetrics(SM_CYSCREEN) - 120)
+	// Ensure tasklist dialog does not exceed the current Display height and
+	// also leave some more space at bottom to avoid overlap at taskbar
+	if (_rc.bottom > _nCurrentDisplayMaxH - 120)
 	{
-		_rc.bottom = ::GetSystemMetrics(SM_CYSCREEN) - 120;
+		_rc.bottom = _nCurrentDisplayMaxH - 120;
 	}
 	reSizeTo(_rc);
 
@@ -288,3 +289,25 @@ LRESULT TaskList::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 	}
 }
 
+void TaskList::getCurrentDisplayResolution(int& nHeight, int& nWidth)
+{
+	HMONITOR currentMonitor;	// Handle to monitor where npp is being displayed
+	MONITORINFO mi;				// Info of that monitor
+	HWND hWnd = getHParent() != NULL ? getHParent() : GetActiveWindow();	// In both the cases (Right click+scroll and ctrl+tab)
+																			// GetActiveWindow() will always return npp HWND as npp window will be active
+	currentMonitor = ::MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);	//should always be valid monitor handle
+	mi.cbSize = sizeof(MONITORINFO);
+	if (::GetMonitorInfo(currentMonitor, &mi) != FALSE)
+	{
+		nHeight = mi.rcMonitor.bottom - mi.rcMonitor.top;
+		nWidth = mi.rcMonitor.right - mi.rcMonitor.left;
+	}
+	else
+	{
+		// This is fall back option
+		// In case not able to get height for current display then get it for primary display
+		// So atleast size overflow can be avoided if npp is running on primary display
+		nHeight = ::GetSystemMetrics(SM_CYSCREEN);
+		nWidth = ::GetSystemMetrics(SM_CXSCREEN);
+	}
+}

--- a/PowerEditor/src/WinControls/TaskList/TaskList.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.h
@@ -44,6 +44,7 @@ public:
 		_rc.top = 0;
 		_rc.right = 150;
 		_rc.bottom = 0;
+		getCurrentDisplayResolution(_nCurrentDisplayMaxH, _nCurrentDisplayMaxW);
 	};
 
 	virtual ~TaskList() {};
@@ -69,10 +70,13 @@ protected:
 		return (((TaskList *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->runProc(hwnd, Message, wParam, lParam));
 	};
 
+	void getCurrentDisplayResolution(int& nHeight, int& nWidth);
+
 	HFONT _hFont = nullptr;
 	HFONT _hFontSelected = nullptr;
 	int _nbItem = 0;
 	int _currentIndex = 0;
 	RECT _rc;
+	int _nCurrentDisplayMaxH, _nCurrentDisplayMaxW;
 };
 

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -227,3 +227,20 @@ void TaskListDlg::drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 	::SetTextColor(hDC, textColor);
 	::DrawText(hDC, label, lstrlen(label), &rect, DT_SINGLELINE | DT_VCENTER | DT_LEFT);
 }
+
+void TaskListDlg::goToCenter()
+{
+	RECT rc;
+	::GetClientRect(_hParent, &rc);
+	POINT center;
+	center.x = rc.left + (rc.right - rc.left) / 2;
+	center.y = rc.top + (rc.bottom - rc.top) / 2;
+	::ClientToScreen(_hParent, &center);
+
+	int x = center.x - (_rc.right - _rc.left) / 2;
+	int y = center.y - (_rc.bottom - _rc.top) / 2;
+	if (y < 0)
+		y = 40;
+
+	::SetWindowPos(_hSelf, HWND_TOP, x, y, _rc.right - _rc.left, _rc.bottom - _rc.top, SWP_SHOWWINDOW);
+}

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -70,6 +70,7 @@ public :
         };
         int doDialog(bool isRTL = false);
 		virtual void destroy() {};
+		void goToCenter();
 
 protected :
 	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
If number of opened files are more and NPP is running on secondary display, then MRU list exceed the length of the current display monitor and not visible which item is currently being selected. This PR fixed this issue and ensure that

1. MRU list does not exceed current display height
2. Current selected item is visible

![image](https://cloud.githubusercontent.com/assets/14791461/23579694/867397d0-0118-11e7-88ff-136f12febc91.png)