### PR TITLE
use scintilla namespace

### DIFF
--- a/scintilla/boostregex/AnsiDocumentIterator.h
+++ b/scintilla/boostregex/AnsiDocumentIterator.h
@@ -1,6 +1,10 @@
 ﻿#ifndef ANSIDOCUMENTITERATOR_H_12481491281240
 #define ANSIDOCUMENTITERATOR_H_12481491281240
 
+#ifdef SCI_NAMESPACE
+namespace Scintilla {
+#endif
+
 class AnsiDocumentIterator : public std::iterator<std::bidirectional_iterator_tag, char>
 {
 public:
@@ -90,5 +94,9 @@ private:
 	int m_end;
 	Document* m_doc;
 };
+
+#ifdef SCI_NAMESPACE
+}
+#endif
 
 #endif

--- a/scintilla/boostregex/UTF8DocumentIterator.cxx
+++ b/scintilla/boostregex/UTF8DocumentIterator.cxx
@@ -1,5 +1,8 @@
 ﻿#include "UTF8DocumentIterator.h"
 
+#ifdef SCI_NAMESPACE
+using namespace Scintilla;
+#endif
 
 void UTF8DocumentIterator::readCharacter()
 {

--- a/scintilla/boostregex/UTF8DocumentIterator.h
+++ b/scintilla/boostregex/UTF8DocumentIterator.h
@@ -15,6 +15,12 @@
 #include "CaseFolder.h"
 #include <Document.h>
 
+
+#ifdef SCI_NAMESPACE
+namespace Scintilla {
+#endif
+
+
 class UTF8DocumentIterator : public std::iterator<std::bidirectional_iterator_tag, wchar_t>
 {
 public:
@@ -152,5 +158,9 @@ private:
         Document* m_doc;
 		static const unsigned char m_firstByteMask[];
 };
+
+#ifdef SCI_NAMESPACE
+}
+#endif
 
 #endif // UTF8DOCUMENTITERATOR_H_3452843291318441149

--- a/scintilla/lexers/LexObjC.cxx
+++ b/scintilla/lexers/LexObjC.cxx
@@ -27,6 +27,10 @@
 #include "Scintilla.h"
 #include "SciLexer.h"
 
+#ifdef SCI_NAMESPACE
+using namespace Scintilla;
+#endif
+
 #define KEYWORD_BOXHEADER 1
 #define KEYWORD_FOLDCONTRACTED 2
 

--- a/scintilla/lexers/LexSearchResult.cxx
+++ b/scintilla/lexers/LexSearchResult.cxx
@@ -39,6 +39,10 @@
 #include "CharacterSet.h"
 #include "LexerModule.h"
 
+#ifdef SCI_NAMESPACE
+using namespace Scintilla;
+#endif
+
 // The following definitions are a copy of the ones in FindReplaceDlg.h
 enum { searchHeaderLevel = SC_FOLDLEVELBASE + 1, fileHeaderLevel, resultLevel };
 

--- a/scintilla/win32/SciLexer.vcxproj
+++ b/scintilla/win32/SciLexer.vcxproj
@@ -57,7 +57,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <PreprocessorDefinitions>WIN32;SCI_LEXER;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;SCI_OWNREGEX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;SCI_LEXER;_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES;_CRT_SECURE_NO_DEPRECATE;_WINDOWS;_USRDLL;SCI_OWNREGEX;SCI_NAMESPACE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include;..\src;..\lexlib;</AdditionalIncludeDirectories>
       <BrowseInformation>true</BrowseInformation>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/scintilla/win32/scintilla.mak
+++ b/scintilla/win32/scintilla.mak
@@ -51,6 +51,9 @@ LDFLAGS=$(LDDEBUG) $(LDFLAGS)
 CXXFLAGS=$(CXXFLAGS) $(CXXNDEBUG)
 !ENDIF
 
+#unconditionally use scintilla namespace
+CXXFLAGS=$(CXXFLAGS) -DSCI_NAMESPACE
+
 INCLUDEDIRS=-I../include -I../src -I../lexlib
 CXXFLAGS=$(CXXFLAGS) $(INCLUDEDIRS)
 


### PR DESCRIPTION
- activated usage of scintilla namespace in nmakefile
- corrected missing namespaces

-preparation for static build of scintilla lib, see discussion https://github.com/notepad-plus-plus/notepad-plus-plus/commit/b869163609473f05c4f5d1d72a579b9f6af66ccd