### PR TITLE
RTL printing support for header & footer

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1810,7 +1810,7 @@ void Notepad_plus::filePrint(bool showDialog)
 	int startPos = int(_pEditView->execute(SCI_GETSELECTIONSTART));
 	int endPos = int(_pEditView->execute(SCI_GETSELECTIONEND));
 
-	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, startPos, endPos);
+	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, startPos, endPos, _nativeLangSpeaker.isRTL());
 	printer.doPrint();
 }
 

--- a/PowerEditor/src/ScitillaComponent/Printer.h
+++ b/PowerEditor/src/ScitillaComponent/Printer.h
@@ -46,7 +46,7 @@ class Printer
 {
 public :
 	Printer(){};
-	void init(HINSTANCE hInst, HWND hwnd, ScintillaEditView *pSEView, bool showDialog, int startPos, int endPos);
+	void init(HINSTANCE hInst, HWND hwnd, ScintillaEditView *pSEView, bool showDialog, int startPos, int endPos, bool isRTL = false);
 	size_t doPrint() {
 		if (!::PrintDlg(&_pdlg))
 				return 0;
@@ -61,6 +61,7 @@ private :
 	size_t _startPos = 0;
 	size_t _endPos = 0;
 	size_t _nbPageTotal =0;
+	bool _isRTL = false;
 };
 
 #endif //PRINTER_H


### PR DESCRIPTION
Support RTL at least for header n footer. 
Whole doc RTL printing is not supported as this moment as scintilla does not support it (latest version might support).

![image](https://cloud.githubusercontent.com/assets/14791461/25405513/28c18e30-2a21-11e7-9959-94a183b27a43.png)
