### PR TITLE
Improve whitespace visibility

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -362,6 +362,7 @@ public:
 
 	void showWSAndTab(bool willBeShowed = true) {
 		execute(SCI_SETVIEWWS, willBeShowed?SCWS_VISIBLEALWAYS:SCWS_INVISIBLE);
+		execute(SCI_SETWHITESPACESIZE, 2, 0);
 	};
 
 	void showEOL(bool willBeShowed = true) {


### PR DESCRIPTION
White spaces are not visible properly. Visibility of white-space which may be useful for languages in which white space is significant, such as Python.

![image](https://cloud.githubusercontent.com/assets/14791461/25302233/4646eeae-2757-11e7-91cf-4bbb8167438e.png)
