### PR TITLE
Setting fold.quotes.python in ScintillaEditView::setPythonLexer

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -749,6 +749,7 @@ protected:
 
 	void setPythonLexer() {
 		setLexer(SCLEX_PYTHON, L_PYTHON, LIST_0 | LIST_1);
+		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.quotes.python"), reinterpret_cast<LPARAM>("1"));
 	};
 
 	void setBatchLexer() {


### PR DESCRIPTION
This pull request addresses issue [2936](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/2936)