### PR TITLE
More fixes for multi-line feature

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -228,11 +228,11 @@ void TabBar::reSizeTo(RECT & rc2Ajust)
 	else // (rowCount >= 2)
 	{
 		style |= TCS_BUTTONS;
-		marge = 3; // in TCS_BUTTONS mode, each row has few pixels higher
+		marge = (rowCount - 2) * 3; // in TCS_BUTTONS mode, each row has few pixels higher
 	}
 
 	::SetWindowLongPtr(_hSelf, GWL_STYLE, style);
-	tabsHight = rowCount * (larger - smaller + marge);
+	tabsHight = rowCount * (larger - smaller) + marge;
 	tabsHight += GetSystemMetrics(_isVertical ? SM_CXEDGE : SM_CYEDGE);
 
 	if (_isVertical)

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -627,6 +627,16 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 
 		case WM_RBUTTONDOWN :	//rightclick selects tab aswell
 		{
+			// TCS_BUTTONS doesn't select the tab
+			if (::GetWindowLongPtr(_hSelf, GWL_STYLE) & TCS_BUTTONS)
+			{
+				int nTab = getTabIndexAt(LOWORD(lParam), HIWORD(lParam));
+				if (nTab != -1 && nTab != static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0)))
+				{
+					setActiveTab(nTab);
+				}
+			}
+
 			::CallWindowProc(_tabBarDefaultProc, hwnd, WM_LBUTTONDOWN, wParam, lParam);
 			return TRUE;
 		}


### PR DESCRIPTION
1. Remove excess margin between tab control and text document (mimic tab style). [Before](https://cloud.githubusercontent.com/assets/965580/25245988/458390e6-25d4-11e7-8418-6622a47e04c3.png), [After](https://cloud.githubusercontent.com/assets/965580/25245993/4a8930a0-25d4-11e7-8acd-81d6fefada3c.png)
2. Fix right clicking tabs with multi-line enabled. [Fixes #3186](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/3186)