### PR TITLE
Pressing "Save all" by mistake on many unsaved documents causes multiple Save As dialogs #2929

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1281,7 +1281,11 @@ bool Notepad_plus::fileSaveAll()
 		for(size_t i = 0; i < _mainDocTab.nbItem(); ++i)
 		{
 			BufferID idToSave = _mainDocTab.getBufferByIndex(i);
-			fileSave(idToSave);
+			if (false == fileSave(idToSave))
+			{
+				//prevent mulitple dialogs if the user clicks cancel
+				return false;
+			}
 		}
 	}
 
@@ -1290,7 +1294,11 @@ bool Notepad_plus::fileSaveAll()
 		for(size_t i = 0; i < _subDocTab.nbItem(); ++i)
 		{
 			BufferID idToSave = _subDocTab.getBufferByIndex(i);
-			fileSave(idToSave);
+			if (false == fileSave(idToSave))
+			{
+				//prevent mulitple dialogs if the user clicks cancel
+				return false;
+			}
 		}
 	}
 	checkDocState();


### PR DESCRIPTION
Added a return inside the file save all loop to prevent multiple dialog windows