### PR TITLE
Make "Window->Windows...->Sort Tabs" more user friendly

### DIFF
--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
@@ -82,6 +82,7 @@ protected :
 	virtual void onGetMinMaxInfo(MINMAXINFO* lpMMI);
 	virtual LRESULT onWinMgr(WPARAM wp, LPARAM lp);
 	virtual void destroy();
+	void updateColumnNames();
 	void fitColumnsToSize();
 	void resetSelection();
 	void doSave();
@@ -89,6 +90,7 @@ protected :
 	void doSortToTabs();
 	void updateButtonState();
 	void activateCurrent();
+	void doColumnSort();
 
 	HWND _hList = nullptr;
 	static RECT _lastKnownLocation;
@@ -96,8 +98,9 @@ protected :
 	SIZE _szMinListCtrl;
 	DocTabView *_pTab = nullptr;
 	std::vector<int> _idxMap;
+	int _currentColumn = -1;
 	int _lastSort = -1;
-	bool _isSorted = false;
+	bool _reverseSort = false;
 	TiXmlNodeA *_dlgNode = nullptr;
 
 private:


### PR DESCRIPTION
Changes:

1. **Sort tabs** button is always available now.
2. Added carets to indicate direction of sorting.
3. If two entries match in **Name** and **Type** sorting, it will sort them by **File Path** now.
4. Fixed graphical issues caused by failing to InvalidateRect after sorting.
5. Fixed displayed order of sorted tabs being wrong after sorting.

Closes [#3245](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/3245)