### PR TITLE
Add strongly typed interface for Scintilla

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -298,8 +298,8 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_subEditView.execute(SCI_SETEDGECOLUMN, svp1._edgeNbColumn);
 	_subEditView.execute(SCI_SETEDGEMODE, svp1._edgeMode);
 
-	_mainEditView.showEOL(svp1._eolShow);
-	_subEditView.showEOL(svp1._eolShow);
+	_mainEditView.SetViewEOL(svp1._eolShow);
+	_subEditView.SetViewEOL(svp1._eolShow);
 
 	_mainEditView.showWSAndTab(svp1._whiteSpaceShow);
 	_subEditView.showWSAndTab(svp1._whiteSpaceShow);
@@ -2533,7 +2533,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 			// Get previous line's Indent
 			if (prevLine >= 0)
 			{
-				indentAmountPrevLine = _pEditView->getLineIndent(prevLine);
+				indentAmountPrevLine = _pEditView->GetLineIndentation(prevLine);
 			}
 
 			// get previous char from current line
@@ -2598,7 +2598,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 			// Get previous line's Indent
 			if (prevLine >= 0)
 			{
-				indentAmountPrevLine = _pEditView->getLineIndent(prevLine);
+				indentAmountPrevLine = _pEditView->GetLineIndentation(prevLine);
 
 				auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, prevLine);
 				auto endPos = _pEditView->execute(SCI_GETLINEENDPOSITION, prevLine);
@@ -2637,7 +2637,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 				return;
 
 			// { is in another line, get its indentation
-			indentAmountPrevLine = _pEditView->getLineIndent(matchedPairLine);
+			indentAmountPrevLine = _pEditView->GetLineIndentation(matchedPairLine);
 
 			// aligned } indent with {
 			_pEditView->setLineIndent(curLine, indentAmountPrevLine);
@@ -2660,7 +2660,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 
 			if (prevLine >= 0)
 			{
-				indentAmountPrevLine = _pEditView->getLineIndent(prevLine);
+				indentAmountPrevLine = _pEditView->GetLineIndentation(prevLine);
 			}
 
 			if (indentAmountPrevLine > 0)
@@ -3112,7 +3112,7 @@ void Notepad_plus::updateStatusBar()
 
     TCHAR strDocLen[256];
 	wsprintf(strDocLen, TEXT("length : %s    lines : %s"),
-		commafyInt(_pEditView->getCurrentDocLen()).c_str(),
+		commafyInt(_pEditView->GetLength()).c_str(),
 		commafyInt(_pEditView->execute(SCI_GETLINECOUNT)).c_str());
 
     _statusBar.setText(strDocLen, STATUSBAR_DOC_SIZE);
@@ -4378,7 +4378,7 @@ void Notepad_plus::getTaskListInfo(TaskListInfo *tli)
 bool Notepad_plus::goToPreviousIndicator(int indicID2Search, bool isWrap) const
 {
     auto position = _pEditView->execute(SCI_GETCURRENTPOS);
-	auto docLen = _pEditView->getCurrentDocLen();
+	auto docLen = _pEditView->GetLength();
 
     bool isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  position) != 0;
     auto posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
@@ -4431,7 +4431,7 @@ bool Notepad_plus::goToPreviousIndicator(int indicID2Search, bool isWrap) const
 bool Notepad_plus::goToNextIndicator(int indicID2Search, bool isWrap) const
 {
     auto position = _pEditView->execute(SCI_GETCURRENTPOS);
-	int docLen = _pEditView->getCurrentDocLen();
+	int docLen = _pEditView->GetLength();
 
     bool isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  position) != 0;
     auto posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
@@ -4799,7 +4799,7 @@ void Notepad_plus::doSynScorll(HWND whichView)
     else
         return;
 
-	pView->scroll(column, line);
+	pView->LineScroll(column, line);
 }
 
 bool Notepad_plus::getIntegralDockingData(tTbData & dockData, int & iCont, bool & isVisible)

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -242,8 +242,8 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.display();
 
 	_invisibleEditView.init(_pPublicInterface->getHinst(), hwnd);
-	_invisibleEditView.execute(SCI_SETUNDOCOLLECTION);
-	_invisibleEditView.execute(SCI_EMPTYUNDOBUFFER);
+	_invisibleEditView.SetUndoCollection(false);
+	_invisibleEditView.EmptyUndoBuffer();
 	_invisibleEditView.wrap(false); // Make sure no slow down
 
 	// Configuration of 2 scintilla views
@@ -272,31 +272,31 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.setWrapMode(svp1._lineWrapMethod);
     _subEditView.setWrapMode(svp1._lineWrapMethod);
 
-	_mainEditView.execute(SCI_SETCARETLINEVISIBLE, svp1._currentLineHilitingShow);
-	_subEditView.execute(SCI_SETCARETLINEVISIBLE, svp1._currentLineHilitingShow);
+	_mainEditView.SetCaretLineVisible(svp1._currentLineHilitingShow);
+	_subEditView.SetCaretLineVisible(svp1._currentLineHilitingShow);
 
-	_mainEditView.execute(SCI_SETENDATLASTLINE, not svp1._scrollBeyondLastLine);
-	_subEditView.execute(SCI_SETENDATLASTLINE, not svp1._scrollBeyondLastLine);
+	_mainEditView.SetEndAtLastLine(not svp1._scrollBeyondLastLine);
+	_subEditView.SetEndAtLastLine(not svp1._scrollBeyondLastLine);
 
 	if (svp1._doSmoothFont)
 	{
-		_mainEditView.execute(SCI_SETFONTQUALITY, SC_EFF_QUALITY_LCD_OPTIMIZED);
-		_subEditView.execute(SCI_SETFONTQUALITY, SC_EFF_QUALITY_LCD_OPTIMIZED);
+		_mainEditView.SetFontQuality(SC_EFF_QUALITY_LCD_OPTIMIZED);
+		_subEditView.SetFontQuality(SC_EFF_QUALITY_LCD_OPTIMIZED);
 	}
 
 	_mainEditView.setBorderEdge(svp1._showBorderEdge);
 	_subEditView.setBorderEdge(svp1._showBorderEdge);
 
-	_mainEditView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
-	_subEditView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
+	_mainEditView.SetCaretLineVisibleAlways(true);
+	_subEditView.SetCaretLineVisibleAlways(true);
 
 	_mainEditView.wrap(svp1._doWrap);
 	_subEditView.wrap(svp1._doWrap);
 
-	_mainEditView.execute(SCI_SETEDGECOLUMN, svp1._edgeNbColumn);
-	_mainEditView.execute(SCI_SETEDGEMODE, svp1._edgeMode);
-	_subEditView.execute(SCI_SETEDGECOLUMN, svp1._edgeNbColumn);
-	_subEditView.execute(SCI_SETEDGEMODE, svp1._edgeMode);
+	_mainEditView.SetEdgeColumn(svp1._edgeNbColumn);
+	_mainEditView.SetEdgeMode(svp1._edgeMode);
+	_subEditView.SetEdgeColumn(svp1._edgeNbColumn);
+	_subEditView.SetEdgeMode(svp1._edgeMode);
 
 	_mainEditView.SetViewEOL(svp1._eolShow);
 	_subEditView.SetViewEOL(svp1._eolShow);
@@ -310,27 +310,27 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.performGlobalStyles();
 	_subEditView.performGlobalStyles();
 
-	_zoomOriginalValue = static_cast<int32_t>(_pEditView->execute(SCI_GETZOOM));
-	_mainEditView.execute(SCI_SETZOOM, svp1._zoom);
-	_subEditView.execute(SCI_SETZOOM, svp1._zoom2);
+	_zoomOriginalValue = _pEditView->GetZoom();
+	_mainEditView.SetZoom(svp1._zoom);
+	_subEditView.SetZoom(svp1._zoom2);
 
     ::SendMessage(hwnd, NPPM_INTERNAL_SETMULTISELCTION, 0, 0);
 
 	// Make backspace or delete work with multiple selections
-	_mainEditView.execute(SCI_SETADDITIONALSELECTIONTYPING, true);
-	_subEditView.execute(SCI_SETADDITIONALSELECTIONTYPING, true);
+	_mainEditView.SetAdditionalSelectionTyping(true);
+	_subEditView.SetAdditionalSelectionTyping(true);
 
 	// Turn virtual space on
-	_mainEditView.execute(SCI_SETVIRTUALSPACEOPTIONS, SCVS_RECTANGULARSELECTION);
-	_subEditView.execute(SCI_SETVIRTUALSPACEOPTIONS, SCVS_RECTANGULARSELECTION);
+	_mainEditView.SetVirtualSpaceOptions(SCVS_RECTANGULARSELECTION);
+	_subEditView.SetVirtualSpaceOptions(SCVS_RECTANGULARSELECTION);
 
 	// Turn multi-paste on
-	_mainEditView.execute(SCI_SETMULTIPASTE, SC_MULTIPASTE_EACH);
-	_subEditView.execute(SCI_SETMULTIPASTE, SC_MULTIPASTE_EACH);
+	_mainEditView.SetMultiPaste(SC_MULTIPASTE_EACH);
+	_subEditView.SetMultiPaste(SC_MULTIPASTE_EACH);
 
 	// Let Scintilla deal with some of the folding functionality
-	_mainEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW);
-	_subEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW);
+	_mainEditView.SetAutomaticFold(SC_AUTOMATICFOLD_SHOW);
+	_subEditView.SetAutomaticFold(SC_AUTOMATICFOLD_SHOW);
 
 	TabBarPlus::doDragNDrop(true);
 
@@ -533,8 +533,8 @@ LRESULT Notepad_plus::init(HWND hwnd)
 
 	if (pNppParam->hasCustomContextMenu())
 	{
-		_mainEditView.execute(SCI_USEPOPUP, FALSE);
-		_subEditView.execute(SCI_USEPOPUP, FALSE);
+		_mainEditView.UsePopUp(false);
+		_subEditView.UsePopUp(false);
 	}
 
 	generic_string pluginsTrans, windowTrans;
@@ -974,8 +974,8 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 	fclose(f);
 
 	// Put data in _invisibleEditView
-	_invisibleEditView.execute(SCI_CLEARALL);
-	_invisibleEditView.execute(SCI_APPENDTEXT, lenFile, reinterpret_cast<LPARAM>(data));
+	_invisibleEditView.ClearAll();
+	_invisibleEditView.AppendText(static_cast<int>(lenFile), data);
 
 	const char *encodingAliasRegExpr = "[a-zA-Z0-9_-]+";
 
@@ -987,23 +987,23 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 
         size_t startPos = 0;
 		size_t endPos = lenFile-1;
-		_invisibleEditView.execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
+		_invisibleEditView.SetSearchFlags(SCFIND_REGEXP | SCFIND_POSIX);
 
-		_invisibleEditView.execute(SCI_SETTARGETRANGE, startPos, endPos);
+		_invisibleEditView.SetTargetRange(static_cast<int>(startPos), static_cast<int>(endPos));
 
-		auto posFound = _invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(xmlHeaderRegExpr), reinterpret_cast<LPARAM>(xmlHeaderRegExpr));
+		auto posFound = _invisibleEditView.SearchInTarget(static_cast<int>(strlen(xmlHeaderRegExpr)), xmlHeaderRegExpr);
 		if (posFound != -1 && posFound != -2)
 		{
             const char *encodingBlockRegExpr = "encoding[ \\t]*=[ \\t]*\"[^\".]+\"";
-			_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(encodingBlockRegExpr), reinterpret_cast<LPARAM>(encodingBlockRegExpr));
+			_invisibleEditView.SearchInTarget(static_cast<int>(strlen(encodingBlockRegExpr)), encodingBlockRegExpr);
 
             const char *encodingRegExpr = "\".+\"";
-			_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(encodingRegExpr), reinterpret_cast<LPARAM>(encodingRegExpr));
+			_invisibleEditView.SearchInTarget(static_cast<int>(strlen(encodingRegExpr)), encodingRegExpr);
 
-			_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(encodingAliasRegExpr), reinterpret_cast<LPARAM>(encodingAliasRegExpr));
+			_invisibleEditView.SearchInTarget(static_cast<int>(strlen(encodingAliasRegExpr)), encodingAliasRegExpr);
 
-            startPos = int(_invisibleEditView.execute(SCI_GETTARGETSTART));
-			endPos = _invisibleEditView.execute(SCI_GETTARGETEND);
+            startPos = _invisibleEditView.GetTargetStart();
+			endPos = _invisibleEditView.GetTargetEnd();
 
             char encodingStr[128];
             _invisibleEditView.getText(encodingStr, startPos, endPos);
@@ -1023,25 +1023,25 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 		const char *encodingStrRE = "[^ \\t=]+";
 
         int startPos = 0;
-		auto endPos = lenFile - 1;
-		_invisibleEditView.execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
+		int endPos = static_cast<int>(lenFile - 1);
+		_invisibleEditView.SetSearchFlags(SCFIND_REGEXP | SCFIND_POSIX);
 
-		_invisibleEditView.execute(SCI_SETTARGETRANGE, startPos, endPos);
+		_invisibleEditView.SetTargetRange(startPos, endPos);
 
-		int posFound = static_cast<int32_t>(_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(htmlHeaderRegExpr), reinterpret_cast<LPARAM>(htmlHeaderRegExpr)));
+		int posFound = _invisibleEditView.SearchInTarget(static_cast<int>(strlen(htmlHeaderRegExpr)), htmlHeaderRegExpr);
 
 		if (posFound == -1 || posFound == -2)
 		{
-			posFound = static_cast<int32_t>(_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(htmlHeaderRegExpr2), reinterpret_cast<LPARAM>(htmlHeaderRegExpr2)));
+			posFound = _invisibleEditView.SearchInTarget(static_cast<int>(strlen(htmlHeaderRegExpr2)), htmlHeaderRegExpr2);
 			if (posFound == -1 || posFound == -2)
 				return -1;
 		}
-		_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(charsetBlock), reinterpret_cast<LPARAM>(charsetBlock));
-		_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(intermediaire), reinterpret_cast<LPARAM>(intermediaire));
-		_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(encodingStrRE), reinterpret_cast<LPARAM>(encodingStrRE));
+		_invisibleEditView.SearchInTarget(static_cast<int>(strlen(charsetBlock)), charsetBlock);
+		_invisibleEditView.SearchInTarget(static_cast<int>(strlen(intermediaire)), intermediaire);
+		_invisibleEditView.SearchInTarget(static_cast<int>(strlen(encodingStrRE)), encodingStrRE);
 
-        startPos = int(_invisibleEditView.execute(SCI_GETTARGETSTART));
-		endPos = _invisibleEditView.execute(SCI_GETTARGETEND);
+		startPos = _invisibleEditView.GetTargetStart();
+		endPos = _invisibleEditView.GetTargetEnd();
 
         char encodingStr[128];
         _invisibleEditView.getText(encodingStr, startPos, endPos);
@@ -1057,7 +1057,7 @@ bool Notepad_plus::replaceInOpenedFiles() {
 
 	ScintillaEditView *pOldView = _pEditView;
 	_pEditView = &_invisibleEditView;
-	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
+	Document oldDoc = _invisibleEditView.GetDocPointer();
 	Buffer * oldBuf = _invisibleEditView.getCurrentBuffer();	//for manually setting the buffer, so notifications can be handled properly
 
 	Buffer * pBuf = NULL;
@@ -1072,13 +1072,13 @@ bool Notepad_plus::replaceInOpenedFiles() {
 			pBuf = MainFileManager->getBufferByID(_mainDocTab.getBufferByIndex(i));
 			if (pBuf->isReadOnly())
 				continue;
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-			UINT cp = static_cast<UINT>(_invisibleEditView.execute(SCI_GETCODEPAGE));
-			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+			_invisibleEditView.SetDocPointer(pBuf->getDocument());
+			UINT cp = static_cast<UINT>(_invisibleEditView.GetCodePage());
+			_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 			_invisibleEditView.setCurrentBuffer(pBuf);
-		    _invisibleEditView.execute(SCI_BEGINUNDOACTION);
+		    _invisibleEditView.BeginUndoAction();
 			nbTotal += _findReplaceDlg.processAll(ProcessReplaceAll, FindReplaceDlg::_env, isEntireDoc);
-			_invisibleEditView.execute(SCI_ENDUNDOACTION);
+			_invisibleEditView.EndUndoAction();
 		}
 	}
 
@@ -1089,17 +1089,17 @@ bool Notepad_plus::replaceInOpenedFiles() {
 			pBuf = MainFileManager->getBufferByID(_subDocTab.getBufferByIndex(i));
 			if (pBuf->isReadOnly())
 				continue;
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-			UINT cp = static_cast<UINT>(_invisibleEditView.execute(SCI_GETCODEPAGE));
-			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+			_invisibleEditView.SetDocPointer(pBuf->getDocument());
+			UINT cp = static_cast<UINT>(_invisibleEditView.GetCodePage());
+			_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 			_invisibleEditView.setCurrentBuffer(pBuf);
-		    _invisibleEditView.execute(SCI_BEGINUNDOACTION);
+		    _invisibleEditView.BeginUndoAction();
 			nbTotal += _findReplaceDlg.processAll(ProcessReplaceAll, FindReplaceDlg::_env, isEntireDoc);
-			_invisibleEditView.execute(SCI_ENDUNDOACTION);
+			_invisibleEditView.EndUndoAction();
 		}
 	}
 
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
+	_invisibleEditView.SetDocPointer(oldDoc);
 	_invisibleEditView.setCurrentBuffer(oldBuf);
 	_pEditView = pOldView;
 
@@ -1120,17 +1120,17 @@ bool Notepad_plus::replaceInOpenedFiles() {
 
 void Notepad_plus::wsTabConvert(spaceTab whichWay)
 {
-	int tabWidth = static_cast<int32_t>(_pEditView->execute(SCI_GETTABWIDTH));
-	int currentPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+	int tabWidth = _pEditView->GetTabWidth();
+	int currentPos = _pEditView->GetCurrentPos();
     int lastLine = _pEditView->lastZeroBasedLineNumber();
-	int docLength = static_cast<int32_t>(_pEditView->execute(SCI_GETLENGTH) + 1);
+	int docLength = _pEditView->GetLength() + 1;
     if (docLength < 2)
         return;
 
     int count = 0;
     int column = 0;
     int newCurrentPos = 0;
-	int tabStop = static_cast<int32_t>(tabWidth - 1);   // remember, counting from zero !
+	int tabStop = tabWidth - 1;   // remember, counting from zero !
     bool onlyLeading = false;
     vector<int> bookmarks;
     vector<int> folding;
@@ -1140,15 +1140,15 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
         if (bookmarkPresent(i))
             bookmarks.push_back(i);
 
-        if ((_pEditView->execute(SCI_GETFOLDLEVEL, i) & SC_FOLDLEVELHEADERFLAG))
-            if (_pEditView->execute(SCI_GETFOLDEXPANDED, i) == 0)
+        if ((_pEditView->GetFoldLevel(i) & SC_FOLDLEVELHEADERFLAG))
+            if (_pEditView->GetFoldExpanded(i) == 0)
                 folding.push_back(i);
     }
 
     char * source = new char[docLength];
     if (source == NULL)
         return;
-	_pEditView->execute(SCI_GETTEXT, docLength, reinterpret_cast<LPARAM>(source));
+	_pEditView->GetText(docLength, source);
 
     if (whichWay == tab2Space)
     {
@@ -1316,17 +1316,17 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
         }
     }
 
-    _pEditView->execute(SCI_BEGINUNDOACTION);
-	_pEditView->execute(SCI_SETTEXT, 0, reinterpret_cast<LPARAM>(destination));
-    _pEditView->execute(SCI_GOTOPOS, newCurrentPos);
+	_pEditView->BeginUndoAction();
+	_pEditView->SetText(destination);
+    _pEditView->GotoPos(newCurrentPos);
 
     for (size_t i=0; i<bookmarks.size(); ++i)
-        _pEditView->execute(SCI_MARKERADD, bookmarks[i], MARK_BOOKMARK);
+        _pEditView->MarkerAdd(bookmarks[i], MARK_BOOKMARK);
 
     for (size_t i=0; i<folding.size(); ++i)
         _pEditView->fold(folding[i], false);
 
-    _pEditView->execute(SCI_ENDUNDOACTION);
+    _pEditView->EndUndoAction();
 
     // clean up
     delete [] source;
@@ -1466,7 +1466,7 @@ bool Notepad_plus::replaceInFiles()
 
 	ScintillaEditView *pOldView = _pEditView;
 	_pEditView = &_invisibleEditView;
-	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
+	Document oldDoc = _invisibleEditView.GetDocPointer();
 	Buffer * oldBuf = _invisibleEditView.getCurrentBuffer();	//for manually setting the buffer, so notifications can be handled properly
 
 	vector<generic_string> patterns2Match;
@@ -1507,9 +1507,9 @@ bool Notepad_plus::replaceInFiles()
 		if (id != BUFFER_INVALID)
 		{
 			Buffer * pBuf = MainFileManager->getBufferByID(id);
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-			auto cp = _invisibleEditView.execute(SCI_GETCODEPAGE);
-			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+			_invisibleEditView.SetDocPointer(pBuf->getDocument());
+			auto cp = _invisibleEditView.GetCodePage();
+			_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 			_invisibleEditView.setCurrentBuffer(pBuf);
 
 			FindersInfo findersInfo;
@@ -1537,7 +1537,7 @@ bool Notepad_plus::replaceInFiles()
 
 	progress.close();
 
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
+	_invisibleEditView.SetDocPointer(oldDoc);
 	_invisibleEditView.setCurrentBuffer(oldBuf);
 	_pEditView = pOldView;
 
@@ -1553,7 +1553,7 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 	int nbTotal = 0;
 	ScintillaEditView *pOldView = _pEditView;
 	_pEditView = &_invisibleEditView;
-	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
+	Document oldDoc = _invisibleEditView.GetDocPointer();
 
 	vector<generic_string> patterns2Match;
 	_findReplaceDlg.getPatterns(patterns2Match);
@@ -1595,9 +1595,9 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 		if (id != BUFFER_INVALID)
 		{
 			Buffer * pBuf = MainFileManager->getBufferByID(id);
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-			auto cp = _invisibleEditView.execute(SCI_GETCODEPAGE);
-			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+			_invisibleEditView.SetDocPointer(pBuf->getDocument());
+			auto cp = _invisibleEditView.GetCodePage();
+			_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 
 			findInFolderInfo->_pFileName = fileNames.at(i).c_str();
 			nbTotal += _findReplaceDlg.processAll(ProcessFindInFinder, &(findInFolderInfo->_findOption), true, findInFolderInfo);
@@ -1618,7 +1618,7 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 
 	findInFolderInfo->_pDestFinder->finishFilesSearch(nbTotal, findInFolderInfo->_findOption._isMatchLineNumber);
 
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
+	_invisibleEditView.SetDocPointer(oldDoc);
 	_pEditView = pOldView;
 
 	return true;
@@ -1638,7 +1638,7 @@ bool Notepad_plus::findInFiles()
 	int nbTotal = 0;
 	ScintillaEditView *pOldView = _pEditView;
 	_pEditView = &_invisibleEditView;
-	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
+	Document oldDoc = _invisibleEditView.GetDocPointer();
 
 	vector<generic_string> patterns2Match;
 	_findReplaceDlg.getPatterns(patterns2Match);
@@ -1680,9 +1680,9 @@ bool Notepad_plus::findInFiles()
 		if (id != BUFFER_INVALID)
 		{
 			Buffer * pBuf = MainFileManager->getBufferByID(id);
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-			auto cp = _invisibleEditView.execute(SCI_GETCODEPAGE);
-			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+			_invisibleEditView.SetDocPointer(pBuf->getDocument());
+			auto cp = _invisibleEditView.GetCodePage();
+			_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 			FindersInfo findersInfo;
 			findersInfo._pFileName = fileNames.at(i).c_str();
 			nbTotal += _findReplaceDlg.processAll(ProcessFindAll, FindReplaceDlg::_env, true, &findersInfo);
@@ -1704,7 +1704,7 @@ bool Notepad_plus::findInFiles()
 
 	_findReplaceDlg.finishFilesSearch(nbTotal);
 
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
+	_invisibleEditView.SetDocPointer(oldDoc);
 	_pEditView = pOldView;
 
 	_findReplaceDlg.putFindResult(nbTotal);
@@ -1721,7 +1721,7 @@ bool Notepad_plus::findInOpenedFiles()
 	int nbTotal = 0;
 	ScintillaEditView *pOldView = _pEditView;
 	_pEditView = &_invisibleEditView;
-	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
+	Document oldDoc = _invisibleEditView.GetDocPointer();
 
 	Buffer * pBuf = NULL;
 
@@ -1734,9 +1734,9 @@ bool Notepad_plus::findInOpenedFiles()
 		for (size_t i = 0, len = _mainDocTab.nbItem(); i < len ; ++i)
 	    {
 			pBuf = MainFileManager->getBufferByID(_mainDocTab.getBufferByIndex(i));
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-			auto cp = _invisibleEditView.execute(SCI_GETCODEPAGE);
-			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+			_invisibleEditView.SetDocPointer(pBuf->getDocument());
+			auto cp = _invisibleEditView.GetCodePage();
+			_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 			FindersInfo findersInfo;
 			findersInfo._pFileName = pBuf->getFullPathName();
 			nbTotal += _findReplaceDlg.processAll(ProcessFindAll, FindReplaceDlg::_env, isEntireDoc, &findersInfo);
@@ -1748,9 +1748,9 @@ bool Notepad_plus::findInOpenedFiles()
 		for (size_t i = 0, len2 = _subDocTab.nbItem(); i < len2 ; ++i)
 	    {
 			pBuf = MainFileManager->getBufferByID(_subDocTab.getBufferByIndex(i));
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-			auto cp = _invisibleEditView.execute(SCI_GETCODEPAGE);
-			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+			_invisibleEditView.SetDocPointer(pBuf->getDocument());
+			auto cp = _invisibleEditView.GetCodePage();
+			_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 			FindersInfo findersInfo;
 			findersInfo._pFileName = pBuf->getFullPathName();
 			nbTotal += _findReplaceDlg.processAll(ProcessFindAll, FindReplaceDlg::_env, isEntireDoc, &findersInfo);
@@ -1759,7 +1759,7 @@ bool Notepad_plus::findInOpenedFiles()
 
 	_findReplaceDlg.finishFilesSearch(nbTotal);
 
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
+	_invisibleEditView.SetDocPointer(oldDoc);
 	_pEditView = pOldView;
 
 	_findReplaceDlg.putFindResult(nbTotal);
@@ -1777,22 +1777,22 @@ bool Notepad_plus::findInCurrentFile()
 	Buffer * pBuf = _pEditView->getCurrentBuffer();
 	ScintillaEditView *pOldView = _pEditView;
 	_pEditView = &_invisibleEditView;
-	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
+	Document oldDoc = _invisibleEditView.GetDocPointer();
 
 	const bool isEntireDoc = true;
 
 	_findReplaceDlg.beginNewFilesSearch();
 
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-	UINT cp = static_cast<UINT>(_invisibleEditView.execute(SCI_GETCODEPAGE));
-	_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
+	_invisibleEditView.SetDocPointer(pBuf->getDocument());
+	UINT cp = static_cast<UINT>(_invisibleEditView.GetCodePage());
+	_invisibleEditView.SetCodePage(pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);
 	FindersInfo findersInfo;
 	findersInfo._pFileName = pBuf->getFullPathName();
 	nbTotal += _findReplaceDlg.processAll(ProcessFindAll, FindReplaceDlg::_env, isEntireDoc, &findersInfo);
 
 	_findReplaceDlg.finishFilesSearch(nbTotal);
 
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
+	_invisibleEditView.SetDocPointer(oldDoc);
 	_pEditView = pOldView;
 
 	_findReplaceDlg.putFindResult(nbTotal);
@@ -1807,8 +1807,8 @@ void Notepad_plus::filePrint(bool showDialog)
 {
 	Printer printer;
 
-	int startPos = int(_pEditView->execute(SCI_GETSELECTIONSTART));
-	int endPos = int(_pEditView->execute(SCI_GETSELECTIONEND));
+	int startPos = _pEditView->GetSelectionStart();
+	int endPos = _pEditView->GetSelectionEnd();
 
 	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, startPos, endPos, _nativeLangSpeaker.isRTL());
 	printer.doPrint();
@@ -1873,8 +1873,8 @@ void Notepad_plus::enableCommand(int cmdID, bool doEnable, int which) const
 
 void Notepad_plus::checkClipboard()
 {
-	bool hasSelection = (_pEditView->execute(SCI_GETSELECTIONSTART) != _pEditView->execute(SCI_GETSELECTIONEND));
-	bool canPaste = (_pEditView->execute(SCI_CANPASTE) != 0);
+	bool hasSelection = _pEditView->GetSelectionStart() != _pEditView->GetSelectionEnd();
+	bool canPaste = _pEditView->CanPaste();
 	enableCommand(IDM_EDIT_CUT, hasSelection, MENU | TOOLBAR);
 	enableCommand(IDM_EDIT_COPY, hasSelection, MENU | TOOLBAR);
 
@@ -1951,8 +1951,8 @@ void Notepad_plus::checkDocState()
 
 void Notepad_plus::checkUndoState()
 {
-	enableCommand(IDM_EDIT_UNDO, _pEditView->execute(SCI_CANUNDO) != 0, MENU | TOOLBAR);
-	enableCommand(IDM_EDIT_REDO, _pEditView->execute(SCI_CANREDO) != 0, MENU | TOOLBAR);
+	enableCommand(IDM_EDIT_UNDO, _pEditView->CanUndo(), MENU | TOOLBAR);
+	enableCommand(IDM_EDIT_REDO, _pEditView->CanRedo(), MENU | TOOLBAR);
 }
 
 void Notepad_plus::checkMacroState()
@@ -2099,7 +2099,7 @@ void Notepad_plus::cutMarkedLines()
 	int lastLine = _pEditView->lastZeroBasedLineNumber();
 	generic_string globalStr = TEXT("");
 
-	_pEditView->execute(SCI_BEGINUNDOACTION);
+	_pEditView->BeginUndoAction();
 	for (int i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
@@ -2110,7 +2110,7 @@ void Notepad_plus::cutMarkedLines()
 			deleteMarkedline(i);
 		}
 	}
-	_pEditView->execute(SCI_ENDUNDOACTION);
+	_pEditView->EndUndoAction();
 	str2Cliboard(globalStr);
 }
 
@@ -2120,13 +2120,13 @@ void Notepad_plus::deleteMarkedLines(bool isMarked)
 
 	int lastLine = _pEditView->lastZeroBasedLineNumber();
 
-	_pEditView->execute(SCI_BEGINUNDOACTION);
+	_pEditView->BeginUndoAction();
 	for (int i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i) == isMarked)
 			deleteMarkedline(i);
 	}
-	_pEditView->execute(SCI_ENDUNDOACTION);
+	_pEditView->EndUndoAction();
 }
 
 void Notepad_plus::pasteToMarkedLines()
@@ -2151,7 +2151,7 @@ void Notepad_plus::pasteToMarkedLines()
 	::GlobalUnlock(clipboardData);
 	::CloseClipboard();
 
-	_pEditView->execute(SCI_BEGINUNDOACTION);
+	_pEditView->BeginUndoAction();
 	for (int i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
@@ -2159,13 +2159,13 @@ void Notepad_plus::pasteToMarkedLines()
 			replaceMarkedline(i, clipboardStr.c_str());
 		}
 	}
-	_pEditView->execute(SCI_ENDUNDOACTION);
+	_pEditView->EndUndoAction();
 }
 
 void Notepad_plus::deleteMarkedline(int ln)
 {
-	int lineLen = static_cast<int32_t>(_pEditView->execute(SCI_LINELENGTH, ln));
-	int lineBegin = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, ln));
+	int lineLen = _pEditView->LineLength(ln);
+	int lineBegin = _pEditView->PositionFromLine(ln);
 
 	bookmarkDelete(ln);
 	TCHAR emptyString[2] = TEXT("");
@@ -2190,16 +2190,16 @@ void Notepad_plus::inverseMarks()
 
 void Notepad_plus::replaceMarkedline(int ln, const TCHAR *str)
 {
-	int lineBegin = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, ln));
-	int lineEnd = static_cast<int32_t>(_pEditView->execute(SCI_GETLINEENDPOSITION, ln));
+	int lineBegin = _pEditView->PositionFromLine(ln);
+	int lineEnd = _pEditView->GetLineEndPosition(ln);
 
 	_pEditView->replaceTarget(str, lineBegin, lineEnd);
 }
 
 generic_string Notepad_plus::getMarkedLine(int ln)
 {
-	auto lineLen = _pEditView->execute(SCI_LINELENGTH, ln);
-	auto lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
+	auto lineLen = _pEditView->LineLength(ln);
+	auto lineBegin = _pEditView->PositionFromLine(ln);
 
 	TCHAR * buf = new TCHAR[lineLen+1];
 	_pEditView->getGenericText(buf, lineLen + 1, lineBegin, lineBegin + lineLen);
@@ -2211,16 +2211,16 @@ generic_string Notepad_plus::getMarkedLine(int ln)
 
 void Notepad_plus::findMatchingBracePos(int & braceAtCaret, int & braceOpposite)
 {
-	int caretPos = int(_pEditView->execute(SCI_GETCURRENTPOS));
+	int caretPos = _pEditView->GetCurrentPos();
 	braceAtCaret = -1;
 	braceOpposite = -1;
 	TCHAR charBefore = '\0';
 
-	int lengthDoc = int(_pEditView->execute(SCI_GETLENGTH));
+	int lengthDoc = _pEditView->GetLength();
 
 	if ((lengthDoc > 0) && (caretPos > 0))
     {
-		charBefore = TCHAR(_pEditView->execute(SCI_GETCHARAT, caretPos - 1, 0));
+		charBefore = TCHAR(_pEditView->GetCharAt(caretPos - 1));
 	}
 	// Priority goes to character before caret
 	if (charBefore && generic_strchr(TEXT("[](){}"), charBefore))
@@ -2231,14 +2231,14 @@ void Notepad_plus::findMatchingBracePos(int & braceAtCaret, int & braceOpposite)
 	if (lengthDoc > 0  && (braceAtCaret < 0))
     {
 		// No brace found so check other side
-		TCHAR charAfter = TCHAR(_pEditView->execute(SCI_GETCHARAT, caretPos, 0));
+		TCHAR charAfter = TCHAR(_pEditView->GetCharAt(caretPos));
 		if (charAfter && generic_strchr(TEXT("[](){}"), charAfter))
         {
 			braceAtCaret = caretPos;
 		}
 	}
 	if (braceAtCaret >= 0)
-		braceOpposite = int(_pEditView->execute(SCI_BRACEMATCH, braceAtCaret, 0));
+		braceOpposite = _pEditView->BraceMatch(braceAtCaret);
 }
 
 // return true if 1 or 2 (matched) brace(s) is found
@@ -2250,19 +2250,19 @@ bool Notepad_plus::braceMatch()
 
 	if ((braceAtCaret != -1) && (braceOpposite == -1))
     {
-		_pEditView->execute(SCI_BRACEBADLIGHT, braceAtCaret);
-		_pEditView->execute(SCI_SETHIGHLIGHTGUIDE, 0);
+		_pEditView->BraceBadLight(braceAtCaret);
+		_pEditView->SetHighlightGuide(0);
 	}
     else
     {
-		_pEditView->execute(SCI_BRACEHIGHLIGHT, braceAtCaret, braceOpposite);
+		_pEditView->BraceHighlight(braceAtCaret, braceOpposite);
 
 		if (_pEditView->isShownIndentGuide())
         {
-            int columnAtCaret = int(_pEditView->execute(SCI_GETCOLUMN, braceAtCaret));
-		    int columnOpposite = int(_pEditView->execute(SCI_GETCOLUMN, braceOpposite));
-			_pEditView->execute(SCI_SETHIGHLIGHTGUIDE, (columnAtCaret < columnOpposite)?columnAtCaret:columnOpposite);
-        }
+            int columnAtCaret = _pEditView->GetColumn(braceAtCaret);
+			int columnOpposite = _pEditView->GetColumn(braceOpposite);
+			_pEditView->SetHighlightGuide((columnAtCaret < columnOpposite) ? columnAtCaret : columnOpposite);
+		}
     }
 
 	const bool enable = (braceAtCaret != -1) && (braceOpposite != -1);
@@ -2344,13 +2344,13 @@ void Notepad_plus::addHotSpot()
 {
 	int startPos = 0;
 	int endPos = -1;
-	auto endStyle = _pEditView->execute(SCI_GETENDSTYLED);
+	auto endStyle = _pEditView->GetEndStyled();
 
 	_pEditView->getVisibleStartAndEndPosition(&startPos, &endPos);
 
-	_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
+	_pEditView->SetSearchFlags(SCFIND_REGEXP | SCFIND_POSIX);
 
-	_pEditView->execute(SCI_SETTARGETRANGE, startPos, endPos);
+	_pEditView->SetTargetRange(startPos, endPos);
 
 	std::vector<unsigned char> hotspotPairs; //= _pEditView->GetHotspotPairs();
 
@@ -2375,14 +2375,14 @@ void Notepad_plus::addHotSpot()
 	else if (type == L_PS)
 		mask = 16;
 
-	int posFound = static_cast<int32_t>(_pEditView->execute(SCI_SEARCHINTARGET, strlen(URL_REG_EXPR), reinterpret_cast<LPARAM>(URL_REG_EXPR)));
+	int posFound = _pEditView->SearchInTarget(static_cast<int>(strlen(URL_REG_EXPR)), URL_REG_EXPR);
 
 	while (posFound != -1 && posFound != -2)
 	{
-		int start = int(_pEditView->execute(SCI_GETTARGETSTART));
-		int end = int(_pEditView->execute(SCI_GETTARGETEND));
+		int start = _pEditView->GetTargetStart();
+		int end = _pEditView->GetTargetEnd();
 		int foundTextLen = end - start;
-		unsigned char idStyle = static_cast<unsigned char>(_pEditView->execute(SCI_GETSTYLEAT, posFound));
+		unsigned char idStyle = static_cast<unsigned char>(_pEditView->GetStyleAt(posFound));
 
 		// Search the style
 		int fs = -1;
@@ -2392,7 +2392,7 @@ void Notepad_plus::addHotSpot()
 			if ((hotspotPairs[i] & ~mask) == (idStyle & ~mask))
 			{
 				fs = hotspotPairs[i];
-				_pEditView->execute(SCI_STYLEGETFORE, fs);
+				_pEditView->StyleGetFore(fs);
 					break;
 			}
 		}
@@ -2400,8 +2400,8 @@ void Notepad_plus::addHotSpot()
 		// if we found it then use it to colourize
 		if (fs != -1)
 		{
-			_pEditView->execute(SCI_STARTSTYLING, start, 0xFF);
-			_pEditView->execute(SCI_SETSTYLING, foundTextLen, fs);
+			_pEditView->StartStyling(start, 0xFF);
+			_pEditView->SetStyling(foundTextLen, fs);
 		}
 		else // generalize a new style and add it into a array
 		{
@@ -2413,7 +2413,7 @@ void Notepad_plus::addHotSpot()
 			Style hotspotStyle;
 
 			hotspotStyle._styleID = static_cast<int>(style_hotspot);
-			_pEditView->execute(SCI_STYLEGETFONT, idStyleMSBunset, reinterpret_cast<LPARAM>(fontNameA));
+			_pEditView->StyleGetFont(idStyleMSBunset, fontNameA);
 			TCHAR *generic_fontname = new TCHAR[128];
 
 			WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
@@ -2421,13 +2421,13 @@ void Notepad_plus::addHotSpot()
 			lstrcpy(generic_fontname, fontNameW);
 			hotspotStyle._fontName = generic_fontname;
 
-			hotspotStyle._fgColor = static_cast<COLORREF>(_pEditView->execute(SCI_STYLEGETFORE, idStyleMSBunset));
-			hotspotStyle._bgColor = static_cast<COLORREF>(_pEditView->execute(SCI_STYLEGETBACK, idStyleMSBunset));
-			hotspotStyle._fontSize = static_cast<int32_t>(_pEditView->execute(SCI_STYLEGETSIZE, idStyleMSBunset));
+			hotspotStyle._fgColor = static_cast<COLORREF>(_pEditView->StyleGetFore(idStyleMSBunset));
+			hotspotStyle._bgColor = static_cast<COLORREF>(_pEditView->StyleGetBack(idStyleMSBunset));
+			hotspotStyle._fontSize = static_cast<int32_t>(_pEditView->StyleGetSize(idStyleMSBunset));
 
-			auto isBold = _pEditView->execute(SCI_STYLEGETBOLD, idStyleMSBunset);
-			auto isItalic = _pEditView->execute(SCI_STYLEGETITALIC, idStyleMSBunset);
-			auto isUnderline = _pEditView->execute(SCI_STYLEGETUNDERLINE, idStyleMSBunset);
+			auto isBold = _pEditView->StyleGetBold(idStyleMSBunset);
+			auto isItalic = _pEditView->StyleGetItalic(idStyleMSBunset);
+			auto isUnderline = _pEditView->StyleGetUnderline(idStyleMSBunset);
 			hotspotStyle._fontStyle = (isBold?FONTSTYLE_BOLD:0) | (isItalic?FONTSTYLE_ITALIC:0) | (isUnderline?FONTSTYLE_UNDERLINE:0);
 
 			int urlAction = (NppParameters::getInstance())->getNppGUI()._styleURL;
@@ -2436,44 +2436,44 @@ void Notepad_plus::addHotSpot()
 
 			_pEditView->setHotspotStyle(hotspotStyle);
 
-			_pEditView->execute(SCI_STYLESETHOTSPOT, style_hotspot, TRUE);
+			_pEditView->StyleSetHotSpot(style_hotspot, true);
 			int activeFG = 0xFF0000;
 			Style *urlHovered = getStyleFromName(TEXT("URL hovered"));
 			if (urlHovered)
 				activeFG = urlHovered->_fgColor;
-			_pEditView->execute(SCI_SETHOTSPOTACTIVEFORE, TRUE, activeFG);
-			_pEditView->execute(SCI_SETHOTSPOTSINGLELINE, style_hotspot, 0);
+			_pEditView->SetHotspotActiveFore(true, activeFG);
+			_pEditView->SetHotspotSingleLine(true);
 
 			// colourize it!
-			_pEditView->execute(SCI_STARTSTYLING, start, 0xFF);
-			_pEditView->execute(SCI_SETSTYLING, foundTextLen, style_hotspot);
+			_pEditView->StartStyling(start, 0xFF);
+			_pEditView->SetStyling(foundTextLen, style_hotspot);
 		}
 
-		_pEditView->execute(SCI_SETTARGETRANGE, posFound + foundTextLen, endPos);
+		_pEditView->SetTargetRange(posFound + foundTextLen, endPos);
 
-		posFound = static_cast<int32_t>(_pEditView->execute(SCI_SEARCHINTARGET, strlen(URL_REG_EXPR), reinterpret_cast<LPARAM>(URL_REG_EXPR)));
+		posFound = _pEditView->SearchInTarget(static_cast<int>(strlen(URL_REG_EXPR)), URL_REG_EXPR);
 	}
 
-	_pEditView->execute(SCI_STARTSTYLING, endStyle, 0xFF);
-	_pEditView->execute(SCI_SETSTYLING, 0, 0);
+	_pEditView->StartStyling(endStyle, 0xFF);
+	_pEditView->SetStyling(0, 0);
 }
 
 bool Notepad_plus::isConditionExprLine(int lineNumber)
 {
-	if (lineNumber < 0 || lineNumber > _pEditView->execute(SCI_GETLINECOUNT))
+	if (lineNumber < 0 || lineNumber > _pEditView->GetLineCount())
 		return false;
 
-	auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
-	auto endPos = _pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
-	_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP | SCFIND_POSIX);
-	_pEditView->execute(SCI_SETTARGETRANGE, startPos, endPos);
+	auto startPos = _pEditView->PositionFromLine(lineNumber);
+	auto endPos = _pEditView->GetLineEndPosition(lineNumber);
+	_pEditView->SetSearchFlags(SCFIND_REGEXP | SCFIND_POSIX);
+	_pEditView->SetTargetRange(startPos, endPos);
 
 	const char ifElseForWhileExpr[] = "((else[ \t]+)?if|for|while)[ \t]*[(].*[)][ \t]*|else[ \t]*";
 
-	auto posFound = _pEditView->execute(SCI_SEARCHINTARGET, strlen(ifElseForWhileExpr), reinterpret_cast<LPARAM>(ifElseForWhileExpr));
+	auto posFound = _pEditView->SearchInTarget(static_cast<int>(strlen(ifElseForWhileExpr)), ifElseForWhileExpr);
 	if (posFound != -1 && posFound != -2)
 	{
-		auto end = _pEditView->execute(SCI_GETTARGETEND);
+		auto end = _pEditView->GetTargetEnd();
 		if (end == endPos)
 			return true;
 	}
@@ -2491,7 +2491,7 @@ int Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char target
 		int balance = 0;
 		for (int i = int(startPos); i >= int(endPos); --i)
 		{
-			char aChar = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, i));
+			char aChar = static_cast<char>(_pEditView->GetCharAt(i));
 			if (aChar == targetSymbol)
 			{
 				if (balance == 0)
@@ -2512,11 +2512,11 @@ int Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char target
 
 void Notepad_plus::maintainIndentation(TCHAR ch)
 {
-	int eolMode = static_cast<int32_t>((_pEditView->execute(SCI_GETEOLMODE)));
+	int eolMode = _pEditView->GetEOLMode();
 	int curLine = static_cast<int32_t>((_pEditView->getCurrentLineNumber()));
 	int prevLine = curLine - 1;
 	int indentAmountPrevLine = 0;
-	int tabWidth = static_cast<int32_t>(_pEditView->execute(SCI_GETTABWIDTH));
+	int tabWidth = _pEditView->GetTabWidth();
 
 	LangType type = _pEditView->getCurrentBuffer()->getLangType();
 
@@ -2537,10 +2537,10 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 			}
 
 			// get previous char from current line
-			int prevPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS)) - (eolMode == SC_EOL_CRLF ? 3 : 2);
-			UCHAR prevChar = (UCHAR)_pEditView->execute(SCI_GETCHARAT, prevPos);
-			auto curPos = _pEditView->execute(SCI_GETCURRENTPOS);
-			UCHAR nextChar = (UCHAR)_pEditView->execute(SCI_GETCHARAT, curPos);
+			int prevPos = _pEditView->GetCurrentPos() - (eolMode == SC_EOL_CRLF ? 3 : 2);
+			UCHAR prevChar = (UCHAR)_pEditView->GetCharAt(prevPos);
+			auto curPos = _pEditView->GetCurrentPos();
+			UCHAR nextChar = (UCHAR)_pEditView->GetCharAt(curPos);
 
 			if (prevChar == '{')
 			{
@@ -2554,7 +2554,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 					else
 						eolChars = "\r";
 
-					_pEditView->execute(SCI_INSERTTEXT, _pEditView->execute(SCI_GETCURRENTPOS), reinterpret_cast<LPARAM>(eolChars));
+					_pEditView->InsertText(_pEditView->GetCurrentPos(), eolChars);
 					_pEditView->setLineIndent(curLine + 1, indentAmountPrevLine);
 				}
 				_pEditView->setLineIndent(curLine, indentAmountPrevLine + tabWidth);
@@ -2581,12 +2581,12 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 		else if (ch == '{')
 		{
 			// if no character in front of {, aligned with prev line's indentation
-			auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, curLine);
-			LRESULT endPos = _pEditView->execute(SCI_GETCURRENTPOS);
+			int startPos = _pEditView->PositionFromLine(curLine);
+			int endPos = _pEditView->GetCurrentPos();
 
-			for (LRESULT i = endPos - 2; i > 0 && i > startPos; --i)
+			for (int i = endPos - 2; i > 0 && i > startPos; --i)
 			{
-				UCHAR aChar = (UCHAR)_pEditView->execute(SCI_GETCHARAT, i);
+				UCHAR aChar = (UCHAR)_pEditView->GetCharAt(i);
 				if (aChar != ' ' && aChar != '\t')
 					return;
 			}
@@ -2600,17 +2600,17 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 			{
 				indentAmountPrevLine = _pEditView->GetLineIndentation(prevLine);
 
-				auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, prevLine);
-				auto endPos = _pEditView->execute(SCI_GETLINEENDPOSITION, prevLine);
-				_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP | SCFIND_POSIX);
-				_pEditView->execute(SCI_SETTARGETRANGE, startPos, endPos);
+				auto startPos = _pEditView->PositionFromLine(prevLine);
+				auto endPos = _pEditView->GetLineEndPosition(prevLine);
+				_pEditView->SetSearchFlags(SCFIND_REGEXP | SCFIND_POSIX);
+				_pEditView->SetTargetRange(startPos, endPos);
 
 				const char braceExpr[] = "[ \t]*\\{.*";
 
-				int posFound = static_cast<int32_t>(_pEditView->execute(SCI_SEARCHINTARGET, strlen(braceExpr), reinterpret_cast<LPARAM>(braceExpr)));
+				int posFound = _pEditView->SearchInTarget(static_cast<int>(strlen(braceExpr)), braceExpr);
 				if (posFound != -1 && posFound != -2)
 				{
-					int end = int(_pEditView->execute(SCI_GETTARGETEND));
+					int end = _pEditView->GetTargetEnd();
 					if (end == endPos)
 						indentAmountPrevLine += tabWidth;
 				}
@@ -2622,7 +2622,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 		else if (ch == '}')
 		{
 			// Look backward for the pair {
-			int startPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+			int startPos = _pEditView->GetCurrentPos();
 			if (startPos != 0)
 				startPos -= 1;
 			int posFound = findMachedBracePos(startPos - 1, 0, '{', '}');
@@ -2632,7 +2632,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 				return;
 
 			// if { is in the same line, do nothing
-			int matchedPairLine = static_cast<int32_t>(_pEditView->execute(SCI_LINEFROMPOSITION, posFound));
+			int matchedPairLine = _pEditView->LineFromPosition(posFound);
 			if (matchedPairLine == curLine)
 				return;
 
@@ -2697,8 +2697,8 @@ void Notepad_plus::setLanguage(LangType langType)
 		{
 			reset = true;
 			_subEditView.saveCurrentPos();
-			prev = _subEditView.execute(SCI_GETDOCPOINTER);
-			_subEditView.execute(SCI_SETDOCPOINTER, 0, 0);
+			prev = _subEditView.GetDocPointer();
+			_subEditView.SetDocPointer(0);
 		}
 	}
 	
@@ -2713,7 +2713,7 @@ void Notepad_plus::setLanguage(LangType langType)
 
 	if (reset)
 	{
-		_subEditView.execute(SCI_SETDOCPOINTER, 0, prev);
+		_subEditView.SetDocPointer(prev);
 		_subEditView.restoreCurrentPos();
 	}
 };
@@ -2936,22 +2936,22 @@ static const char utflen[] = {1,1,2,3};
 size_t Notepad_plus::getSelectedCharNumber(UniMode u)
 {
 	size_t result = 0;
-	int numSel = static_cast<int32_t>(_pEditView->execute(SCI_GETSELECTIONS));
+	int numSel = _pEditView->GetSelections();
 	if (u == uniUTF8 || u == uniCookie)
 	{
 		for (int i=0; i < numSel; ++i)
 		{
-			size_t line1 = _pEditView->execute(SCI_LINEFROMPOSITION, _pEditView->execute(SCI_GETSELECTIONNSTART, i));
-			size_t line2 = _pEditView->execute(SCI_LINEFROMPOSITION, _pEditView->execute(SCI_GETSELECTIONNEND, i));
+			size_t line1 = _pEditView->LineFromPosition(_pEditView->GetSelectionNStart(i));
+			size_t line2 = _pEditView->LineFromPosition(_pEditView->GetSelectionNEnd(i));
 			for (size_t j = line1; j <= line2; ++j)
 			{
-				size_t stpos = _pEditView->execute(SCI_GETLINESELSTARTPOSITION, j);
+				size_t stpos = _pEditView->GetLineSelStartPosition(static_cast<int>(j));
 				if (stpos != INVALID_POSITION)
 				{
-					size_t endpos = _pEditView->execute(SCI_GETLINESELENDPOSITION, j);
+					size_t endpos = _pEditView->GetLineSelEndPosition(static_cast<int>(j));
 					for (size_t pos = stpos; pos < endpos; ++pos)
 					{
-						unsigned char c = 0xf0 & static_cast<unsigned char>(_pEditView->execute(SCI_GETCHARAT, pos));
+						unsigned char c = 0xf0 & static_cast<unsigned char>(_pEditView->GetCharAt(static_cast<int>(pos)));
 						if (c >= 0xc0)
 							pos += utflen[(c & 0x30) >>  4];
 						++result;
@@ -2964,13 +2964,13 @@ size_t Notepad_plus::getSelectedCharNumber(UniMode u)
 	{
 		for (int i=0; i < numSel; ++i)
 		{
-			size_t stpos = _pEditView->execute(SCI_GETSELECTIONNSTART, i);
-			size_t endpos = _pEditView->execute(SCI_GETSELECTIONNEND, i);
+			size_t stpos = _pEditView->GetSelectionNStart(i);
+			size_t endpos = _pEditView->GetSelectionNEnd(i);
 			result += (endpos - stpos);
-			size_t line1 = _pEditView->execute(SCI_LINEFROMPOSITION, stpos);
-			size_t line2 = _pEditView->execute(SCI_LINEFROMPOSITION, endpos);
+			size_t line1 = _pEditView->LineFromPosition(static_cast<int>(stpos));
+			size_t line2 = _pEditView->LineFromPosition(static_cast<int>(endpos));
 			line2 -= line1;
-			if (_pEditView->execute(SCI_GETEOLMODE) == SC_EOL_CRLF) line2 *= 2;
+			if (_pEditView->GetEOLMode() == SC_EOL_CRLF) line2 *= 2;
 			result -= line2;
 		}
 		if (u != uni8Bit && u != uni7Bit) result *= 2;
@@ -2982,7 +2982,7 @@ size_t Notepad_plus::getSelectedCharNumber(UniMode u)
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-static inline size_t countUtf8Characters(unsigned char *buf, size_t pos, size_t endpos)
+static inline size_t countUtf8Characters(const unsigned char *buf, size_t pos, size_t endpos)
 {
 	size_t result = 0;
 	while(pos < endpos)
@@ -3002,10 +3002,10 @@ size_t Notepad_plus::getCurrentDocCharCount(UniMode u)
 {
 	if (u != uniUTF8 && u != uniCookie)
 	{
-		size_t numLines = _pEditView->execute(SCI_GETLINECOUNT);
-		auto result = _pEditView->execute(SCI_GETLENGTH);
+		size_t numLines = _pEditView->GetLineCount();
+		size_t result = _pEditView->GetLength();
 		size_t lines = numLines==0?0:numLines-1;
-		if (_pEditView->execute(SCI_GETEOLMODE) == SC_EOL_CRLF) lines *= 2;
+		if (_pEditView->GetEOLMode() == SC_EOL_CRLF) lines *= 2;
 		result -= lines;
 		return (result < 0) ? 0 : result;
 	}
@@ -3016,8 +3016,8 @@ size_t Notepad_plus::getCurrentDocCharCount(UniMode u)
 		// it would not be appropriate for counting characters in a small selection.
 		size_t result = 0;
 
-		size_t endpos = _pEditView->execute(SCI_GETLENGTH);
-		unsigned char* buf = (unsigned char*)_pEditView->execute(SCI_GETCHARACTERPOINTER); // Scintilla doc said the pointer can be invalidated by any other "execute"
+		size_t endpos = _pEditView->GetLength();
+		const unsigned char* buf = (const unsigned char*)_pEditView->GetCharacterPointer(); // Scintilla doc said the pointer can be invalidated by any other "execute"
 
 #ifdef _OPENMP // parallel counting of characters with OpenMP
 		if (endpos > 50000) // starting threads takes time; for small files it is better to simply count in one thread
@@ -3064,18 +3064,18 @@ int Notepad_plus::getBOMSize(UniMode u)
 
 size_t Notepad_plus::getSelectedAreas()
 {
-	size_t numSel = _pEditView->execute(SCI_GETSELECTIONS);
+	size_t numSel = _pEditView->GetSelections();
 	if (numSel == 1) // either 0 or 1 selection
-		return (_pEditView->execute(SCI_GETSELECTIONNSTART, 0) == _pEditView->execute(SCI_GETSELECTIONNEND, 0)) ? 0 : 1;
-	return (_pEditView->execute(SCI_SELECTIONISRECTANGLE)) ? 1 : numSel;
+		return (_pEditView->GetSelectionNStart(0) == _pEditView->GetSelectionNEnd(0)) ? 0 : 1;
+	return (_pEditView->SelectionIsRectangle()) ? 1 : numSel;
 }
 
 size_t Notepad_plus::getSelectedBytes()
 {
-	size_t numSel = _pEditView->execute(SCI_GETSELECTIONS);
+	size_t numSel = _pEditView->GetSelections();
 	size_t result = 0;
 	for (size_t i = 0; i < numSel; ++i)
-		result += (_pEditView->execute(SCI_GETSELECTIONNEND, i) - _pEditView->execute(SCI_GETSELECTIONNSTART, i));
+		result += (_pEditView->GetSelectionNEnd(static_cast<int>(i)) - _pEditView->GetSelectionNStart(static_cast<int>(i)));
 	return result;
 }
 
@@ -3113,10 +3113,10 @@ void Notepad_plus::updateStatusBar()
     TCHAR strDocLen[256];
 	wsprintf(strDocLen, TEXT("length : %s    lines : %s"),
 		commafyInt(_pEditView->GetLength()).c_str(),
-		commafyInt(_pEditView->execute(SCI_GETLINECOUNT)).c_str());
+		commafyInt(_pEditView->GetLineCount()).c_str());
 
     _statusBar.setText(strDocLen, STATUSBAR_DOC_SIZE);
-    _statusBar.setText(_pEditView->execute(SCI_GETOVERTYPE) ? TEXT("OVR") : TEXT("INS"), STATUSBAR_TYPING_MODE);
+    _statusBar.setText(_pEditView->GetOvertype() ? TEXT("OVR") : TEXT("INS"), STATUSBAR_TYPING_MODE);
 }
 
 void Notepad_plus::dropFiles(HDROP hdrop)
@@ -3676,9 +3676,9 @@ void Notepad_plus::performPostReload(int whichOne) {
 	if (!toEnd)
 		return;
 	if (whichOne == MAIN_VIEW) {
-		_mainEditView.execute(SCI_GOTOLINE, _mainEditView.execute(SCI_GETLINECOUNT) -1);
+		_mainEditView.GotoLine( _mainEditView.GetLineCount() - 1);
 	} else {
-		_subEditView.execute(SCI_GOTOLINE, _subEditView.execute(SCI_GETLINECOUNT) -1);
+		_subEditView.GotoLine(_subEditView.GetLineCount() - 1);
 	}
 }
 
@@ -3691,7 +3691,7 @@ void Notepad_plus::bookmarkNext(bool forwardScan)
 	if (!forwardScan)
     {
 		lineStart = lineno - 1;		//Scan starting from previous line
-		lineRetry = int(_pEditView->execute(SCI_GETLINECOUNT));	//If not found, try from the end
+		lineRetry = _pEditView->GetLineCount();	//If not found, try from the end
 		sci_marker = SCI_MARKERPREVIOUS;
 	}
 	int nextLine = int(_pEditView->execute(sci_marker, lineStart, 1 << MARK_BOOKMARK));
@@ -3701,8 +3701,8 @@ void Notepad_plus::bookmarkNext(bool forwardScan)
 	if (nextLine < 0)
 		return;
 
-    _pEditView->execute(SCI_ENSUREVISIBLEENFORCEPOLICY, nextLine);
-	_pEditView->execute(SCI_GOTOLINE, nextLine);
+    _pEditView->EnsureVisibleEnforcePolicy(nextLine);
+	_pEditView->GotoLine(nextLine);
 }
 
 void Notepad_plus::staticCheckMenuAndTB() const
@@ -3989,16 +3989,16 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 		advCommentEnd_length = advCommentEnd.length();
 	}
 
-    size_t selectionStart = _pEditView->execute(SCI_GETSELECTIONSTART);
-    size_t selectionEnd = _pEditView->execute(SCI_GETSELECTIONEND);
-    size_t caretPosition = _pEditView->execute(SCI_GETCURRENTPOS);
+	size_t selectionStart = _pEditView->GetSelectionStart();
+	size_t selectionEnd = _pEditView->GetSelectionEnd();
+	size_t caretPosition = _pEditView->GetCurrentPos();
     // checking if caret is located in _beginning_ of selected block
     bool move_caret = caretPosition < selectionEnd;
-	int selStartLine = static_cast<int32_t>(_pEditView->execute(SCI_LINEFROMPOSITION, selectionStart));
-	int selEndLine = static_cast<int32_t>(_pEditView->execute(SCI_LINEFROMPOSITION, selectionEnd));
+	int selStartLine = _pEditView->LineFromPosition(static_cast<int>(selectionStart));
+	int selEndLine = _pEditView->LineFromPosition(static_cast<int>(selectionEnd));
     int lines = selEndLine - selStartLine;
     // "caret return" is part of the last selected line
-    if ((lines > 0) && (selectionEnd == static_cast<size_t>(_pEditView->execute(SCI_POSITIONFROMLINE, selEndLine))))
+    if ((lines > 0) && (selectionEnd == static_cast<size_t>(_pEditView->PositionFromLine(selEndLine))))
 		selEndLine--;
 	// count lines which were un-commented to decide if undoStreamComment() shall be called.
 	int nUncomments = 0;
@@ -4007,13 +4007,13 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 	//Some Lexers comment blank lines, per their standards.
 	const bool commentEmptyLines = (buf->getLangType() == L_BAANC);
 
-    _pEditView->execute(SCI_BEGINUNDOACTION);
+	_pEditView->BeginUndoAction();
 
     for (int i = selStartLine; i <= selEndLine; ++i)
 	{
-		size_t lineStart = _pEditView->execute(SCI_POSITIONFROMLINE, i);
-		size_t lineIndent = _pEditView->execute(SCI_GETLINEINDENTPOSITION, i);
-		size_t lineEnd = _pEditView->execute(SCI_GETLINEENDPOSITION, i);
+		size_t lineStart = _pEditView->PositionFromLine(i);
+		size_t lineIndent = _pEditView->GetLineIndentPosition(i);
+		size_t lineEnd = _pEditView->GetLineEndPosition(i);
 
 		// empty lines are not commented, unless required by the language.
 		if (lineIndent == lineEnd && !commentEmptyLines)
@@ -4040,7 +4040,7 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 				{
 					size_t len = linebufStr[comment_length - 1] == aSpace[0] ? comment_length : !(buf->getLangType() == L_BAANC) ? comment_length - 1 : comment_length;
 
-					_pEditView->execute(SCI_SETSEL, lineIndent, lineIndent + len);
+					_pEditView->SetSel(static_cast<int>(lineIndent), static_cast<int>(lineIndent + len));
 					_pEditView->replaceSelWith("");
 
 					// SELECTION RANGE ADJUSTMENT .......................
@@ -4078,9 +4078,9 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 					size_t startLen = linebufStr[advCommentStart_length - 1] == aSpace[0] ? advCommentStart_length : advCommentStart_length - 1;
 					size_t endLen = linebufStr[linebufStr.length() - advCommentEnd_length] == aSpace[0] ? advCommentEnd_length : advCommentEnd_length - 1;
 
-					_pEditView->execute(SCI_SETSEL, lineIndent, lineIndent + startLen);
+					_pEditView->SetSel(static_cast<int>(lineIndent), static_cast<int>(lineIndent + startLen));
 					_pEditView->replaceSelWith("");
-					_pEditView->execute(SCI_SETSEL, lineEnd - startLen - endLen, lineEnd - startLen);
+					_pEditView->SetSel(static_cast<int>(lineEnd - startLen - endLen), static_cast<int>(lineEnd - startLen));
 					_pEditView->replaceSelWith("");
 
 					// SELECTION RANGE ADJUSTMENT .......................
@@ -4167,14 +4167,14 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
     if (move_caret)
 	{
         // moving caret to the beginning of selected block
-        _pEditView->execute(SCI_GOTOPOS, selectionEnd);
-        _pEditView->execute(SCI_SETCURRENTPOS, selectionStart);
+        _pEditView->GotoPos(static_cast<int>(selectionEnd));
+        _pEditView->SetCurrentPos(static_cast<int>(selectionStart));
     }
 	else
 	{
-        _pEditView->execute(SCI_SETSEL, selectionStart, selectionEnd);
+        _pEditView->SetSel(static_cast<int>(selectionStart), static_cast<int>(selectionEnd));
     }
-    _pEditView->execute(SCI_ENDUNDOACTION);
+    _pEditView->EndUndoAction();
 
 	// undoStreamComment: If there were no block-comments to un-comment try uncommenting of stream-comment.
 	if ((currCommentMode == cm_uncomment) && (nUncomments == 0)) {
@@ -4240,20 +4240,20 @@ bool Notepad_plus::doStreamComment()
 	white_space += end_comment;
 	end_comment = white_space;
 	size_t start_comment_length = start_comment.length();
-	size_t selectionStart = _pEditView->execute(SCI_GETSELECTIONSTART);
-	size_t selectionEnd = _pEditView->execute(SCI_GETSELECTIONEND);
-	size_t caretPosition = _pEditView->execute(SCI_GETCURRENTPOS);
+	size_t selectionStart = _pEditView->GetSelectionStart();
+	size_t selectionEnd = _pEditView->GetSelectionEnd();
+	size_t caretPosition = _pEditView->GetCurrentPos();
 	// checking if caret is located in _beginning_ of selected block
 	bool move_caret = caretPosition < selectionEnd;
 
 	// if there is no selection?
 	if (selectionEnd - selectionStart <= 0)
 	{
-		auto selLine = _pEditView->execute(SCI_LINEFROMPOSITION, selectionStart);
-		selectionStart = _pEditView->execute(SCI_GETLINEINDENTPOSITION, selLine);
-		selectionEnd = _pEditView->execute(SCI_GETLINEENDPOSITION, selLine);
+		auto selLine = _pEditView->LineFromPosition(static_cast<int>(selectionStart));
+		selectionStart = _pEditView->GetLineIndentPosition(selLine);
+		selectionEnd = _pEditView->GetLineEndPosition(selLine);
 	}
-	_pEditView->execute(SCI_BEGINUNDOACTION);
+	_pEditView->BeginUndoAction();
 	_pEditView->insertGenericTextFrom(selectionStart, start_comment.c_str());
 	selectionEnd += start_comment_length;
 	selectionStart += start_comment_length;
@@ -4261,14 +4261,14 @@ bool Notepad_plus::doStreamComment()
 	if (move_caret)
 	{
 		// moving caret to the beginning of selected block
-		_pEditView->execute(SCI_GOTOPOS, selectionEnd);
-		_pEditView->execute(SCI_SETCURRENTPOS, selectionStart);
+		_pEditView->GotoPos(static_cast<int>(selectionEnd));
+		_pEditView->SetCurrentPos(static_cast<int>(selectionStart));
 	}
 	else
 	{
-		_pEditView->execute(SCI_SETSEL, selectionStart, selectionEnd);
+		_pEditView->SetSel(static_cast<int>(selectionStart), static_cast<int>(selectionEnd));
 	}
-	_pEditView->execute(SCI_ENDUNDOACTION);
+	_pEditView->EndUndoAction();
 	return true;
 }
 
@@ -4276,8 +4276,8 @@ void Notepad_plus::saveScintillasZoom()
 {
 	NppParameters * pNppParam = NppParameters::getInstance();
 	ScintillaViewParams & svp = (ScintillaViewParams &)pNppParam->getSVP();
-	svp._zoom = static_cast<int>(_mainEditView.execute(SCI_GETZOOM));
-	svp._zoom2 = static_cast<int>(_subEditView.execute(SCI_GETZOOM));
+	svp._zoom = _mainEditView.GetZoom();
+	svp._zoom2 = _subEditView.GetZoom();
 }
 
 bool Notepad_plus::addCurrentMacro()
@@ -4377,12 +4377,12 @@ void Notepad_plus::getTaskListInfo(TaskListInfo *tli)
 
 bool Notepad_plus::goToPreviousIndicator(int indicID2Search, bool isWrap) const
 {
-    auto position = _pEditView->execute(SCI_GETCURRENTPOS);
+    auto position = _pEditView->GetCurrentPos();
 	auto docLen = _pEditView->GetLength();
 
-    bool isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  position) != 0;
-    auto posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
-    auto posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search,  position);
+    bool isInIndicator = _pEditView->IndicatorValueAt(indicID2Search, position) != 0;
+    auto posStart = _pEditView->IndicatorStart(indicID2Search, position);
+    auto posEnd = _pEditView->IndicatorEnd(indicID2Search, position);
 
 	// pre-condition
 	if ((posStart == 0) && (posEnd == docLen - 1))
@@ -4393,36 +4393,36 @@ bool Notepad_plus::goToPreviousIndicator(int indicID2Search, bool isWrap) const
 		if (!isWrap)
 			return false;
 
-		isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  docLen - 1) != 0;
-		posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  docLen - 1);
+		isInIndicator = _pEditView->IndicatorValueAt(indicID2Search, docLen - 1) != 0;
+		posStart = _pEditView->IndicatorStart(indicID2Search, docLen - 1);
 	}
 
     if (isInIndicator) // try to get out of indicator
     {
-        posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search, posStart - 1);
+        posStart = _pEditView->IndicatorStart(indicID2Search, posStart - 1);
         if (posStart <= 0)
 		{
 			if (!isWrap)
 				return false;
-			posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  docLen - 1);
+			posStart = _pEditView->IndicatorStart(indicID2Search,  docLen - 1);
 		}
 	}
 
     auto newPos = posStart - 1;
-    posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search, newPos);
-    posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search, newPos);
+    posStart = _pEditView->IndicatorStart(indicID2Search, newPos);
+    posEnd = _pEditView->IndicatorEnd(indicID2Search, newPos);
 
 	// found
-	if (_pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search, posStart))
+	if (_pEditView->IndicatorValueAt(indicID2Search, posStart))
 	{
 		NppGUI & nppGUI = const_cast<NppGUI &>((NppParameters::getInstance())->getNppGUI());
 		nppGUI._disableSmartHiliteTmp = true;
 
-        auto currentline = _pEditView->execute(SCI_LINEFROMPOSITION, posEnd);
-	    _pEditView->execute(SCI_ENSUREVISIBLE, currentline);	// make sure target line is unfolded
+        auto currentline = _pEditView->LineFromPosition(posEnd);
+	    _pEditView->EnsureVisible(currentline);	// make sure target line is unfolded
 
-		_pEditView->execute(SCI_SETSEL, posEnd, posStart);
-		_pEditView->execute(SCI_SCROLLCARET);
+		_pEditView->SetSel(posEnd, posStart);
+		_pEditView->ScrollCaret();
 		return true;
 	}
 	return false;
@@ -4430,12 +4430,12 @@ bool Notepad_plus::goToPreviousIndicator(int indicID2Search, bool isWrap) const
 
 bool Notepad_plus::goToNextIndicator(int indicID2Search, bool isWrap) const
 {
-    auto position = _pEditView->execute(SCI_GETCURRENTPOS);
+    auto position = _pEditView->GetCurrentPos();
 	int docLen = _pEditView->GetLength();
 
-    bool isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  position) != 0;
-    auto posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
-    auto posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search,  position);
+    bool isInIndicator = _pEditView->IndicatorValueAt(indicID2Search, position) != 0;
+    auto posStart = _pEditView->IndicatorStart(indicID2Search, position);
+    auto posEnd = _pEditView->IndicatorEnd(indicID2Search,  position);
 
 	// pre-condition
 	if ((posStart == 0) && (posEnd == docLen - 1))
@@ -4446,36 +4446,36 @@ bool Notepad_plus::goToNextIndicator(int indicID2Search, bool isWrap) const
 		if (!isWrap)
 			return false;
 
-		isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  0) != 0;
-		posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search, 0);
+		isInIndicator = _pEditView->IndicatorValueAt(indicID2Search, 0) != 0;
+		posEnd = _pEditView->IndicatorEnd(indicID2Search, 0);
 	}
 
     if (isInIndicator) // try to get out of indicator
     {
-        posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search, posEnd);
+        posEnd = _pEditView->IndicatorEnd(indicID2Search, posEnd);
 
         if (posEnd >= docLen)
 		{
 			if (!isWrap)
 				return false;
-			posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search, 0);
+			posEnd = _pEditView->IndicatorEnd(indicID2Search, 0);
 		}
     }
     auto newPos = posEnd;
-    posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search, newPos);
-    posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search, newPos);
+    posStart = _pEditView->IndicatorStart(indicID2Search, newPos);
+    posEnd = _pEditView->IndicatorEnd(indicID2Search, newPos);
 
 	// found
-	if (_pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search, posStart))
+	if (_pEditView->IndicatorValueAt(indicID2Search, posStart))
 	{
 		NppGUI & nppGUI = const_cast<NppGUI &>((NppParameters::getInstance())->getNppGUI());
 		nppGUI._disableSmartHiliteTmp = true;
 
-        auto currentline = _pEditView->execute(SCI_LINEFROMPOSITION, posEnd);
-	    _pEditView->execute(SCI_ENSUREVISIBLE, currentline);	// make sure target line is unfolded
+        auto currentline = _pEditView->LineFromPosition(posEnd);
+	    _pEditView->EnsureVisible(currentline);	// make sure target line is unfolded
 
-		_pEditView->execute(SCI_SETSEL, posStart, posEnd);
-		_pEditView->execute(SCI_SCROLLCARET);
+		_pEditView->SetSel(posStart, posEnd);
+		_pEditView->ScrollCaret();
 		return true;
 	}
 	return false;
@@ -4755,19 +4755,19 @@ void Notepad_plus::doSynScorll(HWND whichView)
 		if (_syncInfo._isSynScollV)
 		{
 			// Compute for Line
-			mainCurrentLine = static_cast<int32_t>(_mainEditView.execute(SCI_GETFIRSTVISIBLELINE));
-			subCurrentLine = static_cast<int32_t>(_subEditView.execute(SCI_GETFIRSTVISIBLELINE));
+			mainCurrentLine = _mainEditView.GetFirstVisibleLine();
+			subCurrentLine = _subEditView.GetFirstVisibleLine();
 			line = mainCurrentLine - _syncInfo._line - subCurrentLine;
 		}
 		if (_syncInfo._isSynScollH)
 		{
 			// Compute for Column
-			mxoffset = static_cast<int32_t>(_mainEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			mxoffset = _mainEditView.GetXOffset();
+			pixel = _mainEditView.TextWidth(STYLE_DEFAULT, "P");
 			mainColumn = mxoffset/pixel;
 
-			sxoffset = static_cast<int32_t>(_subEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			sxoffset = _subEditView.GetXOffset();
+			pixel = _subEditView.TextWidth(STYLE_DEFAULT, "P");
 			subColumn = sxoffset/pixel;
 			column = mainColumn - _syncInfo._column - subColumn;
 		}
@@ -4778,19 +4778,19 @@ void Notepad_plus::doSynScorll(HWND whichView)
 		if (_syncInfo._isSynScollV)
 		{
 			// Compute for Line
-			mainCurrentLine = static_cast<int32_t>(_mainEditView.execute(SCI_GETFIRSTVISIBLELINE));
-			subCurrentLine = static_cast<int32_t>(_subEditView.execute(SCI_GETFIRSTVISIBLELINE));
+			mainCurrentLine = _mainEditView.GetFirstVisibleLine();
+			subCurrentLine = _subEditView.GetFirstVisibleLine();
 			line = subCurrentLine + _syncInfo._line - mainCurrentLine;
 		}
 		if (_syncInfo._isSynScollH)
 		{
 			// Compute for Column
-			mxoffset = static_cast<int32_t>(_mainEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			mxoffset = _mainEditView.GetXOffset();
+			pixel = _mainEditView.TextWidth(STYLE_DEFAULT, "P");
 			mainColumn = mxoffset/pixel;
 
-			sxoffset = static_cast<int32_t>(_subEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			sxoffset = _subEditView.GetXOffset();
+			pixel = _subEditView.TextWidth(STYLE_DEFAULT, "P");
 			subColumn = sxoffset/pixel;
 			column = subColumn + _syncInfo._column - mainColumn;
 		}
@@ -4839,7 +4839,7 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includUntitledD
 	session._activeSubIndex = _subDocTab.getCurrentTabIndex();
 
 	//Use _invisibleEditView to temporarily open documents to retrieve markers
-	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
+	Document oldDoc = _invisibleEditView.GetDocPointer();
 	const int nbElem = 2;
 	DocTabView *docTab[nbElem];
 	docTab[0] = &_mainDocTab;
@@ -4867,12 +4867,12 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includUntitledD
 			const TCHAR *langName = languageName.c_str();
 			sessionFileInfo sfi(buf->getFullPathName(), langName, buf->getEncoding(), buf->getPosition(editView), buf->getBackupFileName().c_str(), int(buf->getLastModifiedTimestamp()), buf->getMapPosition());
 
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			size_t maxLine = static_cast<size_t>(_invisibleEditView.execute(SCI_GETLINECOUNT));
+			_invisibleEditView.SetDocPointer(buf->getDocument());
+			size_t maxLine = _invisibleEditView.GetLineCount();
 
 			for (size_t j = 0 ; j < maxLine ; ++j)
 			{
-				if ((_invisibleEditView.execute(SCI_MARKERGET, j) & (1 << MARK_BOOKMARK)) != 0)
+				if ((_invisibleEditView.MarkerGet(static_cast<int>(j)) & (1 << MARK_BOOKMARK)) != 0)
 				{
 					sfi._marks.push_back(j);
 				}
@@ -4889,7 +4889,7 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includUntitledD
 			viewFiles->push_back(sfi);
 		}
 	}
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
+	_invisibleEditView.SetDocPointer(oldDoc);
 }
 
 bool Notepad_plus::str2Cliboard(const generic_string & str2cpy)
@@ -4967,7 +4967,7 @@ void Notepad_plus::prepareBufferChangedDialog(Buffer * buffer)
 
 	// prevent flickering issue by "manually" clicking and activating the _pEditView
 	// (mouse events seem to get lost / improperly handled when showing the dialog)
-	auto curPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	auto curPos = _pEditView->GetCurrentPos();
 	::PostMessage(_pEditView->getHSelf(), WM_LBUTTONDOWN, 0, 0);
 	::PostMessage(_pEditView->getHSelf(), WM_LBUTTONUP, 0, 0);
 	::PostMessage(_pEditView->getHSelf(), SCI_SETSEL, curPos, curPos);
@@ -5027,12 +5027,12 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 				// not only test main view
 				if (buffer == _mainEditView.getCurrentBuffer())
 				{
-					_mainEditView.execute(SCI_GOTOLINE, _mainEditView.execute(SCI_GETLINECOUNT) - 1);
+					_mainEditView.GotoLine(_mainEditView.GetLineCount() - 1);
 				}
 				// but also test sub-view, because the buffer could be clonned
 				if (buffer == _subEditView.getCurrentBuffer())
 				{
-					_subEditView.execute(SCI_GOTOLINE, _subEditView.execute(SCI_GETLINECOUNT) - 1);
+					_subEditView.GotoLine(_subEditView.GetLineCount() - 1);
 				}
 
 				break;
@@ -5246,20 +5246,20 @@ void Notepad_plus::loadCommandlineParams(const TCHAR * commandLine, CmdLineParam
 
 			if (cpos != -1)
 			{
-				_pEditView->execute(SCI_GOTOPOS, cpos);
+				_pEditView->GotoPos(cpos);
 			}
             else
 			if (cn == -1)
 			{
-				_pEditView->execute(SCI_GOTOLINE, ln-1);
+				_pEditView->GotoLine(ln-1);
 			}
             else
             {
-                auto pos = _pEditView->execute(SCI_FINDCOLUMN, ln-1, cn-1);
-                _pEditView->execute(SCI_GOTOPOS, pos);
+                auto pos = _pEditView->FindColumn(ln-1, cn-1);
+                _pEditView->GotoPos(pos);
             }
 
-			_pEditView->scrollPosToCenter(_pEditView->execute(SCI_GETCURRENTPOS));
+			_pEditView->scrollPosToCenter(_pEditView->GetCurrentPos());
 
 			switchEditViewTo(iView);	//restore view
 		}
@@ -6567,10 +6567,10 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 	// do as long as stream-comments are within selection
 	do
 	{
-		auto selectionStart = _pEditView->execute(SCI_GETSELECTIONSTART);
-		auto selectionEnd = _pEditView->execute(SCI_GETSELECTIONEND);
-		auto caretPosition = _pEditView->execute(SCI_GETCURRENTPOS);
-		auto docLength = _pEditView->execute(SCI_GETLENGTH);
+		auto selectionStart = _pEditView->GetSelectionStart();
+		auto selectionEnd = _pEditView->GetSelectionEnd();
+		auto caretPosition = _pEditView->GetCurrentPos();
+		auto docLength = _pEditView->GetLength();
 
 		// checking if caret is located in _beginning_ of selected block
 		bool move_caret = caretPosition < selectionEnd;
@@ -6589,7 +6589,7 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		//-- Directly use Scintilla-Functions
 		//   rather than _findReplaceDlg.processFindNext()which does not return the find-position and is not quiet!
 		flags = SCFIND_WORDSTART;
-		_pEditView->execute(SCI_SETSEARCHFLAGS, flags);
+		_pEditView->SetSearchFlags(flags);
 		//-- Find all start- and end-comments before and after the selectionStart position.
 		//-- When searching upwards the start-position for searching must be moved one after the current position
 		//   to find a search-string just starting before the current position!
@@ -6664,9 +6664,9 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 			posEndComment-=1;
 		}
 		//-- Delete end stream-comment string ---------
-		_pEditView->execute(SCI_BEGINUNDOACTION);
-		_pEditView->execute(SCI_SETSEL, posEndComment, posEndComment + endCommentLength);
-		_pEditView->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
+		_pEditView->BeginUndoAction();
+		_pEditView->SetSel(posEndComment, posEndComment + endCommentLength);
+		_pEditView->ReplaceSel("");
 
 		//-- Get character after start-comment to decide, if there is a white character after the start-comment, which will be removed too!
 		_pEditView->getGenericText(charbuf, charbufLen, posStartComment+startCommentLength, posStartComment+startCommentLength+1);
@@ -6674,9 +6674,9 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 			startCommentLength +=1;
 
 		//-- Delete starting stream-comment string ---------
-		_pEditView->execute(SCI_SETSEL, posStartComment, posStartComment + startCommentLength);
-		_pEditView->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
-		_pEditView->execute(SCI_ENDUNDOACTION);
+		_pEditView->SetSel(posStartComment, posStartComment + startCommentLength);
+		_pEditView->ReplaceSel("");
+		_pEditView->EndUndoAction();
 
 		//-- Reset selection before calling the routine
 		//-- Determine selection movement
@@ -6703,12 +6703,12 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		if (move_caret)
 		{
 			// moving caret to the beginning of selected block
-			_pEditView->execute(SCI_GOTOPOS, selectionEnd+selectionEndMove);
-			_pEditView->execute(SCI_SETCURRENTPOS, selectionStart+selectionStartMove);
+			_pEditView->GotoPos(selectionEnd+selectionEndMove);
+			_pEditView->SetCurrentPos(selectionStart+selectionStartMove);
 		}
 		else
 		{
-			_pEditView->execute(SCI_SETSEL, selectionStart+selectionStartMove, selectionEnd+selectionEndMove);
+			_pEditView->SetSel(selectionStart+selectionStartMove, selectionEnd+selectionEndMove);
 		}
 	}
 	while(1); //do as long as stream-comments are within selection

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -463,7 +463,7 @@ private:
 		if (lineno == -1)
 			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
 		if (!bookmarkPresent(lineno))
-			_pEditView->execute(SCI_MARKERADD, lineno, MARK_BOOKMARK);
+			_pEditView->MarkerAdd(lineno, MARK_BOOKMARK);
 	}
 
     void bookmarkDelete(int lineno) const
@@ -471,14 +471,14 @@ private:
 		if (lineno == -1)
 			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
 		while (bookmarkPresent(lineno))
-			_pEditView->execute(SCI_MARKERDELETE, lineno, MARK_BOOKMARK);
+			_pEditView->MarkerDelete(lineno, MARK_BOOKMARK);
 	}
 
     bool bookmarkPresent(int lineno) const
 	{
 		if (lineno == -1)
 			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
-		LRESULT state = _pEditView->execute(SCI_MARKERGET, lineno);
+		int state = _pEditView->MarkerGet(lineno);
 		return ((state & (1 << MARK_BOOKMARK)) != 0);
 	}
 
@@ -496,7 +496,7 @@ private:
     void bookmarkNext(bool forwardScan);
 	void bookmarkClearAll() const
 	{
-		_pEditView->execute(SCI_MARKERDELETEALL, MARK_BOOKMARK);
+		_pEditView->MarkerDeleteAll(MARK_BOOKMARK);
 	}
 
 	void copyMarkedLines();

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -990,9 +990,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				return -1;
 
 			// get text of current scintilla
-			auto length = pSci->execute(SCI_GETTEXTLENGTH, 0, 0) + 1;
+			size_t length = static_cast<size_t>(pSci->GetTextLength() + 1);
 			char* buffer = new char[length];
-			pSci->execute(SCI_GETTEXT, length, reinterpret_cast<LPARAM>(buffer));
+			pSci->GetText(static_cast<int>(length), buffer);
 
 			// convert here
 			UniMode unicodeMode = pSci->getCurrentBuffer()->getUnicodeMode();
@@ -1001,14 +1001,14 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			length = UnicodeConvertor.convert(buffer, length-1);
 
 			// set text in target
-			pSci->execute(SCI_CLEARALL);
+			pSci->ClearAll();
 			pSci->addText(length, UnicodeConvertor.getNewBuf());
-			pSci->execute(SCI_EMPTYUNDOBUFFER);
+			pSci->EmptyUndoBuffer();
 
-			pSci->execute(SCI_SETCODEPAGE);
+			pSci->SetCodePage(CP_ACP);
 
 			// set cursor position
-			pSci->execute(SCI_GOTOPOS);
+			pSci->GotoPos(0);
 
 			// clean buffer
 			delete [] buffer;
@@ -1028,21 +1028,21 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				return -1;
 
 			// get text of current scintilla
-			auto length = pSci->execute(SCI_GETTEXTLENGTH, 0, 0) + 1;
+			size_t length = static_cast<size_t>(pSci->GetTextLength() + 1);
 			char* buffer = new char[length];
-			pSci->execute(SCI_GETTEXT, length, reinterpret_cast<LPARAM>(buffer));
+			pSci->GetText(static_cast<int>(length), buffer);
 
 			Utf8_16_Read UnicodeConvertor;
 			length = UnicodeConvertor.convert(buffer, length-1);
 
 			// set text in target
-			pSci->execute(SCI_CLEARALL);
+			pSci->ClearAll();
 			pSci->addText(length, UnicodeConvertor.getNewBuf());
 
-			pSci->execute(SCI_EMPTYUNDOBUFFER);
+			pSci->EmptyUndoBuffer();
 
 			// set cursor position
-			pSci->execute(SCI_GOTOPOS);
+			pSci->GotoPos(0);
 
 			// clean buffer
 			delete [] buffer;
@@ -1146,7 +1146,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					break;
 
 				int counter = 0;
-				int lastLine = static_cast<int32_t>(_pEditView->execute(SCI_GETLINECOUNT)) - 1;
+				int lastLine = _pEditView->GetLineCount() - 1;
 				int currLine = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
 				int indexMacro = _runMacroDlg.getMacro2Exec();
 				int deltaLastLine = 0;
@@ -1160,7 +1160,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					m = ms[indexMacro].getMacro();
 				}
 
-				_pEditView->execute(SCI_BEGINUNDOACTION);
+				_pEditView->BeginUndoAction();
 				for (;;)
 				{
 					macroPlayback(m);
@@ -1173,7 +1173,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					else // run until eof
 					{
 						bool cursorMovedUp = deltaCurrLine < 0;
-						deltaLastLine = static_cast<int32_t>(_pEditView->execute(SCI_GETLINECOUNT)) - 1 - lastLine;
+						deltaLastLine = _pEditView->GetLineCount() - 1 - lastLine;
 						deltaCurrLine = static_cast<int32_t>(_pEditView->getCurrentLineNumber()) - currLine;
 
 						if (( deltaCurrLine == 0 )	// line no. not changed?
@@ -1196,7 +1196,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 						}
 					}
 				}
-				_pEditView->execute(SCI_ENDUNDOACTION);
+				_pEditView->EndUndoAction();
 			}
 			break;
 		}
@@ -1352,17 +1352,17 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 			if (nppGUI._caretWidth < 4)
 			{
-				_mainEditView.execute(SCI_SETCARETSTYLE, CARETSTYLE_LINE);
-				_subEditView.execute(SCI_SETCARETSTYLE, CARETSTYLE_LINE);
-				_mainEditView.execute(SCI_SETCARETWIDTH, nppGUI._caretWidth);
-				_subEditView.execute(SCI_SETCARETWIDTH, nppGUI._caretWidth);
+				_mainEditView.SetCaretStyle(CARETSTYLE_LINE);
+				_subEditView.SetCaretStyle(CARETSTYLE_LINE);
+				_mainEditView.SetCaretWidth(nppGUI._caretWidth);
+				_subEditView.SetCaretWidth(nppGUI._caretWidth);
 			}
 			else
 			{
-				_mainEditView.execute(SCI_SETCARETWIDTH, 1);
-				_subEditView.execute(SCI_SETCARETWIDTH, 1);
-				_mainEditView.execute(SCI_SETCARETSTYLE, CARETSTYLE_BLOCK);
-				_subEditView.execute(SCI_SETCARETSTYLE, CARETSTYLE_BLOCK);
+				_mainEditView.SetCaretWidth(1);
+				_subEditView.SetCaretWidth(1);
+				_mainEditView.SetCaretStyle(CARETSTYLE_BLOCK);
+				_subEditView.SetCaretStyle(CARETSTYLE_BLOCK);
 			}
 			return TRUE;
 		}
@@ -1370,8 +1370,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_SETSMOOTHFONT:
 		{
 			int param = (lParam == 0 ? SC_EFF_QUALITY_DEFAULT : SC_EFF_QUALITY_LCD_OPTIMIZED);
-			_mainEditView.execute(SCI_SETFONTQUALITY, param);
-			_subEditView.execute(SCI_SETFONTQUALITY, param);
+			_mainEditView.SetFontQuality(param);
+			_subEditView.SetFontQuality(param);
 			return TRUE;
 		}
 
@@ -1386,8 +1386,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_INTERNAL_SCROLLBEYONDLASTLINE:
 		{
 			const bool endAtLastLine = not (pNppParam->getSVP())._scrollBeyondLastLine;
-			_mainEditView.execute(SCI_SETENDATLASTLINE, endAtLastLine);
-			_subEditView.execute(SCI_SETENDATLASTLINE, endAtLastLine);
+			_mainEditView.SetEndAtLastLine(endAtLastLine);
+			_subEditView.SetEndAtLastLine(endAtLastLine);
 			return TRUE;
 		}
 
@@ -1401,16 +1401,16 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_INTERNAL_SETMULTISELCTION:
 		{
 			const NppGUI & nppGUI = pNppParam->getNppGUI();
-			_mainEditView.execute(SCI_SETMULTIPLESELECTION, nppGUI._enableMultiSelection);
-			_subEditView.execute(SCI_SETMULTIPLESELECTION, nppGUI._enableMultiSelection);
+			_mainEditView.SetMultipleSelection(nppGUI._enableMultiSelection);
+			_subEditView.SetMultipleSelection(nppGUI._enableMultiSelection);
 			return TRUE;
 		}
 
 		case NPPM_INTERNAL_SETCARETBLINKRATE:
 		{
 			const NppGUI & nppGUI = pNppParam->getNppGUI();
-			_mainEditView.execute(SCI_SETCARETPERIOD, nppGUI._caretBlinkRate);
-			_subEditView.execute(SCI_SETCARETPERIOD, nppGUI._caretBlinkRate);
+			_mainEditView.SetCaretPeriod(nppGUI._caretBlinkRate);
+			_subEditView.SetCaretPeriod(nppGUI._caretBlinkRate);
 			return TRUE;
 		}
 
@@ -2256,8 +2256,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_INTERNAL_SETTING_EDGE_SIZE:
 		{
 			ScintillaViewParams & svp = (ScintillaViewParams &)(NppParameters::getInstance())->getSVP();
-			_mainEditView.execute(SCI_SETEDGECOLUMN, svp._edgeNbColumn);
-			_subEditView.execute(SCI_SETEDGECOLUMN, svp._edgeNbColumn);
+			_mainEditView.SetEdgeColumn(svp._edgeNbColumn);
+			_subEditView.SetEdgeColumn(svp._edgeNbColumn);
 			break;
 		}
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1446,7 +1446,7 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_EOL2WS:
 			_pEditView->execute(SCI_BEGINUNDOACTION);
-			_pEditView->execute(SCI_SETTARGETRANGE, 0, _pEditView->getCurrentDocLen());
+			_pEditView->execute(SCI_SETTARGETRANGE, 0, _pEditView->GetLength());
 			_pEditView->execute(SCI_LINESJOIN);
 			_pEditView->execute(SCI_ENDUNDOACTION);
 			break;
@@ -1455,7 +1455,7 @@ void Notepad_plus::command(int id)
 			_pEditView->execute(SCI_BEGINUNDOACTION);
 			doTrim(lineTail);
 			doTrim(lineHeader);
-			_pEditView->execute(SCI_SETTARGETRANGE, 0, _pEditView->getCurrentDocLen());
+			_pEditView->execute(SCI_SETTARGETRANGE, 0, _pEditView->GetLength());
 			_pEditView->execute(SCI_LINESJOIN);
 			_pEditView->execute(SCI_ENDUNDOACTION);
 			break;
@@ -1708,9 +1708,9 @@ void Notepad_plus::command(int id)
 			::CheckMenuItem(_mainMenuHandle, IDM_VIEW_ALL_CHARACTERS, MF_BYCOMMAND | MF_UNCHECKED);
 			::CheckMenuItem(_mainMenuHandle, IDM_VIEW_TAB_SPACE, MF_BYCOMMAND | (isChecked?MF_CHECKED:MF_UNCHECKED));
 			_toolBar.setCheck(IDM_VIEW_ALL_CHARACTERS, false);
-			_mainEditView.showEOL(false);
+			_mainEditView.SetViewEOL(false);
 			_mainEditView.showWSAndTab(isChecked);
-			_subEditView.showEOL(false);
+			_subEditView.SetViewEOL(false);
 			_subEditView.showWSAndTab(isChecked);
 
             ScintillaViewParams & svp1 = (ScintillaViewParams &)(NppParameters::getInstance())->getSVP();
@@ -1725,8 +1725,8 @@ void Notepad_plus::command(int id)
 			::CheckMenuItem(_mainMenuHandle, IDM_VIEW_EOL, MF_BYCOMMAND | (isChecked?MF_CHECKED:MF_UNCHECKED));
 			::CheckMenuItem(_mainMenuHandle, IDM_VIEW_ALL_CHARACTERS, MF_BYCOMMAND | MF_UNCHECKED);
 			_toolBar.setCheck(IDM_VIEW_ALL_CHARACTERS, false);
-			_mainEditView.showEOL(isChecked);
-			_subEditView.showEOL(isChecked);
+			_mainEditView.SetViewEOL(isChecked);
+			_subEditView.SetViewEOL(isChecked);
 			_mainEditView.showWSAndTab(false);
 			_subEditView.showWSAndTab(false);
 
@@ -2339,7 +2339,7 @@ void Notepad_plus::command(int id)
 				_pEditView->saveCurrentPos();
 
 				// Cut all text
-				int docLen = _pEditView->getCurrentDocLen();
+				int docLen = _pEditView->GetLength();
 				_pEditView->execute(SCI_COPYRANGE, 0, docLen);
 				_pEditView->execute(SCI_CLEARALL);
 

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -423,11 +423,11 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	bool subVisisble = (_subEditView.getCurrentBufferID() == id);
 	if (mainVisisble) {
 		_mainEditView.saveCurrentPos();
-		_mainEditView.execute(SCI_SETDOCPOINTER, 0, 0);
+		_mainEditView.SetDocPointer(0);
 	}
 	if (subVisisble) {
 		_subEditView.saveCurrentPos();
-		_subEditView.execute(SCI_SETDOCPOINTER, 0, 0);
+		_subEditView.SetDocPointer(0);
 	}
 
 	if (!mainVisisble && !subVisisble) {
@@ -437,11 +437,11 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	bool res = MainFileManager->reloadBuffer(id);
 	Buffer * pBuf = MainFileManager->getBufferByID(id);
 	if (mainVisisble) {
-		_mainEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
+		_mainEditView.SetDocPointer(pBuf->getDocument());
 		_mainEditView.restoreCurrentPos();
 	}
 	if (subVisisble) {
-		_subEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
+		_subEditView.SetDocPointer(pBuf->getDocument());
 		_subEditView.restoreCurrentPos();
 	}
 
@@ -1615,13 +1615,13 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 
 			//Force in the document so we can add the markers
 			//Don't use default methods because of performance
-			Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
-			_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+			Document prevDoc = _mainEditView.GetDocPointer();
+			_mainEditView.SetDocPointer(buf->getDocument());
 			for (size_t j = 0, len = session._mainViewFiles[i]._marks.size(); j < len ; ++j)
 			{
-				_mainEditView.execute(SCI_MARKERADD, session._mainViewFiles[i]._marks[j], MARK_BOOKMARK);
+				_mainEditView.MarkerAdd(static_cast<int>(session._mainViewFiles[i]._marks[j]), MARK_BOOKMARK);
 			}
-			_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+			_mainEditView.SetDocPointer(prevDoc);
 			++i;
 		}
 		else
@@ -1725,13 +1725,13 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 
 			//Force in the document so we can add the markers
 			//Don't use default methods because of performance
-			Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
-			_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+			Document prevDoc = _subEditView.GetDocPointer();
+			_subEditView.SetDocPointer(buf->getDocument());
 			for (size_t j = 0, len = session._subViewFiles[k]._marks.size(); j < len ; ++j)
 			{
-				_subEditView.execute(SCI_MARKERADD, session._subViewFiles[k]._marks[j], MARK_BOOKMARK);
+				_subEditView.MarkerAdd(static_cast<int>(session._subViewFiles[k]._marks[j]), MARK_BOOKMARK);
 			}
-			_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+			_subEditView.SetDocPointer(prevDoc);
 
 			++k;
 		}

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -985,7 +985,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 			int startPos, endPos, docLen;
 			startPos = endPos = notification->position;
-			docLen = notifyView->getCurrentDocLen();
+			docLen = notifyView->GetLength();
 
 			// Walk backwards/forwards to get the contiguous text in the same style
 			while (startPos > 0 && static_cast<uint8_t>(notifyView->execute(SCI_GETSTYLEAT, startPos - 1)) == style)

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -548,7 +548,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 	char charNext = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, caretPos));
 
 	bool isCharPrevBlank = (charPrev == ' ' || charPrev == '\t' || charPrev == '\n' || charPrev == '\r' || charPrev == '\0');
-	int docLen = _pEditView->getCurrentDocLen();
+	int docLen = _pEditView->GetLength();
 	bool isCharNextBlank = (charNext == ' ' || charNext == '\t' || charNext == '\n' || charNext == '\r' || caretPos == docLen);
 	bool isInSandwich = (charPrev == '(' && charNext == ')') || (charPrev == '[' && charNext == ']') || (charPrev == '{' && charNext == '}');
 

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -53,8 +53,8 @@ bool AutoCompletion::showApiComplete()
 		return false;
 
 	// calculate entered word's length
-	int curPos = int(_pEditView->execute(SCI_GETCURRENTPOS));
-	int startPos = int(_pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true));
+	int curPos = _pEditView->GetCurrentPos();
+	int startPos = _pEditView->WordStartPosition(curPos, true);
 
 	if (curPos == startPos)
 		return false;
@@ -63,8 +63,8 @@ bool AutoCompletion::showApiComplete()
 	if (len >= _keyWordMaxLen)
 		return false;
 
-	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
-	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
+	_pEditView->AutoCSetSeparator(' ');
+	_pEditView->AutoCSetIgnoreCase(_ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, _keyWords.c_str());
 
 	return true;
@@ -72,8 +72,8 @@ bool AutoCompletion::showApiComplete()
 
 bool AutoCompletion::showApiAndWordComplete()
 {
-	auto curPos = _pEditView->execute(SCI_GETCURRENTPOS);
-	auto startPos = _pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true);
+	auto curPos = _pEditView->GetCurrentPos();
+	auto startPos = _pEditView->WordStartPosition(curPos, true);
 
 	if (curPos == startPos)
 		return false;
@@ -118,8 +118,8 @@ bool AutoCompletion::showApiAndWordComplete()
 			words += TEXT(" ");
 	}
 
-	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
-	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
+	_pEditView->AutoCSetSeparator(' ');
+	_pEditView->AutoCSetIgnoreCase( _ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, words.c_str());
 	return true;
 }
@@ -137,17 +137,17 @@ void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beg
 	expr += beginChars;
 	expr += TEXT("[^ \\t\\n\\r.,;:\"()=<>'+!\\[\\]]+");
 
-	int docLength = int(_pEditView->execute(SCI_GETLENGTH));
+	int docLength = _pEditView->GetLength();
 
 	int flags = SCFIND_WORDSTART | SCFIND_MATCHCASE | SCFIND_REGEXP | SCFIND_POSIX;
 
-	_pEditView->execute(SCI_SETSEARCHFLAGS, flags);
+	_pEditView->SetSearchFlags(flags);
 	int posFind = _pEditView->searchInTarget(expr.c_str(), int(expr.length()), 0, docLength);
 
 	while (posFind != -1 && posFind != -2)
 	{
-		int wordStart = int(_pEditView->execute(SCI_GETTARGETSTART));
-		int wordEnd = int(_pEditView->execute(SCI_GETTARGETEND));
+		int wordStart = _pEditView->GetTargetStart();
+		int wordEnd = _pEditView->GetTargetEnd();
 
 		size_t foundTextLen = wordEnd - wordStart;
 		if (foundTextLen < bufSize)
@@ -255,7 +255,7 @@ void AutoCompletion::showPathCompletion()
 	{
 		const size_t bufSize = MAX_PATH;
 		TCHAR buf[bufSize + 1];
-		const size_t currentPos = static_cast<size_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+		const size_t currentPos = _pEditView->GetCurrentPos();
 		const auto startPos = max(0, currentPos - bufSize);
 		_pEditView->getGenericText(buf, bufSize + 1, startPos, currentPos);
 		currentLine = buf;
@@ -311,16 +311,16 @@ void AutoCompletion::showPathCompletion()
 	}
 
 	// Show autocompletion box.
-	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM('\n'));
-	_pEditView->execute(SCI_AUTOCSETIGNORECASE, true);
+	_pEditView->AutoCSetSeparator('\n');
+	_pEditView->AutoCSetIgnoreCase(true);
 	_pEditView->showAutoComletion(rawPath.length(), autoCompleteEntries.c_str());
 	return;
 }
 
 bool AutoCompletion::showWordComplete(bool autoInsert)
 {
-	int curPos = int(_pEditView->execute(SCI_GETCURRENTPOS));
-	int startPos = int(_pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true));
+	int curPos = _pEditView->GetCurrentPos();
+	int startPos = _pEditView->WordStartPosition(curPos, true);
 
 	if (curPos == startPos)
 		return false;
@@ -343,7 +343,7 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 	if (wordArray.size() == 1 && autoInsert)
 	{
 		int replacedLength = _pEditView->replaceTargetRegExMode(wordArray[0].c_str(), startPos, curPos);
-		_pEditView->execute(SCI_GOTOPOS, startPos + replacedLength);
+		_pEditView->GotoPos(startPos + replacedLength);
 		return true;
 	}
 
@@ -359,8 +359,8 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 			words += TEXT(" ");
 	}
 
-	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
-	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
+	_pEditView->AutoCSetSeparator(' ');
+	_pEditView->AutoCSetIgnoreCase( _ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, words.c_str());
 	return true;
 }
@@ -382,13 +382,13 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	if (isHTML)
 	{
 		// Skip if caretPos is within any scripting language
-		int style = static_cast<int>(_pEditView->execute(SCI_GETSTYLEAT, caretPos));
+		int style = _pEditView->GetStyleAt(static_cast<int>(caretPos));
 		if (style >= SCE_HJ_START)
 			return;
 	}
 
-	char prev = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, caretPos - 2));
-	char prevprev = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, caretPos - 3));
+	char prev = static_cast<char>(_pEditView->GetCharAt(static_cast<int>(caretPos - 2)));
+	char prevprev = static_cast<char>(_pEditView->GetCharAt(static_cast<int>(caretPos - 3)));
 
 	// Closing a tag (i.e. "-->") will be ignored
 	if (prevprev == '-' && prev == '-')
@@ -399,7 +399,7 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 		return;
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX;
-	_pEditView->execute(SCI_SETSEARCHFLAGS, flags);
+	_pEditView->SetSearchFlags(flags);
 	TCHAR tag2find[] = TEXT("<[^\\s>]*");
 
 	int targetStart = _pEditView->searchInTarget(tag2find, lstrlen(tag2find), caretPos, 0);
@@ -407,7 +407,7 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	if (targetStart == -1 || targetStart == -2)
 		return;
 
-	int targetEnd = int(_pEditView->execute(SCI_GETTARGETEND));
+	int targetEnd = _pEditView->GetTargetEnd();;
 	int foundTextLen = targetEnd - targetStart;
 	if (foundTextLen < 2) // "<>" will be ignored
 		return;
@@ -462,8 +462,8 @@ void InsertedMatchedChars::removeInvalidElements(MatchedCharInserted mci)
 		{
 			if (_insertedMatchedChars[i]._pos < mci._pos)
 			{
-				auto posToDetectLine = _pEditView->execute(SCI_LINEFROMPOSITION, mci._pos);
-				auto startPosLine = _pEditView->execute(SCI_LINEFROMPOSITION, _insertedMatchedChars[i]._pos);
+				auto posToDetectLine = _pEditView->LineFromPosition(mci._pos);
+				auto startPosLine = _pEditView->LineFromPosition(_insertedMatchedChars[i]._pos);
 
 				if (posToDetectLine != startPosLine) //not in the same line
 				{
@@ -491,7 +491,7 @@ int InsertedMatchedChars::search(char startChar, char endChar, int posToDetect)
 {
 	if (isEmpty())
 		return -1;
-	auto posToDetectLine = _pEditView->execute(SCI_LINEFROMPOSITION, posToDetect);
+	auto posToDetectLine = _pEditView->LineFromPosition(posToDetect);
 
 	for (int i = int32_t(_insertedMatchedChars.size()) - 1; i >= 0; --i)
 	{
@@ -499,14 +499,14 @@ int InsertedMatchedChars::search(char startChar, char endChar, int posToDetect)
 		{
 			if (_insertedMatchedChars[i]._pos < posToDetect)
 			{
-				auto startPosLine = _pEditView->execute(SCI_LINEFROMPOSITION, _insertedMatchedChars[i]._pos);
+				auto startPosLine = _pEditView->LineFromPosition(_insertedMatchedChars[i]._pos);
 				if (posToDetectLine == startPosLine)
 				{
-					auto endPos = _pEditView->execute(SCI_GETLINEENDPOSITION, startPosLine);
+					auto endPos = _pEditView->GetLineEndPosition(startPosLine);
 
 					for (int j = posToDetect; j <= endPos; ++j)
 					{
-						char aChar = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, j));
+						char aChar = static_cast<char>(_pEditView->GetCharAt(j));
 
 						if (aChar != ' ') // non space is not allowed
 						{
@@ -541,11 +541,11 @@ int InsertedMatchedChars::search(char startChar, char endChar, int posToDetect)
 void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & matchedPairConf)
 {
 	const vector< pair<char, char> > & matchedPairs = matchedPairConf._matchedPairs;
-	int caretPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+	int caretPos = _pEditView->GetCurrentPos();
 	char *matchedChars = NULL;
 
-	char charPrev = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, caretPos - 2));
-	char charNext = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, caretPos));
+	char charPrev = static_cast<char>(_pEditView->GetCharAt(caretPos - 2));
+	char charNext = static_cast<char>(_pEditView->GetCharAt(caretPos));
 
 	bool isCharPrevBlank = (charPrev == ' ' || charPrev == '\t' || charPrev == '\n' || charPrev == '\r' || charPrev == '\0');
 	int docLen = _pEditView->GetLength();
@@ -561,7 +561,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 			{
 				char userMatchedChar[2] = { '\0', '\0' };
 				userMatchedChar[0] = matchedPairs[i].second;
-				_pEditView->execute(SCI_INSERTTEXT, caretPos, reinterpret_cast<LPARAM>(userMatchedChar));
+				_pEditView->InsertText(caretPos, userMatchedChar);
 				return;
 			}
 		}
@@ -616,8 +616,8 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 					int pos = _insertedMatchedChars.search('"', static_cast<char>(character), caretPos);
 					if (pos != -1)
 					{
-						_pEditView->execute(SCI_DELETERANGE, pos, 1);
-						_pEditView->execute(SCI_GOTOPOS, pos);
+						_pEditView->DeleteRange(pos, 1);
+						_pEditView->GotoPos(pos);
 						return;
 					}
 				}
@@ -640,8 +640,8 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 					int pos = _insertedMatchedChars.search('\'', static_cast<char>(character), caretPos);
 					if (pos != -1)
 					{
-						_pEditView->execute(SCI_DELETERANGE, pos, 1);
-						_pEditView->execute(SCI_GOTOPOS, pos);
+						_pEditView->DeleteRange(pos, 1);
+						_pEditView->GotoPos(pos);
 						return;
 					}
 				}
@@ -696,8 +696,8 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 				int pos = _insertedMatchedChars.search(startChar, static_cast<char>(character), caretPos);
 				if (pos != -1)
 				{
-					_pEditView->execute(SCI_DELETERANGE, pos, 1);
-					_pEditView->execute(SCI_GOTOPOS, pos);
+					_pEditView->DeleteRange(pos, 1);
+					_pEditView->GotoPos(pos);
 				}
 				return;
 			}
@@ -709,7 +709,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 	}
 
 	if (matchedChars)
-		_pEditView->execute(SCI_INSERTTEXT, caretPos, reinterpret_cast<LPARAM>(matchedChars));
+		_pEditView->InsertText(caretPos, matchedChars);
 }
 
 
@@ -731,7 +731,7 @@ void AutoCompletion::update(int character)
 	}
 
 	//If autocomplete already active, let Scintilla handle it
-	if (_pEditView->execute(SCI_AUTOCACTIVE) != 0)
+	if (_pEditView->AutoCActive())
 		return;
 
 	const int wordSize = 64;

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -847,7 +847,7 @@ bool FileManager::backupCurrentBuffer()
 			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wb"));
 			if (fp)
 			{
-				int lengthDoc = _pNotepadPlus->_pEditView->getCurrentDocLen();
+				int lengthDoc = _pNotepadPlus->_pEditView->GetLength();
 				char* buf = (char*)_pNotepadPlus->_pEditView->execute(SCI_GETCHARACTERPOINTER);	//to get characters directly from Scintilla buffer
 				size_t items_written = 0;
 				if (encoding == -1) //no special encoding; can be handled directly by Utf8_16_Write
@@ -1038,7 +1038,7 @@ bool FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool isCopy, g
 	{
 		_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, buffer->_doc);	//generate new document
 
-		int lengthDoc = _pscratchTilla->getCurrentDocLen();
+		int lengthDoc = _pscratchTilla->GetLength();
 		char* buf = (char*)_pscratchTilla->execute(SCI_GETCHARACTERPOINTER);	//to get characters directly from Scintilla buffer
 		size_t items_written = 0;
 		if (encoding == -1) //no special encoding; can be handled directly by Utf8_16_Write
@@ -1539,7 +1539,7 @@ int FileManager::getFileNameFromBuffer(BufferID id, TCHAR * fn2copy)
 int FileManager::docLength(Buffer* buffer) const
 {
 	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, buffer->_doc);
-	int docLen = _pscratchTilla->getCurrentDocLen();
+	int docLen = _pscratchTilla->GetLength();
 	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, _scratchDocDefault);
 	return docLen;
 }

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -211,7 +211,7 @@ void Searching::displaySectionCentered(int posStart, int posEnd, ScintillaEditVi
 		//use center
 		linesToScroll += static_cast<int>(linesVisible/2);
 	}
-	pEditView->scroll(0, linesToScroll);
+	pEditView->LineScroll(0, linesToScroll);
 
 	//Make sure the caret is visible, scroll horizontally (this will also fix wrapping problems)
 	pEditView->execute(SCI_GOTOPOS, posStart);

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -167,7 +167,7 @@ private:
 
 
 	void setFinderReadOnly(bool isReadOnly) {
-		_scintView.execute(SCI_SETREADONLY, isReadOnly);
+		_scintView.SetReadOnly(isReadOnly);
 	};
 
 	bool isLineActualSearchResult(const generic_string & s) const;

--- a/PowerEditor/src/ScitillaComponent/FunctionCallTip.cpp
+++ b/PowerEditor/src/ScitillaComponent/FunctionCallTip.cpp
@@ -96,7 +96,7 @@ bool FunctionCallTip::updateCalltip(int ch, bool needShown)
 	if (not needShown && ch != _start && ch != _param && not isVisible())		//must be already visible
 		return false;
 
-	_curPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+	_curPos = _pEditView->GetCurrentPos();
 
 	//recalculate everything
 	if (not getCursorFunction())
@@ -127,16 +127,16 @@ void FunctionCallTip::close()
 	if (!isVisible() || !_selfActivated)
 		return;
 
-	_pEditView->execute(SCI_CALLTIPCANCEL);
+	_pEditView->CallTipCancel();
 	_selfActivated = false;
 	_currentOverload = 0;
 }
 
 bool FunctionCallTip::getCursorFunction()
 {
-	auto line = _pEditView->execute(SCI_LINEFROMPOSITION, _curPos);
-	int startpos = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, line));
-	int endpos = static_cast<int32_t>(_pEditView->execute(SCI_GETLINEENDPOSITION, line));
+	auto line = _pEditView->LineFromPosition(_curPos);
+	int startpos = _pEditView->PositionFromLine(line);
+	int endpos = _pEditView->GetLineEndPosition(line);
 	int len = endpos - startpos + 3;	//also take CRLF in account, even if not there
 	int offset = _curPos - startpos;	//offset is cursor location, only stuff before cursor has influence
 	const int maxLen = 256;
@@ -430,7 +430,7 @@ void FunctionCallTip::showCalltip()
 	}
 
 	if (isVisible())
-		_pEditView->execute(SCI_CALLTIPCANCEL);
+		_pEditView->CallTipCancel();
 	else
 		_startPos = _curPos;
 	_pEditView->showCallTip(_startPos, callTipText.str().c_str());
@@ -438,7 +438,7 @@ void FunctionCallTip::showCalltip()
 	_selfActivated = true;
 	if (highlightstart != highlightend)
 	{
-		_pEditView->execute(SCI_CALLTIPSETHLT, highlightstart, highlightend);
+		_pEditView->CallTipSetHlt(highlightstart, highlightend);
 	}
 }
 

--- a/PowerEditor/src/ScitillaComponent/FunctionCallTip.h
+++ b/PowerEditor/src/ScitillaComponent/FunctionCallTip.h
@@ -43,7 +43,7 @@ public:
 	bool updateCalltip(int ch, bool needShown = false);	//Ch is character typed, or 0 if another event occured. NeedShown is true if calltip should be attempted to displayed. Return true if calltip was made visible
 	void showNextOverload();							//show next overlaoded parameters
 	void showPrevOverload();							//show prev overlaoded parameters
-	bool isVisible() { return _pEditView?_pEditView->execute(SCI_CALLTIPACTIVE) == TRUE:false; };	//true if calltip visible
+	bool isVisible() { return _pEditView ? _pEditView->CallTipActive() : false; };	//true if calltip visible
 	void close();					//Close calltip if visible
 
 private:

--- a/PowerEditor/src/ScitillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/GoToLineDlg.cpp
@@ -134,7 +134,7 @@ void GoToLineDlg::updateLinesNumbers() const
 	else
 	{
 		current = static_cast<unsigned int>((*_ppEditView)->execute(SCI_GETCURRENTPOS));
-		limit = static_cast<unsigned int>((*_ppEditView)->getCurrentDocLen() - 1);
+		limit = static_cast<unsigned int>((*_ppEditView)->GetLength() - 1);
 	}
     ::SetDlgItemInt(_hSelf, ID_CURRLINE, current, FALSE);
     ::SetDlgItemInt(_hSelf, ID_LASTLINE, limit, FALSE);

--- a/PowerEditor/src/ScitillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/GoToLineDlg.cpp
@@ -57,14 +57,14 @@ INT_PTR CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
                         cleanLineEdit();
 						if (_mode == go2line)
 						{
-							(*_ppEditView)->execute(SCI_ENSUREVISIBLE, line-1);
-							(*_ppEditView)->execute(SCI_GOTOLINE, line-1);
+							(*_ppEditView)->EnsureVisible(line-1);
+							(*_ppEditView)->GotoLine(line-1);
 						}
 						else
 						{
-							auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, line);
-							(*_ppEditView)->execute(SCI_ENSUREVISIBLE, sci_line);
-							(*_ppEditView)->execute(SCI_GOTOPOS, line);
+							auto sci_line = (*_ppEditView)->LineFromPosition(line);
+							(*_ppEditView)->EnsureVisible(sci_line);
+							(*_ppEditView)->GotoPos(line);
 						}
                     }
 
@@ -129,11 +129,11 @@ void GoToLineDlg::updateLinesNumbers() const
 	if (_mode == go2line)
 	{
 		current = static_cast<unsigned int>((*_ppEditView)->getCurrentLineNumber() + 1);
-		limit = static_cast<unsigned int>((*_ppEditView)->execute(SCI_GETLINECOUNT));
+		limit = static_cast<unsigned int>((*_ppEditView)->GetLineCount());
 	}
 	else
 	{
-		current = static_cast<unsigned int>((*_ppEditView)->execute(SCI_GETCURRENTPOS));
+		current = static_cast<unsigned int>((*_ppEditView)->GetCurrentPos());
 		limit = static_cast<unsigned int>((*_ppEditView)->GetLength() - 1);
 	}
     ::SetDlgItemInt(_hSelf, ID_CURRLINE, current, FALSE);

--- a/PowerEditor/src/ScitillaComponent/Printer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Printer.cpp
@@ -205,7 +205,7 @@ size_t Printer::doPrint(bool justDoIt)
 	
 	// By default, we will print all the document
 	long lengthPrinted = 0;
-	long lengthDoc = _pSEView->getCurrentDocLen();
+	long lengthDoc = _pSEView->GetLength();
 	long lengthDocMax = lengthDoc;
 
 	// In the case that the print dialog was launched and that there's a range of selection

--- a/PowerEditor/src/ScitillaComponent/Printer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Printer.cpp
@@ -343,7 +343,7 @@ size_t Printer::doPrint(bool justDoIt)
 	size_t pageNum = 1;
 	const TCHAR pageVar[] = TEXT("$(CURRENT_PRINTING_PAGE)");
 
-	_pSEView->execute(SCI_SETPRINTCOLOURMODE, nppGUI._printSettings._printOption); // setting mode once is enough
+	_pSEView->SetPrintColourMode(nppGUI._printSettings._printOption); // setting mode once is enough
 	while (lengthPrinted < lengthDoc) 
 	{
 		bool printPage = (!(_pdlg.Flags & PD_PAGENUMS) ||
@@ -499,7 +499,7 @@ size_t Printer::doPrint(bool justDoIt)
 	if (!nppGUI._printSettings._printLineNumber)
 		_pSEView->showMargin(ScintillaEditView::_SC_MARGE_LINENUMBER, isShown);
 
-	_pSEView->execute(SCI_FORMATRANGE, FALSE, 0);
+	_pSEView->FormatRange(false, nullptr);
 	::EndDoc(_pdlg.hDC);
 	::DeleteDC(_pdlg.hDC);
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1709,7 +1709,7 @@ void ScintillaEditView::restoreCurrentPos()
 	execute(SCI_CHOOSECARETX); // choose current x position
 
 	int lineToShow = static_cast<int32_t>(execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine));
-	scroll(0, lineToShow);
+	LineScroll(0, lineToShow);
 }
 
 void ScintillaEditView::restyleBuffer() {
@@ -3002,7 +3002,7 @@ void ScintillaEditView::scrollPosToCenter(size_t pos)
 	else
 		middleLine = lastVisibleDocLine -  nbLine/2;
 	int nbLines2scroll =  line - middleLine;
-	scroll(0, nbLines2scroll);
+	LineScroll(0, nbLines2scroll);
 }
 
 void ScintillaEditView::hideLines()

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -238,73 +238,73 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 		throw std::runtime_error("ScintillaEditView::init : SCI_GETDIRECTPOINTER message failed");
 	}
 
-    execute(SCI_SETMARGINMASKN, _SC_MARGE_FOLDER, SC_MASK_FOLDERS);
+	SetMarginMaskN(_SC_MARGE_FOLDER, SC_MASK_FOLDERS);
     showMargin(_SC_MARGE_FOLDER, true);
 
-    execute(SCI_SETMARGINMASKN, _SC_MARGE_SYBOLE, (1<<MARK_BOOKMARK) | (1<<MARK_HIDELINESBEGIN) | (1<<MARK_HIDELINESEND) | (1<<MARK_HIDELINESUNDERLINE));
+	SetMarginMaskN(_SC_MARGE_SYBOLE, (1 << MARK_BOOKMARK) | (1 << MARK_HIDELINESBEGIN) | (1 << MARK_HIDELINESEND) | (1 << MARK_HIDELINESUNDERLINE));
 
-	execute(SCI_MARKERSETALPHA, MARK_BOOKMARK, 70);
+	MarkerSetAlpha(MARK_BOOKMARK, 70);
 
-	execute(SCI_MARKERDEFINE, MARK_HIDELINESUNDERLINE, SC_MARK_UNDERLINE);
-	execute(SCI_MARKERSETBACK, MARK_HIDELINESUNDERLINE, 0x77CC77);
+	MarkerDefine(MARK_HIDELINESUNDERLINE, SC_MARK_UNDERLINE);
+	MarkerSetBack(MARK_HIDELINESUNDERLINE, 0x77CC77);
 
 	if (NppParameters::getInstance()->_dpiManager.scaleX(100) >= 150)
 	{
-		execute(SCI_RGBAIMAGESETWIDTH, 18);
-		execute(SCI_RGBAIMAGESETHEIGHT, 18);
-		execute(SCI_MARKERDEFINERGBAIMAGE, MARK_BOOKMARK, reinterpret_cast<LPARAM>(bookmark18));
-		execute(SCI_MARKERDEFINERGBAIMAGE, MARK_HIDELINESBEGIN, reinterpret_cast<LPARAM>(hidelines_begin18));
-		execute(SCI_MARKERDEFINERGBAIMAGE, MARK_HIDELINESEND, reinterpret_cast<LPARAM>(hidelines_end18));
+		RGBAImageSetWidth(18);
+		RGBAImageSetHeight(18);
+		MarkerDefineRGBAImage(MARK_BOOKMARK, reinterpret_cast<const char*>(bookmark18));
+		MarkerDefineRGBAImage(MARK_HIDELINESBEGIN, reinterpret_cast<const char*>(hidelines_begin18));
+		MarkerDefineRGBAImage(MARK_HIDELINESEND, reinterpret_cast<const char*>(hidelines_end18));
 	}
 	else
 	{
-		execute(SCI_RGBAIMAGESETWIDTH, 14);
-		execute(SCI_RGBAIMAGESETHEIGHT, 14);
-		execute(SCI_MARKERDEFINERGBAIMAGE, MARK_BOOKMARK, reinterpret_cast<LPARAM>(bookmark14));
-		execute(SCI_MARKERDEFINERGBAIMAGE, MARK_HIDELINESBEGIN, reinterpret_cast<LPARAM>(hidelines_begin14));
-		execute(SCI_MARKERDEFINERGBAIMAGE, MARK_HIDELINESEND, reinterpret_cast<LPARAM>(hidelines_end14));
+		RGBAImageSetWidth(14);
+		RGBAImageSetHeight(14);
+		MarkerDefineRGBAImage(MARK_BOOKMARK, reinterpret_cast<const char*>(bookmark14));
+		MarkerDefineRGBAImage(MARK_HIDELINESBEGIN, reinterpret_cast<const char*>(hidelines_begin14));
+		MarkerDefineRGBAImage(MARK_HIDELINESEND, reinterpret_cast<const char*>(hidelines_end14));
 	}
 
-    execute(SCI_SETMARGINSENSITIVEN, _SC_MARGE_FOLDER, true);
-    execute(SCI_SETMARGINSENSITIVEN, _SC_MARGE_SYBOLE, true);
+	SetMarginSensitiveN(_SC_MARGE_FOLDER, true);
+	SetMarginSensitiveN(_SC_MARGE_SYBOLE, true);
 
-    execute(SCI_SETFOLDFLAGS, 16);
-	execute(SCI_SETSCROLLWIDTHTRACKING, true);
-	execute(SCI_SETSCROLLWIDTH, 1);	//default empty document: override default width of 2000
+	SetFoldFlags(16);
+	SetScrollWidthTracking(true);
+	SetScrollWidth(1); //default empty document: override default width of 2000
 
 	// smart hilighting
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE_SMART, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE_INC, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_TAGMATCH, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_TAGATTR, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE_EXT1, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE_EXT2, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE_EXT3, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE_EXT4, INDIC_ROUNDBOX);
-	execute(SCI_INDICSETSTYLE, SCE_UNIVERSAL_FOUND_STYLE_EXT5, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE_SMART, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE_INC, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_TAGMATCH, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_TAGATTR, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE_EXT1, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE_EXT2, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE_EXT3, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE_EXT4, INDIC_ROUNDBOX);
+	IndicSetStyle(SCE_UNIVERSAL_FOUND_STYLE_EXT5, INDIC_ROUNDBOX);
 
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE_SMART, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE_INC, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_TAGMATCH, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_TAGATTR, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE_EXT1, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE_EXT2, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE_EXT3, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE_EXT4, 100);
-	execute(SCI_INDICSETALPHA, SCE_UNIVERSAL_FOUND_STYLE_EXT5, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE_SMART, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE_INC, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_TAGMATCH, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_TAGATTR, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE_EXT1, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE_EXT2, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE_EXT3, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE_EXT4, 100);
+	IndicSetAlpha(SCE_UNIVERSAL_FOUND_STYLE_EXT5, 100);
 
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_SMART, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_INC, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_TAGMATCH, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_TAGATTR, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT1, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT2, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT3, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT4, true);
-	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT5, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE_SMART, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE_INC, true);
+	IndicSetUnder(SCE_UNIVERSAL_TAGMATCH, true);
+	IndicSetUnder(SCE_UNIVERSAL_TAGATTR, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE_EXT1, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE_EXT2, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE_EXT3, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE_EXT4, true);
+	IndicSetUnder(SCE_UNIVERSAL_FOUND_STYLE_EXT5, true);
 	_pParameter = NppParameters::getInstance();
 
 	_codepage = ::GetACP();
@@ -315,12 +315,7 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 
 	if (_defaultCharList.empty())
 	{
-		auto defaultCharListLen = execute(SCI_GETWORDCHARS);
-		char *defaultCharList = new char[defaultCharListLen + 1];
-		execute(SCI_GETWORDCHARS, 0, reinterpret_cast<LPARAM>(defaultCharList));
-		defaultCharList[defaultCharListLen] = '\0';
-		_defaultCharList = defaultCharList;
-		delete[] defaultCharList;
+		_defaultCharList = GetWordChars();
 	}
 	//Get the startup document and make a buffer for it so it can be accessed like a file
 	attachDefaultDoc();
@@ -391,12 +386,12 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 				RECONVERTSTRING   *	reconvert = (RECONVERTSTRING *)lParam;
 
 				// does nothing with a rectangular selection
-				if (execute(SCI_SELECTIONISRECTANGLE, 0, 0))
+				if (SelectionIsRectangle())
 					return 0;
 
 				// get the codepage of the text
 
-				UINT codepage = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+				UINT codepage = static_cast<UINT>(GetCodePage());
 
 				// get the current text selection
 
@@ -487,10 +482,10 @@ void ScintillaEditView::setSpecialStyle(const Style & styleToSet)
 {
 	int styleID = styleToSet._styleID;
 	if ( styleToSet._colorStyle & COLORSTYLE_FOREGROUND )
-	    execute(SCI_STYLESETFORE, styleID, styleToSet._fgColor);
+		StyleSetFore(styleID, styleToSet._fgColor);
 
     if ( styleToSet._colorStyle & COLORSTYLE_BACKGROUND )
-	    execute(SCI_STYLESETBACK, styleID, styleToSet._bgColor);
+		StyleSetBack(styleID, styleToSet._bgColor);
 
     if (styleToSet._fontName && lstrcmp(styleToSet._fontName, TEXT("")) != 0)
 	{
@@ -498,24 +493,24 @@ void ScintillaEditView::setSpecialStyle(const Style & styleToSet)
 
 		if (not _pParameter->isInFontList(styleToSet._fontName))
 		{
-			execute(SCI_STYLESETFONT, styleID, reinterpret_cast<LPARAM>(DEFAULT_FONT_NAME));
+			StyleSetFont(styleID, DEFAULT_FONT_NAME);
 		}
 		else
 		{
 			const char * fontNameA = wmc->wchar2char(styleToSet._fontName, CP_UTF8);
-			execute(SCI_STYLESETFONT, styleID, reinterpret_cast<LPARAM>(fontNameA));
+			StyleSetFont(styleID, fontNameA);
 		}
 	}
 	int fontStyle = styleToSet._fontStyle;
     if (fontStyle != STYLE_NOT_USED)
     {
-        execute(SCI_STYLESETBOLD,		styleID, fontStyle & FONTSTYLE_BOLD);
-        execute(SCI_STYLESETITALIC,		styleID, fontStyle & FONTSTYLE_ITALIC);
-        execute(SCI_STYLESETUNDERLINE,	styleID, fontStyle & FONTSTYLE_UNDERLINE);
+        StyleSetBold(styleID, (fontStyle & FONTSTYLE_BOLD) != 0);
+        StyleSetItalic(styleID, (fontStyle & FONTSTYLE_ITALIC) != 0);
+        StyleSetUnderline(styleID, (fontStyle & FONTSTYLE_UNDERLINE) != 0);
     }
 
 	if (styleToSet._fontSize > 0)
-		execute(SCI_STYLESETSIZE, styleID, styleToSet._fontSize);
+		StyleSetSize(styleID, styleToSet._fontSize);
 }
 
 void ScintillaEditView::setHotspotStyle(Style& styleToSet)
@@ -613,31 +608,31 @@ void ScintillaEditView::setXmlLexer(LangType type)
 {
 	if (type == L_XML)
 	{
-        execute(SCI_SETLEXER, SCLEX_XML);
+		SetLexer(SCLEX_XML);
 		for (int i = 0 ; i < 4 ; ++i)
-			execute(SCI_SETKEYWORDS, i, reinterpret_cast<LPARAM>(TEXT("")));
+			SetKeyWords(i, "");
 
         makeStyle(type);
 	}
 	else if ((type == L_HTML) || (type == L_PHP) || (type == L_ASP) || (type == L_JSP))
 	{
-        execute(SCI_SETLEXER, SCLEX_HTML);
+		SetLexer(SCLEX_HTML);
         const TCHAR *htmlKeyWords_generic =_pParameter->getWordList(L_HTML, LANG_INDEX_INSTR);
 
 		WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 		const char *htmlKeyWords = wmc->wchar2char(htmlKeyWords_generic, CP_ACP);
-		execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(htmlKeyWords?htmlKeyWords:""));
+		SetKeyWords(0, htmlKeyWords ? htmlKeyWords : "");
 		makeStyle(L_HTML);
 
         setEmbeddedJSLexer();
         setEmbeddedPhpLexer();
 		setEmbeddedAspLexer();
 	}
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.compact"), reinterpret_cast<LPARAM>("0"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.html"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("fold", "1");
+	SetProperty("fold.compact", "0");
+	SetProperty("fold.html", "1");
 	// This allow to fold comment strem in php/javascript code
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.hypertext.comment"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("fold.hypertext.comment", "1");
 }
 
 void ScintillaEditView::setEmbeddedJSLexer()
@@ -652,15 +647,15 @@ void ScintillaEditView::setEmbeddedJSLexer()
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
-	execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList, L_JS, LANG_INDEX_INSTR)));
-	execute(SCI_STYLESETEOLFILLED, SCE_HJ_DEFAULT, true);
-	execute(SCI_STYLESETEOLFILLED, SCE_HJ_COMMENT, true);
-	execute(SCI_STYLESETEOLFILLED, SCE_HJ_COMMENTDOC, true);
+	SetKeyWords(1, getCompleteKeywordList(keywordList, L_JS, LANG_INDEX_INSTR));
+	StyleSetEOLFilled(SCE_HJ_DEFAULT, true);
+	StyleSetEOLFilled(SCE_HJ_COMMENT, true);
+	StyleSetEOLFilled(SCE_HJ_COMMENTDOC, true);
 }
 
 void ScintillaEditView::setJsonLexer()
 {
-	execute(SCI_SETLEXER, SCLEX_CPP);
+	SetLexer(SCLEX_CPP);
 
 	const TCHAR *pKwArray[10] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
@@ -673,13 +668,13 @@ void ScintillaEditView::setJsonLexer()
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
-	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList, L_JSON, LANG_INDEX_INSTR)));
+	SetKeyWords(0, getCompleteKeywordList(keywordList, L_JSON, LANG_INDEX_INSTR));
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.compact"), reinterpret_cast<LPARAM>("0"));
+	SetProperty("fold", "1");
+	SetProperty("fold.compact", "0");
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.comment"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.preprocessor"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("fold.comment", "1");
+	SetProperty("fold.preprocessor", "1");
 }
 
 void ScintillaEditView::setEmbeddedPhpLexer()
@@ -694,10 +689,11 @@ void ScintillaEditView::setEmbeddedPhpLexer()
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
-	execute(SCI_SETKEYWORDS, 4, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList, L_PHP, LANG_INDEX_INSTR)));
+	SetKeyWords(4, getCompleteKeywordList(keywordList, L_PHP, LANG_INDEX_INSTR));
 
-	execute(SCI_STYLESETEOLFILLED, SCE_HPHP_DEFAULT, true);
-	execute(SCI_STYLESETEOLFILLED, SCE_HPHP_COMMENT, true);
+
+	StyleSetEOLFilled(SCE_HPHP_DEFAULT, true);
+	StyleSetEOLFilled(SCE_HPHP_COMMENT, true);
 }
 
 void ScintillaEditView::setEmbeddedAspLexer()
@@ -712,15 +708,15 @@ void ScintillaEditView::setEmbeddedAspLexer()
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
-	execute(SCI_SETKEYWORDS, 2, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList, L_VB, LANG_INDEX_INSTR)));
+	SetKeyWords(2, getCompleteKeywordList(keywordList, L_VB, LANG_INDEX_INSTR));
 
-    execute(SCI_STYLESETEOLFILLED, SCE_HBA_DEFAULT, true);
+	StyleSetEOLFilled(SCE_HBA_DEFAULT, true);
 }
 
 void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 {
 	int setKeywordsCounter = 0;
-    execute(SCI_SETLEXER, SCLEX_USER);
+	SetLexer(SCLEX_USER);
 
 	UserLangContainer * userLangContainer = userLangName?_pParameter->getULCFromName(userLangName):_userDefineDlg._pCurrentUserLang;
 
@@ -741,16 +737,17 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 								// but this is the best match WideCharToMultiByte offers
 	}
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.isCaseIgnored"),		  reinterpret_cast<LPARAM>(userLangContainer->_isCaseIgnored ? "1":"0"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.allowFoldOfComments"),  reinterpret_cast<LPARAM>(userLangContainer->_allowFoldOfComments ? "1":"0"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.foldCompact"),		  reinterpret_cast<LPARAM>(userLangContainer->_foldCompact ? "1":"0"));
+	SetProperty("fold", "1");
+	SetProperty("userDefine.isCaseIgnored", userLangContainer->_isCaseIgnored ? "1" : "0");
+	SetProperty("userDefine.allowFoldOfComments", userLangContainer->_allowFoldOfComments ? "1" : "0");
+	SetProperty("userDefine.foldCompact", userLangContainer->_foldCompact ? "1" : "0");
+
 
     char name[] = "userDefine.prefixKeywords0";
 	for (int i=0 ; i<SCE_USER_TOTAL_KEYWORD_GROUPS ; ++i)
 	{
 		itoa(i+1, (name+25), 10);
-		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>(name), reinterpret_cast<LPARAM>(userLangContainer->_isPrefix[i] ? "1" : "0"));
+		SetProperty(name, userLangContainer->_isPrefix[i] ? "1" : "0");
 	}
 
 	for (int i = 0 ; i < SCE_USER_KWLIST_TOTAL ; ++i)
@@ -760,7 +757,7 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 
 		if (globalMappper().setLexerMapper.find(i) != globalMappper().setLexerMapper.end())
 		{
-			execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>(globalMappper().setLexerMapper[i].c_str()), reinterpret_cast<LPARAM>(keyWords_char));
+			SetProperty(globalMappper().setLexerMapper[i].c_str(), keyWords_char);
 		}
 		else // OPERATORS2, FOLDERS_IN_CODE2, FOLDERS_IN_COMMENT, KEYWORDS1-8
 		{
@@ -812,7 +809,7 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 
 			}
 			temp[index++] = 0;
-			execute(SCI_SETKEYWORDS, setKeywordsCounter++, reinterpret_cast<LPARAM>(temp));
+			SetKeyWords(setKeywordsCounter++, temp);
 		}
 	}
 
@@ -820,17 +817,17 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 	char nestingBuffer[] = "userDefine.nesting.00";
 
     itoa(userLangContainer->_forcePureLC, intBuffer, 10);
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.forcePureLC"), reinterpret_cast<LPARAM>(intBuffer));
+	SetProperty("userDefine.forcePureLC", intBuffer);
 
     itoa(userLangContainer->_decimalSeparator, intBuffer, 10);
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.decimalSeparator"), reinterpret_cast<LPARAM>(intBuffer));
+	SetProperty("userDefine.decimalSeparator", intBuffer);
 
 	// at the end (position SCE_USER_KWLIST_TOTAL) send id values
 	itoa(reinterpret_cast<int>(userLangContainer->getName()), intBuffer, 10); // use numeric value of TCHAR pointer
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.udlName"), reinterpret_cast<LPARAM>(intBuffer));
+	SetProperty("userDefine.udlName", intBuffer);
 
     itoa(reinterpret_cast<int>(_currentBufferID), intBuffer, 10); // use numeric value of BufferID pointer
-    execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.currentBufferID"), reinterpret_cast<LPARAM>(intBuffer));
+    SetProperty("userDefine.currentBufferID", intBuffer);
 
 	for (int i = 0 ; i < SCE_USER_STYLE_TOTAL_STYLES ; ++i)
 	{
@@ -841,7 +838,7 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 
 		if (i < 10)	itoa(i, (nestingBuffer+20), 10);
 		else		itoa(i, (nestingBuffer+19), 10);
-		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>(nestingBuffer), reinterpret_cast<LPARAM>(itoa(style._nesting, intBuffer, 10)));
+		SetProperty(nestingBuffer, itoa(style._nesting, intBuffer, 10));
 
 		setStyle(style);
 	}
@@ -855,7 +852,7 @@ void ScintillaEditView::setExternalLexer(LangType typeDoc)
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 	const char *pName = wmc->wchar2char(name, CP_ACP);
 
-	execute(SCI_SETLEXERLANGUAGE, 0, reinterpret_cast<LPARAM>(pName));
+	SetLexerLanguage(pName);
 
 	LexerStyler *pStyler = (_pParameter->getLStylerArray()).getLexerStylerByName(name);
 	if (pStyler)
@@ -873,7 +870,7 @@ void ScintillaEditView::setExternalLexer(LangType typeDoc)
 				{
 					keywordList = wstring2string(*(style._keywords), CP_ACP);
 				}
-				execute(SCI_SETKEYWORDS, style._keywordClass, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList, typeDoc, style._keywordClass)));
+				SetKeyWords(style._keywordClass, getCompleteKeywordList(keywordList, typeDoc, style._keywordClass));
 			}
 		}
 	}
@@ -885,7 +882,7 @@ void ScintillaEditView::setCppLexer(LangType langType)
     const char *cppTypes;
     const TCHAR *doxygenKeyWords  = _pParameter->getWordList(L_CPP, LANG_INDEX_TYPE2);
 
-    execute(SCI_SETLEXER, SCLEX_CPP);
+	SetLexer(SCLEX_CPP);
 
 	if (langType != L_RC)
     {
@@ -893,7 +890,7 @@ void ScintillaEditView::setCppLexer(LangType langType)
 		{
 			WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 			const char * doxygenKeyWords_char = wmc->wchar2char(doxygenKeyWords, CP_ACP);
-			execute(SCI_SETKEYWORDS, 2, reinterpret_cast<LPARAM>(doxygenKeyWords_char));
+			SetKeyWords(2, doxygenKeyWords_char);
 		}
     }
 
@@ -916,25 +913,25 @@ void ScintillaEditView::setCppLexer(LangType langType)
 	}
 	cppTypes = getCompleteKeywordList(keywordListType, langType, LANG_INDEX_TYPE);
 
-	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(cppInstrs));
-	execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(cppTypes));
+	SetKeyWords(0, cppInstrs);
+	SetKeyWords(1, cppTypes);
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.compact"), reinterpret_cast<LPARAM>("0"));
+	SetProperty("fold", "1");
+	SetProperty("fold.compact", "0");
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.comment"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.preprocessor"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("fold.comment", "1");
+	SetProperty("fold.preprocessor", "1");
 
 	// Disable track preprocessor to avoid incorrect detection.
 	// In the most of cases, the symbols are defined outside of file.
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("lexer.cpp.track.preprocessor"), reinterpret_cast<LPARAM>("0"));
+	SetProperty("lexer.cpp.track.preprocessor", "0");
 }
 
 void ScintillaEditView::setJsLexer()
 {
 	const TCHAR *doxygenKeyWords = _pParameter->getWordList(L_CPP, LANG_INDEX_TYPE2);
 
-	execute(SCI_SETLEXER, SCLEX_CPP);
+	SetLexer(SCLEX_CPP);
 	const TCHAR *pKwArray[10] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 	makeStyle(L_JAVASCRIPT, pKwArray);
 
@@ -942,7 +939,7 @@ void ScintillaEditView::setJsLexer()
 	{
 		WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 		const char * doxygenKeyWords_char = wmc->wchar2char(doxygenKeyWords, CP_ACP);
-		execute(SCI_SETKEYWORDS, 2, reinterpret_cast<LPARAM>(doxygenKeyWords_char));
+		SetKeyWords(2, doxygenKeyWords_char);
 	}
 
 	const TCHAR *newLexerName = ScintillaEditView::langNames[L_JAVASCRIPT].lexerName;
@@ -983,9 +980,9 @@ void ScintillaEditView::setJsLexer()
 		}
 		const char *jsInstrs2 = getCompleteKeywordList(keywordListInstruction2, L_JAVASCRIPT, LANG_INDEX_INSTR2);
 
-		execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(jsInstrs));
-		execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(jsTypes));
-		execute(SCI_SETKEYWORDS, 3, reinterpret_cast<LPARAM>(jsInstrs2));
+		SetKeyWords(0, jsInstrs);
+		SetKeyWords(1, jsTypes);
+		SetKeyWords(3, jsInstrs2);
 	}
 	else // New js styler is not available, we use the old styling for the sake of retro-compatibility
 	{
@@ -1017,10 +1014,10 @@ void ScintillaEditView::setJsLexer()
 				setStyle(style);
 			}
 		}
-		execute(SCI_STYLESETEOLFILLED, SCE_C_DEFAULT, true);
-		execute(SCI_STYLESETEOLFILLED, SCE_C_COMMENTLINE, true);
-		execute(SCI_STYLESETEOLFILLED, SCE_C_COMMENT, true);
-		execute(SCI_STYLESETEOLFILLED, SCE_C_COMMENTDOC, true);
+		StyleSetEOLFilled(SCE_C_DEFAULT, true);
+		StyleSetEOLFilled(SCE_C_COMMENTLINE, true);
+		StyleSetEOLFilled(SCE_C_COMMENT, true);
+		StyleSetEOLFilled(SCE_C_COMMENTDOC, true);
 
 		makeStyle(L_JS, pKwArray);
 
@@ -1031,19 +1028,19 @@ void ScintillaEditView::setJsLexer()
 			keywordListInstruction = wstring2string(kwlW, CP_ACP);
 		}
 		const char *jsEmbeddedInstrs = getCompleteKeywordList(keywordListInstruction, L_JS, LANG_INDEX_INSTR);
-		execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(jsEmbeddedInstrs));
+		SetKeyWords(0, jsEmbeddedInstrs);
 	}
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.compact"), reinterpret_cast<LPARAM>("0"));
+	SetProperty("fold", "1");
+	SetProperty("fold.compact", "0");
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.comment"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.preprocessor"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("fold.comment", "1");
+	SetProperty("fold.preprocessor", "1");
 
 	// Disable track preprocessor to avoid incorrect detection.
 	// In the most of cases, the symbols are defined outside of file.
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("lexer.cpp.track.preprocessor"), reinterpret_cast<LPARAM>("0"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("lexer.cpp.backquoted.strings"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("lexer.cpp.track.preprocessor", "0");
+	SetProperty("lexer.cpp.backquoted.strings", "1");
 }
 
 void ScintillaEditView::setTclLexer()
@@ -1052,7 +1049,7 @@ void ScintillaEditView::setTclLexer()
     const char *tclTypes;
 
 
-    execute(SCI_SETLEXER, SCLEX_TCL);
+	SetLexer(SCLEX_TCL);
 
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 	makeStyle(L_TCL, pKwArray);
@@ -1073,14 +1070,14 @@ void ScintillaEditView::setTclLexer()
 	}
 	tclTypes = getCompleteKeywordList(keywordListType, L_TCL, LANG_INDEX_TYPE);
 
-	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(tclInstrs));
-	execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(tclTypes));
+	SetKeyWords(0, tclInstrs);
+	SetKeyWords(1, tclTypes);
 }
 
 //used by Objective-C and Actionscript
 void ScintillaEditView::setObjCLexer(LangType langType)
 {
-    execute(SCI_SETLEXER, SCLEX_OBJC);
+	SetLexer(SCLEX_OBJC);
 
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
@@ -1125,29 +1122,29 @@ void ScintillaEditView::setObjCLexer(LangType langType)
 	}
 	const char *doxygenKeyWords = doxygenKeyWordsString.c_str();
 
-	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(objcInstrs));
-    execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(objcTypes));
-	execute(SCI_SETKEYWORDS, 2, reinterpret_cast<LPARAM>(doxygenKeyWords));
-	execute(SCI_SETKEYWORDS, 3, reinterpret_cast<LPARAM>(objCDirective));
-	execute(SCI_SETKEYWORDS, 4, reinterpret_cast<LPARAM>(objCQualifier));
+	SetKeyWords(0, objcInstrs);
+    SetKeyWords(1, objcTypes);
+	SetKeyWords(2, doxygenKeyWords);
+	SetKeyWords(3, objCDirective);
+	SetKeyWords(4, objCQualifier);
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.compact"), reinterpret_cast<LPARAM>("0"));
+	SetProperty("fold", "1");
+	SetProperty("fold.compact", "0");
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.comment"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.preprocessor"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("fold.comment", "1");
+	SetProperty("fold.preprocessor", "1");
 }
 
 void ScintillaEditView::setKeywords(LangType langType, const char *keywords, int index)
 {
 	std::basic_string<char> wordList;
 	wordList = (keywords)?keywords:"";
-	execute(SCI_SETKEYWORDS, index, reinterpret_cast<LPARAM>(getCompleteKeywordList(wordList, langType, index)));
+	SetKeyWords(index, getCompleteKeywordList(wordList, langType, index));
 }
 
 void ScintillaEditView::setLexer(int lexerID, LangType langType, int whichList)
 {
-	execute(SCI_SETLEXER, lexerID);
+	SetLexer(lexerID);
 
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
@@ -1196,10 +1193,10 @@ void ScintillaEditView::setLexer(int lexerID, LangType langType, int whichList)
 		const char * keyWords_char = wmc->wchar2char(pKwArray[LANG_INDEX_TYPE5], CP_ACP);
 		setKeywords(langType, keyWords_char, LANG_INDEX_TYPE5);
 	}
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.compact"), reinterpret_cast<LPARAM>("0"));
+	SetProperty("fold", "1");
+	SetProperty("fold.compact", "0");
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.comment"), reinterpret_cast<LPARAM>("1"));
+	SetProperty("fold.comment", "1");
 }
 
 void ScintillaEditView::makeStyle(LangType language, const TCHAR **keywordArray)
@@ -1223,7 +1220,7 @@ void ScintillaEditView::makeStyle(LangType language, const TCHAR **keywordArray)
 
 void ScintillaEditView::restoreDefaultWordChars()
 {
-	execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>(_defaultCharList.c_str()));
+	SetWordChars(_defaultCharList);
 }
 
 void ScintillaEditView::addCustomWordChars()
@@ -1258,7 +1255,7 @@ void ScintillaEditView::addCustomWordChars()
 	{
 		string newCharList = _defaultCharList;
 		newCharList += chars2addStr;
-		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>(newCharList.c_str()));
+		SetWordChars(newCharList);
 	}
 }
 
@@ -1283,7 +1280,7 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 	    setStyle(styleDefault);
     }
 
-    execute(SCI_STYLECLEARALL);
+	StyleClearAll();
 
 	Style *pStyle;
 	Style defaultIndicatorStyle;
@@ -1396,9 +1393,9 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 		if (getCurrentBuffer()->getUnicodeMode() == uni8Bit)
 		{
 			if (typeDoc == L_CSS || typeDoc == L_CAML || typeDoc == L_ASM || typeDoc == L_MATLAB)
-				execute(SCI_SETCODEPAGE, CP_ACP);
+				SetCodePage(CP_ACP);
 			else
-				execute(SCI_SETCODEPAGE, _codepage);
+				SetCodePage(_codepage);
 		}
 	}
 
@@ -1478,7 +1475,7 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 				}
 			}
 			setSpecialStyle(nfoStyle);
-			execute(SCI_STYLECLEARALL);
+			StyleClearAll();
 
 			Buffer * buf = MainFileManager->getBufferByID(_currentBufferID);
 
@@ -1615,7 +1612,7 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 			if (typeDoc >= L_EXTERNAL && typeDoc < _pParameter->L_END)
 				setExternalLexer(typeDoc);
 			else
-				execute(SCI_SETLEXER, (_codepage == CP_CHINESE_TRADITIONAL)?SCLEX_MAKEFILE:SCLEX_NULL);
+				SetLexer((_codepage == CP_CHINESE_TRADITIONAL) ? SCLEX_MAKEFILE : SCLEX_NULL);
 			break;
 
 	}
@@ -1647,16 +1644,17 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
     }
     setTabSettings(_pParameter->getLangFromID(typeDoc));
 
-	execute(SCI_SETSTYLEBITS, 8);	// Always use 8 bit mask in Document class (Document::stylingBitsMask),
-									// in that way Editor::PositionIsHotspot will return correct hotspot styleID.
-									// This value has no effect on LexAccessor::mask.
+	SetStyleBits(8);	// Always use 8 bit mask in Document class (Document::stylingBitsMask),
+						// in that way Editor::PositionIsHotspot will return correct hotspot styleID.
+						// This value has no effect on LexAccessor::mask.
 }
 
 BufferID ScintillaEditView::attachDefaultDoc()
 {
 	// get the doc pointer attached (by default) on the view Scintilla
-	Document doc = execute(SCI_GETDOCPOINTER, 0, 0);
-	execute(SCI_ADDREFDOCUMENT, 0, doc);
+	Document doc = GetDocPointer();
+	
+	AddRefDocument(doc);
 	BufferID id = MainFileManager->bufferFromDocument(doc, false, true);//true, true);	//keep counter on 1
 	Buffer * buf = MainFileManager->getBufferByID(id);
 
@@ -1672,8 +1670,8 @@ BufferID ScintillaEditView::attachDefaultDoc()
 void ScintillaEditView::saveCurrentPos()
 {
 	//Save data so, that the current topline becomes visible again after restoring.
-	int32_t displayedLine = static_cast<int32_t>(execute(SCI_GETFIRSTVISIBLELINE));
-	int32_t docLine = static_cast<int32_t>(execute(SCI_DOCLINEFROMVISIBLE, displayedLine));		//linenumber of the line displayed in the top
+	int32_t displayedLine = static_cast<int32_t>(GetFirstVisibleLine());
+	int32_t docLine = static_cast<int32_t>(DocLineFromVisible(displayedLine));		//linenumber of the line displayed in the top
 	//int offset = displayedLine - execute(SCI_VISIBLEFROMDOCLINE, docLine);		//use this to calc offset of wrap. If no wrap this should be zero
 
 	Buffer * buf = MainFileManager->getBufferByID(_currentBufferID);
@@ -1681,11 +1679,11 @@ void ScintillaEditView::saveCurrentPos()
 	Position pos;
 	// the correct visible line number
 	pos._firstVisibleLine = docLine;
-	pos._startPos = static_cast<int>(execute(SCI_GETANCHOR));
-	pos._endPos = static_cast<int>(execute(SCI_GETCURRENTPOS));
-	pos._xOffset = static_cast<int>(execute(SCI_GETXOFFSET));
-	pos._selMode = static_cast<int32_t>(execute(SCI_GETSELECTIONMODE));
-	pos._scrollWidth = static_cast<int32_t>(execute(SCI_GETSCROLLWIDTH));
+	pos._startPos = GetAnchor();
+	pos._endPos = GetCurrentPos();
+	pos._xOffset = GetXOffset();
+	pos._selMode = GetSelectionMode();
+	pos._scrollWidth = GetScrollWidth();
 
 	buf->setPosition(pos, this);
 }
@@ -1695,26 +1693,27 @@ void ScintillaEditView::restoreCurrentPos()
 	Buffer * buf = MainFileManager->getBufferByID(_currentBufferID);
 	Position & pos = buf->getPosition(this);
 
-	execute(SCI_GOTOPOS, 0);	//make sure first line visible by setting caret there, will scroll to top of document
+	GotoPos(0); //make sure first line visible by setting caret there, will scroll to top of document
 
-	execute(SCI_SETSELECTIONMODE, pos._selMode);	//enable
-	execute(SCI_SETANCHOR, pos._startPos);
-	execute(SCI_SETCURRENTPOS, pos._endPos);
-	execute(SCI_CANCEL);							//disable
+	SetSelectionMode(pos._selMode);	//enable
+	SetAnchor(pos._startPos);
+	SetCurrentPos(pos._endPos);
+	Cancel();						//disable
 	if (not isWrap()) //only offset if not wrapping, otherwise the offset isnt needed at all
 	{
-		execute(SCI_SETSCROLLWIDTH, pos._scrollWidth);
-		execute(SCI_SETXOFFSET, pos._xOffset);
+		SetScrollWidth(pos._scrollWidth);
+		SetXOffset(pos._xOffset);
 	}
-	execute(SCI_CHOOSECARETX); // choose current x position
+	ChooseCaretX(); // choose current x position
 
-	int lineToShow = static_cast<int32_t>(execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine));
+	int lineToShow = VisibleFromDocLine(pos._firstVisibleLine);
+	
 	LineScroll(0, lineToShow);
 }
 
 void ScintillaEditView::restyleBuffer() {
-	execute(SCI_CLEARDOCUMENTSTYLE);
-	execute(SCI_COLOURISE, 0, -1);
+	ClearDocumentStyle();
+	Colourise(0, -1);
 	_currentBuffer->setNeedsLexing(false);
 }
 
@@ -1747,7 +1746,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer)
 	// change the doc, this operation will decrease
 	// the ref count of old current doc and increase the one of the new doc. FileManager should manage the rest
 	// Note that the actual reference in the Buffer itself is NOT decreased, Notepad_plus does that if neccessary
-	execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
+	SetDocPointer(_currentBuffer->getDocument());
 
 	// Due to execute(SCI_CLEARDOCUMENTSTYLE); in defineDocType() function
 	// defineDocType() function should be called here, but not be after the fold info loop
@@ -1768,7 +1767,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer)
 	bufferUpdated(_currentBuffer, (BufferChangeMask & ~BufferChangeLanguage));	//everything should be updated, but the language (which undoes some operations done here like folding)
 
 	//setup line number margin
-	int numLines = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
+	int numLines = GetLineCount();
 
 	char numLineStr[32];
 	itoa(numLines, numLineStr, 10);
@@ -1784,7 +1783,7 @@ void ScintillaEditView::getCurrentFoldStates(std::vector<size_t> & lineStateVect
 	size_t contractedFoldHeaderLine = 0;
 
 	do {
-		contractedFoldHeaderLine = static_cast<size_t>(execute(SCI_CONTRACTEDFOLDNEXT, contractedFoldHeaderLine));
+		contractedFoldHeaderLine = static_cast<size_t>(ContractedFoldNext(static_cast<int>(contractedFoldHeaderLine)));
 		if (contractedFoldHeaderLine != -1)
 		{
 			//-- Store contracted line
@@ -1826,11 +1825,11 @@ void ScintillaEditView::bufferUpdated(Buffer * buffer, int mask)
 
 		if (mask & BufferChangeFormat)
 		{
-			execute(SCI_SETEOLMODE, static_cast<int>(_currentBuffer->getEolFormat()));
+			SetEOLMode(static_cast<int>(_currentBuffer->getEolFormat()));
 		}
 		if (mask & BufferChangeReadonly)
 		{
-			execute(SCI_SETREADONLY, _currentBuffer->isReadOnly());
+			SetReadOnly(_currentBuffer->isReadOnly());
 		}
 		if (mask & BufferChangeUnicode)
 		{
@@ -1850,20 +1849,20 @@ void ScintillaEditView::bufferUpdated(Buffer * buffer, int mask)
 			}
 			else	//CP UTF8 for all unicode
 				enc = SC_CP_UTF8;
-            execute(SCI_SETCODEPAGE, enc);
+			SetCodePage(enc);
 		}
 	}
 }
 
 void ScintillaEditView::collapse(int level2Collapse, bool mode)
 {
-	execute(SCI_COLOURISE, 0, -1);
+	Colourise(0, -1);
 
-	int maxLine = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
+	int maxLine = GetLineCount();
 
 	for (int line = 0; line < maxLine; ++line)
 	{
-		int level = static_cast<int32_t>(execute(SCI_GETFOLDLEVEL, line));
+		int level = GetFoldLevel(line);
 		if (level & SC_FOLDLEVELHEADERFLAG)
 		{
 			level -= SC_FOLDLEVELBASE;
@@ -1886,27 +1885,27 @@ void ScintillaEditView::foldCurrentPos(bool mode)
 
 void ScintillaEditView::fold(size_t line, bool mode)
 {
-    auto endStyled = execute(SCI_GETENDSTYLED);
-    auto len = execute(SCI_GETTEXTLENGTH);
+	auto endStyled = GetEndStyled();
+	auto len = GetTextLength();
 
     if (endStyled < len)
-        execute(SCI_COLOURISE, 0, -1);
+       Colourise(0, -1);
 
 	int headerLine;
-	auto level = execute(SCI_GETFOLDLEVEL, line);
+	auto level = GetFoldLevel(static_cast<int>(line));
 
 	if (level & SC_FOLDLEVELHEADERFLAG)
-		headerLine = static_cast<int32_t>(line);
+		headerLine = static_cast<int>(line);
 	else
 	{
-		headerLine = static_cast<int32_t>(execute(SCI_GETFOLDPARENT, line));
+		headerLine = GetFoldParent(static_cast<int>(line));
 		if (headerLine == -1)
 			return;
 	}
 
 	if (isFolded(headerLine) != mode)
 	{
-		execute(SCI_TOGGLEFOLD, headerLine);
+		ToggleFold(headerLine);
 
 		SCNotification scnN;
 		scnN.nmhdr.code = SCN_FOLDINGSTATECHANGED;
@@ -1921,11 +1920,11 @@ void ScintillaEditView::fold(size_t line, bool mode)
 
 void ScintillaEditView::foldAll(bool mode)
 {
-	auto maxLine = execute(SCI_GETLINECOUNT);
+	auto maxLine = GetLineCount();
 
 	for (int line = 0; line < maxLine; ++line)
 	{
-		auto level = execute(SCI_GETFOLDLEVEL, line);
+		auto level = GetFoldLevel(line);
 		if (level & SC_FOLDLEVELHEADERFLAG)
 			if (isFolded(line) != mode)
 				fold(line, mode);
@@ -1938,7 +1937,7 @@ void ScintillaEditView::getText(char *dest, size_t start, size_t end) const
 	tr.chrg.cpMin = static_cast<long>(start);
 	tr.chrg.cpMax = static_cast<long>(end);
 	tr.lpstrText = dest;
-	execute(SCI_GETTEXTRANGE, 0, reinterpret_cast<LPARAM>(&tr));
+	GetTextRange(&tr);
 }
 
 generic_string ScintillaEditView::getGenericTextAsString(size_t start, size_t end) const
@@ -1957,7 +1956,7 @@ void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, size_t start
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 	char *destA = new char[end - start + 1];
 	getText(destA, start, end);
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const TCHAR *destW = wmc->char2wchar(destA, cp);
 	_tcsncpy_s(dest, destlen, destW, _TRUNCATE);
 	delete [] destA;
@@ -1971,7 +1970,7 @@ void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, int start, i
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 	char *destA = new char[end - start + 1];
 	getText(destA, start, end);
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE))    ;
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const TCHAR *destW = wmc->char2wchar(destA, cp, mstart, mend);
 	_tcsncpy_s(dest, destlen, destW, _TRUNCATE);
 	delete [] destA;
@@ -1980,28 +1979,28 @@ void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, int start, i
 void ScintillaEditView::insertGenericTextFrom(size_t position, const TCHAR *text2insert) const
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *text2insertA = wmc->wchar2char(text2insert, cp);
-	execute(SCI_INSERTTEXT, position, reinterpret_cast<LPARAM>(text2insertA));
+	InsertText(static_cast<int>(position), text2insertA);
 }
 
 void ScintillaEditView::replaceSelWith(const char * replaceText)
 {
-	execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(replaceText));
+	ReplaceSel(replaceText);
 }
 
 void ScintillaEditView::getVisibleStartAndEndPosition(int * startPos, int * endPos)
 {
 	assert(startPos != NULL && endPos != NULL);
 
-	auto firstVisibleLine = execute(SCI_GETFIRSTVISIBLELINE);
-	*startPos = static_cast<int32_t>(execute(SCI_POSITIONFROMLINE, execute(SCI_DOCLINEFROMVISIBLE, firstVisibleLine)));
-	auto linesOnScreen = execute(SCI_LINESONSCREEN);
-	auto lineCount = execute(SCI_GETLINECOUNT);
-	auto visibleLine = execute(SCI_DOCLINEFROMVISIBLE, firstVisibleLine + min(linesOnScreen, lineCount));
-	*endPos = static_cast<int32_t>(execute(SCI_POSITIONFROMLINE, visibleLine));
-	if (*endPos == -1) 
-		*endPos = static_cast<int32_t>(execute(SCI_GETLENGTH));
+	auto firstVisibleLine = GetFirstVisibleLine();;
+	*startPos = PositionFromLine(DocLineFromVisible(firstVisibleLine));
+	auto linesOnScreen = LinesOnScreen();
+	auto lineCount = GetLineCount();
+	auto visibleLine = DocLineFromVisible(firstVisibleLine + min(linesOnScreen, lineCount));
+	*endPos = PositionFromLine(visibleLine);
+	if (*endPos == -1)
+		*endPos = GetLength();
 }
 
 char * ScintillaEditView::getWordFromRange(char * txt, int size, int pos1, int pos2)
@@ -2034,7 +2033,7 @@ char * ScintillaEditView::getWordOnCaretPos(char * txt, int size)
 TCHAR * ScintillaEditView::getGenericWordOnCaretPos(TCHAR * txt, int size)
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	char *txtA = new char[size + 1];
 	getWordOnCaretPos(txtA, size);
 
@@ -2065,7 +2064,7 @@ char * ScintillaEditView::getSelectedText(char * txt, int size, bool expand)
 TCHAR * ScintillaEditView::getGenericSelectedText(TCHAR * txt, int size, bool expand)
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	char *txtA = new char[size + 1];
 	getSelectedText(txtA, size, expand);
 
@@ -2077,83 +2076,84 @@ TCHAR * ScintillaEditView::getGenericSelectedText(TCHAR * txt, int size, bool ex
 
 int ScintillaEditView::searchInTarget(const TCHAR * text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const
 {
-	execute(SCI_SETTARGETRANGE, fromPos, toPos);
+	SetTargetRange(static_cast<int>(fromPos), static_cast<int>(toPos));
 
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *text2FindA = wmc->wchar2char(text2Find, cp);
 	size_t text2FindALen = strlen(text2FindA);
-   	size_t len = (lenOfText2Find > text2FindALen) ? lenOfText2Find : text2FindALen;
-	return static_cast<int32_t>(execute(SCI_SEARCHINTARGET, len, reinterpret_cast<LPARAM>(text2FindA)));
+	size_t len = (lenOfText2Find > text2FindALen) ? lenOfText2Find : text2FindALen;
+	return SearchInTarget(static_cast<int>(len), text2FindA);
 }
 
 void ScintillaEditView::appandGenericText(const TCHAR * text2Append) const
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *text2AppendA =wmc->wchar2char(text2Append, cp);
-	execute(SCI_APPENDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
+	AppendText(static_cast<int>(strlen(text2AppendA)), text2AppendA);
 }
 
 void ScintillaEditView::addGenericText(const TCHAR * text2Append) const
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *text2AppendA =wmc->wchar2char(text2Append, cp);
-	execute(SCI_ADDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
+	AddText(static_cast<int>(strlen(text2AppendA)), text2AppendA);
 }
 
 void ScintillaEditView::addGenericText(const TCHAR * text2Append, long *mstart, long *mend) const
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *text2AppendA =wmc->wchar2char(text2Append, cp, mstart, mend);
-	execute(SCI_ADDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
+	AddText(static_cast<int>(strlen(text2AppendA)), text2AppendA);
 }
 
 int32_t ScintillaEditView::replaceTarget(const TCHAR * str2replace, int fromTargetPos, int toTargetPos) const
 {
 	if (fromTargetPos != -1 || toTargetPos != -1)
 	{
-		execute(SCI_SETTARGETRANGE, fromTargetPos, toTargetPos);
+		SetTargetRange(fromTargetPos, toTargetPos);
 	}
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *str2replaceA = wmc->wchar2char(str2replace, cp);
-	return static_cast<int32_t>(execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(str2replaceA)));
+	return static_cast<int32_t>(ReplaceTarget(-1, str2replaceA));
 }
 
 int ScintillaEditView::replaceTargetRegExMode(const TCHAR * re, int fromTargetPos, int toTargetPos) const
 {
 	if (fromTargetPos != -1 || toTargetPos != -1)
 	{
-		execute(SCI_SETTARGETRANGE, fromTargetPos, toTargetPos);
+		SetTargetRange(fromTargetPos, toTargetPos);
+
 	}
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *reA = wmc->wchar2char(re, cp);
-	return static_cast<int32_t>(execute(SCI_REPLACETARGETRE, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(reA)));
+	return ReplaceTargetRE(-1, reA);
 }
 
 void ScintillaEditView::showAutoComletion(size_t lenEntered, const TCHAR* list)
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *listA = wmc->wchar2char(list, cp);
-	execute(SCI_AUTOCSHOW, lenEntered, reinterpret_cast<LPARAM>(listA));
+	AutoCShow(static_cast<int>(lenEntered), listA);
 }
 
 void ScintillaEditView::showCallTip(int startPos, const TCHAR * def)
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	const char *defA = wmc->wchar2char(def, cp);
-	execute(SCI_CALLTIPSHOW, startPos, reinterpret_cast<LPARAM>(defA));
+	CallTipShow(startPos, defA);
 }
 
 generic_string ScintillaEditView::getLine(size_t lineNumber)
 {
-	int32_t lineLen = static_cast<int32_t>(execute(SCI_LINELENGTH, lineNumber));
+	int32_t lineLen = static_cast<int32_t>(LineLength(static_cast<int>(lineNumber)));
 	const int bufSize = lineLen + 1;
 	std::unique_ptr<TCHAR[]> buf = std::make_unique<TCHAR[]>(bufSize);
 	getLine(lineNumber, buf.get(), bufSize);
@@ -2163,11 +2163,11 @@ generic_string ScintillaEditView::getLine(size_t lineNumber)
 void ScintillaEditView::getLine(size_t lineNumber, TCHAR * line, int lineBufferLen)
 {
 	WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	UINT cp = static_cast<UINT>(GetCodePage());
 	char *lineA = new char[lineBufferLen];
 	// From Scintilla documentation for SCI_GETLINE: "The buffer is not terminated by a 0 character."
 	memset(lineA, 0x0, sizeof(char) * lineBufferLen);
-	execute(SCI_GETLINE, lineNumber, reinterpret_cast<LPARAM>(lineA));
+	GetLine(static_cast<int>(lineNumber), lineA);
 	const TCHAR *lineW = wmc->char2wchar(lineA, cp);
 	lstrcpyn(line, lineW, lineBufferLen);
 	delete [] lineA;
@@ -2175,18 +2175,18 @@ void ScintillaEditView::getLine(size_t lineNumber, TCHAR * line, int lineBufferL
 
 void ScintillaEditView::addText(size_t length, const char *buf)
 {
-	execute(SCI_ADDTEXT, length, reinterpret_cast<LPARAM>(buf));
+	AddText(static_cast<int>(length), buf);
 }
 
 void ScintillaEditView::beginOrEndSelect()
 {
 	if (_beginSelectPosition == -1)
 	{
-		_beginSelectPosition = static_cast<int32_t>(execute(SCI_GETCURRENTPOS));
+		_beginSelectPosition = GetCurrentPos();
 	}
 	else
 	{
-		execute(SCI_SETANCHOR, _beginSelectPosition);
+		SetAnchor(_beginSelectPosition);
 		_beginSelectPosition = -1;
 	}
 }
@@ -2206,14 +2206,14 @@ void ScintillaEditView::updateBeginEndSelectPosition(const bool is_insert, const
 
 void ScintillaEditView::marginClick(int position, int modifiers)
 {
-	int lineClick = int(execute(SCI_LINEFROMPOSITION, position, 0));
-	int levelClick = int(execute(SCI_GETFOLDLEVEL, lineClick, 0));
+	int lineClick = LineFromPosition(position);
+	int levelClick = GetFoldLevel(lineClick);
 	if (levelClick & SC_FOLDLEVELHEADERFLAG)
     {
 		if (modifiers & SCMOD_SHIFT)
         {
 			// Ensure all children visible
-			execute(SCI_SETFOLDEXPANDED, lineClick, 1);
+			SetFoldExpanded(lineClick, true);
 			expand(lineClick, true, true, 100, levelClick);
 		}
         else if (modifiers & SCMOD_CTRL)
@@ -2221,13 +2221,13 @@ void ScintillaEditView::marginClick(int position, int modifiers)
 			if (isFolded(lineClick))
             {
 				// Contract this line and all children
-				execute(SCI_SETFOLDEXPANDED, lineClick, 0);
+				SetFoldExpanded(lineClick, false);
 				expand(lineClick, false, true, 0, levelClick);
 			}
             else
             {
 				// Expand this line and all children
-				execute(SCI_SETFOLDEXPANDED, lineClick, 1);
+				SetFoldExpanded(lineClick, true);
 				expand(lineClick, true, true, 100, levelClick);
 			}
 		}
@@ -2243,32 +2243,35 @@ void ScintillaEditView::marginClick(int position, int modifiers)
 
 void ScintillaEditView::expand(int &line, bool doExpand, bool force, int visLevels, int level)
 {
-	int lineMaxSubord = int(execute(SCI_GETLASTCHILD, line, level & SC_FOLDLEVELNUMBERMASK));
+	int lineMaxSubord = GetLastChild(line, level & SC_FOLDLEVELNUMBERMASK);
 	++line;
 	while (line <= lineMaxSubord)
     {
 		if (force)
         {
-			execute(((visLevels > 0) ? SCI_SHOWLINES : SCI_HIDELINES), line, line);
+			if (visLevels > 0)
+				ShowLines(line, line);
+			else
+				HideLines(line, line);
 		}
         else
         {
 			if (doExpand)
-				execute(SCI_SHOWLINES, line, line);
+				ShowLines(line, line);
 		}
 
 		int levelLine = level;
 		if (levelLine == -1)
-			levelLine = int(execute(SCI_GETFOLDLEVEL, line, 0));
+			levelLine = GetFoldLevel(line);
 
 		if (levelLine & SC_FOLDLEVELHEADERFLAG)
         {
 			if (force)
             {
 				if (visLevels > 1)
-					execute(SCI_SETFOLDEXPANDED, line, 1);
+					SetFoldExpanded(line, true);
 				else
-					execute(SCI_SETFOLDEXPANDED, line, 0);
+					SetFoldExpanded(line, false);
 				expand(line, doExpand, force, visLevels - 1);
 			}
             else
@@ -2276,7 +2279,7 @@ void ScintillaEditView::expand(int &line, bool doExpand, bool force, int visLeve
 				if (doExpand)
                 {
 					if (!isFolded(line))
-						execute(SCI_SETFOLDEXPANDED, line, 1);
+						SetFoldExpanded(line, true);
 
 					expand(line, true, force, visLevels - 1);
 				}
@@ -2300,7 +2303,7 @@ void ScintillaEditView::performGlobalStyles()
 	if (i != -1)
 	{
 		Style & style = stylers.getStyler(i);
-		execute(SCI_SETCARETLINEBACK, style._bgColor);
+		SetCaretLineBack(style._bgColor);
 	}
 
     COLORREF selectColorBack = grey;
@@ -2311,7 +2314,7 @@ void ScintillaEditView::performGlobalStyles()
         Style & style = stylers.getStyler(i);
 		selectColorBack = style._bgColor;
     }
-	execute(SCI_SETSELBACK, 1, selectColorBack);
+	SetSelBack(true, selectColorBack);
 
     COLORREF caretColor = black;
 	i = stylers.getStylerIndexByID(SCI_SETCARETFORE);
@@ -2320,7 +2323,7 @@ void ScintillaEditView::performGlobalStyles()
         Style & style = stylers.getStyler(i);
         caretColor = style._fgColor;
     }
-    execute(SCI_SETCARETFORE, caretColor);
+	SetCaretFore(caretColor);
 
 	COLORREF edgeColor = liteGrey;
 	i = stylers.getStylerIndexByName(TEXT("Edge colour"));
@@ -2329,7 +2332,7 @@ void ScintillaEditView::performGlobalStyles()
 		Style & style = stylers.getStyler(i);
 		edgeColor = style._fgColor;
 	}
-	execute(SCI_SETEDGECOLOUR, edgeColor);
+	SetEdgeColour(edgeColor);
 
 	COLORREF foldMarginColor = grey;
 	COLORREF foldMarginHiColor = white;
@@ -2340,8 +2343,8 @@ void ScintillaEditView::performGlobalStyles()
 		foldMarginHiColor = style._fgColor;
 		foldMarginColor = style._bgColor;
 	}
-	execute(SCI_SETFOLDMARGINCOLOUR, true, foldMarginColor);
-	execute(SCI_SETFOLDMARGINHICOLOUR, true, foldMarginHiColor);
+	SetFoldMarginColour(true, foldMarginColor);
+	SetFoldMarginHiColour(true, foldMarginHiColor);
 
 	COLORREF foldfgColor = white, foldbgColor = grey, activeFoldFgColor = red;
 	getFoldColor(foldfgColor, foldbgColor, activeFoldFgColor);
@@ -2350,7 +2353,7 @@ void ScintillaEditView::performGlobalStyles()
 	for (int j = 0 ; j < NB_FOLDER_STATE ; ++j)
 		defineMarker(_markersArray[FOLDER_TYPE][j], _markersArray[svp._folderStyle][j], foldfgColor, foldbgColor, activeFoldFgColor);
 
-	execute(SCI_MARKERENABLEHIGHLIGHT, true);
+	MarkerEnableHighlight(true);
 
 	COLORREF wsSymbolFgColor = black;
 	i = stylers.getStylerIndexByName(TEXT("White space symbol"));
@@ -2359,16 +2362,16 @@ void ScintillaEditView::performGlobalStyles()
 		Style & style = stylers.getStyler(i);
 		wsSymbolFgColor = style._fgColor;
 	}
-	execute(SCI_SETWHITESPACEFORE, true, wsSymbolFgColor);
+	SetWhitespaceFore(true, wsSymbolFgColor);
 }
 
 void ScintillaEditView::setLineIndent(int line, int indent) const {
 	if (indent < 0)
 		return;
 	CharacterRange crange = getSelection();
-	int posBefore = static_cast<int32_t>(execute(SCI_GETLINEINDENTPOSITION, line));
-	execute(SCI_SETLINEINDENTATION, line, indent);
-	int32_t posAfter = static_cast<int32_t>(execute(SCI_GETLINEINDENTPOSITION, line));
+	int posBefore = GetLineIndentPosition(line);
+	SetLineIndentation(line, indent);
+	int32_t posAfter = static_cast<int32_t>(GetLineIndentPosition(line));
 	int posDifference = posAfter - posBefore;
 	if (posAfter > posBefore) {
 		// Move selection on
@@ -2393,26 +2396,26 @@ void ScintillaEditView::setLineIndent(int line, int indent) const {
 				crange.cpMax = posAfter;
 		}
 	}
-	execute(SCI_SETSEL, crange.cpMin, crange.cpMax);
+	SetSel(crange.cpMin, crange.cpMax);
 }
 
 void ScintillaEditView::updateLineNumberWidth()
 {
 	if (_lineNumbersShown)
 	{
-		auto linesVisible = execute(SCI_LINESONSCREEN);
+		auto linesVisible = LinesOnScreen();
 		if (linesVisible)
 		{
-			auto firstVisibleLineVis = execute(SCI_GETFIRSTVISIBLELINE);
+			auto firstVisibleLineVis = GetFirstVisibleLine();
 			auto lastVisibleLineVis = linesVisible + firstVisibleLineVis + 1;
 
-			if (execute(SCI_GETWRAPMODE) != SC_WRAP_NONE)
+			if (GetWrapMode() != SC_WRAP_NONE)
 			{
-				auto numLinesDoc = execute(SCI_GETLINECOUNT);
-				auto prevLineDoc = execute(SCI_DOCLINEFROMVISIBLE, firstVisibleLineVis);
+				auto numLinesDoc = GetLineCount();
+				auto prevLineDoc = DocLineFromVisible(firstVisibleLineVis);
 				for (auto i = firstVisibleLineVis + 1; i <= lastVisibleLineVis; ++i)
 				{
-					auto lineDoc = execute(SCI_DOCLINEFROMVISIBLE, i);
+					auto lineDoc = DocLineFromVisible(i);
 					if (lineDoc == numLinesDoc)
 						break;
 					if (lineDoc == prevLineDoc)
@@ -2421,7 +2424,7 @@ void ScintillaEditView::updateLineNumberWidth()
 				}
 			}
 
-			auto lastVisibleLineDoc = execute(SCI_DOCLINEFROMVISIBLE, lastVisibleLineVis);
+			auto lastVisibleLineDoc = DocLineFromVisible(lastVisibleLineVis);
 			int i = 0;
 
 			while (lastVisibleLineDoc)
@@ -2431,8 +2434,8 @@ void ScintillaEditView::updateLineNumberWidth()
 			}
 
 			i = max(i, 3);
-			auto pixelWidth = 8 + i * execute(SCI_TEXTWIDTH, STYLE_LINENUMBER, reinterpret_cast<LPARAM>("8"));
-			execute(SCI_SETMARGINWIDTHN, _SC_MARGE_LINENUMBER, pixelWidth);
+			auto pixelWidth = 8 + i * TextWidth(STYLE_LINENUMBER, "8");
+			SetMarginWidthN(_SC_MARGE_LINENUMBER, pixelWidth);
 		}
 	}
 }
@@ -2457,15 +2460,15 @@ void ScintillaEditView::setMultiSelections(const ColumnModeInfos & cmi)
 		{
 			int selStart = cmi[i]._direction == L2R?cmi[i]._selLpos:cmi[i]._selRpos;
 			int selEnd   = cmi[i]._direction == L2R?cmi[i]._selRpos:cmi[i]._selLpos;
-			execute(SCI_SETSELECTIONNSTART, i, selStart);
-			execute(SCI_SETSELECTIONNEND, i, selEnd);
+			SetSelectionNStart(static_cast<int>(i), selStart);
+			SetSelectionNEnd(static_cast<int>(i), selEnd);
 		}
 		//if (cmi[i].hasVirtualSpace())
 		//{
 		if (cmi[i]._nbVirtualAnchorSpc)
-			execute(SCI_SETSELECTIONNANCHORVIRTUALSPACE, i, cmi[i]._nbVirtualAnchorSpc);
+			SetSelectionNAnchorVirtualSpace(static_cast<int>(i), cmi[i]._nbVirtualAnchorSpc);
 		if (cmi[i]._nbVirtualCaretSpc)
-			execute(SCI_SETSELECTIONNCARETVIRTUALSPACE, i, cmi[i]._nbVirtualCaretSpc);
+			SetSelectionNCaretVirtualSpace(static_cast<int>(i), cmi[i]._nbVirtualCaretSpc);
 		//}
 	}
 }
@@ -2475,28 +2478,28 @@ void ScintillaEditView::setMultiSelections(const ColumnModeInfos & cmi)
 pair<int, int> ScintillaEditView::getSelectionLinesRange() const
 {
     pair<int, int> range(-1, -1);
-    if (execute(SCI_GETSELECTIONS) > 1) // multi-selection
+    if (GetSelections() > 1) // multi-selection
         return range;
-	int32_t start = static_cast<int32_t>(execute(SCI_GETSELECTIONSTART));
-	int32_t end = static_cast<int32_t>(execute(SCI_GETSELECTIONEND));
+	int start = GetSelectionStart();
+	int end = GetSelectionEnd();
 
-	range.first = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, start));
-	range.second = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, end));
+	range.first = LineFromPosition(start);
+	range.second = LineFromPosition(end);
 
     return range;
 }
 
 void ScintillaEditView::currentLinesUp() const
 {
-	execute(SCI_MOVESELECTEDLINESUP);
+	MoveSelectedLinesUp();
 }
 
 void ScintillaEditView::currentLinesDown() const
 {
-	execute(SCI_MOVESELECTEDLINESDOWN);
+	MoveSelectedLinesDown();
 
 	// Ensure the selection is within view
-	execute(SCI_SCROLLRANGE, execute(SCI_GETSELECTIONEND), execute(SCI_GETSELECTIONSTART));
+	ScrollRange(GetSelectionEnd(), GetSelectionStart());
 }
 
 void ScintillaEditView::changeCase(__inout wchar_t * const strWToConvert, const int & nbChars, const TextCase & caseToConvert) const
@@ -2628,9 +2631,9 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 	if (um != uni8Bit)
 	codepage = CP_UTF8;
 
-	if (execute(SCI_GETSELECTIONS) > 1) // Multi-Selection || Column mode
+	if (GetSelections() > 1) // Multi-Selection || Column mode
 	{
-        execute(SCI_BEGINUNDOACTION);
+		BeginUndoAction();
 
 		ColumnModeInfos cmi = getColumnModeSelectInfo();
 
@@ -2650,8 +2653,8 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 
 			::WideCharToMultiByte(codepage, 0, destStr, len, srcStr, len, NULL, NULL);
 
-			execute(SCI_SETTARGETRANGE, start, end);
-			execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(srcStr));
+			SetTargetRange(start, end);
+			ReplaceTarget(-1, srcStr);
 
 			delete [] srcStr;
 			delete [] destStr;
@@ -2659,12 +2662,12 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 
 		setMultiSelections(cmi);
 
-		execute(SCI_ENDUNDOACTION);
+		EndUndoAction();
 		return;
 	}
 
-	size_t selectionStart = execute(SCI_GETSELECTIONSTART);
-	size_t selectionEnd = execute(SCI_GETSELECTIONEND);
+	size_t selectionStart = GetSelectionStart();
+	size_t selectionEnd = GetSelectionEnd();
 
 	int32_t strLen = static_cast<int32_t>(selectionEnd - selectionStart);
 	if (strLen)
@@ -2674,7 +2677,7 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 		int strWSize = strSize * 2;
 		wchar_t *selectedStrW = new wchar_t[strWSize+3];
 
-		execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selectedStr));
+		GetSelText(selectedStr);
 
 		int nbChar = ::MultiByteToWideChar(codepage, 0, selectedStr, strSize, selectedStrW, strWSize);
 
@@ -2682,9 +2685,9 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 
 		::WideCharToMultiByte(codepage, 0, selectedStrW, strWSize, selectedStr, strSize, NULL, NULL);
 
-		execute(SCI_SETTARGETRANGE, selectionStart, selectionEnd);
-		execute(SCI_REPLACETARGET, strLen, reinterpret_cast<LPARAM>(selectedStr));
-		execute(SCI_SETSEL, selectionStart, selectionEnd);
+		SetTargetRange(static_cast<int>(selectionStart), static_cast<int>(selectionEnd));
+		ReplaceTarget(strLen, selectedStr);
+		SetSel(static_cast<int>(selectionStart), static_cast<int>(selectionEnd));
 		delete [] selectedStr;
 		delete [] selectedStrW;
 	}
@@ -2694,9 +2697,9 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 
 pair<int, int> ScintillaEditView::getWordRange()
 {
-    auto caretPos = execute(SCI_GETCURRENTPOS, 0, 0);
-	int startPos = static_cast<int>(execute(SCI_WORDSTARTPOSITION, caretPos, true));
-	int endPos = static_cast<int>(execute(SCI_WORDENDPOSITION, caretPos, true));
+    auto caretPos = GetCurrentPos();
+	int startPos = WordStartPosition(caretPos, true);
+	int endPos = WordEndPosition(caretPos, true);
     return pair<int, int>(startPos, endPos);
 }
 
@@ -2704,8 +2707,8 @@ bool ScintillaEditView::expandWordSelection()
 {
     pair<int, int> wordRange = 	getWordRange();
     if (wordRange.first != wordRange.second) {
-        execute(SCI_SETSELECTIONSTART, wordRange.first);
-        execute(SCI_SETSELECTIONEND, wordRange.second);
+		SetSelectionStart(wordRange.first);
+		SetSelectionEnd(wordRange.second);
 		return true;
 	}
 	return false;
@@ -2774,18 +2777,18 @@ TCHAR * int2str(TCHAR *str, int strLen, int number, int base, int nbChiffre, boo
 ColumnModeInfos ScintillaEditView::getColumnModeSelectInfo()
 {
 	ColumnModeInfos columnModeInfos;
-	if (execute(SCI_GETSELECTIONS) > 1) // Multi-Selection || Column mode
+	if (GetSelections() > 1) // Multi-Selection || Column mode
 	{
-		int nbSel = static_cast<int32_t>(execute(SCI_GETSELECTIONS));
+		int nbSel = GetSelections();
 
 		for (int i = 0 ; i < nbSel ; ++i)
 		{
-			int absPosSelStartPerLine = static_cast<int32_t>(execute(SCI_GETSELECTIONNANCHOR, i));
-			int absPosSelEndPerLine = static_cast<int32_t>(execute(SCI_GETSELECTIONNCARET, i));
-			int nbVirtualAnchorSpc = static_cast<int32_t>(execute(SCI_GETSELECTIONNANCHORVIRTUALSPACE, i));
-			int nbVirtualCaretSpc = static_cast<int32_t>(execute(SCI_GETSELECTIONNCARETVIRTUALSPACE, i));
+			int absPosSelStartPerLine = GetSelectionNAnchor(i);
+			int absPosSelEndPerLine = GetSelectionNCaret(i);
+			int nbVirtualAnchorSpc = GetSelectionNAnchorVirtualSpace(i);
+			int nbVirtualCaretSpc = GetSelectionNCaretVirtualSpace(i);
 
-			if (absPosSelStartPerLine == absPosSelEndPerLine && execute(SCI_SELECTIONISRECTANGLE))
+			if (absPosSelStartPerLine == absPosSelEndPerLine && SelectionIsRectangle())
 			{
 				bool dir = nbVirtualAnchorSpc<nbVirtualCaretSpc?L2R:R2L;
 				columnModeInfos.push_back(ColumnModeInfo(absPosSelStartPerLine, absPosSelEndPerLine, i, dir, nbVirtualAnchorSpc, nbVirtualCaretSpc));
@@ -2817,18 +2820,18 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, const TCHAR *str)
 			{
 				for (int j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
 				{
-					execute(SCI_INSERTTEXT, k, reinterpret_cast<LPARAM>(" "));
+					InsertText(k, " ");
 				}
 				cmi[i]._selLpos += cmi[i]._nbVirtualAnchorSpc;
 				cmi[i]._selRpos += cmi[i]._nbVirtualCaretSpc;
 			}
 
-			execute(SCI_SETTARGETRANGE, cmi[i]._selLpos, cmi[i]._selRpos);
+			SetTargetRange(cmi[i]._selLpos, cmi[i]._selRpos);
 
 			WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-			UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+			UINT cp = static_cast<UINT>(GetCodePage());
 			const char *strA = wmc->wchar2char(str, cp);
-			execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(strA));
+			ReplaceTarget(-1, strA);
 
 			if (hasVirtualSpc)
 			{
@@ -2925,17 +2928,17 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 			{
 				for (int j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
 				{
-					execute(SCI_INSERTTEXT, k, reinterpret_cast<LPARAM>(" "));
+					InsertText(k, " ");
 				}
 				cmi[i]._selLpos += cmi[i]._nbVirtualAnchorSpc;
 				cmi[i]._selRpos += cmi[i]._nbVirtualCaretSpc;
 			}
-			execute(SCI_SETTARGETRANGE, cmi[i]._selLpos, cmi[i]._selRpos);
+			SetTargetRange(cmi[i]._selLpos, cmi[i]._selRpos);
 
 			WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
-			UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+			UINT cp = static_cast<UINT>(GetCodePage());
 			const char *strA = wmc->wchar2char(str, cp);
-			execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(strA));
+			ReplaceTarget(-1, strA);
 
 			if (hasVirtualSpc)
 			{
@@ -2961,7 +2964,7 @@ void ScintillaEditView::foldChanged(int line, int levelNow, int levelPrev)
 		if (!(levelPrev & SC_FOLDLEVELHEADERFLAG))	//but previously couldnt
 		{
 			// Adding a fold point.
-			execute(SCI_SETFOLDEXPANDED, line, 1);
+			SetFoldExpanded(line, true);
 			expand(line, true, false, 0, levelPrev);
 		}
 	}
@@ -2971,7 +2974,7 @@ void ScintillaEditView::foldChanged(int line, int levelNow, int levelPrev)
 		{
 			// Removing the fold from one that has been contracted so should expand
 			// otherwise lines are left invisible with no way to make them visible
-			execute(SCI_SETFOLDEXPANDED, line, 1);
+			SetFoldExpanded(line, true);
 			expand(line, true, false, 0, levelPrev);
 		}
 	}
@@ -2979,22 +2982,22 @@ void ScintillaEditView::foldChanged(int line, int levelNow, int levelPrev)
 	        ((levelPrev & SC_FOLDLEVELNUMBERMASK) > (levelNow & SC_FOLDLEVELNUMBERMASK)))
 	{
 		// See if should still be hidden
-		int parentLine = static_cast<int32_t>(execute(SCI_GETFOLDPARENT, line));
-		if ((parentLine < 0) || !isFolded(parentLine && execute(SCI_GETLINEVISIBLE, parentLine)))
-			execute(SCI_SHOWLINES, line, line);
+		int parentLine = GetFoldParent(line);
+		if ((parentLine < 0) || !isFolded(parentLine && GetLineVisible(parentLine)))
+			ShowLines(line, line);
 	}
 }
 
 
 void ScintillaEditView::scrollPosToCenter(size_t pos)
 {
-	execute(SCI_GOTOPOS, pos);
-	int line = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, pos));
+	GotoPos(static_cast<int>(pos));
+	int line = LineFromPosition(static_cast<int>(pos));
 
-	int firstVisibleDisplayLine = static_cast<int32_t>(execute(SCI_GETFIRSTVISIBLELINE));
-	int firstVisibleDocLine = static_cast<int32_t>(execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine));
-	int nbLine = static_cast<int32_t>(execute(SCI_LINESONSCREEN, firstVisibleDisplayLine));
-	int lastVisibleDocLine = static_cast<int32_t>(execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine + nbLine));
+	int firstVisibleDisplayLine = GetFirstVisibleLine();
+	int firstVisibleDocLine = DocLineFromVisible(firstVisibleDisplayLine);
+	int nbLine = LinesOnScreen();
+	int lastVisibleDocLine = DocLineFromVisible(firstVisibleDisplayLine + nbLine);
 
 	int middleLine;
 	if (line - firstVisibleDocLine < lastVisibleDocLine - line)
@@ -3011,11 +3014,11 @@ void ScintillaEditView::hideLines()
 	//Adding runMarkers(hide, foldstart) directly (folding on single document) can help
 
 	//Special func on buffer. If markers are added, create notification with location of start, and hide bool set to true
-	int startLine = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, execute(SCI_GETSELECTIONSTART)));
-	int endLine = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, execute(SCI_GETSELECTIONEND)));
+	int startLine = LineFromPosition(GetSelectionStart());
+	int endLine = LineFromPosition(GetSelectionEnd());
 	//perform range check: cannot hide very first and very last lines
 	//Offset them one off the edges, and then check if they are within the reasonable
-	int nrLines = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
+	int nrLines = GetLineCount();
 	if (nrLines < 3)
 		return;	//cannot possibly hide anything
 	if (!startLine)
@@ -3029,25 +3032,25 @@ void ScintillaEditView::hideLines()
 	//Hide the lines. We add marks on the outside of the hidden section and hide the lines
 	//execute(SCI_HIDELINES, startLine, endLine);
 	//Add markers
-	execute(SCI_MARKERADD, startLine-1, MARK_HIDELINESBEGIN);
-	execute(SCI_MARKERADD, startLine-1, MARK_HIDELINESUNDERLINE);
-	execute(SCI_MARKERADD, endLine+1, MARK_HIDELINESEND);
+	MarkerAdd(startLine-1, MARK_HIDELINESBEGIN);
+	MarkerAdd(startLine-1, MARK_HIDELINESUNDERLINE);
+	MarkerAdd(endLine+1, MARK_HIDELINESEND);
 
 	//remove any markers in between
 	int scope = 0;
 	for(int i = startLine; i <= endLine; ++i)
 	{
-		auto state = execute(SCI_MARKERGET, i);
+		auto state = MarkerGet(i);
 		bool closePresent = ((state & (1 << MARK_HIDELINESEND)) != 0);	//check close first, then open, since close closes scope
 		bool openPresent = ((state & (1 << MARK_HIDELINESBEGIN | 1 << MARK_HIDELINESUNDERLINE)) != 0);
 		if (closePresent)
 		{
-			execute(SCI_MARKERDELETE, i, MARK_HIDELINESEND);
+			MarkerDelete(i, MARK_HIDELINESEND);
 			if (scope > 0) scope--;
 		}
 		if (openPresent) {
-			execute(SCI_MARKERDELETE, i, MARK_HIDELINESBEGIN);
-			execute(SCI_MARKERDELETE, i, MARK_HIDELINESUNDERLINE);
+			MarkerDelete(i, MARK_HIDELINESBEGIN);
+			MarkerDelete(i, MARK_HIDELINESUNDERLINE);
 			++scope;
 		}
 	}
@@ -3062,7 +3065,7 @@ void ScintillaEditView::hideLines()
 
 bool ScintillaEditView::markerMarginClick(int lineNumber)
 {
-	auto state = execute(SCI_MARKERGET, lineNumber);
+	auto state = MarkerGet(lineNumber);
 	bool openPresent = ((state & (1 << MARK_HIDELINESBEGIN | 1 << MARK_HIDELINESUNDERLINE)) != 0);
 	bool closePresent = ((state & (1 << MARK_HIDELINESEND)) != 0);
 
@@ -3080,7 +3083,7 @@ bool ScintillaEditView::markerMarginClick(int lineNumber)
 		openPresent = false;
 		for(lineNumber--; lineNumber >= 0 && !openPresent; lineNumber--)
 		{
-			state = execute(SCI_MARKERGET, lineNumber);
+			state = MarkerGet(lineNumber);
 			openPresent = ((state & (1 << MARK_HIDELINESBEGIN | 1 << MARK_HIDELINESUNDERLINE)) != 0);
 		}
 
@@ -3128,19 +3131,19 @@ void ScintillaEditView::runMarkers(bool doHide, int searchStart, bool endOfDoc, 
 				Skip to LASTCHILD
 				Set last start to lastchild
 	*/
-	int maxLines = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
+	int maxLines = GetLineCount();
 	if (doHide)
 	{
 		int startHiding = searchStart;
 		bool isInSection = false;
 		for (int i = searchStart; i < maxLines; ++i)
 		{
-			auto state = execute(SCI_MARKERGET, i);
+			auto state = MarkerGet(i);
 			if ( ((state & (1 << MARK_HIDELINESEND)) != 0) )
 			{
 				if (isInSection)
 				{
-					execute(SCI_HIDELINES, startHiding, i-1);
+					HideLines(startHiding, i - 1);
 					if (!endOfDoc)
 					{
 						return;	//done, only single section requested
@@ -3162,11 +3165,11 @@ void ScintillaEditView::runMarkers(bool doHide, int searchStart, bool endOfDoc, 
 		bool isInSection = false;
 		for (int i = searchStart; i < maxLines; ++i)
 		{
-			auto state = execute(SCI_MARKERGET, i);
+			auto state = MarkerGet(i);
 			if ( ((state & (1 << MARK_HIDELINESEND)) != 0) )
 			{
 				if (doDelete)
-					execute(SCI_MARKERDELETE, i, MARK_HIDELINESEND);
+					MarkerDelete(i, MARK_HIDELINESEND);
 				 else if (isInSection)
 				 {
 					if (startShowing >= i)
@@ -3180,7 +3183,7 @@ void ScintillaEditView::runMarkers(bool doHide, int searchStart, bool endOfDoc, 
 							continue;
 						}
 					}
-					execute(SCI_SHOWLINES, startShowing, i-1);
+					ShowLines(startShowing, i-1);
 					if (!endOfDoc)
 					{
 						return;	//done, only single section requested
@@ -3192,8 +3195,8 @@ void ScintillaEditView::runMarkers(bool doHide, int searchStart, bool endOfDoc, 
 			{
 				if (doDelete)
 				{
-					execute(SCI_MARKERDELETE, i, MARK_HIDELINESBEGIN);
-					execute(SCI_MARKERDELETE, i, MARK_HIDELINESUNDERLINE);
+					MarkerDelete(i, MARK_HIDELINESBEGIN);
+					MarkerDelete(i, MARK_HIDELINESUNDERLINE);
 				}
 				else
 				{
@@ -3202,12 +3205,12 @@ void ScintillaEditView::runMarkers(bool doHide, int searchStart, bool endOfDoc, 
 				}
 			}
 
-			auto levelLine = execute(SCI_GETFOLDLEVEL, i, 0);
+			auto levelLine = GetFoldLevel(i);
 			if (levelLine & SC_FOLDLEVELHEADERFLAG)
 			{	//fold section. Dont show lines if fold is closed
 				if (isInSection && !isFolded(i))
 				{
-					execute(SCI_SHOWLINES, startShowing, i);
+					ShowLines(startShowing, i);
 					//startShowing = execute(SCI_GETLASTCHILD, i, (levelLine & SC_FOLDLEVELNUMBERMASK));
 				}
 			}
@@ -3223,18 +3226,18 @@ void ScintillaEditView::setTabSettings(Lang *lang)
 		if (lang->_langID == L_JAVASCRIPT)
 		{
 			Lang *ljs = _pParameter->getLangFromID(L_JS);
-			execute(SCI_SETTABWIDTH, ljs->_tabSize);
-			execute(SCI_SETUSETABS, !ljs->_isTabReplacedBySpace);
+			SetTabWidth(ljs->_tabSize);
+			SetUseTabs(!ljs->_isTabReplacedBySpace);
 			return;
 		}
-        execute(SCI_SETTABWIDTH, lang->_tabSize);
-        execute(SCI_SETUSETABS, !lang->_isTabReplacedBySpace);
+		SetTabWidth(lang->_tabSize);
+		SetUseTabs(!lang->_isTabReplacedBySpace);
     }
     else
     {
         const NppGUI & nppgui = _pParameter->getNppGUI();
-        execute(SCI_SETTABWIDTH, nppgui._tabSize);
-		execute(SCI_SETUSETABS, !nppgui._tabReplacedBySpace);
+		SetTabWidth(nppgui._tabSize);
+		SetUseTabs(!nppgui._tabReplacedBySpace);
     }
 }
 
@@ -3250,19 +3253,19 @@ void ScintillaEditView::insertNewLineAboveCurrentLine()
 	else
 	{
 		const auto eol_length = newline.length();
-		const auto position = static_cast<size_t>(execute(SCI_POSITIONFROMLINE, current_line)) - eol_length;
+		const auto position = PositionFromLine(static_cast<int>(current_line)) - eol_length;
 		insertGenericTextFrom(position, newline.c_str());
 	}
-	execute(SCI_SETEMPTYSELECTION, execute(SCI_POSITIONFROMLINE, current_line));
+	SetEmptySelection(PositionFromLine(static_cast<int>(current_line)));
 }
 
 
 void ScintillaEditView::insertNewLineBelowCurrentLine()
 {
 	generic_string newline = getEOLString();
-	const auto line_count = static_cast<size_t>(execute(SCI_GETLINECOUNT));
+	const auto line_count = GetLineCount();
 	const auto current_line = getCurrentLineNumber();
-	if(current_line == line_count - 1)
+	if(current_line == static_cast<size_t>(line_count - 1))
 	{
 		// Special handling if caret is at last line.
 		appandGenericText(newline.c_str());
@@ -3270,10 +3273,10 @@ void ScintillaEditView::insertNewLineBelowCurrentLine()
 	else
 	{
 		const auto eol_length = newline.length();
-		const auto position = eol_length + execute(SCI_GETLINEENDPOSITION, current_line);
+		const auto position = eol_length + GetLineEndPosition(static_cast<int>(current_line));
 		insertGenericTextFrom(position, newline.c_str());
 	}
-	execute(SCI_SETEMPTYSELECTION, execute(SCI_POSITIONFROMLINE, current_line + 1));
+	SetEmptySelection(PositionFromLine(static_cast<int>(current_line + 1)));
 }
 
 void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, ISorter *pSort)
@@ -3283,11 +3286,11 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, ISorter *pSort
 		return;
 	}
 
-	const auto startPos = execute(SCI_POSITIONFROMLINE, fromLine);
-	const auto endPos = execute(SCI_POSITIONFROMLINE, toLine) + execute(SCI_LINELENGTH, toLine);
+	const auto startPos = PositionFromLine(static_cast<int>(fromLine));
+	const auto endPos = PositionFromLine(static_cast<int>(toLine)) + LineLength(static_cast<int>(toLine));
 	const generic_string text = getGenericTextAsString(startPos, endPos);
 	std::vector<generic_string> splitText = stringSplit(text, getEOLString());
-	const size_t lineCount = execute(SCI_GETLINECOUNT);
+	const size_t lineCount = GetLineCount();
 	const bool sortEntireDocument = toLine == lineCount - 1;
 	if (!sortEntireDocument)
 	{
@@ -3326,7 +3329,7 @@ void ScintillaEditView::changeTextDirection(bool isRTL)
 
 generic_string ScintillaEditView::getEOLString()
 {
-	const int eol_mode = int(execute(SCI_GETEOLMODE));
+	const int eol_mode = GetEOLMode();
 	if (eol_mode == SC_EOL_CRLF)
 	{
 		return TEXT("\r\n");

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -282,20 +282,16 @@ public:
 		return _beginSelectPosition != -1;
 	};
 
-	int getCurrentDocLen() const {
-		return int(execute(SCI_GETLENGTH));
-	};
-
 	CharacterRange getSelection() const {
 		CharacterRange crange;
-		crange.cpMin = long(execute(SCI_GETSELECTIONSTART));
-		crange.cpMax = long(execute(SCI_GETSELECTIONEND));
+		crange.cpMin = long(GetSelectionStart());
+		crange.cpMax = long(GetSelectionEnd());
 		return crange;
 	};
 
 	void getWordToCurrentPos(TCHAR * str, int strLen) const {
-		auto caretPos = execute(SCI_GETCURRENTPOS);
-		auto startPos = execute(SCI_WORDSTARTPOSITION, caretPos, true);
+		auto caretPos = GetCurrentPos();
+		auto startPos = WordStartPosition(caretPos, true);
 
 		str[0] = '\0';
 		if ((caretPos - startPos) < strLen)
@@ -308,10 +304,10 @@ public:
 
     static UserDefineDialog * getUserDefineDlg() {return &_userDefineDlg;};
 
-    void setCaretColorWidth(int color, int width = 1) const {
-        execute(SCI_SETCARETFORE, color);
-        execute(SCI_SETCARETWIDTH, width);
-    };
+	void setCaretColorWidth(int color, int width = 1) const {
+		SetCaretFore(color);
+		SetCaretWidth(width);
+	};
 
 	void beSwitched() {
 		_userDefineDlg.setScintilla(this);
@@ -333,13 +329,13 @@ public:
 				width = NppParameters::getInstance()->_dpiManager.scaleX(100) >= 150 ? 20 : 16;
 			else if (whichMarge == _SC_MARGE_FOLDER)
 				width = NppParameters::getInstance()->_dpiManager.scaleX(100) >= 150 ? 18 : 14;
-			execute(SCI_SETMARGINWIDTHN, whichMarge, willBeShowed ? width : 0);
+			SetMarginWidthN(whichMarge, willBeShowed ? width : 0);
 		}
     };
 
-    bool hasMarginShowed(int witchMarge) {
-		return (execute(SCI_GETMARGINWIDTHN, witchMarge, 0) != 0);
-    };
+	bool hasMarginShowed(int witchMarge) {
+		return (GetMarginWidthN(witchMarge) != 0);
+	};
 
     void updateBeginEndSelectPosition(const bool is_insert, const int position, const int length);
     void marginClick(int position, int modifiers);
@@ -368,108 +364,84 @@ public:
 	void setWrapMode(lineWrapMethod meth) {
 		int mode = (meth == LINEWRAP_ALIGNED)?SC_WRAPINDENT_SAME:\
 				(meth == LINEWRAP_INDENT)?SC_WRAPINDENT_INDENT:SC_WRAPINDENT_FIXED;
-		execute(SCI_SETWRAPINDENTMODE, mode);
+		SetWrapIndentMode(mode);
 	};
 
 
 	void showWSAndTab(bool willBeShowed = true) {
-		execute(SCI_SETVIEWWS, willBeShowed?SCWS_VISIBLEALWAYS:SCWS_INVISIBLE);
-		execute(SCI_SETWHITESPACESIZE, 2, 0);
-	};
-
-	void showEOL(bool willBeShowed = true) {
-		execute(SCI_SETVIEWEOL, willBeShowed);
+		SetViewWS(willBeShowed ? SCWS_VISIBLEALWAYS : SCWS_INVISIBLE);
+		SetWhitespaceSize(2);
 	};
 
 	bool isEolVisible() {
-		return (execute(SCI_GETVIEWEOL) != 0);
+		return (GetViewEOL() != 0);
 	};
+
 	void showInvisibleChars(bool willBeShowed = true) {
 		showWSAndTab(willBeShowed);
-		showEOL(willBeShowed);
+		SetViewEOL(willBeShowed);
 	};
 
 	bool isInvisibleCharsShown() {
-		return (execute(SCI_GETVIEWWS) != 0);
+		return (GetViewWS() != 0);
 	};
 
 	void showIndentGuideLine(bool willBeShowed = true) {
-		execute(SCI_SETINDENTATIONGUIDES, willBeShowed ? SC_IV_LOOKBOTH : SC_IV_NONE);
+		SetIndentationGuides(willBeShowed ? SC_IV_LOOKBOTH : SC_IV_NONE);
 	};
 
 	bool isShownIndentGuide() const {
-		return (execute(SCI_GETINDENTATIONGUIDES) != 0);
+		return (GetIndentationGuides() != 0);
 	};
 
-    void wrap(bool willBeWrapped = true) {
-        execute(SCI_SETWRAPMODE, willBeWrapped);
-    };
+	void wrap(bool willBeWrapped = true) {
+		SetWrapMode(willBeWrapped ? SC_WRAP_WORD : SC_WRAP_NONE);
+	};
 
-    bool isWrap() const {
-        return (execute(SCI_GETWRAPMODE) == SC_WRAP_WORD);
-    };
+	bool isWrap() const {
+		return (GetWrapMode() == SC_WRAP_WORD);
+	};
 
 	bool isWrapSymbolVisible() const {
-		return (execute(SCI_GETWRAPVISUALFLAGS) != SC_WRAPVISUALFLAG_NONE);
+		return (GetWrapVisualFlags() != SC_WRAPVISUALFLAG_NONE);
 	};
 
-    void showWrapSymbol(bool willBeShown = true) {
-		execute(SCI_SETWRAPVISUALFLAGSLOCATION, SC_WRAPVISUALFLAGLOC_DEFAULT);
-		execute(SCI_SETWRAPVISUALFLAGS, willBeShown?SC_WRAPVISUALFLAG_END:SC_WRAPVISUALFLAG_NONE);
-    };
+	void showWrapSymbol(bool willBeShown = true) {
+		SetWrapVisualFlagsLocation(SC_WRAPVISUALFLAGLOC_DEFAULT);
+		SetWrapVisualFlags(willBeShown ? SC_WRAPVISUALFLAG_END : SC_WRAPVISUALFLAG_NONE);
+	};
 
 	size_t getCurrentLineNumber()const {
-		return static_cast<size_t>(execute(SCI_LINEFROMPOSITION, execute(SCI_GETCURRENTPOS)));
+		return static_cast<size_t>(LineFromPosition(GetCurrentPos()));
 	};
 
 	int32_t lastZeroBasedLineNumber() const {
-		auto endPos = execute(SCI_GETLENGTH);
-		return static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, endPos));
+		auto endPos = GetLength();
+		return static_cast<int32_t>(LineFromPosition(endPos));
 	};
 
-	long getCurrentXOffset()const{
-		return long(execute(SCI_GETXOFFSET));
+	int getCurrentPointX() const {
+		return PointXFromPosition(GetCurrentPos());
 	};
 
-	void setCurrentXOffset(long xOffset){
-		execute(SCI_SETXOFFSET,xOffset);
+	int getCurrentPointY() const {
+		return PointYFromPosition(GetCurrentPos());
 	};
 
-	void scroll(int column, int line){
-		execute(SCI_LINESCROLL, column, line);
+	int getCurrentColumnNumber() const {
+		return GetColumn(GetCurrentPos());
 	};
-
-	long getCurrentPointX()const{
-		return long (execute(SCI_POINTXFROMPOSITION, 0, execute(SCI_GETCURRENTPOS)));
-	};
-
-	long getCurrentPointY()const{
-		return long (execute(SCI_POINTYFROMPOSITION, 0, execute(SCI_GETCURRENTPOS)));
-	};
-
-	long getTextHeight()const{
-		return long(execute(SCI_TEXTHEIGHT));
-	};
-
-	void gotoLine(int line){
-		if (line < execute(SCI_GETLINECOUNT))
-			execute(SCI_GOTOLINE,line);
-	};
-
-	long getCurrentColumnNumber() const {
-        return long(execute(SCI_GETCOLUMN, execute(SCI_GETCURRENTPOS)));
-    };
 
 	bool getSelectedCount(int & selByte, int & selLine) const {
 		// return false if it's multi-selection or rectangle selection
-		if ((execute(SCI_GETSELECTIONS) > 1) || execute(SCI_SELECTIONISRECTANGLE))
+		if ((GetSelections() > 1) || SelectionIsRectangle())
 			return false;
-		long pStart = long(execute(SCI_GETSELECTIONSTART));
-		long pEnd = long(execute(SCI_GETSELECTIONEND));
+		int pStart = GetSelectionStart();
+		int pEnd = GetSelectionEnd();
 		selByte = pEnd - pStart;
 
-		long lStart = long(execute(SCI_LINEFROMPOSITION, pStart));
-		long lEnd = long(execute(SCI_LINEFROMPOSITION, pEnd));
+		int lStart = LineFromPosition(pStart);
+		int lEnd = LineFromPosition(pEnd);
 		selLine = lEnd - lStart;
 		if (selLine || selByte)
 			++selLine;
@@ -480,12 +452,12 @@ public:
 	long getUnicodeSelectedLength() const
 	{
 		// return -1 if it's multi-selection or rectangle selection
-		if ((execute(SCI_GETSELECTIONS) > 1) || execute(SCI_SELECTIONISRECTANGLE))
+		if ((GetSelections() > 1) || SelectionIsRectangle())
 			return -1;
-		auto size_selected = execute(SCI_GETSELTEXT);
-		char *selected = new char[size_selected + 1];
-		execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selected));
-		char *c = selected;
+
+		auto text = GetSelText();
+
+		const char *c = text.c_str();
 		long length = 0;
 		while(*c != '\0')
 		{
@@ -493,17 +465,12 @@ public:
 				++length;
 			++c;
 		}
-		delete [] selected;
 		return length;
-    }
+	}
 
 
-	long getLineLength(int line) const {
-		return long(execute(SCI_GETLINEENDPOSITION, line) - execute(SCI_POSITIONFROMLINE, line));
-	};
-
-	long getLineIndent(int line) const {
-		return long(execute(SCI_GETLINEINDENTATION, line));
+	int getLineLength(int line) const {
+		return GetLineEndPosition(line) - PositionFromLine(line);
 	};
 
 	void setLineIndent(int line, int indent) const;
@@ -518,21 +485,21 @@ public:
 		}
 		else
 		{
-			execute(SCI_SETMARGINWIDTHN, _SC_MARGE_LINENUMBER, 0);
+			SetMarginWidthN(_SC_MARGE_LINENUMBER, 0);
 		}
 	}
 
 	void updateLineNumberWidth();
 
 	void setCurrentLineHiLiting(bool isHiliting, COLORREF bgColor) const {
-		execute(SCI_SETCARETLINEVISIBLE, isHiliting);
+		SetCaretLineVisible(isHiliting);
 		if (!isHiliting)
 			return;
-		execute(SCI_SETCARETLINEBACK, bgColor);
+		SetCaretLineBack(bgColor);
 	};
 
 	bool isCurrentLineHiLiting() const {
-		return (execute(SCI_GETCARETLINEVISIBLE) != 0);
+		return (GetCaretLineVisible() != 0);
 	};
 
 	void performGlobalStyles();
@@ -552,7 +519,7 @@ public:
 		if ((NppParameters::getInstance())->isTransparentAvailable())
 			convertSelectedTextTo(LOWERCASE);
 		else
-			execute(SCI_LOWERCASE);
+			LowerCase();
 	};
 
     void convertSelectedTextToUpperCase() {
@@ -560,7 +527,7 @@ public:
 		if ((NppParameters::getInstance())->isTransparentAvailable())
 			convertSelectedTextTo(UPPERCASE);
 		else
-			execute(SCI_UPPERCASE);
+			UpperCase();
 	};
 
 	void convertSelectedTextToNewerCase(const TextCase & caseToConvert) {
@@ -575,7 +542,7 @@ public:
 	void foldAll(bool mode);
 	void fold(size_t line, bool mode);
 	bool isFolded(int line){
-		return (execute(SCI_GETFOLDEXPANDED, line) != 0);
+		return (GetFoldExpanded(line) != 0);
 	};
 	void foldCurrentPos(bool mode);
 	int getCodepage() const {return _codepage;};
@@ -592,9 +559,9 @@ public:
 	void foldChanged(int line, int levelNow, int levelPrev);
 	void clearIndicator(int indicatorNumber) {
 		int docStart = 0;
-		int docEnd = getCurrentDocLen();
-		execute(SCI_SETINDICATORCURRENT, indicatorNumber);
-		execute(SCI_INDICATORCLEARRANGE, docStart, docEnd-docStart);
+		int docEnd = GetLength();
+		SetIndicatorCurrent(indicatorNumber);
+		IndicatorClearRange(docStart, docEnd - docStart);
 	};
 
 	static LanguageName langNames[L_EXTERNAL+1];

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -186,6 +186,15 @@ struct LanguageName {
 
 class ISorter;
 
+#define SCI_UNUSED 0
+
+typedef struct {
+	unsigned char ch;
+	unsigned char style;
+} Cell;
+
+typedef COLORREF Colour;
+
 class ScintillaEditView : public Window
 {
 friend class Finder;
@@ -222,8 +231,9 @@ public:
 
 	virtual void init(HINSTANCE hInst, HWND hPere);
 
-	LRESULT execute(UINT Msg, WPARAM wParam=0, LPARAM lParam=0) const {
-		return _pScintillaFunc(_pScintillaPtr, Msg, wParam, lParam);
+	template<typename T = uptr_t, typename U = sptr_t>
+	inline sptr_t execute(unsigned int Msg, T wParam = 0, U lParam = 0) const {
+		return _pScintillaFunc(_pScintillaPtr, Msg, (uptr_t)wParam, (sptr_t)lParam);
 	};
 
 	void activateBuffer(BufferID buffer);
@@ -647,6 +657,4086 @@ public:
 	void changeTextDirection(bool isRTL);
 	bool isTextDirectionRTL() const;
 
+	void AddText(int length, const char* text) const
+	{
+		execute(SCI_ADDTEXT, length, text);
+	};
+
+	void AddText(const std::string& text) const
+	{
+		execute(SCI_ADDTEXT, text.length(), text.c_str());
+	};
+
+	void AddStyledText(int length, const Cell* c) const
+	{
+		execute(SCI_ADDSTYLEDTEXT, length, c);
+	};
+
+	void InsertText(int pos, const char* text) const
+	{
+		execute(SCI_INSERTTEXT, pos, text);
+	};
+
+	void InsertText(int pos, const std::string& text) const
+	{
+		execute(SCI_INSERTTEXT, pos, text.c_str());
+	};
+
+	void ChangeInsertion(int length, const char* text) const
+	{
+		execute(SCI_CHANGEINSERTION, length, text);
+	};
+
+	void ChangeInsertion(const std::string& text) const
+	{
+		execute(SCI_CHANGEINSERTION, text.length(), text.c_str());
+	};
+
+	void ClearAll() const
+	{
+		execute(SCI_CLEARALL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DeleteRange(int pos, int deleteLength) const
+	{
+		execute(SCI_DELETERANGE, pos, deleteLength);
+	};
+
+	void ClearDocumentStyle() const
+	{
+		execute(SCI_CLEARDOCUMENTSTYLE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int GetLength() const
+	{
+		sptr_t res = execute(SCI_GETLENGTH, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetCharAt(int pos) const
+	{
+		sptr_t res = execute(SCI_GETCHARAT, pos, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetCurrentPos() const
+	{
+		sptr_t res = execute(SCI_GETCURRENTPOS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetAnchor() const
+	{
+		sptr_t res = execute(SCI_GETANCHOR, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetStyleAt(int pos) const
+	{
+		sptr_t res = execute(SCI_GETSTYLEAT, pos, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void Redo() const
+	{
+		execute(SCI_REDO, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetUndoCollection(bool collectUndo) const
+	{
+		execute(SCI_SETUNDOCOLLECTION, collectUndo, SCI_UNUSED);
+	};
+
+	void SelectAll() const
+	{
+		execute(SCI_SELECTALL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetSavePoint() const
+	{
+		execute(SCI_SETSAVEPOINT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int GetStyledText(Sci_TextRange* tr) const
+	{
+		sptr_t res = execute(SCI_GETSTYLEDTEXT, SCI_UNUSED, tr);
+		return static_cast<int>(res);
+	};
+
+	bool CanRedo() const
+	{
+		sptr_t res = execute(SCI_CANREDO, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int MarkerLineFromHandle(int handle) const
+	{
+		sptr_t res = execute(SCI_MARKERLINEFROMHANDLE, handle, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void MarkerDeleteHandle(int handle) const
+	{
+		execute(SCI_MARKERDELETEHANDLE, handle, SCI_UNUSED);
+	};
+
+	bool GetUndoCollection() const
+	{
+		sptr_t res = execute(SCI_GETUNDOCOLLECTION, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int GetViewWS() const
+	{
+		sptr_t res = execute(SCI_GETVIEWWS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetViewWS(int viewWS) const
+	{
+		execute(SCI_SETVIEWWS, viewWS, SCI_UNUSED);
+	};
+
+	int PositionFromPoint(int x, int y) const
+	{
+		sptr_t res = execute(SCI_POSITIONFROMPOINT, x, y);
+		return static_cast<int>(res);
+	};
+
+	int PositionFromPointClose(int x, int y) const
+	{
+		sptr_t res = execute(SCI_POSITIONFROMPOINTCLOSE, x, y);
+		return static_cast<int>(res);
+	};
+
+	void GotoLine(int line) const
+	{
+		execute(SCI_GOTOLINE, line, SCI_UNUSED);
+	};
+
+	void GotoPos(int pos) const
+	{
+		execute(SCI_GOTOPOS, pos, SCI_UNUSED);
+	};
+
+	void SetAnchor(int posAnchor) const
+	{
+		execute(SCI_SETANCHOR, posAnchor, SCI_UNUSED);
+	};
+
+	int GetCurLine(int length, char* text) const
+	{
+		sptr_t res = execute(SCI_GETCURLINE, length, text);
+		return static_cast<int>(res);
+	};
+
+	std::string GetCurLine() const
+	{
+		auto size = execute(SCI_GETCURLINE, SCI_UNUSED, NULL);
+		std::string text(size + 1, '\0');
+		execute(SCI_GETCURLINE, text.length(), &text[0]);
+		trim(text);
+		return text;
+	};
+
+	int GetEndStyled() const
+	{
+		sptr_t res = execute(SCI_GETENDSTYLED, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void ConvertEOLs(int eolMode) const
+	{
+		execute(SCI_CONVERTEOLS, eolMode, SCI_UNUSED);
+	};
+
+	int GetEOLMode() const
+	{
+		sptr_t res = execute(SCI_GETEOLMODE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetEOLMode(int eolMode) const
+	{
+		execute(SCI_SETEOLMODE, eolMode, SCI_UNUSED);
+	};
+
+	void StartStyling(int pos, int mask) const
+	{
+		execute(SCI_STARTSTYLING, pos, mask);
+	};
+
+	void SetStyling(int length, int style) const
+	{
+		execute(SCI_SETSTYLING, length, style);
+	};
+
+	bool GetBufferedDraw() const
+	{
+		sptr_t res = execute(SCI_GETBUFFEREDDRAW, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetBufferedDraw(bool buffered) const
+	{
+		execute(SCI_SETBUFFEREDDRAW, buffered, SCI_UNUSED);
+	};
+
+	void SetTabWidth(int tabWidth) const
+	{
+		execute(SCI_SETTABWIDTH, tabWidth, SCI_UNUSED);
+	};
+
+	int GetTabWidth() const
+	{
+		sptr_t res = execute(SCI_GETTABWIDTH, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void ClearTabStops(int line) const
+	{
+		execute(SCI_CLEARTABSTOPS, line, SCI_UNUSED);
+	};
+
+	void AddTabStop(int line, int x) const
+	{
+		execute(SCI_ADDTABSTOP, line, x);
+	};
+
+	int GetNextTabStop(int line, int x) const
+	{
+		sptr_t res = execute(SCI_GETNEXTTABSTOP, line, x);
+		return static_cast<int>(res);
+	};
+
+	void SetCodePage(int codePage) const
+	{
+		execute(SCI_SETCODEPAGE, codePage, SCI_UNUSED);
+	};
+
+	int GetIMEInteraction() const
+	{
+		sptr_t res = execute(SCI_GETIMEINTERACTION, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetIMEInteraction(int imeInteraction) const
+	{
+		execute(SCI_SETIMEINTERACTION, imeInteraction, SCI_UNUSED);
+	};
+
+	void MarkerDefine(int markerNumber, int markerSymbol) const
+	{
+		execute(SCI_MARKERDEFINE, markerNumber, markerSymbol);
+	};
+
+	void MarkerSetFore(int markerNumber, Colour fore) const
+	{
+		execute(SCI_MARKERSETFORE, markerNumber, fore);
+	};
+
+	void MarkerSetBack(int markerNumber, Colour back) const
+	{
+		execute(SCI_MARKERSETBACK, markerNumber, back);
+	};
+
+	void MarkerSetBackSelected(int markerNumber, Colour back) const
+	{
+		execute(SCI_MARKERSETBACKSELECTED, markerNumber, back);
+	};
+
+	void MarkerEnableHighlight(bool enabled) const
+	{
+		execute(SCI_MARKERENABLEHIGHLIGHT, enabled, SCI_UNUSED);
+	};
+
+	int MarkerAdd(int line, int markerNumber) const
+	{
+		sptr_t res = execute(SCI_MARKERADD, line, markerNumber);
+		return static_cast<int>(res);
+	};
+
+	void MarkerDelete(int line, int markerNumber) const
+	{
+		execute(SCI_MARKERDELETE, line, markerNumber);
+	};
+
+	void MarkerDeleteAll(int markerNumber) const
+	{
+		execute(SCI_MARKERDELETEALL, markerNumber, SCI_UNUSED);
+	};
+
+	int MarkerGet(int line) const
+	{
+		sptr_t res = execute(SCI_MARKERGET, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int MarkerNext(int lineStart, int markerMask) const
+	{
+		sptr_t res = execute(SCI_MARKERNEXT, lineStart, markerMask);
+		return static_cast<int>(res);
+	};
+
+	int MarkerPrevious(int lineStart, int markerMask) const
+	{
+		sptr_t res = execute(SCI_MARKERPREVIOUS, lineStart, markerMask);
+		return static_cast<int>(res);
+	};
+
+	void MarkerDefinePixmap(int markerNumber, const char* pixmap) const
+	{
+		execute(SCI_MARKERDEFINEPIXMAP, markerNumber, pixmap);
+	};
+
+	void MarkerDefinePixmap(int markerNumber, const std::string& pixmap) const
+	{
+		execute(SCI_MARKERDEFINEPIXMAP, markerNumber, pixmap.c_str());
+	};
+
+	void MarkerAddSet(int line, int set) const
+	{
+		execute(SCI_MARKERADDSET, line, set);
+	};
+
+	void MarkerSetAlpha(int markerNumber, int alpha) const
+	{
+		execute(SCI_MARKERSETALPHA, markerNumber, alpha);
+	};
+
+	void SetMarginTypeN(int margin, int marginType) const
+	{
+		execute(SCI_SETMARGINTYPEN, margin, marginType);
+	};
+
+	int GetMarginTypeN(int margin) const
+	{
+		sptr_t res = execute(SCI_GETMARGINTYPEN, margin, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetMarginWidthN(int margin, int pixelWidth) const
+	{
+		execute(SCI_SETMARGINWIDTHN, margin, pixelWidth);
+	};
+
+	int GetMarginWidthN(int margin) const
+	{
+		sptr_t res = execute(SCI_GETMARGINWIDTHN, margin, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetMarginMaskN(int margin, int mask) const
+	{
+		execute(SCI_SETMARGINMASKN, margin, mask);
+	};
+
+	int GetMarginMaskN(int margin) const
+	{
+		sptr_t res = execute(SCI_GETMARGINMASKN, margin, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetMarginSensitiveN(int margin, bool sensitive) const
+	{
+		execute(SCI_SETMARGINSENSITIVEN, margin, sensitive);
+	};
+
+	bool GetMarginSensitiveN(int margin) const
+	{
+		sptr_t res = execute(SCI_GETMARGINSENSITIVEN, margin, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetMarginCursorN(int margin, int cursor) const
+	{
+		execute(SCI_SETMARGINCURSORN, margin, cursor);
+	};
+
+	int GetMarginCursorN(int margin) const
+	{
+		sptr_t res = execute(SCI_GETMARGINCURSORN, margin, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void StyleClearAll() const
+	{
+		execute(SCI_STYLECLEARALL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void StyleSetFore(int style, Colour fore) const
+	{
+		execute(SCI_STYLESETFORE, style, fore);
+	};
+
+	void StyleSetBack(int style, Colour back) const
+	{
+		execute(SCI_STYLESETBACK, style, back);
+	};
+
+	void StyleSetBold(int style, bool bold) const
+	{
+		execute(SCI_STYLESETBOLD, style, bold);
+	};
+
+	void StyleSetItalic(int style, bool italic) const
+	{
+		execute(SCI_STYLESETITALIC, style, italic);
+	};
+
+	void StyleSetSize(int style, int sizePoints) const
+	{
+		execute(SCI_STYLESETSIZE, style, sizePoints);
+	};
+
+	void StyleSetFont(int style, const char* fontName) const
+	{
+		execute(SCI_STYLESETFONT, style, fontName);
+	};
+
+	void StyleSetFont(int style, const std::string& fontName) const
+	{
+		execute(SCI_STYLESETFONT, style, fontName.c_str());
+	};
+
+	void StyleSetEOLFilled(int style, bool filled) const
+	{
+		execute(SCI_STYLESETEOLFILLED, style, filled);
+	};
+
+	void StyleResetDefault() const
+	{
+		execute(SCI_STYLERESETDEFAULT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void StyleSetUnderline(int style, bool underline) const
+	{
+		execute(SCI_STYLESETUNDERLINE, style, underline);
+	};
+
+	Colour StyleGetFore(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETFORE, style, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	Colour StyleGetBack(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETBACK, style, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	bool StyleGetBold(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETBOLD, style, SCI_UNUSED);
+		return res != 0;
+	};
+
+	bool StyleGetItalic(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETITALIC, style, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int StyleGetSize(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETSIZE, style, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int StyleGetFont(int style, char* fontName) const
+	{
+		sptr_t res = execute(SCI_STYLEGETFONT, style, fontName);
+		return static_cast<int>(res);
+	};
+
+	std::string StyleGetFont(int style) const
+	{
+		auto size = execute(SCI_STYLEGETFONT, style, NULL);
+		std::string fontName(size + 1, '\0');
+		execute(SCI_STYLEGETFONT, style, &fontName[0]);
+		trim(fontName);
+		return fontName;
+	};
+
+	bool StyleGetEOLFilled(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETEOLFILLED, style, SCI_UNUSED);
+		return res != 0;
+	};
+
+	bool StyleGetUnderline(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETUNDERLINE, style, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int StyleGetCase(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETCASE, style, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int StyleGetCharacterSet(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETCHARACTERSET, style, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	bool StyleGetVisible(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETVISIBLE, style, SCI_UNUSED);
+		return res != 0;
+	};
+
+	bool StyleGetChangeable(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETCHANGEABLE, style, SCI_UNUSED);
+		return res != 0;
+	};
+
+	bool StyleGetHotSpot(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETHOTSPOT, style, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void StyleSetCase(int style, int caseForce) const
+	{
+		execute(SCI_STYLESETCASE, style, caseForce);
+	};
+
+	void StyleSetSizeFractional(int style, int caseForce) const
+	{
+		execute(SCI_STYLESETSIZEFRACTIONAL, style, caseForce);
+	};
+
+	int StyleGetSizeFractional(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETSIZEFRACTIONAL, style, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void StyleSetWeight(int style, int weight) const
+	{
+		execute(SCI_STYLESETWEIGHT, style, weight);
+	};
+
+	int StyleGetWeight(int style) const
+	{
+		sptr_t res = execute(SCI_STYLEGETWEIGHT, style, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void StyleSetCharacterSet(int style, int characterSet) const
+	{
+		execute(SCI_STYLESETCHARACTERSET, style, characterSet);
+	};
+
+	void StyleSetHotSpot(int style, bool hotspot) const
+	{
+		execute(SCI_STYLESETHOTSPOT, style, hotspot);
+	};
+
+	void SetSelFore(bool useSetting, Colour fore) const
+	{
+		execute(SCI_SETSELFORE, useSetting, fore);
+	};
+
+	void SetSelBack(bool useSetting, Colour back) const
+	{
+		execute(SCI_SETSELBACK, useSetting, back);
+	};
+
+	int GetSelAlpha() const
+	{
+		sptr_t res = execute(SCI_GETSELALPHA, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelAlpha(int alpha) const
+	{
+		execute(SCI_SETSELALPHA, alpha, SCI_UNUSED);
+	};
+
+	bool GetSelEOLFilled() const
+	{
+		sptr_t res = execute(SCI_GETSELEOLFILLED, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetSelEOLFilled(bool filled) const
+	{
+		execute(SCI_SETSELEOLFILLED, filled, SCI_UNUSED);
+	};
+
+	void SetCaretFore(Colour fore) const
+	{
+		execute(SCI_SETCARETFORE, fore, SCI_UNUSED);
+	};
+
+	void AssignCmdKey(int km, int msg) const
+	{
+		execute(SCI_ASSIGNCMDKEY, km, msg);
+	};
+
+	void ClearCmdKey(int km) const
+	{
+		execute(SCI_CLEARCMDKEY, km, SCI_UNUSED);
+	};
+
+	void ClearAllCmdKeys() const
+	{
+		execute(SCI_CLEARALLCMDKEYS, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetStylingEx(int length, const char* styles) const
+	{
+		execute(SCI_SETSTYLINGEX, length, styles);
+	};
+
+	void SetStylingEx(const std::string& styles) const
+	{
+		execute(SCI_SETSTYLINGEX, styles.length(), styles.c_str());
+	};
+
+	void StyleSetVisible(int style, bool visible) const
+	{
+		execute(SCI_STYLESETVISIBLE, style, visible);
+	};
+
+	int GetCaretPeriod() const
+	{
+		sptr_t res = execute(SCI_GETCARETPERIOD, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetCaretPeriod(int periodMilliseconds) const
+	{
+		execute(SCI_SETCARETPERIOD, periodMilliseconds, SCI_UNUSED);
+	};
+
+	void SetWordChars(const char* characters) const
+	{
+		execute(SCI_SETWORDCHARS, SCI_UNUSED, characters);
+	};
+
+	void SetWordChars(const std::string& characters) const
+	{
+		execute(SCI_SETWORDCHARS, SCI_UNUSED, characters.c_str());
+	};
+
+	int GetWordChars(char* characters) const
+	{
+		sptr_t res = execute(SCI_GETWORDCHARS, SCI_UNUSED, characters);
+		return static_cast<int>(res);
+	};
+
+	std::string GetWordChars() const
+	{
+		auto size = execute(SCI_GETWORDCHARS, SCI_UNUSED, NULL);
+		std::string characters(size + 1, '\0');
+		execute(SCI_GETWORDCHARS, SCI_UNUSED, &characters[0]);
+		trim(characters);
+		return characters;
+	};
+
+	void BeginUndoAction() const
+	{
+		execute(SCI_BEGINUNDOACTION, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void EndUndoAction() const
+	{
+		execute(SCI_ENDUNDOACTION, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void IndicSetStyle(int indic, int style) const
+	{
+		execute(SCI_INDICSETSTYLE, indic, style);
+	};
+
+	int IndicGetStyle(int indic) const
+	{
+		sptr_t res = execute(SCI_INDICGETSTYLE, indic, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void IndicSetFore(int indic, Colour fore) const
+	{
+		execute(SCI_INDICSETFORE, indic, fore);
+	};
+
+	Colour IndicGetFore(int indic) const
+	{
+		sptr_t res = execute(SCI_INDICGETFORE, indic, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	void IndicSetUnder(int indic, bool under) const
+	{
+		execute(SCI_INDICSETUNDER, indic, under);
+	};
+
+	bool IndicGetUnder(int indic) const
+	{
+		sptr_t res = execute(SCI_INDICGETUNDER, indic, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void IndicSetHoverStyle(int indic, int style) const
+	{
+		execute(SCI_INDICSETHOVERSTYLE, indic, style);
+	};
+
+	int IndicGetHoverStyle(int indic) const
+	{
+		sptr_t res = execute(SCI_INDICGETHOVERSTYLE, indic, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void IndicSetHoverFore(int indic, Colour fore) const
+	{
+		execute(SCI_INDICSETHOVERFORE, indic, fore);
+	};
+
+	Colour IndicGetHoverFore(int indic) const
+	{
+		sptr_t res = execute(SCI_INDICGETHOVERFORE, indic, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	void IndicSetFlags(int indic, int flags) const
+	{
+		execute(SCI_INDICSETFLAGS, indic, flags);
+	};
+
+	int IndicGetFlags(int indic) const
+	{
+		sptr_t res = execute(SCI_INDICGETFLAGS, indic, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetWhitespaceFore(bool useSetting, Colour fore) const
+	{
+		execute(SCI_SETWHITESPACEFORE, useSetting, fore);
+	};
+
+	void SetWhitespaceBack(bool useSetting, Colour back) const
+	{
+		execute(SCI_SETWHITESPACEBACK, useSetting, back);
+	};
+
+	void SetWhitespaceSize(int size) const
+	{
+		execute(SCI_SETWHITESPACESIZE, size, SCI_UNUSED);
+	};
+
+	int GetWhitespaceSize() const
+	{
+		sptr_t res = execute(SCI_GETWHITESPACESIZE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetStyleBits(int bits) const
+	{
+		execute(SCI_SETSTYLEBITS, bits, SCI_UNUSED);
+	};
+
+	int GetStyleBits() const
+	{
+		sptr_t res = execute(SCI_GETSTYLEBITS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetLineState(int line, int state) const
+	{
+		execute(SCI_SETLINESTATE, line, state);
+	};
+
+	int GetLineState(int line) const
+	{
+		sptr_t res = execute(SCI_GETLINESTATE, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetMaxLineState() const
+	{
+		sptr_t res = execute(SCI_GETMAXLINESTATE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	bool GetCaretLineVisible() const
+	{
+		sptr_t res = execute(SCI_GETCARETLINEVISIBLE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetCaretLineVisible(bool show) const
+	{
+		execute(SCI_SETCARETLINEVISIBLE, show, SCI_UNUSED);
+	};
+
+	Colour GetCaretLineBack() const
+	{
+		sptr_t res = execute(SCI_GETCARETLINEBACK, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	void SetCaretLineBack(Colour back) const
+	{
+		execute(SCI_SETCARETLINEBACK, back, SCI_UNUSED);
+	};
+
+	void StyleSetChangeable(int style, bool changeable) const
+	{
+		execute(SCI_STYLESETCHANGEABLE, style, changeable);
+	};
+
+	void AutoCShow(int lenEntered, const char* itemList) const
+	{
+		execute(SCI_AUTOCSHOW, lenEntered, itemList);
+	};
+
+	void AutoCShow(int lenEntered, const std::string& itemList) const
+	{
+		execute(SCI_AUTOCSHOW, lenEntered, itemList.c_str());
+	};
+
+	void AutoCCancel() const
+	{
+		execute(SCI_AUTOCCANCEL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	bool AutoCActive() const
+	{
+		sptr_t res = execute(SCI_AUTOCACTIVE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int AutoCPosStart() const
+	{
+		sptr_t res = execute(SCI_AUTOCPOSSTART, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AutoCComplete() const
+	{
+		execute(SCI_AUTOCCOMPLETE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void AutoCStops(const char* characterSet) const
+	{
+		execute(SCI_AUTOCSTOPS, SCI_UNUSED, characterSet);
+	};
+
+	void AutoCStops(const std::string& characterSet) const
+	{
+		execute(SCI_AUTOCSTOPS, SCI_UNUSED, characterSet.c_str());
+	};
+
+	void AutoCSetSeparator(int separatorCharacter) const
+	{
+		execute(SCI_AUTOCSETSEPARATOR, separatorCharacter, SCI_UNUSED);
+	};
+
+	int AutoCGetSeparator() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETSEPARATOR, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AutoCSelect(const char* text) const
+	{
+		execute(SCI_AUTOCSELECT, SCI_UNUSED, text);
+	};
+
+	void AutoCSelect(const std::string& text) const
+	{
+		execute(SCI_AUTOCSELECT, SCI_UNUSED, text.c_str());
+	};
+
+	void AutoCSetCancelAtStart(bool cancel) const
+	{
+		execute(SCI_AUTOCSETCANCELATSTART, cancel, SCI_UNUSED);
+	};
+
+	bool AutoCGetCancelAtStart() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETCANCELATSTART, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void AutoCSetFillUps(const char* characterSet) const
+	{
+		execute(SCI_AUTOCSETFILLUPS, SCI_UNUSED, characterSet);
+	};
+
+	void AutoCSetFillUps(const std::string& characterSet) const
+	{
+		execute(SCI_AUTOCSETFILLUPS, SCI_UNUSED, characterSet.c_str());
+	};
+
+	void AutoCSetChooseSingle(bool chooseSingle) const
+	{
+		execute(SCI_AUTOCSETCHOOSESINGLE, chooseSingle, SCI_UNUSED);
+	};
+
+	bool AutoCGetChooseSingle() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETCHOOSESINGLE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void AutoCSetIgnoreCase(bool ignoreCase) const
+	{
+		execute(SCI_AUTOCSETIGNORECASE, ignoreCase, SCI_UNUSED);
+	};
+
+	bool AutoCGetIgnoreCase() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETIGNORECASE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void UserListShow(int listType, const char* itemList) const
+	{
+		execute(SCI_USERLISTSHOW, listType, itemList);
+	};
+
+	void UserListShow(int listType, const std::string& itemList) const
+	{
+		execute(SCI_USERLISTSHOW, listType, itemList.c_str());
+	};
+
+	void AutoCSetAutoHide(bool autoHide) const
+	{
+		execute(SCI_AUTOCSETAUTOHIDE, autoHide, SCI_UNUSED);
+	};
+
+	bool AutoCGetAutoHide() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETAUTOHIDE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void AutoCSetDropRestOfWord(bool dropRestOfWord) const
+	{
+		execute(SCI_AUTOCSETDROPRESTOFWORD, dropRestOfWord, SCI_UNUSED);
+	};
+
+	bool AutoCGetDropRestOfWord() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETDROPRESTOFWORD, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void RegisterImage(int type, const char* xpmData) const
+	{
+		execute(SCI_REGISTERIMAGE, type, xpmData);
+	};
+
+	void RegisterImage(int type, const std::string& xpmData) const
+	{
+		execute(SCI_REGISTERIMAGE, type, xpmData.c_str());
+	};
+
+	void ClearRegisteredImages() const
+	{
+		execute(SCI_CLEARREGISTEREDIMAGES, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int AutoCGetTypeSeparator() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETTYPESEPARATOR, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AutoCSetTypeSeparator(int separatorCharacter) const
+	{
+		execute(SCI_AUTOCSETTYPESEPARATOR, separatorCharacter, SCI_UNUSED);
+	};
+
+	void AutoCSetMaxWidth(int characterCount) const
+	{
+		execute(SCI_AUTOCSETMAXWIDTH, characterCount, SCI_UNUSED);
+	};
+
+	int AutoCGetMaxWidth() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETMAXWIDTH, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AutoCSetMaxHeight(int rowCount) const
+	{
+		execute(SCI_AUTOCSETMAXHEIGHT, rowCount, SCI_UNUSED);
+	};
+
+	int AutoCGetMaxHeight() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETMAXHEIGHT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetIndent(int indentSize) const
+	{
+		execute(SCI_SETINDENT, indentSize, SCI_UNUSED);
+	};
+
+	int GetIndent() const
+	{
+		sptr_t res = execute(SCI_GETINDENT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetUseTabs(bool useTabs) const
+	{
+		execute(SCI_SETUSETABS, useTabs, SCI_UNUSED);
+	};
+
+	bool GetUseTabs() const
+	{
+		sptr_t res = execute(SCI_GETUSETABS, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetLineIndentation(int line, int indentSize) const
+	{
+		execute(SCI_SETLINEINDENTATION, line, indentSize);
+	};
+
+	int GetLineIndentation(int line) const
+	{
+		sptr_t res = execute(SCI_GETLINEINDENTATION, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLineIndentPosition(int line) const
+	{
+		sptr_t res = execute(SCI_GETLINEINDENTPOSITION, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetColumn(int pos) const
+	{
+		sptr_t res = execute(SCI_GETCOLUMN, pos, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int CountCharacters(int startPos, int endPos) const
+	{
+		sptr_t res = execute(SCI_COUNTCHARACTERS, startPos, endPos);
+		return static_cast<int>(res);
+	};
+
+	void SetHScrollBar(bool show) const
+	{
+		execute(SCI_SETHSCROLLBAR, show, SCI_UNUSED);
+	};
+
+	bool GetHScrollBar() const
+	{
+		sptr_t res = execute(SCI_GETHSCROLLBAR, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetIndentationGuides(int indentView) const
+	{
+		execute(SCI_SETINDENTATIONGUIDES, indentView, SCI_UNUSED);
+	};
+
+	int GetIndentationGuides() const
+	{
+		sptr_t res = execute(SCI_GETINDENTATIONGUIDES, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetHighlightGuide(int column) const
+	{
+		execute(SCI_SETHIGHLIGHTGUIDE, column, SCI_UNUSED);
+	};
+
+	int GetHighlightGuide() const
+	{
+		sptr_t res = execute(SCI_GETHIGHLIGHTGUIDE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLineEndPosition(int line) const
+	{
+		sptr_t res = execute(SCI_GETLINEENDPOSITION, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetCodePage() const
+	{
+		sptr_t res = execute(SCI_GETCODEPAGE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	Colour GetCaretFore() const
+	{
+		sptr_t res = execute(SCI_GETCARETFORE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	bool GetReadOnly() const
+	{
+		sptr_t res = execute(SCI_GETREADONLY, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetCurrentPos(int pos) const
+	{
+		execute(SCI_SETCURRENTPOS, pos, SCI_UNUSED);
+	};
+
+	void SetSelectionStart(int pos) const
+	{
+		execute(SCI_SETSELECTIONSTART, pos, SCI_UNUSED);
+	};
+
+	int GetSelectionStart() const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONSTART, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelectionEnd(int pos) const
+	{
+		execute(SCI_SETSELECTIONEND, pos, SCI_UNUSED);
+	};
+
+	int GetSelectionEnd() const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONEND, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetEmptySelection(int pos) const
+	{
+		execute(SCI_SETEMPTYSELECTION, pos, SCI_UNUSED);
+	};
+
+	void SetPrintMagnification(int magnification) const
+	{
+		execute(SCI_SETPRINTMAGNIFICATION, magnification, SCI_UNUSED);
+	};
+
+	int GetPrintMagnification() const
+	{
+		sptr_t res = execute(SCI_GETPRINTMAGNIFICATION, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetPrintColourMode(int mode) const
+	{
+		execute(SCI_SETPRINTCOLOURMODE, mode, SCI_UNUSED);
+	};
+
+	int GetPrintColourMode() const
+	{
+		sptr_t res = execute(SCI_GETPRINTCOLOURMODE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int FindText(int flags, Sci_TextToFind* ft) const
+	{
+		sptr_t res = execute(SCI_FINDTEXT, flags, ft);
+		return static_cast<int>(res);
+	};
+
+	int FormatRange(bool draw, Sci_RangeToFormat* fr) const
+	{
+		sptr_t res = execute(SCI_FORMATRANGE, draw, fr);
+		return static_cast<int>(res);
+	};
+
+	int GetFirstVisibleLine() const
+	{
+		sptr_t res = execute(SCI_GETFIRSTVISIBLELINE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLine(int line, char* text) const
+	{
+		sptr_t res = execute(SCI_GETLINE, line, text);
+		return static_cast<int>(res);
+	};
+
+	std::string GetLine(int line) const
+	{
+		auto size = execute(SCI_GETLINE, line, NULL);
+		std::string text(size + 1, '\0');
+		execute(SCI_GETLINE, line, &text[0]);
+		trim(text);
+		return text;
+	};
+
+	int GetLineCount() const
+	{
+		sptr_t res = execute(SCI_GETLINECOUNT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetMarginLeft(int pixelWidth) const
+	{
+		execute(SCI_SETMARGINLEFT, SCI_UNUSED, pixelWidth);
+	};
+
+	int GetMarginLeft() const
+	{
+		sptr_t res = execute(SCI_GETMARGINLEFT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetMarginRight(int pixelWidth) const
+	{
+		execute(SCI_SETMARGINRIGHT, SCI_UNUSED, pixelWidth);
+	};
+
+	int GetMarginRight() const
+	{
+		sptr_t res = execute(SCI_GETMARGINRIGHT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	bool GetModify() const
+	{
+		sptr_t res = execute(SCI_GETMODIFY, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetSel(int start, int end) const
+	{
+		execute(SCI_SETSEL, start, end);
+	};
+
+	int GetSelText(char* text) const
+	{
+		sptr_t res = execute(SCI_GETSELTEXT, SCI_UNUSED, text);
+		return static_cast<int>(res);
+	};
+
+	std::string GetSelText() const
+	{
+		auto size = execute(SCI_GETSELTEXT, SCI_UNUSED, NULL);
+		std::string text(size + 1, '\0');
+		execute(SCI_GETSELTEXT, SCI_UNUSED, &text[0]);
+		trim(text);
+		return text;
+	};
+
+	int GetTextRange(Sci_TextRange* tr) const
+	{
+		sptr_t res = execute(SCI_GETTEXTRANGE, SCI_UNUSED, tr);
+		return static_cast<int>(res);
+	};
+
+	void HideSelection(bool normal) const
+	{
+		execute(SCI_HIDESELECTION, normal, SCI_UNUSED);
+	};
+
+	int PointXFromPosition(int pos) const
+	{
+		sptr_t res = execute(SCI_POINTXFROMPOSITION, SCI_UNUSED, pos);
+		return static_cast<int>(res);
+	};
+
+	int PointYFromPosition(int pos) const
+	{
+		sptr_t res = execute(SCI_POINTYFROMPOSITION, SCI_UNUSED, pos);
+		return static_cast<int>(res);
+	};
+
+	int LineFromPosition(int pos) const
+	{
+		sptr_t res = execute(SCI_LINEFROMPOSITION, pos, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int PositionFromLine(int line) const
+	{
+		sptr_t res = execute(SCI_POSITIONFROMLINE, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void LineScroll(int columns, int lines) const
+	{
+		execute(SCI_LINESCROLL, columns, lines);
+	};
+
+	void ScrollCaret() const
+	{
+		execute(SCI_SCROLLCARET, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void ScrollRange(int secondary, int primary) const
+	{
+		execute(SCI_SCROLLRANGE, secondary, primary);
+	};
+
+	void ReplaceSel(const char* text) const
+	{
+		execute(SCI_REPLACESEL, SCI_UNUSED, text);
+	};
+
+	void ReplaceSel(const std::string& text) const
+	{
+		execute(SCI_REPLACESEL, SCI_UNUSED, text.c_str());
+	};
+
+	void SetReadOnly(bool readOnly) const
+	{
+		execute(SCI_SETREADONLY, readOnly, SCI_UNUSED);
+	};
+
+	void Null() const
+	{
+		execute(SCI_NULL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	bool CanPaste() const
+	{
+		sptr_t res = execute(SCI_CANPASTE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	bool CanUndo() const
+	{
+		sptr_t res = execute(SCI_CANUNDO, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void EmptyUndoBuffer() const
+	{
+		execute(SCI_EMPTYUNDOBUFFER, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Undo() const
+	{
+		execute(SCI_UNDO, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Cut() const
+	{
+		execute(SCI_CUT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Copy() const
+	{
+		execute(SCI_COPY, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Paste() const
+	{
+		execute(SCI_PASTE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Clear() const
+	{
+		execute(SCI_CLEAR, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetText(const char* text) const
+	{
+		execute(SCI_SETTEXT, SCI_UNUSED, text);
+	};
+
+	void SetText(const std::string& text) const
+	{
+		execute(SCI_SETTEXT, SCI_UNUSED, text.c_str());
+	};
+
+	int GetText(int length, char* text) const
+	{
+		sptr_t res = execute(SCI_GETTEXT, length, text);
+		return static_cast<int>(res);
+	};
+
+	std::string GetText() const
+	{
+		auto size = execute(SCI_GETTEXT, SCI_UNUSED, NULL);
+		std::string text(size + 1, '\0');
+		execute(SCI_GETTEXT, text.length(), &text[0]);
+		trim(text);
+		return text;
+	};
+
+	int GetTextLength() const
+	{
+		sptr_t res = execute(SCI_GETTEXTLENGTH, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	sptr_t GetDirectFunction() const
+	{
+		return execute(SCI_GETDIRECTFUNCTION, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	sptr_t GetDirectPointer() const
+	{
+		return execute(SCI_GETDIRECTPOINTER, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetOvertype(bool overtype) const
+	{
+		execute(SCI_SETOVERTYPE, overtype, SCI_UNUSED);
+	};
+
+	bool GetOvertype() const
+	{
+		sptr_t res = execute(SCI_GETOVERTYPE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetCaretWidth(int pixelWidth) const
+	{
+		execute(SCI_SETCARETWIDTH, pixelWidth, SCI_UNUSED);
+	};
+
+	int GetCaretWidth() const
+	{
+		sptr_t res = execute(SCI_GETCARETWIDTH, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetTargetStart(int pos) const
+	{
+		execute(SCI_SETTARGETSTART, pos, SCI_UNUSED);
+	};
+
+	int GetTargetStart() const
+	{
+		sptr_t res = execute(SCI_GETTARGETSTART, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetTargetEnd(int pos) const
+	{
+		execute(SCI_SETTARGETEND, pos, SCI_UNUSED);
+	};
+
+	int GetTargetEnd() const
+	{
+		sptr_t res = execute(SCI_GETTARGETEND, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetTargetRange(int start, int end) const
+	{
+		execute(SCI_SETTARGETRANGE, start, end);
+	};
+
+	int GetTargetText(char* characters) const
+	{
+		sptr_t res = execute(SCI_GETTARGETTEXT, SCI_UNUSED, characters);
+		return static_cast<int>(res);
+	};
+
+	std::string GetTargetText() const
+	{
+		auto size = execute(SCI_GETTARGETTEXT, SCI_UNUSED, NULL);
+		std::string characters(size + 1, '\0');
+		execute(SCI_GETTARGETTEXT, SCI_UNUSED, &characters[0]);
+		trim(characters);
+		return characters;
+	};
+
+	int ReplaceTarget(int length, const char* text) const
+	{
+		sptr_t res = execute(SCI_REPLACETARGET, length, text);
+		return static_cast<int>(res);
+	};
+
+	int ReplaceTarget(const std::string& text) const
+	{
+		sptr_t res = execute(SCI_REPLACETARGET, text.length(), text.c_str());
+		return static_cast<int>(res);
+	};
+
+	int ReplaceTargetRE(int length, const char* text) const
+	{
+		sptr_t res = execute(SCI_REPLACETARGETRE, length, text);
+		return static_cast<int>(res);
+	};
+
+	int ReplaceTargetRE(const std::string& text) const
+	{
+		sptr_t res = execute(SCI_REPLACETARGETRE, text.length(), text.c_str());
+		return static_cast<int>(res);
+	};
+
+	int SearchInTarget(int length, const char* text) const
+	{
+		sptr_t res = execute(SCI_SEARCHINTARGET, length, text);
+		return static_cast<int>(res);
+	};
+
+	int SearchInTarget(const std::string& text) const
+	{
+		sptr_t res = execute(SCI_SEARCHINTARGET, text.length(), text.c_str());
+		return static_cast<int>(res);
+	};
+
+	void SetSearchFlags(int flags) const
+	{
+		execute(SCI_SETSEARCHFLAGS, flags, SCI_UNUSED);
+	};
+
+	int GetSearchFlags() const
+	{
+		sptr_t res = execute(SCI_GETSEARCHFLAGS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void CallTipShow(int pos, const char* definition) const
+	{
+		execute(SCI_CALLTIPSHOW, pos, definition);
+	};
+
+	void CallTipShow(int pos, const std::string& definition) const
+	{
+		execute(SCI_CALLTIPSHOW, pos, definition.c_str());
+	};
+
+	void CallTipCancel() const
+	{
+		execute(SCI_CALLTIPCANCEL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	bool CallTipActive() const
+	{
+		sptr_t res = execute(SCI_CALLTIPACTIVE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int CallTipPosStart() const
+	{
+		sptr_t res = execute(SCI_CALLTIPPOSSTART, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void CallTipSetPosStart(int posStart) const
+	{
+		execute(SCI_CALLTIPSETPOSSTART, posStart, SCI_UNUSED);
+	};
+
+	void CallTipSetHlt(int start, int end) const
+	{
+		execute(SCI_CALLTIPSETHLT, start, end);
+	};
+
+	void CallTipSetBack(Colour back) const
+	{
+		execute(SCI_CALLTIPSETBACK, back, SCI_UNUSED);
+	};
+
+	void CallTipSetFore(Colour fore) const
+	{
+		execute(SCI_CALLTIPSETFORE, fore, SCI_UNUSED);
+	};
+
+	void CallTipSetForeHlt(Colour fore) const
+	{
+		execute(SCI_CALLTIPSETFOREHLT, fore, SCI_UNUSED);
+	};
+
+	void CallTipUseStyle(int tabSize) const
+	{
+		execute(SCI_CALLTIPUSESTYLE, tabSize, SCI_UNUSED);
+	};
+
+	void CallTipSetPosition(bool above) const
+	{
+		execute(SCI_CALLTIPSETPOSITION, above, SCI_UNUSED);
+	};
+
+	int VisibleFromDocLine(int line) const
+	{
+		sptr_t res = execute(SCI_VISIBLEFROMDOCLINE, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int DocLineFromVisible(int lineDisplay) const
+	{
+		sptr_t res = execute(SCI_DOCLINEFROMVISIBLE, lineDisplay, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int WrapCount(int line) const
+	{
+		sptr_t res = execute(SCI_WRAPCOUNT, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetFoldLevel(int line, int level) const
+	{
+		execute(SCI_SETFOLDLEVEL, line, level);
+	};
+
+	int GetFoldLevel(int line) const
+	{
+		sptr_t res = execute(SCI_GETFOLDLEVEL, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLastChild(int line, int level) const
+	{
+		sptr_t res = execute(SCI_GETLASTCHILD, line, level);
+		return static_cast<int>(res);
+	};
+
+	int GetFoldParent(int line) const
+	{
+		sptr_t res = execute(SCI_GETFOLDPARENT, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void ShowLines(int lineStart, int lineEnd) const
+	{
+		execute(SCI_SHOWLINES, lineStart, lineEnd);
+	};
+
+	void HideLines(int lineStart, int lineEnd) const
+	{
+		execute(SCI_HIDELINES, lineStart, lineEnd);
+	};
+
+	bool GetLineVisible(int line) const
+	{
+		sptr_t res = execute(SCI_GETLINEVISIBLE, line, SCI_UNUSED);
+		return res != 0;
+	};
+
+	bool GetAllLinesVisible() const
+	{
+		sptr_t res = execute(SCI_GETALLLINESVISIBLE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetFoldExpanded(int line, bool expanded) const
+	{
+		execute(SCI_SETFOLDEXPANDED, line, expanded);
+	};
+
+	bool GetFoldExpanded(int line) const
+	{
+		sptr_t res = execute(SCI_GETFOLDEXPANDED, line, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void ToggleFold(int line) const
+	{
+		execute(SCI_TOGGLEFOLD, line, SCI_UNUSED);
+	};
+
+	void FoldLine(int line, int action) const
+	{
+		execute(SCI_FOLDLINE, line, action);
+	};
+
+	void FoldChildren(int line, int action) const
+	{
+		execute(SCI_FOLDCHILDREN, line, action);
+	};
+
+	void ExpandChildren(int line, int level) const
+	{
+		execute(SCI_EXPANDCHILDREN, line, level);
+	};
+
+	void FoldAll(int action) const
+	{
+		execute(SCI_FOLDALL, action, SCI_UNUSED);
+	};
+
+	void EnsureVisible(int line) const
+	{
+		execute(SCI_ENSUREVISIBLE, line, SCI_UNUSED);
+	};
+
+	void SetAutomaticFold(int automaticFold) const
+	{
+		execute(SCI_SETAUTOMATICFOLD, automaticFold, SCI_UNUSED);
+	};
+
+	int GetAutomaticFold() const
+	{
+		sptr_t res = execute(SCI_GETAUTOMATICFOLD, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetFoldFlags(int flags) const
+	{
+		execute(SCI_SETFOLDFLAGS, flags, SCI_UNUSED);
+	};
+
+	void EnsureVisibleEnforcePolicy(int line) const
+	{
+		execute(SCI_ENSUREVISIBLEENFORCEPOLICY, line, SCI_UNUSED);
+	};
+
+	void SetTabIndents(bool tabIndents) const
+	{
+		execute(SCI_SETTABINDENTS, tabIndents, SCI_UNUSED);
+	};
+
+	bool GetTabIndents() const
+	{
+		sptr_t res = execute(SCI_GETTABINDENTS, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetBackSpaceUnIndents(bool bsUnIndents) const
+	{
+		execute(SCI_SETBACKSPACEUNINDENTS, bsUnIndents, SCI_UNUSED);
+	};
+
+	bool GetBackSpaceUnIndents() const
+	{
+		sptr_t res = execute(SCI_GETBACKSPACEUNINDENTS, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetMouseDwellTime(int periodMilliseconds) const
+	{
+		execute(SCI_SETMOUSEDWELLTIME, periodMilliseconds, SCI_UNUSED);
+	};
+
+	int GetMouseDwellTime() const
+	{
+		sptr_t res = execute(SCI_GETMOUSEDWELLTIME, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int WordStartPosition(int pos, bool onlyWordCharacters) const
+	{
+		sptr_t res = execute(SCI_WORDSTARTPOSITION, pos, onlyWordCharacters);
+		return static_cast<int>(res);
+	};
+
+	int WordEndPosition(int pos, bool onlyWordCharacters) const
+	{
+		sptr_t res = execute(SCI_WORDENDPOSITION, pos, onlyWordCharacters);
+		return static_cast<int>(res);
+	};
+
+	void SetWrapMode(int mode) const
+	{
+		execute(SCI_SETWRAPMODE, mode, SCI_UNUSED);
+	};
+
+	int GetWrapMode() const
+	{
+		sptr_t res = execute(SCI_GETWRAPMODE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetWrapVisualFlags(int wrapVisualFlags) const
+	{
+		execute(SCI_SETWRAPVISUALFLAGS, wrapVisualFlags, SCI_UNUSED);
+	};
+
+	int GetWrapVisualFlags() const
+	{
+		sptr_t res = execute(SCI_GETWRAPVISUALFLAGS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetWrapVisualFlagsLocation(int wrapVisualFlagsLocation) const
+	{
+		execute(SCI_SETWRAPVISUALFLAGSLOCATION, wrapVisualFlagsLocation, SCI_UNUSED);
+	};
+
+	int GetWrapVisualFlagsLocation() const
+	{
+		sptr_t res = execute(SCI_GETWRAPVISUALFLAGSLOCATION, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetWrapStartIndent(int indent) const
+	{
+		execute(SCI_SETWRAPSTARTINDENT, indent, SCI_UNUSED);
+	};
+
+	int GetWrapStartIndent() const
+	{
+		sptr_t res = execute(SCI_GETWRAPSTARTINDENT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetWrapIndentMode(int mode) const
+	{
+		execute(SCI_SETWRAPINDENTMODE, mode, SCI_UNUSED);
+	};
+
+	int GetWrapIndentMode() const
+	{
+		sptr_t res = execute(SCI_GETWRAPINDENTMODE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetLayoutCache(int mode) const
+	{
+		execute(SCI_SETLAYOUTCACHE, mode, SCI_UNUSED);
+	};
+
+	int GetLayoutCache() const
+	{
+		sptr_t res = execute(SCI_GETLAYOUTCACHE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetScrollWidth(int pixelWidth) const
+	{
+		execute(SCI_SETSCROLLWIDTH, pixelWidth, SCI_UNUSED);
+	};
+
+	int GetScrollWidth() const
+	{
+		sptr_t res = execute(SCI_GETSCROLLWIDTH, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetScrollWidthTracking(bool tracking) const
+	{
+		execute(SCI_SETSCROLLWIDTHTRACKING, tracking, SCI_UNUSED);
+	};
+
+	bool GetScrollWidthTracking() const
+	{
+		sptr_t res = execute(SCI_GETSCROLLWIDTHTRACKING, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int TextWidth(int style, const char* text) const
+	{
+		sptr_t res = execute(SCI_TEXTWIDTH, style, text);
+		return static_cast<int>(res);
+	};
+
+	int TextWidth(int style, const std::string& text) const
+	{
+		sptr_t res = execute(SCI_TEXTWIDTH, style, text.c_str());
+		return static_cast<int>(res);
+	};
+
+	void SetEndAtLastLine(bool endAtLastLine) const
+	{
+		execute(SCI_SETENDATLASTLINE, endAtLastLine, SCI_UNUSED);
+	};
+
+	bool GetEndAtLastLine() const
+	{
+		sptr_t res = execute(SCI_GETENDATLASTLINE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int TextHeight(int line) const
+	{
+		sptr_t res = execute(SCI_TEXTHEIGHT, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetVScrollBar(bool show) const
+	{
+		execute(SCI_SETVSCROLLBAR, show, SCI_UNUSED);
+	};
+
+	bool GetVScrollBar() const
+	{
+		sptr_t res = execute(SCI_GETVSCROLLBAR, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void AppendText(int length, const char* text) const
+	{
+		execute(SCI_APPENDTEXT, length, text);
+	};
+
+	void AppendText(const std::string& text) const
+	{
+		execute(SCI_APPENDTEXT, text.length(), text.c_str());
+	};
+
+	bool GetTwoPhaseDraw() const
+	{
+		sptr_t res = execute(SCI_GETTWOPHASEDRAW, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetTwoPhaseDraw(bool twoPhase) const
+	{
+		execute(SCI_SETTWOPHASEDRAW, twoPhase, SCI_UNUSED);
+	};
+
+	int GetPhasesDraw() const
+	{
+		sptr_t res = execute(SCI_GETPHASESDRAW, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetPhasesDraw(int phases) const
+	{
+		execute(SCI_SETPHASESDRAW, phases, SCI_UNUSED);
+	};
+
+	void SetFontQuality(int fontQuality) const
+	{
+		execute(SCI_SETFONTQUALITY, fontQuality, SCI_UNUSED);
+	};
+
+	int GetFontQuality() const
+	{
+		sptr_t res = execute(SCI_GETFONTQUALITY, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetFirstVisibleLine(int lineDisplay) const
+	{
+		execute(SCI_SETFIRSTVISIBLELINE, lineDisplay, SCI_UNUSED);
+	};
+
+	void SetMultiPaste(int multiPaste) const
+	{
+		execute(SCI_SETMULTIPASTE, multiPaste, SCI_UNUSED);
+	};
+
+	int GetMultiPaste() const
+	{
+		sptr_t res = execute(SCI_GETMULTIPASTE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetTag(int tagNumber, char* tagValue) const
+	{
+		sptr_t res = execute(SCI_GETTAG, tagNumber, tagValue);
+		return static_cast<int>(res);
+	};
+
+	std::string GetTag(int tagNumber) const
+	{
+		auto size = execute(SCI_GETTAG, tagNumber, NULL);
+		std::string tagValue(size + 1, '\0');
+		execute(SCI_GETTAG, tagNumber, &tagValue[0]);
+		trim(tagValue);
+		return tagValue;
+	};
+
+	void TargetFromSelection() const
+	{
+		execute(SCI_TARGETFROMSELECTION, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LinesJoin() const
+	{
+		execute(SCI_LINESJOIN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LinesSplit(int pixelWidth) const
+	{
+		execute(SCI_LINESSPLIT, pixelWidth, SCI_UNUSED);
+	};
+
+	void SetFoldMarginColour(bool useSetting, Colour back) const
+	{
+		execute(SCI_SETFOLDMARGINCOLOUR, useSetting, back);
+	};
+
+	void SetFoldMarginHiColour(bool useSetting, Colour fore) const
+	{
+		execute(SCI_SETFOLDMARGINHICOLOUR, useSetting, fore);
+	};
+
+	void LineDown() const
+	{
+		execute(SCI_LINEDOWN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineDownExtend() const
+	{
+		execute(SCI_LINEDOWNEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineUp() const
+	{
+		execute(SCI_LINEUP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineUpExtend() const
+	{
+		execute(SCI_LINEUPEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void CharLeft() const
+	{
+		execute(SCI_CHARLEFT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void CharLeftExtend() const
+	{
+		execute(SCI_CHARLEFTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void CharRight() const
+	{
+		execute(SCI_CHARRIGHT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void CharRightExtend() const
+	{
+		execute(SCI_CHARRIGHTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordLeft() const
+	{
+		execute(SCI_WORDLEFT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordLeftExtend() const
+	{
+		execute(SCI_WORDLEFTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordRight() const
+	{
+		execute(SCI_WORDRIGHT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordRightExtend() const
+	{
+		execute(SCI_WORDRIGHTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Home() const
+	{
+		execute(SCI_HOME, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void HomeExtend() const
+	{
+		execute(SCI_HOMEEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineEnd() const
+	{
+		execute(SCI_LINEEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineEndExtend() const
+	{
+		execute(SCI_LINEENDEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DocumentStart() const
+	{
+		execute(SCI_DOCUMENTSTART, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DocumentStartExtend() const
+	{
+		execute(SCI_DOCUMENTSTARTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DocumentEnd() const
+	{
+		execute(SCI_DOCUMENTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DocumentEndExtend() const
+	{
+		execute(SCI_DOCUMENTENDEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void PageUp() const
+	{
+		execute(SCI_PAGEUP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void PageUpExtend() const
+	{
+		execute(SCI_PAGEUPEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void PageDown() const
+	{
+		execute(SCI_PAGEDOWN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void PageDownExtend() const
+	{
+		execute(SCI_PAGEDOWNEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void EditToggleOvertype() const
+	{
+		execute(SCI_EDITTOGGLEOVERTYPE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Cancel() const
+	{
+		execute(SCI_CANCEL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DeleteBack() const
+	{
+		execute(SCI_DELETEBACK, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void Tab() const
+	{
+		execute(SCI_TAB, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void BackTab() const
+	{
+		execute(SCI_BACKTAB, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void NewLine() const
+	{
+		execute(SCI_NEWLINE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void FormFeed() const
+	{
+		execute(SCI_FORMFEED, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void VCHome() const
+	{
+		execute(SCI_VCHOME, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void VCHomeExtend() const
+	{
+		execute(SCI_VCHOMEEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void ZoomIn() const
+	{
+		execute(SCI_ZOOMIN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void ZoomOut() const
+	{
+		execute(SCI_ZOOMOUT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DelWordLeft() const
+	{
+		execute(SCI_DELWORDLEFT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DelWordRight() const
+	{
+		execute(SCI_DELWORDRIGHT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DelWordRightEnd() const
+	{
+		execute(SCI_DELWORDRIGHTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineCut() const
+	{
+		execute(SCI_LINECUT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineDelete() const
+	{
+		execute(SCI_LINEDELETE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineTranspose() const
+	{
+		execute(SCI_LINETRANSPOSE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineDuplicate() const
+	{
+		execute(SCI_LINEDUPLICATE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LowerCase() const
+	{
+		execute(SCI_LOWERCASE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void UpperCase() const
+	{
+		execute(SCI_UPPERCASE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineScrollDown() const
+	{
+		execute(SCI_LINESCROLLDOWN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineScrollUp() const
+	{
+		execute(SCI_LINESCROLLUP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DeleteBackNotLine() const
+	{
+		execute(SCI_DELETEBACKNOTLINE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void HomeDisplay() const
+	{
+		execute(SCI_HOMEDISPLAY, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void HomeDisplayExtend() const
+	{
+		execute(SCI_HOMEDISPLAYEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineEndDisplay() const
+	{
+		execute(SCI_LINEENDDISPLAY, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineEndDisplayExtend() const
+	{
+		execute(SCI_LINEENDDISPLAYEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void HomeWrap() const
+	{
+		execute(SCI_HOMEWRAP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void HomeWrapExtend() const
+	{
+		execute(SCI_HOMEWRAPEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineEndWrap() const
+	{
+		execute(SCI_LINEENDWRAP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineEndWrapExtend() const
+	{
+		execute(SCI_LINEENDWRAPEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void VCHomeWrap() const
+	{
+		execute(SCI_VCHOMEWRAP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void VCHomeWrapExtend() const
+	{
+		execute(SCI_VCHOMEWRAPEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineCopy() const
+	{
+		execute(SCI_LINECOPY, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void MoveCaretInsideView() const
+	{
+		execute(SCI_MOVECARETINSIDEVIEW, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int LineLength(int line) const
+	{
+		sptr_t res = execute(SCI_LINELENGTH, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void BraceHighlight(int pos1, int pos2) const
+	{
+		execute(SCI_BRACEHIGHLIGHT, pos1, pos2);
+	};
+
+	void BraceHighlightIndicator(bool useBraceHighlightIndicator, int indicator) const
+	{
+		execute(SCI_BRACEHIGHLIGHTINDICATOR, useBraceHighlightIndicator, indicator);
+	};
+
+	void BraceBadLight(int pos) const
+	{
+		execute(SCI_BRACEBADLIGHT, pos, SCI_UNUSED);
+	};
+
+	void BraceBadLightIndicator(bool useBraceBadLightIndicator, int indicator) const
+	{
+		execute(SCI_BRACEBADLIGHTINDICATOR, useBraceBadLightIndicator, indicator);
+	};
+
+	int BraceMatch(int pos) const
+	{
+		sptr_t res = execute(SCI_BRACEMATCH, pos, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	bool GetViewEOL() const
+	{
+		sptr_t res = execute(SCI_GETVIEWEOL, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetViewEOL(bool visible) const
+	{
+		execute(SCI_SETVIEWEOL, visible, SCI_UNUSED);
+	};
+
+	sptr_t GetDocPointer() const
+	{
+		return execute(SCI_GETDOCPOINTER, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetDocPointer(sptr_t pointer) const
+	{
+		execute(SCI_SETDOCPOINTER, SCI_UNUSED, pointer);
+	};
+
+	void SetModEventMask(int mask) const
+	{
+		execute(SCI_SETMODEVENTMASK, mask, SCI_UNUSED);
+	};
+
+	int GetEdgeColumn() const
+	{
+		sptr_t res = execute(SCI_GETEDGECOLUMN, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetEdgeColumn(int column) const
+	{
+		execute(SCI_SETEDGECOLUMN, column, SCI_UNUSED);
+	};
+
+	int GetEdgeMode() const
+	{
+		sptr_t res = execute(SCI_GETEDGEMODE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetEdgeMode(int mode) const
+	{
+		execute(SCI_SETEDGEMODE, mode, SCI_UNUSED);
+	};
+
+	Colour GetEdgeColour() const
+	{
+		sptr_t res = execute(SCI_GETEDGECOLOUR, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	void SetEdgeColour(Colour edgeColour) const
+	{
+		execute(SCI_SETEDGECOLOUR, edgeColour, SCI_UNUSED);
+	};
+
+	void SearchAnchor() const
+	{
+		execute(SCI_SEARCHANCHOR, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int SearchNext(int flags, const char* text) const
+	{
+		sptr_t res = execute(SCI_SEARCHNEXT, flags, text);
+		return static_cast<int>(res);
+	};
+
+	int SearchNext(int flags, const std::string& text) const
+	{
+		sptr_t res = execute(SCI_SEARCHNEXT, flags, text.c_str());
+		return static_cast<int>(res);
+	};
+
+	int SearchPrev(int flags, const char* text) const
+	{
+		sptr_t res = execute(SCI_SEARCHPREV, flags, text);
+		return static_cast<int>(res);
+	};
+
+	int SearchPrev(int flags, const std::string& text) const
+	{
+		sptr_t res = execute(SCI_SEARCHPREV, flags, text.c_str());
+		return static_cast<int>(res);
+	};
+
+	int LinesOnScreen() const
+	{
+		sptr_t res = execute(SCI_LINESONSCREEN, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void UsePopUp(bool allowPopUp) const
+	{
+		execute(SCI_USEPOPUP, allowPopUp, SCI_UNUSED);
+	};
+
+	bool SelectionIsRectangle() const
+	{
+		sptr_t res = execute(SCI_SELECTIONISRECTANGLE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetZoom(int zoom) const
+	{
+		execute(SCI_SETZOOM, zoom, SCI_UNUSED);
+	};
+
+	int GetZoom() const
+	{
+		sptr_t res = execute(SCI_GETZOOM, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	sptr_t CreateDocument() const
+	{
+		return execute(SCI_CREATEDOCUMENT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void AddRefDocument(sptr_t doc) const
+	{
+		execute(SCI_ADDREFDOCUMENT, SCI_UNUSED, doc);
+	};
+
+	void ReleaseDocument(sptr_t doc) const
+	{
+		execute(SCI_RELEASEDOCUMENT, SCI_UNUSED, doc);
+	};
+
+	int GetModEventMask() const
+	{
+		sptr_t res = execute(SCI_GETMODEVENTMASK, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetFocus(bool focus) const
+	{
+		execute(SCI_SETFOCUS, focus, SCI_UNUSED);
+	};
+
+	bool GetFocus() const
+	{
+		sptr_t res = execute(SCI_GETFOCUS, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetStatus(int statusCode) const
+	{
+		execute(SCI_SETSTATUS, statusCode, SCI_UNUSED);
+	};
+
+	int GetStatus() const
+	{
+		sptr_t res = execute(SCI_GETSTATUS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetMouseDownCaptures(bool captures) const
+	{
+		execute(SCI_SETMOUSEDOWNCAPTURES, captures, SCI_UNUSED);
+	};
+
+	bool GetMouseDownCaptures() const
+	{
+		sptr_t res = execute(SCI_GETMOUSEDOWNCAPTURES, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetCursor(int cursorType) const
+	{
+		execute(SCI_SETCURSOR, cursorType, SCI_UNUSED);
+	};
+
+	int GetCursor() const
+	{
+		sptr_t res = execute(SCI_GETCURSOR, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetControlCharSymbol(int symbol) const
+	{
+		execute(SCI_SETCONTROLCHARSYMBOL, symbol, SCI_UNUSED);
+	};
+
+	int GetControlCharSymbol() const
+	{
+		sptr_t res = execute(SCI_GETCONTROLCHARSYMBOL, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void WordPartLeft() const
+	{
+		execute(SCI_WORDPARTLEFT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordPartLeftExtend() const
+	{
+		execute(SCI_WORDPARTLEFTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordPartRight() const
+	{
+		execute(SCI_WORDPARTRIGHT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordPartRightExtend() const
+	{
+		execute(SCI_WORDPARTRIGHTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetVisiblePolicy(int visiblePolicy, int visibleSlop) const
+	{
+		execute(SCI_SETVISIBLEPOLICY, visiblePolicy, visibleSlop);
+	};
+
+	void DelLineLeft() const
+	{
+		execute(SCI_DELLINELEFT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void DelLineRight() const
+	{
+		execute(SCI_DELLINERIGHT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetXOffset(int newOffset) const
+	{
+		execute(SCI_SETXOFFSET, newOffset, SCI_UNUSED);
+	};
+
+	int GetXOffset() const
+	{
+		sptr_t res = execute(SCI_GETXOFFSET, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void ChooseCaretX() const
+	{
+		execute(SCI_CHOOSECARETX, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void GrabFocus() const
+	{
+		execute(SCI_GRABFOCUS, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetXCaretPolicy(int caretPolicy, int caretSlop) const
+	{
+		execute(SCI_SETXCARETPOLICY, caretPolicy, caretSlop);
+	};
+
+	void SetYCaretPolicy(int caretPolicy, int caretSlop) const
+	{
+		execute(SCI_SETYCARETPOLICY, caretPolicy, caretSlop);
+	};
+
+	void SetPrintWrapMode(int mode) const
+	{
+		execute(SCI_SETPRINTWRAPMODE, mode, SCI_UNUSED);
+	};
+
+	int GetPrintWrapMode() const
+	{
+		sptr_t res = execute(SCI_GETPRINTWRAPMODE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetHotspotActiveFore(bool useSetting, Colour fore) const
+	{
+		execute(SCI_SETHOTSPOTACTIVEFORE, useSetting, fore);
+	};
+
+	Colour GetHotspotActiveFore() const
+	{
+		sptr_t res = execute(SCI_GETHOTSPOTACTIVEFORE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	void SetHotspotActiveBack(bool useSetting, Colour back) const
+	{
+		execute(SCI_SETHOTSPOTACTIVEBACK, useSetting, back);
+	};
+
+	Colour GetHotspotActiveBack() const
+	{
+		sptr_t res = execute(SCI_GETHOTSPOTACTIVEBACK, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	void SetHotspotActiveUnderline(bool underline) const
+	{
+		execute(SCI_SETHOTSPOTACTIVEUNDERLINE, underline, SCI_UNUSED);
+	};
+
+	bool GetHotspotActiveUnderline() const
+	{
+		sptr_t res = execute(SCI_GETHOTSPOTACTIVEUNDERLINE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetHotspotSingleLine(bool singleLine) const
+	{
+		execute(SCI_SETHOTSPOTSINGLELINE, singleLine, SCI_UNUSED);
+	};
+
+	bool GetHotspotSingleLine() const
+	{
+		sptr_t res = execute(SCI_GETHOTSPOTSINGLELINE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void ParaDown() const
+	{
+		execute(SCI_PARADOWN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void ParaDownExtend() const
+	{
+		execute(SCI_PARADOWNEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void ParaUp() const
+	{
+		execute(SCI_PARAUP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void ParaUpExtend() const
+	{
+		execute(SCI_PARAUPEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int PositionBefore(int pos) const
+	{
+		sptr_t res = execute(SCI_POSITIONBEFORE, pos, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int PositionAfter(int pos) const
+	{
+		sptr_t res = execute(SCI_POSITIONAFTER, pos, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int PositionRelative(int pos, int relative) const
+	{
+		sptr_t res = execute(SCI_POSITIONRELATIVE, pos, relative);
+		return static_cast<int>(res);
+	};
+
+	void CopyRange(int start, int end) const
+	{
+		execute(SCI_COPYRANGE, start, end);
+	};
+
+	void CopyText(int length, const char* text) const
+	{
+		execute(SCI_COPYTEXT, length, text);
+	};
+
+	void CopyText(const std::string& text) const
+	{
+		execute(SCI_COPYTEXT, text.length(), text.c_str());
+	};
+
+	void SetSelectionMode(int mode) const
+	{
+		execute(SCI_SETSELECTIONMODE, mode, SCI_UNUSED);
+	};
+
+	int GetSelectionMode() const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONMODE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLineSelStartPosition(int line) const
+	{
+		sptr_t res = execute(SCI_GETLINESELSTARTPOSITION, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLineSelEndPosition(int line) const
+	{
+		sptr_t res = execute(SCI_GETLINESELENDPOSITION, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void LineDownRectExtend() const
+	{
+		execute(SCI_LINEDOWNRECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineUpRectExtend() const
+	{
+		execute(SCI_LINEUPRECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void CharLeftRectExtend() const
+	{
+		execute(SCI_CHARLEFTRECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void CharRightRectExtend() const
+	{
+		execute(SCI_CHARRIGHTRECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void HomeRectExtend() const
+	{
+		execute(SCI_HOMERECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void VCHomeRectExtend() const
+	{
+		execute(SCI_VCHOMERECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void LineEndRectExtend() const
+	{
+		execute(SCI_LINEENDRECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void PageUpRectExtend() const
+	{
+		execute(SCI_PAGEUPRECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void PageDownRectExtend() const
+	{
+		execute(SCI_PAGEDOWNRECTEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void StutteredPageUp() const
+	{
+		execute(SCI_STUTTEREDPAGEUP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void StutteredPageUpExtend() const
+	{
+		execute(SCI_STUTTEREDPAGEUPEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void StutteredPageDown() const
+	{
+		execute(SCI_STUTTEREDPAGEDOWN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void StutteredPageDownExtend() const
+	{
+		execute(SCI_STUTTEREDPAGEDOWNEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordLeftEnd() const
+	{
+		execute(SCI_WORDLEFTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordLeftEndExtend() const
+	{
+		execute(SCI_WORDLEFTENDEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordRightEnd() const
+	{
+		execute(SCI_WORDRIGHTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void WordRightEndExtend() const
+	{
+		execute(SCI_WORDRIGHTENDEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetWhitespaceChars(const char* characters) const
+	{
+		execute(SCI_SETWHITESPACECHARS, SCI_UNUSED, characters);
+	};
+
+	void SetWhitespaceChars(const std::string& characters) const
+	{
+		execute(SCI_SETWHITESPACECHARS, SCI_UNUSED, characters.c_str());
+	};
+
+	int GetWhitespaceChars(char* characters) const
+	{
+		sptr_t res = execute(SCI_GETWHITESPACECHARS, SCI_UNUSED, characters);
+		return static_cast<int>(res);
+	};
+
+	std::string GetWhitespaceChars() const
+	{
+		auto size = execute(SCI_GETWHITESPACECHARS, SCI_UNUSED, NULL);
+		std::string characters(size + 1, '\0');
+		execute(SCI_GETWHITESPACECHARS, SCI_UNUSED, &characters[0]);
+		trim(characters);
+		return characters;
+	};
+
+	void SetPunctuationChars(const char* characters) const
+	{
+		execute(SCI_SETPUNCTUATIONCHARS, SCI_UNUSED, characters);
+	};
+
+	void SetPunctuationChars(const std::string& characters) const
+	{
+		execute(SCI_SETPUNCTUATIONCHARS, SCI_UNUSED, characters.c_str());
+	};
+
+	int GetPunctuationChars(char* characters) const
+	{
+		sptr_t res = execute(SCI_GETPUNCTUATIONCHARS, SCI_UNUSED, characters);
+		return static_cast<int>(res);
+	};
+
+	std::string GetPunctuationChars() const
+	{
+		auto size = execute(SCI_GETPUNCTUATIONCHARS, SCI_UNUSED, NULL);
+		std::string characters(size + 1, '\0');
+		execute(SCI_GETPUNCTUATIONCHARS, SCI_UNUSED, &characters[0]);
+		trim(characters);
+		return characters;
+	};
+
+	void SetCharsDefault() const
+	{
+		execute(SCI_SETCHARSDEFAULT, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int AutoCGetCurrent() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETCURRENT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int AutoCGetCurrentText(char* s) const
+	{
+		sptr_t res = execute(SCI_AUTOCGETCURRENTTEXT, SCI_UNUSED, s);
+		return static_cast<int>(res);
+	};
+
+	std::string AutoCGetCurrentText() const
+	{
+		auto size = execute(SCI_AUTOCGETCURRENTTEXT, SCI_UNUSED, NULL);
+		std::string s(size + 1, '\0');
+		execute(SCI_AUTOCGETCURRENTTEXT, SCI_UNUSED, &s[0]);
+		trim(s);
+		return s;
+	};
+
+	void AutoCSetCaseInsensitiveBehaviour(int behaviour) const
+	{
+		execute(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, behaviour, SCI_UNUSED);
+	};
+
+	int AutoCGetCaseInsensitiveBehaviour() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETCASEINSENSITIVEBEHAVIOUR, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AutoCSetMulti(int multi) const
+	{
+		execute(SCI_AUTOCSETMULTI, multi, SCI_UNUSED);
+	};
+
+	int AutoCGetMulti() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETMULTI, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AutoCSetOrder(int order) const
+	{
+		execute(SCI_AUTOCSETORDER, order, SCI_UNUSED);
+	};
+
+	int AutoCGetOrder() const
+	{
+		sptr_t res = execute(SCI_AUTOCGETORDER, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void Allocate(int bytes) const
+	{
+		execute(SCI_ALLOCATE, bytes, SCI_UNUSED);
+	};
+
+	int TargetAsUTF8(char* s) const
+	{
+		sptr_t res = execute(SCI_TARGETASUTF8, SCI_UNUSED, s);
+		return static_cast<int>(res);
+	};
+
+	std::string TargetAsUTF8() const
+	{
+		auto size = execute(SCI_TARGETASUTF8, SCI_UNUSED, NULL);
+		std::string s(size + 1, '\0');
+		execute(SCI_TARGETASUTF8, SCI_UNUSED, &s[0]);
+		trim(s);
+		return s;
+	};
+
+	void SetLengthForEncode(int bytes) const
+	{
+		execute(SCI_SETLENGTHFORENCODE, bytes, SCI_UNUSED);
+	};
+
+	int EncodedFromUTF8(const char* utf8, char* encoded) const
+	{
+		sptr_t res = execute(SCI_ENCODEDFROMUTF8, utf8, encoded);
+		return static_cast<int>(res);
+	};
+
+	std::string EncodedFromUTF8(const std::string& utf8) const
+	{
+		auto size = execute(SCI_ENCODEDFROMUTF8, utf8.c_str(), NULL);
+		std::string encoded(size + 1, '\0');
+		execute(SCI_ENCODEDFROMUTF8, utf8.c_str(), &encoded[0]);
+		trim(encoded);
+		return encoded;
+	};
+
+	int FindColumn(int line, int column) const
+	{
+		sptr_t res = execute(SCI_FINDCOLUMN, line, column);
+		return static_cast<int>(res);
+	};
+
+	int GetCaretSticky() const
+	{
+		sptr_t res = execute(SCI_GETCARETSTICKY, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetCaretSticky(int useCaretStickyBehaviour) const
+	{
+		execute(SCI_SETCARETSTICKY, useCaretStickyBehaviour, SCI_UNUSED);
+	};
+
+	void ToggleCaretSticky() const
+	{
+		execute(SCI_TOGGLECARETSTICKY, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetPasteConvertEndings(bool convert) const
+	{
+		execute(SCI_SETPASTECONVERTENDINGS, convert, SCI_UNUSED);
+	};
+
+	bool GetPasteConvertEndings() const
+	{
+		sptr_t res = execute(SCI_GETPASTECONVERTENDINGS, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SelectionDuplicate() const
+	{
+		execute(SCI_SELECTIONDUPLICATE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetCaretLineBackAlpha(int alpha) const
+	{
+		execute(SCI_SETCARETLINEBACKALPHA, alpha, SCI_UNUSED);
+	};
+
+	int GetCaretLineBackAlpha() const
+	{
+		sptr_t res = execute(SCI_GETCARETLINEBACKALPHA, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetCaretStyle(int caretStyle) const
+	{
+		execute(SCI_SETCARETSTYLE, caretStyle, SCI_UNUSED);
+	};
+
+	int GetCaretStyle() const
+	{
+		sptr_t res = execute(SCI_GETCARETSTYLE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetIndicatorCurrent(int indicator) const
+	{
+		execute(SCI_SETINDICATORCURRENT, indicator, SCI_UNUSED);
+	};
+
+	int GetIndicatorCurrent() const
+	{
+		sptr_t res = execute(SCI_GETINDICATORCURRENT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetIndicatorValue(int value) const
+	{
+		execute(SCI_SETINDICATORVALUE, value, SCI_UNUSED);
+	};
+
+	int GetIndicatorValue() const
+	{
+		sptr_t res = execute(SCI_GETINDICATORVALUE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void IndicatorFillRange(int position, int fillLength) const
+	{
+		execute(SCI_INDICATORFILLRANGE, position, fillLength);
+	};
+
+	void IndicatorClearRange(int position, int clearLength) const
+	{
+		execute(SCI_INDICATORCLEARRANGE, position, clearLength);
+	};
+
+	int IndicatorAllOnFor(int position) const
+	{
+		sptr_t res = execute(SCI_INDICATORALLONFOR, position, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int IndicatorValueAt(int indicator, int position) const
+	{
+		sptr_t res = execute(SCI_INDICATORVALUEAT, indicator, position);
+		return static_cast<int>(res);
+	};
+
+	int IndicatorStart(int indicator, int position) const
+	{
+		sptr_t res = execute(SCI_INDICATORSTART, indicator, position);
+		return static_cast<int>(res);
+	};
+
+	int IndicatorEnd(int indicator, int position) const
+	{
+		sptr_t res = execute(SCI_INDICATOREND, indicator, position);
+		return static_cast<int>(res);
+	};
+
+	void SetPositionCache(int size) const
+	{
+		execute(SCI_SETPOSITIONCACHE, size, SCI_UNUSED);
+	};
+
+	int GetPositionCache() const
+	{
+		sptr_t res = execute(SCI_GETPOSITIONCACHE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void CopyAllowLine() const
+	{
+		execute(SCI_COPYALLOWLINE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	const char* GetCharacterPointer() const
+	{
+		sptr_t res = execute(SCI_GETCHARACTERPOINTER, SCI_UNUSED, SCI_UNUSED);
+		return reinterpret_cast<const char*>(res);
+	};
+
+	const char* GetRangePointer(int position, int rangeLength) const
+	{
+		sptr_t res = execute(SCI_GETRANGEPOINTER, position, rangeLength);
+		return reinterpret_cast<const char*>(res);
+	};
+
+	int GetGapPosition() const
+	{
+		sptr_t res = execute(SCI_GETGAPPOSITION, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void IndicSetAlpha(int indicator, int alpha) const
+	{
+		execute(SCI_INDICSETALPHA, indicator, alpha);
+	};
+
+	int IndicGetAlpha(int indicator) const
+	{
+		sptr_t res = execute(SCI_INDICGETALPHA, indicator, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void IndicSetOutlineAlpha(int indicator, int alpha) const
+	{
+		execute(SCI_INDICSETOUTLINEALPHA, indicator, alpha);
+	};
+
+	int IndicGetOutlineAlpha(int indicator) const
+	{
+		sptr_t res = execute(SCI_INDICGETOUTLINEALPHA, indicator, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetExtraAscent(int extraAscent) const
+	{
+		execute(SCI_SETEXTRAASCENT, extraAscent, SCI_UNUSED);
+	};
+
+	int GetExtraAscent() const
+	{
+		sptr_t res = execute(SCI_GETEXTRAASCENT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetExtraDescent(int extraDescent) const
+	{
+		execute(SCI_SETEXTRADESCENT, extraDescent, SCI_UNUSED);
+	};
+
+	int GetExtraDescent() const
+	{
+		sptr_t res = execute(SCI_GETEXTRADESCENT, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int MarkerSymbolDefined(int markerNumber) const
+	{
+		sptr_t res = execute(SCI_MARKERSYMBOLDEFINED, markerNumber, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void MarginSetText(int line, const char* text) const
+	{
+		execute(SCI_MARGINSETTEXT, line, text);
+	};
+
+	void MarginSetText(int line, const std::string& text) const
+	{
+		execute(SCI_MARGINSETTEXT, line, text.c_str());
+	};
+
+	int MarginGetText(int line, char* text) const
+	{
+		sptr_t res = execute(SCI_MARGINGETTEXT, line, text);
+		return static_cast<int>(res);
+	};
+
+	std::string MarginGetText(int line) const
+	{
+		auto size = execute(SCI_MARGINGETTEXT, line, NULL);
+		std::string text(size + 1, '\0');
+		execute(SCI_MARGINGETTEXT, line, &text[0]);
+		trim(text);
+		return text;
+	};
+
+	void MarginSetStyle(int line, int style) const
+	{
+		execute(SCI_MARGINSETSTYLE, line, style);
+	};
+
+	int MarginGetStyle(int line) const
+	{
+		sptr_t res = execute(SCI_MARGINGETSTYLE, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void MarginSetStyles(int line, const char* styles) const
+	{
+		execute(SCI_MARGINSETSTYLES, line, styles);
+	};
+
+	void MarginSetStyles(int line, const std::string& styles) const
+	{
+		execute(SCI_MARGINSETSTYLES, line, styles.c_str());
+	};
+
+	int MarginGetStyles(int line, char* styles) const
+	{
+		sptr_t res = execute(SCI_MARGINGETSTYLES, line, styles);
+		return static_cast<int>(res);
+	};
+
+	std::string MarginGetStyles(int line) const
+	{
+		auto size = execute(SCI_MARGINGETSTYLES, line, NULL);
+		std::string styles(size + 1, '\0');
+		execute(SCI_MARGINGETSTYLES, line, &styles[0]);
+		trim(styles);
+		return styles;
+	};
+
+	void MarginTextClearAll() const
+	{
+		execute(SCI_MARGINTEXTCLEARALL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void MarginSetStyleOffset(int style) const
+	{
+		execute(SCI_MARGINSETSTYLEOFFSET, style, SCI_UNUSED);
+	};
+
+	int MarginGetStyleOffset() const
+	{
+		sptr_t res = execute(SCI_MARGINGETSTYLEOFFSET, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetMarginOptions(int marginOptions) const
+	{
+		execute(SCI_SETMARGINOPTIONS, marginOptions, SCI_UNUSED);
+	};
+
+	int GetMarginOptions() const
+	{
+		sptr_t res = execute(SCI_GETMARGINOPTIONS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AnnotationSetText(int line, const char* text) const
+	{
+		execute(SCI_ANNOTATIONSETTEXT, line, text);
+	};
+
+	void AnnotationSetText(int line, const std::string& text) const
+	{
+		execute(SCI_ANNOTATIONSETTEXT, line, text.c_str());
+	};
+
+	int AnnotationGetText(int line, char* text) const
+	{
+		sptr_t res = execute(SCI_ANNOTATIONGETTEXT, line, text);
+		return static_cast<int>(res);
+	};
+
+	std::string AnnotationGetText(int line) const
+	{
+		auto size = execute(SCI_ANNOTATIONGETTEXT, line, NULL);
+		std::string text(size + 1, '\0');
+		execute(SCI_ANNOTATIONGETTEXT, line, &text[0]);
+		trim(text);
+		return text;
+	};
+
+	void AnnotationSetStyle(int line, int style) const
+	{
+		execute(SCI_ANNOTATIONSETSTYLE, line, style);
+	};
+
+	int AnnotationGetStyle(int line) const
+	{
+		sptr_t res = execute(SCI_ANNOTATIONGETSTYLE, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AnnotationSetStyles(int line, const char* styles) const
+	{
+		execute(SCI_ANNOTATIONSETSTYLES, line, styles);
+	};
+
+	void AnnotationSetStyles(int line, const std::string& styles) const
+	{
+		execute(SCI_ANNOTATIONSETSTYLES, line, styles.c_str());
+	};
+
+	int AnnotationGetStyles(int line, char* styles) const
+	{
+		sptr_t res = execute(SCI_ANNOTATIONGETSTYLES, line, styles);
+		return static_cast<int>(res);
+	};
+
+	std::string AnnotationGetStyles(int line) const
+	{
+		auto size = execute(SCI_ANNOTATIONGETSTYLES, line, NULL);
+		std::string styles(size + 1, '\0');
+		execute(SCI_ANNOTATIONGETSTYLES, line, &styles[0]);
+		trim(styles);
+		return styles;
+	};
+
+	int AnnotationGetLines(int line) const
+	{
+		sptr_t res = execute(SCI_ANNOTATIONGETLINES, line, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AnnotationClearAll() const
+	{
+		execute(SCI_ANNOTATIONCLEARALL, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void AnnotationSetVisible(int visible) const
+	{
+		execute(SCI_ANNOTATIONSETVISIBLE, visible, SCI_UNUSED);
+	};
+
+	int AnnotationGetVisible() const
+	{
+		sptr_t res = execute(SCI_ANNOTATIONGETVISIBLE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AnnotationSetStyleOffset(int style) const
+	{
+		execute(SCI_ANNOTATIONSETSTYLEOFFSET, style, SCI_UNUSED);
+	};
+
+	int AnnotationGetStyleOffset() const
+	{
+		sptr_t res = execute(SCI_ANNOTATIONGETSTYLEOFFSET, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void ReleaseAllExtendedStyles() const
+	{
+		execute(SCI_RELEASEALLEXTENDEDSTYLES, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int AllocateExtendedStyles(int numberStyles) const
+	{
+		sptr_t res = execute(SCI_ALLOCATEEXTENDEDSTYLES, numberStyles, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void AddUndoAction(int token, int flags) const
+	{
+		execute(SCI_ADDUNDOACTION, token, flags);
+	};
+
+	int CharPositionFromPoint(int x, int y) const
+	{
+		sptr_t res = execute(SCI_CHARPOSITIONFROMPOINT, x, y);
+		return static_cast<int>(res);
+	};
+
+	int CharPositionFromPointClose(int x, int y) const
+	{
+		sptr_t res = execute(SCI_CHARPOSITIONFROMPOINTCLOSE, x, y);
+		return static_cast<int>(res);
+	};
+
+	void SetMouseSelectionRectangularSwitch(bool mouseSelectionRectangularSwitch) const
+	{
+		execute(SCI_SETMOUSESELECTIONRECTANGULARSWITCH, mouseSelectionRectangularSwitch, SCI_UNUSED);
+	};
+
+	bool GetMouseSelectionRectangularSwitch() const
+	{
+		sptr_t res = execute(SCI_GETMOUSESELECTIONRECTANGULARSWITCH, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetMultipleSelection(bool multipleSelection) const
+	{
+		execute(SCI_SETMULTIPLESELECTION, multipleSelection, SCI_UNUSED);
+	};
+
+	bool GetMultipleSelection() const
+	{
+		sptr_t res = execute(SCI_GETMULTIPLESELECTION, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetAdditionalSelectionTyping(bool additionalSelectionTyping) const
+	{
+		execute(SCI_SETADDITIONALSELECTIONTYPING, additionalSelectionTyping, SCI_UNUSED);
+	};
+
+	bool GetAdditionalSelectionTyping() const
+	{
+		sptr_t res = execute(SCI_GETADDITIONALSELECTIONTYPING, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetAdditionalCaretsBlink(bool additionalCaretsBlink) const
+	{
+		execute(SCI_SETADDITIONALCARETSBLINK, additionalCaretsBlink, SCI_UNUSED);
+	};
+
+	bool GetAdditionalCaretsBlink() const
+	{
+		sptr_t res = execute(SCI_GETADDITIONALCARETSBLINK, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetAdditionalCaretsVisible(bool additionalCaretsBlink) const
+	{
+		execute(SCI_SETADDITIONALCARETSVISIBLE, additionalCaretsBlink, SCI_UNUSED);
+	};
+
+	bool GetAdditionalCaretsVisible() const
+	{
+		sptr_t res = execute(SCI_GETADDITIONALCARETSVISIBLE, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	int GetSelections() const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	bool GetSelectionEmpty() const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONEMPTY, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void ClearSelections() const
+	{
+		execute(SCI_CLEARSELECTIONS, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int SetSelection(int caret, int anchor) const
+	{
+		sptr_t res = execute(SCI_SETSELECTION, caret, anchor);
+		return static_cast<int>(res);
+	};
+
+	int AddSelection(int caret, int anchor) const
+	{
+		sptr_t res = execute(SCI_ADDSELECTION, caret, anchor);
+		return static_cast<int>(res);
+	};
+
+	void DropSelectionN(int selection) const
+	{
+		execute(SCI_DROPSELECTIONN, selection, SCI_UNUSED);
+	};
+
+	void SetMainSelection(int selection) const
+	{
+		execute(SCI_SETMAINSELECTION, selection, SCI_UNUSED);
+	};
+
+	int GetMainSelection() const
+	{
+		sptr_t res = execute(SCI_GETMAINSELECTION, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelectionNCaret(int selection, int pos) const
+	{
+		execute(SCI_SETSELECTIONNCARET, selection, pos);
+	};
+
+	int GetSelectionNCaret(int selection) const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONNCARET, selection, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelectionNAnchor(int selection, int posAnchor) const
+	{
+		execute(SCI_SETSELECTIONNANCHOR, selection, posAnchor);
+	};
+
+	int GetSelectionNAnchor(int selection) const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONNANCHOR, selection, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelectionNCaretVirtualSpace(int selection, int space) const
+	{
+		execute(SCI_SETSELECTIONNCARETVIRTUALSPACE, selection, space);
+	};
+
+	int GetSelectionNCaretVirtualSpace(int selection) const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONNCARETVIRTUALSPACE, selection, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelectionNAnchorVirtualSpace(int selection, int space) const
+	{
+		execute(SCI_SETSELECTIONNANCHORVIRTUALSPACE, selection, space);
+	};
+
+	int GetSelectionNAnchorVirtualSpace(int selection) const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONNANCHORVIRTUALSPACE, selection, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelectionNStart(int selection, int pos) const
+	{
+		execute(SCI_SETSELECTIONNSTART, selection, pos);
+	};
+
+	int GetSelectionNStart(int selection) const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONNSTART, selection, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetSelectionNEnd(int selection, int pos) const
+	{
+		execute(SCI_SETSELECTIONNEND, selection, pos);
+	};
+
+	int GetSelectionNEnd(int selection) const
+	{
+		sptr_t res = execute(SCI_GETSELECTIONNEND, selection, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetRectangularSelectionCaret(int pos) const
+	{
+		execute(SCI_SETRECTANGULARSELECTIONCARET, pos, SCI_UNUSED);
+	};
+
+	int GetRectangularSelectionCaret() const
+	{
+		sptr_t res = execute(SCI_GETRECTANGULARSELECTIONCARET, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetRectangularSelectionAnchor(int posAnchor) const
+	{
+		execute(SCI_SETRECTANGULARSELECTIONANCHOR, posAnchor, SCI_UNUSED);
+	};
+
+	int GetRectangularSelectionAnchor() const
+	{
+		sptr_t res = execute(SCI_GETRECTANGULARSELECTIONANCHOR, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetRectangularSelectionCaretVirtualSpace(int space) const
+	{
+		execute(SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE, space, SCI_UNUSED);
+	};
+
+	int GetRectangularSelectionCaretVirtualSpace() const
+	{
+		sptr_t res = execute(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetRectangularSelectionAnchorVirtualSpace(int space) const
+	{
+		execute(SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE, space, SCI_UNUSED);
+	};
+
+	int GetRectangularSelectionAnchorVirtualSpace() const
+	{
+		sptr_t res = execute(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetVirtualSpaceOptions(int virtualSpaceOptions) const
+	{
+		execute(SCI_SETVIRTUALSPACEOPTIONS, virtualSpaceOptions, SCI_UNUSED);
+	};
+
+	int GetVirtualSpaceOptions() const
+	{
+		sptr_t res = execute(SCI_GETVIRTUALSPACEOPTIONS, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetRectangularSelectionModifier(int modifier) const
+	{
+		execute(SCI_SETRECTANGULARSELECTIONMODIFIER, modifier, SCI_UNUSED);
+	};
+
+	int GetRectangularSelectionModifier() const
+	{
+		sptr_t res = execute(SCI_GETRECTANGULARSELECTIONMODIFIER, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetAdditionalSelFore(Colour fore) const
+	{
+		execute(SCI_SETADDITIONALSELFORE, fore, SCI_UNUSED);
+	};
+
+	void SetAdditionalSelBack(Colour back) const
+	{
+		execute(SCI_SETADDITIONALSELBACK, back, SCI_UNUSED);
+	};
+
+	void SetAdditionalSelAlpha(int alpha) const
+	{
+		execute(SCI_SETADDITIONALSELALPHA, alpha, SCI_UNUSED);
+	};
+
+	int GetAdditionalSelAlpha() const
+	{
+		sptr_t res = execute(SCI_GETADDITIONALSELALPHA, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetAdditionalCaretFore(Colour fore) const
+	{
+		execute(SCI_SETADDITIONALCARETFORE, fore, SCI_UNUSED);
+	};
+
+	Colour GetAdditionalCaretFore() const
+	{
+		sptr_t res = execute(SCI_GETADDITIONALCARETFORE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<Colour>(res);
+	};
+
+	void RotateSelection() const
+	{
+		execute(SCI_ROTATESELECTION, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SwapMainAnchorCaret() const
+	{
+		execute(SCI_SWAPMAINANCHORCARET, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	int ChangeLexerState(int start, int end) const
+	{
+		sptr_t res = execute(SCI_CHANGELEXERSTATE, start, end);
+		return static_cast<int>(res);
+	};
+
+	int ContractedFoldNext(int lineStart) const
+	{
+		sptr_t res = execute(SCI_CONTRACTEDFOLDNEXT, lineStart, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void VerticalCentreCaret() const
+	{
+		execute(SCI_VERTICALCENTRECARET, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void MoveSelectedLinesUp() const
+	{
+		execute(SCI_MOVESELECTEDLINESUP, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void MoveSelectedLinesDown() const
+	{
+		execute(SCI_MOVESELECTEDLINESDOWN, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetIdentifier(int identifier) const
+	{
+		execute(SCI_SETIDENTIFIER, identifier, SCI_UNUSED);
+	};
+
+	int GetIdentifier() const
+	{
+		sptr_t res = execute(SCI_GETIDENTIFIER, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void RGBAImageSetWidth(int width) const
+	{
+		execute(SCI_RGBAIMAGESETWIDTH, width, SCI_UNUSED);
+	};
+
+	void RGBAImageSetHeight(int height) const
+	{
+		execute(SCI_RGBAIMAGESETHEIGHT, height, SCI_UNUSED);
+	};
+
+	void RGBAImageSetScale(int scalePercent) const
+	{
+		execute(SCI_RGBAIMAGESETSCALE, scalePercent, SCI_UNUSED);
+	};
+
+	void MarkerDefineRGBAImage(int markerNumber, const char* pixels) const
+	{
+		execute(SCI_MARKERDEFINERGBAIMAGE, markerNumber, pixels);
+	};
+
+	void MarkerDefineRGBAImage(int markerNumber, const std::string& pixels) const
+	{
+		execute(SCI_MARKERDEFINERGBAIMAGE, markerNumber, pixels.c_str());
+	};
+
+	void RegisterRGBAImage(int type, const char* pixels) const
+	{
+		execute(SCI_REGISTERRGBAIMAGE, type, pixels);
+	};
+
+	void RegisterRGBAImage(int type, const std::string& pixels) const
+	{
+		execute(SCI_REGISTERRGBAIMAGE, type, pixels.c_str());
+	};
+
+	void ScrollToStart() const
+	{
+		execute(SCI_SCROLLTOSTART, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void ScrollToEnd() const
+	{
+		execute(SCI_SCROLLTOEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetTechnology(int technology) const
+	{
+		execute(SCI_SETTECHNOLOGY, technology, SCI_UNUSED);
+	};
+
+	int GetTechnology() const
+	{
+		sptr_t res = execute(SCI_GETTECHNOLOGY, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int CreateLoader(int bytes) const
+	{
+		sptr_t res = execute(SCI_CREATELOADER, bytes, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void FindIndicatorShow(int start, int end) const
+	{
+		execute(SCI_FINDINDICATORSHOW, start, end);
+	};
+
+	void FindIndicatorFlash(int start, int end) const
+	{
+		execute(SCI_FINDINDICATORFLASH, start, end);
+	};
+
+	void FindIndicatorHide() const
+	{
+		execute(SCI_FINDINDICATORHIDE, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void VCHomeDisplay() const
+	{
+		execute(SCI_VCHOMEDISPLAY, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void VCHomeDisplayExtend() const
+	{
+		execute(SCI_VCHOMEDISPLAYEXTEND, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	bool GetCaretLineVisibleAlways() const
+	{
+		sptr_t res = execute(SCI_GETCARETLINEVISIBLEALWAYS, SCI_UNUSED, SCI_UNUSED);
+		return res != 0;
+	};
+
+	void SetCaretLineVisibleAlways(bool alwaysVisible) const
+	{
+		execute(SCI_SETCARETLINEVISIBLEALWAYS, alwaysVisible, SCI_UNUSED);
+	};
+
+	void SetLineEndTypesAllowed(int lineEndBitSet) const
+	{
+		execute(SCI_SETLINEENDTYPESALLOWED, lineEndBitSet, SCI_UNUSED);
+	};
+
+	int GetLineEndTypesAllowed() const
+	{
+		sptr_t res = execute(SCI_GETLINEENDTYPESALLOWED, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLineEndTypesActive() const
+	{
+		sptr_t res = execute(SCI_GETLINEENDTYPESACTIVE, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void SetRepresentation(const char* encodedCharacter, const char* representation) const
+	{
+		execute(SCI_SETREPRESENTATION, encodedCharacter, representation);
+	};
+
+	void SetRepresentation(const std::string& encodedCharacter, const std::string& representation) const
+	{
+		execute(SCI_SETREPRESENTATION, encodedCharacter.c_str(), representation.c_str());
+	};
+
+	int GetRepresentation(const char* encodedCharacter, char* representation) const
+	{
+		sptr_t res = execute(SCI_GETREPRESENTATION, encodedCharacter, representation);
+		return static_cast<int>(res);
+	};
+
+	std::string GetRepresentation(const std::string& encodedCharacter) const
+	{
+		auto size = execute(SCI_GETREPRESENTATION, encodedCharacter.c_str(), NULL);
+		std::string representation(size + 1, '\0');
+		execute(SCI_GETREPRESENTATION, encodedCharacter.c_str(), &representation[0]);
+		trim(representation);
+		return representation;
+	};
+
+	void ClearRepresentation(const char* encodedCharacter) const
+	{
+		execute(SCI_CLEARREPRESENTATION, encodedCharacter, SCI_UNUSED);
+	};
+
+	void ClearRepresentation(const std::string& encodedCharacter) const
+	{
+		execute(SCI_CLEARREPRESENTATION, encodedCharacter.c_str(), SCI_UNUSED);
+	};
+
+	void StartRecord() const
+	{
+		execute(SCI_STARTRECORD, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void StopRecord() const
+	{
+		execute(SCI_STOPRECORD, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetLexer(int lexer) const
+	{
+		execute(SCI_SETLEXER, lexer, SCI_UNUSED);
+	};
+
+	int GetLexer() const
+	{
+		sptr_t res = execute(SCI_GETLEXER, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void Colourise(int start, int end) const
+	{
+		execute(SCI_COLOURISE, start, end);
+	};
+
+	void SetProperty(const char* key, const char* value) const
+	{
+		execute(SCI_SETPROPERTY, key, value);
+	};
+
+	void SetProperty(const std::string& key, const std::string& value) const
+	{
+		execute(SCI_SETPROPERTY, key.c_str(), value.c_str());
+	};
+
+	void SetKeyWords(int keywordSet, const char* keyWords) const
+	{
+		execute(SCI_SETKEYWORDS, keywordSet, keyWords);
+	};
+
+	void SetKeyWords(int keywordSet, const std::string& keyWords) const
+	{
+		execute(SCI_SETKEYWORDS, keywordSet, keyWords.c_str());
+	};
+
+	void SetLexerLanguage(const char* language) const
+	{
+		execute(SCI_SETLEXERLANGUAGE, SCI_UNUSED, language);
+	};
+
+	void SetLexerLanguage(const std::string& language) const
+	{
+		execute(SCI_SETLEXERLANGUAGE, SCI_UNUSED, language.c_str());
+	};
+
+	void LoadLexerLibrary(const char* path) const
+	{
+		execute(SCI_LOADLEXERLIBRARY, SCI_UNUSED, path);
+	};
+
+	void LoadLexerLibrary(const std::string& path) const
+	{
+		execute(SCI_LOADLEXERLIBRARY, SCI_UNUSED, path.c_str());
+	};
+
+	int GetProperty(const char* key, char* buf) const
+	{
+		sptr_t res = execute(SCI_GETPROPERTY, key, buf);
+		return static_cast<int>(res);
+	};
+
+	std::string GetProperty(const std::string& key) const
+	{
+		auto size = execute(SCI_GETPROPERTY, key.c_str(), NULL);
+		std::string buf(size + 1, '\0');
+		execute(SCI_GETPROPERTY, key.c_str(), &buf[0]);
+		trim(buf);
+		return buf;
+	};
+
+	int GetPropertyExpanded(const char* key, char* buf) const
+	{
+		sptr_t res = execute(SCI_GETPROPERTYEXPANDED, key, buf);
+		return static_cast<int>(res);
+	};
+
+	std::string GetPropertyExpanded(const std::string& key) const
+	{
+		auto size = execute(SCI_GETPROPERTYEXPANDED, key.c_str(), NULL);
+		std::string buf(size + 1, '\0');
+		execute(SCI_GETPROPERTYEXPANDED, key.c_str(), &buf[0]);
+		trim(buf);
+		return buf;
+	};
+
+	int GetPropertyInt(const char* key) const
+	{
+		sptr_t res = execute(SCI_GETPROPERTYINT, key, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetPropertyInt(const std::string& key) const
+	{
+		sptr_t res = execute(SCI_GETPROPERTYINT, key.c_str(), SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetStyleBitsNeeded() const
+	{
+		sptr_t res = execute(SCI_GETSTYLEBITSNEEDED, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetLexerLanguage(char* text) const
+	{
+		sptr_t res = execute(SCI_GETLEXERLANGUAGE, SCI_UNUSED, text);
+		return static_cast<int>(res);
+	};
+
+	std::string GetLexerLanguage() const
+	{
+		auto size = execute(SCI_GETLEXERLANGUAGE, SCI_UNUSED, NULL);
+		std::string text(size + 1, '\0');
+		execute(SCI_GETLEXERLANGUAGE, SCI_UNUSED, &text[0]);
+		trim(text);
+		return text;
+	};
+
+	int PrivateLexerexecute(int operation, sptr_t pointer) const
+	{
+		sptr_t res = execute(SCI_PRIVATELEXERCALL, operation, pointer);
+		return static_cast<int>(res);
+	};
+
+	int PropertyNames(char* names) const
+	{
+		sptr_t res = execute(SCI_PROPERTYNAMES, SCI_UNUSED, names);
+		return static_cast<int>(res);
+	};
+
+	std::string PropertyNames() const
+	{
+		auto size = execute(SCI_PROPERTYNAMES, SCI_UNUSED, NULL);
+		std::string names(size + 1, '\0');
+		execute(SCI_PROPERTYNAMES, SCI_UNUSED, &names[0]);
+		trim(names);
+		return names;
+	};
+
+	int PropertyType(const char* name) const
+	{
+		sptr_t res = execute(SCI_PROPERTYTYPE, name, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int PropertyType(const std::string& name) const
+	{
+		sptr_t res = execute(SCI_PROPERTYTYPE, name.c_str(), SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int DescribeProperty(const char* name, char* description) const
+	{
+		sptr_t res = execute(SCI_DESCRIBEPROPERTY, name, description);
+		return static_cast<int>(res);
+	};
+
+	std::string DescribeProperty(const std::string& name) const
+	{
+		auto size = execute(SCI_DESCRIBEPROPERTY, name.c_str(), NULL);
+		std::string description(size + 1, '\0');
+		execute(SCI_DESCRIBEPROPERTY, name.c_str(), &description[0]);
+		trim(description);
+		return description;
+	};
+
+	int DescribeKeyWordSets(char* descriptions) const
+	{
+		sptr_t res = execute(SCI_DESCRIBEKEYWORDSETS, SCI_UNUSED, descriptions);
+		return static_cast<int>(res);
+	};
+
+	std::string DescribeKeyWordSets() const
+	{
+		auto size = execute(SCI_DESCRIBEKEYWORDSETS, SCI_UNUSED, NULL);
+		std::string descriptions(size + 1, '\0');
+		execute(SCI_DESCRIBEKEYWORDSETS, SCI_UNUSED, &descriptions[0]);
+		trim(descriptions);
+		return descriptions;
+	};
+
+	int GetLineEndTypesSupported() const
+	{
+		sptr_t res = execute(SCI_GETLINEENDTYPESSUPPORTED, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int AllocateSubStyles(int styleBase, int numberStyles) const
+	{
+		sptr_t res = execute(SCI_ALLOCATESUBSTYLES, styleBase, numberStyles);
+		return static_cast<int>(res);
+	};
+
+	int GetSubStylesStart(int styleBase) const
+	{
+		sptr_t res = execute(SCI_GETSUBSTYLESSTART, styleBase, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetSubStylesLength(int styleBase) const
+	{
+		sptr_t res = execute(SCI_GETSUBSTYLESLENGTH, styleBase, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetStyleFromSubStyle(int subStyle) const
+	{
+		sptr_t res = execute(SCI_GETSTYLEFROMSUBSTYLE, subStyle, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetPrimaryStyleFromStyle(int style) const
+	{
+		sptr_t res = execute(SCI_GETPRIMARYSTYLEFROMSTYLE, style, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	void FreeSubStyles() const
+	{
+		execute(SCI_FREESUBSTYLES, SCI_UNUSED, SCI_UNUSED);
+	};
+
+	void SetIdentifiers(int style, const char* identifiers) const
+	{
+		execute(SCI_SETIDENTIFIERS, style, identifiers);
+	};
+
+	void SetIdentifiers(int style, const std::string& identifiers) const
+	{
+		execute(SCI_SETIDENTIFIERS, style, identifiers.c_str());
+	};
+
+	int DistanceToSecondaryStyles() const
+	{
+		sptr_t res = execute(SCI_DISTANCETOSECONDARYSTYLES, SCI_UNUSED, SCI_UNUSED);
+		return static_cast<int>(res);
+	};
+
+	int GetSubStyleBases(char* styles) const
+	{
+		sptr_t res = execute(SCI_GETSUBSTYLEBASES, SCI_UNUSED, styles);
+		return static_cast<int>(res);
+	};
+
+	std::string GetSubStyleBases() const
+	{
+		auto size = execute(SCI_GETSUBSTYLEBASES, SCI_UNUSED, NULL);
+		std::string styles(size + 1, '\0');
+		execute(SCI_GETSUBSTYLEBASES, SCI_UNUSED, &styles[0]);
+		trim(styles);
+		return styles;
+	};
+
 protected:
 	static HINSTANCE _hLib;
 	static int _refCount;
@@ -946,5 +5036,10 @@ protected:
 	std::pair<int, int> getWordRange();
 	bool expandWordSelection();
 	void getFoldColor(COLORREF& fgColor, COLORREF& bgColor, COLORREF& activeFgColor);
+
+	static inline void trim(std::string &s) {
+		while (s.length() > 0 && s.back() == '\0')
+			s.pop_back();
+	}
 };
 

--- a/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
@@ -93,7 +93,7 @@ void SmartHighlighter::highlightViewWithWord(ScintillaEditView * pHighlightView,
 		frInfo._endRange = endPos;
 		if (endPos == -1)
 		{	//past EOF
-			frInfo._endRange = pHighlightView->getCurrentDocLen() - 1;
+			frInfo._endRange = pHighlightView->GetLength() - 1;
 			_pFRDlg->processRange(ProcessMarkAll_2, frInfo, NULL, &fo, -1, pHighlightView);
 			break;
 		}

--- a/PowerEditor/src/ScitillaComponent/columnEditor.cpp
+++ b/PowerEditor/src/ScitillaComponent/columnEditor.cpp
@@ -78,7 +78,7 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 
 				case IDOK :
                 {
-					(*_ppEditView)->execute(SCI_BEGINUNDOACTION);
+					(*_ppEditView)->BeginUndoAction();
 					
 					const int stringSize = 1024;
 					TCHAR str[stringSize];
@@ -91,7 +91,7 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 
 						display(false);
 						
-						if ((*_ppEditView)->execute(SCI_SELECTIONISRECTANGLE) || (*_ppEditView)->execute(SCI_GETSELECTIONS) > 1)
+						if ((*_ppEditView)->SelectionIsRectangle() || (*_ppEditView)->GetSelections() > 1)
 						{
 							ColumnModeInfos colInfos = (*_ppEditView)->getColumnModeSelectInfo();
 							std::sort(colInfos.begin(), colInfos.end(), SortInPositionOrder());
@@ -101,21 +101,21 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 						}
 						else
 						{
-							auto cursorPos = (*_ppEditView)->execute(SCI_GETCURRENTPOS);
-							auto cursorCol = (*_ppEditView)->execute(SCI_GETCOLUMN, cursorPos);
-							auto cursorLine = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, cursorPos);
-							auto endPos = (*_ppEditView)->execute(SCI_GETLENGTH);
-							auto endLine = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, endPos);
+							auto cursorPos = (*_ppEditView)->GetCurrentPos();
+							auto cursorCol = (*_ppEditView)->GetColumn(cursorPos);
+							auto cursorLine = (*_ppEditView)->LineFromPosition(cursorPos);
+							auto endPos = (*_ppEditView)->GetLength();
+							auto endLine = (*_ppEditView)->LineFromPosition(endPos);
 
 							int lineAllocatedLen = 1024;
 							TCHAR *line = new TCHAR[lineAllocatedLen];
 
-							for (size_t i = cursorLine ; i <= static_cast<size_t>(endLine); ++i)
+							for (int i = cursorLine ; i <= endLine; ++i)
 							{
-								auto lineBegin = (*_ppEditView)->execute(SCI_POSITIONFROMLINE, i);
-								auto lineEnd = (*_ppEditView)->execute(SCI_GETLINEENDPOSITION, i);
+								auto lineBegin = (*_ppEditView)->PositionFromLine(i);
+								auto lineEnd = (*_ppEditView)->GetLineEndPosition(i);
 
-								auto lineEndCol = (*_ppEditView)->execute(SCI_GETCOLUMN, lineEnd);
+								auto lineEndCol = (*_ppEditView)->GetColumn(lineEnd);
 								auto lineLen = lineEnd - lineBegin + 1;
 
 								if (lineLen > lineAllocatedLen)
@@ -134,7 +134,7 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 								}
 								else
 								{
-									auto posAbs2Start = (*_ppEditView)->execute(SCI_FINDCOLUMN, i, cursorCol);
+									auto posAbs2Start = (*_ppEditView)->FindColumn(i, cursorCol);
 									auto posRelative2Start = posAbs2Start - lineBegin;
 									s2r.insert(posRelative2Start, str);
 								}
@@ -155,7 +155,7 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 						UCHAR format = getFormat();
 						display(false);
 						
-						if ((*_ppEditView)->execute(SCI_SELECTIONISRECTANGLE) || (*_ppEditView)->execute(SCI_GETSELECTIONS) > 1)
+						if ((*_ppEditView)->SelectionIsRectangle() || (*_ppEditView)->GetSelections() > 1)
 						{
 							ColumnModeInfos colInfos = (*_ppEditView)->getColumnModeSelectInfo();
 
@@ -171,11 +171,11 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 						}
 						else
 						{
-							auto cursorPos = (*_ppEditView)->execute(SCI_GETCURRENTPOS);
-							auto cursorCol = (*_ppEditView)->execute(SCI_GETCOLUMN, cursorPos);
-							auto cursorLine = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, cursorPos);
-							auto endPos = (*_ppEditView)->execute(SCI_GETLENGTH);
-							auto endLine = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, endPos);
+							auto cursorPos = (*_ppEditView)->GetCurrentPos();
+							auto cursorCol = (*_ppEditView)->GetColumn(cursorPos);
+							auto cursorLine = (*_ppEditView)->LineFromPosition(cursorPos);
+							auto endPos = (*_ppEditView)->GetLength();
+							auto endLine = (*_ppEditView)->LineFromPosition(endPos);
 
 							// Compute the numbers to be placed at each column.
 							std::vector<int> numbers;
@@ -218,12 +218,12 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 							int nb = max(nbInit, nbEnd);
 
 
-							for (size_t i = cursorLine ; i <= size_t(endLine) ; ++i)
+							for (int i = cursorLine ; i <= endLine ; ++i)
 							{
-								auto lineBegin = (*_ppEditView)->execute(SCI_POSITIONFROMLINE, i);
-								auto lineEnd = (*_ppEditView)->execute(SCI_GETLINEENDPOSITION, i);
+								auto lineBegin = (*_ppEditView)->PositionFromLine(i);
+								auto lineEnd = (*_ppEditView)->GetLineEndPosition(i);
 
-								auto lineEndCol = (*_ppEditView)->execute(SCI_GETCOLUMN, lineEnd);
+								auto lineEndCol = (*_ppEditView)->GetColumn(lineEnd);
 								auto lineLen = lineEnd - lineBegin + 1;
 
 								if (lineLen > lineAllocatedLen)
@@ -247,7 +247,7 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 								}
 								else
 								{
-									auto posAbs2Start = (*_ppEditView)->execute(SCI_FINDCOLUMN, i, cursorCol);
+									auto posAbs2Start = (*_ppEditView)->FindColumn(i, cursorCol);
 									auto posRelative2Start = posAbs2Start - lineBegin;
 									s2r.insert(posRelative2Start, str);
 								}
@@ -257,7 +257,7 @@ INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 							delete [] line;
 						}
 					}
-					(*_ppEditView)->execute(SCI_ENDUNDOACTION);
+					(*_ppEditView)->EndUndoAction();
                     (*_ppEditView)->getFocus();
                     return TRUE;
                 }

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -126,7 +126,7 @@ void AnsiCharPanel::insertChar(unsigned char char2insert) const
 	int codepage = (*_ppEditView)->getCurrentBuffer()->getEncoding();
 	if (codepage == -1)
 	{
-		bool isUnicode = ((*_ppEditView)->execute(SCI_GETCODEPAGE) == SC_CP_UTF8);
+		bool isUnicode = ((*_ppEditView)->GetCodePage() == SC_CP_UTF8);
 		if (isUnicode)
 		{
 			MultiByteToWideChar(0, 0, charStr, -1, wCharStr, sizeof(wCharStr));
@@ -143,8 +143,8 @@ void AnsiCharPanel::insertChar(unsigned char char2insert) const
 		MultiByteToWideChar(codepage, 0, charStr, -1, wCharStr, sizeof(wCharStr));
 		WideCharToMultiByte(CP_UTF8, 0, wCharStr, -1, multiByteStr, sizeof(multiByteStr), NULL, NULL);
 	}
-	(*_ppEditView)->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
+	(*_ppEditView)->ReplaceSel("");
 	size_t len = (char2insert < 128) ? 1 : strlen(multiByteStr);
-	(*_ppEditView)->execute(SCI_ADDTEXT, len, reinterpret_cast<LPARAM>(multiByteStr));
+	(*_ppEditView)->AddText(static_cast<int>(len), multiByteStr);
 	(*_ppEditView)->getFocus();
 }

--- a/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
+++ b/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
@@ -241,7 +241,7 @@ INT_PTR CALLBACK ClipboardHistoryPanel::run_dlgProc(UINT message, WPARAM wParam,
 							int codepage = (*_ppEditView)->getCurrentBuffer()->getEncoding();
 							if (codepage == -1)
 							{
-								auto cp = (*_ppEditView)->execute(SCI_GETCODEPAGE);
+								auto cp = (*_ppEditView)->GetCodePage();
 								codepage = cp == SC_CP_UTF8 ? SC_CP_UTF8 : 0;
 							}
 							else
@@ -254,8 +254,8 @@ INT_PTR CALLBACK ClipboardHistoryPanel::run_dlgProc(UINT message, WPARAM wParam,
 							char *c = new char[nbChar+1];
 							WideCharToMultiByte(codepage, 0, (wchar_t *)ba.getPointer(), static_cast<int32_t>(ba.getLength()), c, nbChar + 1, NULL, NULL);
 
-							(*_ppEditView)->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
-							(*_ppEditView)->execute(SCI_ADDTEXT, strlen(c), reinterpret_cast<LPARAM>(c));
+							(*_ppEditView)->ReplaceSel("");
+							(*_ppEditView)->AddText(static_cast<int>(strlen(c)), c);
 							(*_ppEditView)->getFocus();
 							delete [] c;
 						}

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -34,8 +34,8 @@ void DocumentMap::reloadMap()
 {
 	if (_pMapView && _ppEditView)
 	{
-		Document currentDoc = (*_ppEditView)->execute(SCI_GETDOCPOINTER);
-		_pMapView->execute(SCI_SETDOCPOINTER, 0, static_cast<LPARAM>(currentDoc));
+		Document currentDoc = (*_ppEditView)->GetDocPointer();
+		_pMapView->SetDocPointer(currentDoc);
 
 		//
 		// sync with the current document
@@ -63,7 +63,7 @@ void DocumentMap::showInMapTemporarily(Buffer *buf2show, ScintillaEditView *from
 {
 	if (_pMapView && fromEditView)
 	{
-		_pMapView->execute(SCI_SETDOCPOINTER, 0, static_cast<LPARAM>(buf2show->getDocument()));
+		_pMapView->SetDocPointer(buf2show->getDocument());
 		_pMapView->setCurrentBuffer(buf2show);
 
 		// folding
@@ -93,7 +93,7 @@ bool DocumentMap::needToRecomputeWith(const ScintillaEditView *editView)
 {
 	const ScintillaEditView *pEditView = editView ? editView : *_ppEditView;
 
-	auto currentZoom = pEditView->execute(SCI_GETZOOM);
+	auto currentZoom = pEditView->GetZoom();
 	if (_displayZoom != currentZoom)
 		return true;
 
@@ -178,7 +178,7 @@ void DocumentMap::wrapMap(const ScintillaEditView *editView)
 
 		// update the wrap needed data
 		_displayWidth = editZoneWidth;
-		_displayZoom = static_cast<int32_t>(pEditView->execute(SCI_GETZOOM));
+		_displayZoom = pEditView->GetZoom();
 		double zr = zoomRatio[_displayZoom + 10];
 
 		// compute doc map width: dzw/ezw = 1/zoomRatio
@@ -188,7 +188,7 @@ void DocumentMap::wrapMap(const ScintillaEditView *editView)
 		_pMapView->wrap(true);
 
 		// sync wrapping indent mode
-		_pMapView->execute(SCI_SETWRAPINDENTMODE, pEditView->execute(SCI_GETWRAPINDENTMODE));
+		_pMapView->SetWrapIndentMode(pEditView->GetWrapIndentMode());
 
 	}
 }
@@ -203,7 +203,7 @@ int DocumentMap::getEditorTextZoneWidth(const ScintillaEditView *editView)
 	int marginWidths = 0;
 	for (int m = 0; m < 4; ++m)
 	{
-		marginWidths += static_cast<int32_t>(pEditView->execute(SCI_GETMARGINWIDTHN, m));
+		marginWidths += pEditView->GetMarginWidthN(m);
 	}
 	return editorRect.right - editorRect.left - marginWidths;
 }
@@ -213,19 +213,18 @@ void DocumentMap::scrollMap()
 	if (_pMapView && _ppEditView)
 	{
 		// Visible document line for the code view (but not displayed line)
-		auto firstVisibleDisplayLine = (*_ppEditView)->execute(SCI_GETFIRSTVISIBLELINE);
-		const auto firstVisibleDocLine = (*_ppEditView)->execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine);
-		const auto nbLine = (*_ppEditView)->execute(SCI_LINESONSCREEN, firstVisibleDisplayLine);
-		const auto lastVisibleDocLine = (*_ppEditView)->execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine + nbLine);
+		auto firstVisibleDisplayLine = (*_ppEditView)->GetFirstVisibleLine();
+		const auto firstVisibleDocLine = (*_ppEditView)->DocLineFromVisible(firstVisibleDisplayLine);
+		const auto nbLine = (*_ppEditView)->LinesOnScreen();
+		const auto lastVisibleDocLine = (*_ppEditView)->DocLineFromVisible(firstVisibleDisplayLine + nbLine);
 
 		// Visible document line for the map view
-		auto firstVisibleDisplayLineMap = _pMapView->execute(SCI_GETFIRSTVISIBLELINE);
-		auto firstVisibleDocLineMap = _pMapView->execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLineMap);
-		auto nbLineMap = _pMapView->execute(SCI_LINESONSCREEN, firstVisibleDocLineMap);
-		auto lastVisibleDocLineMap = _pMapView->execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLineMap + nbLineMap);
+		auto firstVisibleDisplayLineMap = _pMapView->GetFirstVisibleLine();
+		auto nbLineMap = _pMapView->LinesOnScreen();
+		auto lastVisibleDocLineMap = _pMapView->DocLineFromVisible(firstVisibleDisplayLineMap + nbLineMap);
 
 		// If part of editor view is out of map, then scroll map
-		LRESULT mapLineToScroll = 0;
+		int mapLineToScroll = 0;
 		if (lastVisibleDocLineMap < lastVisibleDocLine)
 			mapLineToScroll = lastVisibleDocLine;
 		else
@@ -233,34 +232,34 @@ void DocumentMap::scrollMap()
 		//
 		// Scroll to make whole view zone visible
 		//
-		_pMapView->execute(SCI_GOTOLINE, mapLineToScroll);
+		_pMapView->GotoLine(mapLineToScroll);
 
 		// Get the editor's higher/lower Y, then compute the map's higher/lower Y
-		LRESULT higherY = 0;
-		LRESULT lowerY = 0;
-		LRESULT higherPos = -1 ; // -1 => not (*_ppEditView)->isWrap()
+		int higherY = 0;
+		int lowerY = 0;
+		int higherPos = -1 ; // -1 => not (*_ppEditView)->isWrap()
 		if (not (*_ppEditView)->isWrap())
 		{
-			higherPos = _pMapView->execute(SCI_POSITIONFROMLINE, firstVisibleDocLine);
-			auto lowerPos = _pMapView->execute(SCI_POSITIONFROMLINE, lastVisibleDocLine);
-			higherY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, higherPos);
-			lowerY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, lowerPos);
+			higherPos = _pMapView->PositionFromLine(firstVisibleDocLine);
+			auto lowerPos = _pMapView->PositionFromLine(lastVisibleDocLine);
+			higherY = _pMapView->PointYFromPosition(higherPos);
+			lowerY = _pMapView->PointYFromPosition(lowerPos);
 			if (lowerY == 0)
 			{
-				auto lineHeight = _pMapView->execute(SCI_TEXTHEIGHT, firstVisibleDocLine);
+				auto lineHeight = _pMapView->TextHeight(firstVisibleDocLine);
 				lowerY = nbLine * lineHeight + firstVisibleDocLine;
 			}
 		}
 		else
 		{
 			// Get the position of the 1st showing char from the original edit view
-			higherPos = (*_ppEditView)->execute(SCI_POSITIONFROMPOINT, 0, 0);
+			higherPos = (*_ppEditView)->PositionFromPoint(0, 0);
 
 			// Get the map higher Y point from the position in map
-			higherY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, static_cast<int32_t>(higherPos));
+			higherY = _pMapView->PointYFromPosition(higherPos);
 
 			// Get line height
-			auto lineHeight = _pMapView->execute(SCI_TEXTHEIGHT, firstVisibleDocLine);
+			auto lineHeight = _pMapView->TextHeight(firstVisibleDocLine);
 
 			// Get the map lower Y point
 			lowerY = nbLine * lineHeight + higherY;
@@ -278,13 +277,12 @@ void DocumentMap::scrollMapWith(const MapPosition & mapPos)
 	if (_pMapView)
 	{
 		// Visible document line for the map view
-		auto firstVisibleDisplayLineMap = _pMapView->execute(SCI_GETFIRSTVISIBLELINE);
-		auto firstVisibleDocLineMap = _pMapView->execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLineMap);
-		auto nbLineMap = _pMapView->execute(SCI_LINESONSCREEN, firstVisibleDocLineMap);
-		auto lastVisibleDocLineMap = _pMapView->execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLineMap + nbLineMap);
+		auto firstVisibleDisplayLineMap = _pMapView->GetFirstVisibleLine();
+		auto nbLineMap = _pMapView->LinesOnScreen();
+		auto lastVisibleDocLineMap = _pMapView->DocLineFromVisible(firstVisibleDisplayLineMap + nbLineMap);
 
 		// If part of editor view is out of map, then scroll map
-		LRESULT mapLineToScroll = 0;
+		int mapLineToScroll = 0;
 		if (lastVisibleDocLineMap < mapPos._lastVisibleDocLine)
 			mapLineToScroll = mapPos._lastVisibleDocLine;
 		else
@@ -292,27 +290,27 @@ void DocumentMap::scrollMapWith(const MapPosition & mapPos)
 		//
 		// Scroll to make whole view zone visible
 		//
-		_pMapView->execute(SCI_GOTOLINE, mapLineToScroll);
+		_pMapView->GotoLine(mapLineToScroll);
 
 		// Get the editor's higher/lower Y, then compute the map's higher/lower Y
-		LRESULT higherY = 0;
-		LRESULT lowerY = 0;
+		int higherY = 0;
+		int lowerY = 0;
 		if (not mapPos._isWrap)
 		{
-			auto higherPos = _pMapView->execute(SCI_POSITIONFROMLINE, mapPos._firstVisibleDocLine);
-			auto lowerPos = _pMapView->execute(SCI_POSITIONFROMLINE, mapPos._lastVisibleDocLine);
-			higherY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, higherPos);
-			lowerY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, lowerPos);
+			auto higherPos = _pMapView->PositionFromLine(mapPos._firstVisibleDocLine);
+			auto lowerPos = _pMapView->PositionFromLine(mapPos._lastVisibleDocLine);
+			higherY = _pMapView->PointYFromPosition(higherPos);
+			lowerY = _pMapView->PointYFromPosition(lowerPos);
 			if (lowerY == 0)
 			{
-				auto lineHeight = _pMapView->execute(SCI_TEXTHEIGHT, mapPos._firstVisibleDocLine);
+				auto lineHeight = _pMapView->TextHeight(mapPos._firstVisibleDocLine);
 				lowerY = mapPos._nbLine * lineHeight + mapPos._firstVisibleDocLine;
 			}
 		}
 		else
 		{
-			higherY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, static_cast<int32_t>(mapPos._higherPos));
-			auto lineHeight = _pMapView->execute(SCI_TEXTHEIGHT, mapPos._firstVisibleDocLine);
+			higherY = _pMapView->PointYFromPosition(mapPos._higherPos);
+			auto lineHeight = _pMapView->TextHeight(mapPos._firstVisibleDocLine);
 			lowerY = mapPos._nbLine * lineHeight + higherY;
 		}
 
@@ -345,17 +343,16 @@ void DocumentMap::foldAll(bool mode)
 void DocumentMap::scrollMap(bool direction, moveMode whichMode)
 {
 	// Visible line for the code view
-	auto firstVisibleDisplayLine = (*_ppEditView)->execute(SCI_GETFIRSTVISIBLELINE);
-	auto nbLine = (*_ppEditView)->execute(SCI_LINESONSCREEN, firstVisibleDisplayLine);
+	auto nbLine = (*_ppEditView)->LinesOnScreen();
 	auto nbLine2go = (whichMode == perLine ? 1 : nbLine);
-	(*_ppEditView)->execute(SCI_LINESCROLL, 0, (direction == moveDown) ? nbLine2go : -nbLine2go);
+	(*_ppEditView)->LineScroll(0, (direction == moveDown) ? nbLine2go : -nbLine2go);
 
 	scrollMap();
 }
 
 void DocumentMap::redraw(bool) const
 {
-	_pMapView->execute(SCI_COLOURISE, 0, -1);
+	_pMapView->Colourise(0, -1);
 }
 
 INT_PTR CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
@@ -366,9 +363,9 @@ INT_PTR CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
         {
 			HWND hwndScintilla = reinterpret_cast<HWND>(::SendMessage(_hParent, NPPM_CREATESCINTILLAHANDLE, 0, reinterpret_cast<LPARAM>(_hSelf)));
 			_pMapView = reinterpret_cast<ScintillaEditView *>(::SendMessage(_hParent, NPPM_INTERNAL_GETSCINTEDTVIEW, 0, reinterpret_cast<LPARAM>(hwndScintilla)));
-			_pMapView->execute(SCI_SETZOOM, static_cast<WPARAM>(-10), 0);
-			_pMapView->execute(SCI_SETVSCROLLBAR, FALSE, 0);
-			_pMapView->execute(SCI_SETHSCROLLBAR, FALSE, 0);
+			_pMapView->SetZoom(-10);
+			_pMapView->SetVScrollBar(false);
+			_pMapView->SetHScrollBar(false);
 
 			_pMapView->showIndentGuideLine(false);
 			_pMapView->display();
@@ -470,10 +467,10 @@ INT_PTR CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 		{
 			int newPosY = HIWORD(lParam);
 			int currentCenterPosY = _vzDlg.getCurrentCenterPosY();
-			int pixelPerLine = static_cast<int32_t>(_pMapView->execute(SCI_TEXTHEIGHT, 0));
+			int pixelPerLine = _pMapView->TextHeight(0);
 			int jumpDistance = newPosY - currentCenterPosY;
 			int nbLine2jump = jumpDistance/pixelPerLine;
-			(*_ppEditView)->execute(SCI_LINESCROLL, 0, nbLine2jump);
+			(*_ppEditView)->LineScroll(0, nbLine2jump);
 
 			scrollMap();
 		}

--- a/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
@@ -184,7 +184,7 @@ void DocumentPeeker::saveCurrentSnapshot(ScintillaEditView & editView)
 		}
 
 		// Length of document
-		mapPos._KByteInDoc = editView.getCurrentDocLen() / 1024;
+		mapPos._KByteInDoc = editView.GetLength() / 1024;
 
 		// set current map position in buffer
 		buffer->setMapPosition(mapPos);

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
@@ -52,7 +52,7 @@ INT_PTR CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, L
 
 				case ID_FINDCHAR_NEXT:
 				{
-					int currentPos = static_cast<int32_t>((*_ppEditView)->execute(SCI_GETCURRENTPOS));
+					int currentPos = (*_ppEditView)->GetCurrentPos();
 					unsigned char startRange = 0;
 					unsigned char endRange = 255;
 					bool direction = dirDown;
@@ -122,10 +122,10 @@ bool FindCharsInRangeDlg::findCharInRange(unsigned char beginRange, unsigned cha
 	if (found != -1)
 	{
 		//printInt(found);
-		auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, found);
-		(*_ppEditView)->execute(SCI_ENSUREVISIBLE, sci_line);
-		(*_ppEditView)->execute(SCI_GOTOPOS, found);
-		(*_ppEditView)->execute(SCI_SETSEL, (direction == dirDown)?found:found+1, (direction == dirDown)?found+1:found);
+		auto sci_line = (*_ppEditView)->LineFromPosition(found);
+		(*_ppEditView)->EnsureVisible(sci_line);
+		(*_ppEditView)->GotoPos(found);
+		(*_ppEditView)->SetSel((direction == dirDown) ? found : found + 1, (direction == dirDown) ? found + 1 : found);
 	}
 	delete [] content;
 	return (found != -1);

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
@@ -81,7 +81,7 @@ INT_PTR CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, L
 
 bool FindCharsInRangeDlg::findCharInRange(unsigned char beginRange, unsigned char endRange, int startPos, bool direction, bool wrap)
 {
-	int totalSize = (*_ppEditView)->getCurrentDocLen();
+	int totalSize = (*_ppEditView)->GetLength();
 	if (startPos == -1)
 		startPos = direction==dirDown?0:totalSize-1;
 	if (startPos > totalSize)

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -70,7 +70,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 {
 	size_t cntOpen = 1;
 
-	int docLen = (*_ppEditView)->getCurrentDocLen();
+	int docLen = (*_ppEditView)->GetLength();
 
 	if (begin >= (size_t)docLen)
 		return docLen;

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -84,7 +84,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX;
 
-	(*_ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
+	(*_ppEditView)->SetSearchFlags(flags);
 	int targetStart = (*_ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
 	int targetEnd = 0;
 
@@ -92,7 +92,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 	{
 		if (targetStart != -1 && targetStart != -2) // found open or close symbol
 		{
-			targetEnd = int((*_ppEditView)->execute(SCI_GETTARGETEND));
+			targetEnd = (*_ppEditView)->GetTargetEnd();
 
 			// Now we determinate the symbol (open or close)
 			int tmpStart = (*_ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
@@ -131,7 +131,7 @@ generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::v
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX;
 
-	(*_ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
+	(*_ppEditView)->SetSearchFlags(flags);
 	const TCHAR *regExpr2search = dataToSearch[0].c_str();
 	int targetStart = (*_ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
 
@@ -140,7 +140,7 @@ generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::v
 		foundPos = -1;
 		return TEXT("");
 	}
-	int targetEnd = int((*_ppEditView)->execute(SCI_GETTARGETEND));
+	int targetEnd = (*_ppEditView)->GetTargetEnd();
 
 	if (dataToSearch.size() >= 2)
 	{
@@ -367,8 +367,8 @@ bool FunctionListPanel::openSelection(const TreeView & treeView)
 	if (pos == -1)
 		return false;
 
-	auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, pos);
-	(*_ppEditView)->execute(SCI_ENSUREVISIBLE, sci_line);
+	auto sci_line = (*_ppEditView)->LineFromPosition(pos);
+	(*_ppEditView)->EnsureVisible(sci_line);
 	(*_ppEditView)->scrollPosToCenter(pos);
 
 	return true;

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -320,15 +320,15 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
-	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
+	(*ppEditView)->SetSearchFlags(flags);
 	int targetStart = (*ppEditView)->searchInTarget(_functionExpr.c_str(), _functionExpr.length(), begin, end);
 	int targetEnd = 0;
 	
 	//foundInfos.clear();
 	while (targetStart != -1 && targetStart != -2)
 	{
-		targetStart = int((*ppEditView)->execute(SCI_GETTARGETSTART));
-		targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
+		targetStart = (*ppEditView)->GetTargetStart();
+		targetEnd = (*ppEditView)->GetTargetEnd();
 		if (targetEnd > int(end)) //we found a result but outside our range, therefore do not process it
 		{
 			break;
@@ -400,7 +400,7 @@ generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vect
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX  | SCFIND_REGEXP_DOTMATCHESNL;
 
-	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
+	(*ppEditView)->SetSearchFlags(flags);
 	const TCHAR *regExpr2search = dataToSearch[0].c_str();
 	int targetStart = (*ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
 
@@ -409,7 +409,7 @@ generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vect
 		foundPos = -1;
 		return generic_string();
 	}
-	int targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
+	int targetEnd = (*ppEditView)->GetTargetEnd();
 
 	if (dataToSearch.size() >= 2)
 	{
@@ -462,7 +462,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
-	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
+	(*ppEditView)->SetSearchFlags(flags);
 	int targetStart = (*ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
 	LRESULT targetEnd = 0;
 
@@ -470,7 +470,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 	{
 		if (targetStart != -1 && targetStart != -2) // found open or close symbol
 		{
-			targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
+			targetEnd = (*ppEditView)->GetTargetEnd();
 
 			// Treat it only if it's NOT in the comment zone
 			if (!isInZones(targetStart, commentZones))
@@ -507,14 +507,14 @@ void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
-	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
+	(*ppEditView)->SetSearchFlags(flags);
 	int targetStart = (*ppEditView)->searchInTarget(_rangeExpr.c_str(), _rangeExpr.length(), begin, end);
 
 	int targetEnd = 0;
 	
 	while (targetStart != -1 && targetStart != -2)
 	{
-		targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
+		targetEnd = (*ppEditView)->GetTargetEnd();
 
 		// Get class name
 		int foundPos = 0;
@@ -554,14 +554,14 @@ void FunctionParser::getCommentZones(vector< pair<int, int> > & commentZone, siz
 
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
-	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
+	(*ppEditView)->SetSearchFlags(flags);
 	int targetStart = (*ppEditView)->searchInTarget(_commentExpr.c_str(), _commentExpr.length(), begin, end);
 	int targetEnd = 0;
 	
 	while (targetStart != -1 && targetStart != -2)
 	{
-		targetStart = int((*ppEditView)->execute(SCI_GETTARGETSTART));
-		targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
+		targetStart = (*ppEditView)->GetTargetStart();
+		targetEnd = (*ppEditView)->GetTargetEnd();
 		if (targetEnd > int(end)) //we found a result but outside our range, therefore do not process it
 			break;
 

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -437,7 +437,7 @@ bool FunctionParsersManager::parse(std::vector<foundInfo> & foundInfos, const As
 		return false;
 
 	// parse
-	int docLen = (*_ppEditView)->getCurrentDocLen();
+	int docLen = (*_ppEditView)->GetLength();
 	fp->parse(foundInfos, 0, docLen, _ppEditView);
 
 	return true;
@@ -448,7 +448,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 {
 	size_t cntOpen = 1;
 
-	int docLen = (*ppEditView)->getCurrentDocLen();
+	int docLen = (*ppEditView)->GetLength();
 
 	if (begin >= (size_t)docLen)
 		return docLen;

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -686,7 +686,7 @@ void recordedMacroStep::PlayBack(Window* pNotepad, ScintillaEditView *pEditView)
 		if (_macroType == mtUseSParameter)
 		{
 			char ansiBuffer[3];
-			::WideCharToMultiByte(static_cast<UINT>(pEditView->execute(SCI_GETCODEPAGE)), 0, _sParameter.c_str(), -1, ansiBuffer, 3, NULL, NULL);
+			::WideCharToMultiByte(static_cast<UINT>(pEditView->GetCodePage()), 0, _sParameter.c_str(), -1, ansiBuffer, 3, NULL, NULL);
 			auto lParam = reinterpret_cast<LPARAM>(ansiBuffer);
 			pEditView->execute(_message, _wParameter, lParam);
 		}


### PR DESCRIPTION
Currently to interact with Scintilla, Notepad++ uses the `execute()` call which requires lots of casting and is not able to provide any type checking for what gets passed in. There are also numerous inconsistencies about variable types. For example to represent a "position" within a document, Notepad++ uses a variety of types, such as `size_t`, `long`, `int32_t`, `int`, and `LRESULT` with no real reason why. Scintilla only uses a small set of data types so most of the data that gets passed to Scintilla gets `static_cast<>()` immediately.

This PR adds a thin layer (most likely optimized away) which provides a readable and strongly typed interface for interacting with Scintilla. This PR is broken up into multiple commits for easier review. The first commit simply adds the interface. The 2nd and 3rd updates and cleans up the ScintillaEditView to utilize this interface, and the last replaces nearly all other calls to `execute()` with its alternative.

### About the Interface

Each call to Scintilla (e.g. `SCI_XXX`) has an associated method that makes the code readable and enforces correct variable types. For example:

```cpp
void AddText(int length, const char* text) const
{
    execute(SCI_ADDTEXT, length, text);
}
```

Some calls are also overloaded to accept `std::string`s such as:

```cpp
void AddText(const std::string& text) const
{
    execute(SCI_ADDTEXT, text.length(), text.c_str());
}
```

In other cases it is also able to allocate strings as return types (which avoids potential pitfalls such as buffer overruns):

```cpp
int GetText(int length, char* text) const
{
    sptr_t res = execute(SCI_GETTEXT, length, text);
    return static_cast<int>(res);
}

std::string GetText() const
{
    auto size = execute(SCI_GETTEXT, SCI_UNUSED, NULL);
    std::string text(size + 1, '\0');
    execute(SCI_GETTEXT, text.length(), &text[0]);
    trim(text);
    return text;
}
```

This interface can be generated with a Python script (which I can provide later) by reading the scintilla.iface file. This does away with quite a bit of casting when using the ScintillaEditView (other than casting `size_t` to `int` in places). 

I've attempted to make the minimum number of changes to use this interface throughout the code base. I'm hoping this will lead to more cleanup later by providing a cleaner way of getting data into and out of Scintilla.

---

Since this is a non-trivial code patch I am open to idea/feedback/comments/issues and hope that this gets thoroughly reviewed and tested by anyone willing. 
