### PR TITLE
Auto complete dialog not showing on AdditionaWordCharacter

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.h
@@ -70,6 +70,8 @@ public:
 
 	bool setLanguage(LangType language);
 
+	//Add language defined additional word characters to current word characters
+	bool addLanguageCustomChars();
 	//AutoComplete from the list
 	bool showApiComplete();
 	//WordCompletion from the current file


### PR DESCRIPTION
Fixed issue displaying auto complete dialog when typing a defined additionalWordChar.

For example if auto complete list contains:
object
object.something
object.somethingelse

Then you configure your APIs\language.xml with additionalWordChar="." the dialog will not display when pressing "period" if you already selected "object" from the auto complete.

This update will add the characters defined in the language.xml to the current word characters list before displaying the autocomplete dialog then default back to the configured word characters list.

I did it this way so I could avoid putting the character in Notepad++ configuration for word character list.  This way auto complete will still display but if I double click a word in notepad++ it will not include the periods in the selection.