### PR TITLE
Assign default encoding for new files, to empty files (issue #2947)

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1509,6 +1509,11 @@ bool FileManager::loadFileData(Document doc, const TCHAR * filename, char* data,
 		NppParameters *pNppParamInst = NppParameters::getInstance();
 		const NewDocDefaultSettings & ndds = (pNppParamInst->getNppGUI()).getNewDocDefaultSettings(); // for ndds._format
 		eolFormat = ndds._format;
+		//for empty files, set the encoding to the default for new files
+		if (fileSize == 0)
+		{
+			encoding = ndds._unicodeMode;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
If a 0 byte file is opened the encoding will no longer default to ANSI, the format will be set to the default format for new files.