### PR TITLE
Fix buffer overrun for wordchar list

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -303,6 +303,7 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 		auto defaultCharListLen = execute(SCI_GETWORDCHARS);
 		char *defaultCharList = new char[defaultCharListLen + 1];
 		execute(SCI_GETWORDCHARS, 0, reinterpret_cast<LPARAM>(defaultCharList));
+		defaultCharList[defaultCharListLen] = '\0';
 		_defaultCharList = defaultCharList;
 		delete[] defaultCharList;
 	}


### PR DESCRIPTION
There have been reports of the wordchar list getting unexpected characters (see #3137, #3105, #3100, [here](https://notepad-plus-plus.org/community/topic/13568/double-click-selects-into-previous-line), [here](https://notepad-plus-plus.org/community/topic/13509/sci_wordleft-and-sci_wordright-treats-sentences-as-words-in-new-file/2), [here](https://notepad-plus-plus.org/community/topic/13593/inconsistent-double-click-selection-of-quoted-text)). Though I can't say for certain this PR will fix those bugs since I can't consistently reproduce the issue. Either way this still is a potential buffer overrun that needs fixed.

Also see 71edfb2dba3fd94b9b8b642e3d7dd7c00eeed307 which fixed a very similar issue.