### PR TITLE
Fix issue with clicking links in html/js/asp/php

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -920,7 +920,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				return FALSE;
 
 			// Get the style and make sure it is a hotspot
-			auto style = notifyView->execute(SCI_GETSTYLEAT, notification->position);
+			uint8_t style = static_cast<uint8_t>(notifyView->execute(SCI_GETSTYLEAT, notification->position));
 			if (not notifyView->execute(SCI_STYLEGETHOTSPOT, style))
 				break;
 
@@ -929,9 +929,9 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			docLen = notifyView->getCurrentDocLen();
 
 			// Walk backwards/forwards to get the contiguous text in the same style
-			while (startPos > 0 && notifyView->execute(SCI_GETSTYLEAT, startPos - 1) == style)
+			while (startPos > 0 && static_cast<uint8_t>(notifyView->execute(SCI_GETSTYLEAT, startPos - 1)) == style)
 				startPos--;
-			while (endPos < docLen && notifyView->execute(SCI_GETSTYLEAT, endPos) == style)
+			while (endPos < docLen && static_cast<uint8_t>(notifyView->execute(SCI_GETSTYLEAT, endPos)) == style)
 				endPos++;
 
 			// Select the entire link


### PR DESCRIPTION
The style at the position was reported has having all the higher bits set for some reason, thus when checking if it was a hotspot it was always false. For example the style at the position is reported as:

`4294967168 = 0b11111111111111111111111110000000`

However the styles are only 1 byte worth of data. I'm not sure why the higher bits are being set (possible due to using deprecated API calls) but this solves the immediate issue.