### PR TITLE
Fixes for multi-line feature

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -857,6 +857,19 @@ void TabBarPlus::drawItem(DRAWITEMSTRUCT *pDrawItemStruct)
 			rect.bottom += paddingDynamicTwoY;
 		}
 	}
+	
+	// the active tab's text with TCS_BUTTONS is lower than normal and gets clipped
+	if (::GetWindowLongPtr(_hSelf, GWL_STYLE) & TCS_BUTTONS)
+	{
+		if (_isVertical)
+		{
+			rect.left -= 2;
+		}
+		else
+		{
+			rect.top -= 2;
+		}
+	}
 
 	// draw highlights on tabs (top bar for active tab / darkened background for inactive tab)
 	RECT barRect = rect;

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -486,15 +486,15 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 				return TRUE;
 
 			const bool isForward = ((short)HIWORD(wParam)) < 0; // wheel rotation towards the user will be considered as forward direction
-			const LRESULT lastTabIndex = ::SendMessage(_hSelf, TCM_GETITEMCOUNT, 0, 0) - 1;
+			const int lastTabIndex = static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETITEMCOUNT, 0, 0) - 1);
 
 			if ((wParam & MK_CONTROL) && (wParam & MK_SHIFT))
 			{
-				::SendMessage(_hSelf, TCM_SETCURFOCUS, (isForward ? lastTabIndex : 0), 0);
+				setActiveTab((isForward ? lastTabIndex : 0));
 			}
 			else if (wParam & (MK_CONTROL | MK_SHIFT))
 			{
-				LRESULT tabIndex = ::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0) + (isForward ? 1 : -1);
+				int tabIndex = static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0) + (isForward ? 1 : -1));
 				if (tabIndex < 0)
 				{
 					if (wParam & MK_CONTROL)
@@ -509,7 +509,7 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 					else
 						return TRUE;
 				}
-				::SendMessage(_hSelf, TCM_SETCURFOCUS, tabIndex, 0);
+				setActiveTab(tabIndex);
 			}
 			else if (not _isMultiLine) // don't scroll if in multi-line mode
 			{
@@ -521,7 +521,7 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 				TC_HITTESTINFO hti;
 				LONG xy = NppParameters::getInstance()->_dpiManager.scaleX(12); // an arbitrary coordinate inside the first visible tab
 				hti.pt = { xy, xy };
-				LRESULT scrollTabIndex = ::SendMessage(_hSelf, TCM_HITTEST, 0, reinterpret_cast<LPARAM>(&hti));
+				int scrollTabIndex = static_cast<int32_t>(::SendMessage(_hSelf, TCM_HITTEST, 0, reinterpret_cast<LPARAM>(&hti)));
 
 				if (scrollTabIndex < 1 && (_isVertical ? rcLastTab.bottom < rcTabCtrl.bottom : rcLastTab.right < rcTabCtrl.right)) // nothing to scroll
 					return TRUE;

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -476,7 +476,8 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			// will do previous/next tab WITH scroll wrapping (endless loop)
 			// ..............................................................................
 			// SHIFT + MOUSEWHEEL:
-			// will do previous/next tab WITHOUT scroll wrapping (stops at first/last tab)
+			// if _doDragNDrop is enabled, then moves the tab, otherwise switches 
+			// to previous/next tab WITHOUT scroll wrapping (stops at first/last tab)
 			// ..............................................................................
 			// CTRL + SHIFT + MOUSEWHEEL:
 			// will switch to the first/last tab
@@ -491,6 +492,25 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			if ((wParam & MK_CONTROL) && (wParam & MK_SHIFT))
 			{
 				setActiveTab((isForward ? lastTabIndex : 0));
+			}
+			else if ((wParam & MK_SHIFT) && _doDragNDrop)
+			{
+				int oldTabIndex = static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0));
+				int newTabIndex = oldTabIndex + (isForward ? 1 : -1);
+
+				if (newTabIndex < 0)
+				{
+					newTabIndex = lastTabIndex; // wrap scrolling
+				}
+				else if (newTabIndex > lastTabIndex)
+				{
+					newTabIndex = 0; // wrap scrolling
+				}
+
+				if (oldTabIndex != newTabIndex)
+				{
+					exchangeTabItemData(oldTabIndex, newTabIndex);
+				}
 			}
 			else if (wParam & (MK_CONTROL | MK_SHIFT))
 			{

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -244,6 +244,8 @@ protected:
 	static LRESULT CALLBACK TabBarPlus_Proc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam) {
 		return (((TabBarPlus *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->runProc(hwnd, Message, wParam, lParam));
 	};
+	void setActiveTab(int tabIndex);
+	void exchangeTabItemData(int oldTab, int newTab);
 	void exchangeItemData(POINT point);
 
 

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -223,6 +223,8 @@ protected:
     // it's the boss to decide if we do the drag N drop
     static bool _doDragNDrop;
 	// drag N drop members
+	bool _mightBeDragging;
+	int _dragCount;
 	bool _isDragging = false;
 	bool _isDraggingInside = false;
     int _nSrcTab = -1;

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -223,8 +223,8 @@ protected:
     // it's the boss to decide if we do the drag N drop
     static bool _doDragNDrop;
 	// drag N drop members
-	bool _mightBeDragging;
-	int _dragCount;
+	bool _mightBeDragging = false;
+	int _dragCount = 0;
 	bool _isDragging = false;
 	bool _isDraggingInside = false;
     int _nSrcTab = -1;


### PR DESCRIPTION
Changes:

1. Text on tabs with multi-line are no longer clipped (g, y, etc).
2. Fix tab switching hotkeys  (**shift+MW**, **ctrl+MW**, **shift+ctrl+MW**)
3. Hijack **shift+MW** hotkey to move tabs rather than switch to them (while drag and drop enabled)
4. Fix drag and dropping tabs with multi-line enabled.