### PR TITLE
Fix rapid swapping between two tabs during tab drag and drop.

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -1194,13 +1194,24 @@ void TabBarPlus::exchangeItemData(POINT point)
 
 		if (nTab != _nTabDragged)
 		{
+			if (_previousTabSwapped == nTab)
+			{
+				return;
+			}
+
 			exchangeTabItemData(_nTabDragged, nTab);
+			_previousTabSwapped = _nTabDragged;
 			_nTabDragged = nTab;
+		}
+		else
+		{
+			_previousTabSwapped = -1;
 		}
 	}
 	else
 	{
 		//::SetCursor(::LoadCursor(_hInst, MAKEINTRESOURCE(IDC_DRAG_TAB)));
+		_previousTabSwapped = -1;
 		_isDraggingInside = false;
 	}
 

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -229,6 +229,7 @@ protected:
 	bool _isDraggingInside = false;
     int _nSrcTab = -1;
 	int _nTabDragged = -1;
+	int _previousTabSwapped = -1;
 	POINT _draggingPoint; // coordinate of Screen
 	WNDPROC _tabBarDefaultProc = nullptr;
 


### PR DESCRIPTION
This patch simply prevents swapping back to a tab until you move off of it.

Fixes [#3017](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/3017)