### PR TITLE
[Fixed regression]: Use extension for session file.

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1875,6 +1875,7 @@ const TCHAR * Notepad_plus::fileSaveSession(size_t nbFile, TCHAR ** fileNames)
 			sessionExt += TEXT(".");
 		sessionExt += ext;
 		fDlg.setExtFilter(TEXT("Session file"), sessionExt.c_str(), NULL);
+		fDlg.setExtIndex(0);		// 0 index for "custom extention types"
 	}
 	fDlg.setExtFilter(TEXT("All types"), TEXT(".*"), NULL);
 	sessionFileName = fDlg.doSaveDlg();


### PR DESCRIPTION
Fixed regression for save session file #3029. This regression is caused in [6388d48](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/6388d48e0ce5707e822f287203e46a2923f2881f). Reason was, by default selected index was -1, but if user toggles extension filters than issue does not occur.
