### PR TITLE
Fix C6328: Potential argument type mismatch

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -455,7 +455,7 @@ void PluginsManager::runPluginCommand(size_t i)
 			catch (...)
 			{
 				TCHAR funcInfo[128];
-				generic_sprintf(funcInfo, TEXT("runPluginCommand(size_t i : %d)"), i);
+				generic_sprintf(funcInfo, TEXT("runPluginCommand(size_t i : %ld)"), static_cast<long>(i));
 				pluginCrashAlert(_pluginsCommands[i]._pluginName.c_str(), funcInfo);
 			}
 		}
@@ -511,8 +511,8 @@ void PluginsManager::notify(const SCNotification *notification)
 			catch (...)
 			{
 				TCHAR funcInfo[256];
-				generic_sprintf(funcInfo, TEXT("notify(SCNotification *notification) : \r notification->nmhdr.code == %d\r notification->nmhdr.hwndFrom == %p\r notification->nmhdr.idFrom == %d"),\
-					scNotif.nmhdr.code, scNotif.nmhdr.hwndFrom, scNotif.nmhdr.idFrom);
+				generic_sprintf(funcInfo, TEXT("notify(SCNotification *notification) : \r notification->nmhdr.code == %d\r notification->nmhdr.hwndFrom == %p\r notification->nmhdr.idFrom == %ld"),\
+					scNotif.nmhdr.code, scNotif.nmhdr.hwndFrom, static_cast<long>(scNotif.nmhdr.idFrom));
 				pluginCrashAlert(_pluginInfos[i]->_moduleName.c_str(), funcInfo);
 			}
 		}
@@ -537,7 +537,7 @@ void PluginsManager::relayNppMessages(UINT Message, WPARAM wParam, LPARAM lParam
 			catch (...)
 			{
 				TCHAR funcInfo[128];
-				generic_sprintf(funcInfo, TEXT("relayNppMessages(UINT Message : %d, WPARAM wParam : %d, LPARAM lParam : %d)"), Message, wParam, lParam);
+				generic_sprintf(funcInfo, TEXT("relayNppMessages(UINT Message : %d, WPARAM wParam : %lu, LPARAM lParam : %ld)"), Message, static_cast<unsigned long>(wParam), static_cast<long>(lParam));
 				pluginCrashAlert(_pluginInfos[i]->_moduleName.c_str(), funcInfo);
 			}
 		}
@@ -568,7 +568,7 @@ bool PluginsManager::relayPluginMessages(UINT Message, WPARAM wParam, LPARAM lPa
 				catch (...)
 				{
 					TCHAR funcInfo[128];
-					generic_sprintf(funcInfo, TEXT("relayPluginMessages(UINT Message : %d, WPARAM wParam : %d, LPARAM lParam : %d)"), Message, wParam, lParam);
+					generic_sprintf(funcInfo, TEXT("relayPluginMessages(UINT Message : %d, WPARAM wParam : %lu, LPARAM lParam : %ld)"), Message, static_cast<unsigned long>(wParam), static_cast<long>(lParam));
 					pluginCrashAlert(_pluginInfos[i]->_moduleName.c_str(), funcInfo);
 				}
 				return true;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4921,7 +4921,7 @@ bool Notepad_plus::dumpFiles(const TCHAR * outdir, const TCHAR * fileprefix) {
 			somedirty = true;
 
 		const TCHAR * unitext = (docbuf->getUnicodeMode() != uni8Bit)?TEXT("_utf8"):TEXT("");
-		wsprintf(savePath, TEXT("%s\\%s%03d%s.dump"), outdir, fileprefix, i, unitext);
+		wsprintf(savePath, TEXT("%s\\%s%03ld%s.dump"), outdir, fileprefix, static_cast<long>(i), unitext);
 
 		bool res = MainFileManager->saveBuffer(docbuf->getID(), savePath);
 

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1188,7 +1188,7 @@ BufferID FileManager::newEmptyDocument()
 {
 	generic_string newTitle = UNTITLED_STR;
 	TCHAR nb[10];
-	wsprintf(nb, TEXT("%d"), nextUntitledNewNumber());
+	wsprintf(nb, TEXT("%ld"), static_cast<long>(nextUntitledNewNumber()));
 	newTitle += nb;
 
 	Document doc = (Document)_pscratchTilla->execute(SCI_CREATEDOCUMENT);	//this already sets a reference for filemanager
@@ -1205,7 +1205,7 @@ BufferID FileManager::bufferFromDocument(Document doc, bool dontIncrease, bool d
 {
 	generic_string newTitle = UNTITLED_STR;
 	TCHAR nb[10];
-	wsprintf(nb, TEXT("%d"), nextUntitledNewNumber());
+	wsprintf(nb, TEXT("%ld"), static_cast<long>(nextUntitledNewNumber()));
 	newTitle += nb;
 
 	if (!dontRef)

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2777,7 +2777,7 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
 	generic_string str = TEXT("\tLine ");
 
 	TCHAR lnb[16];
-	wsprintf(lnb, TEXT("%d"), fi._lineNumber);
+	wsprintf(lnb, TEXT("%ld"), static_cast<long>(fi._lineNumber));
 	str += lnb;
 	str += TEXT(": ");
 	mi._start += static_cast<int32_t>(str.length());

--- a/PowerEditor/src/ScitillaComponent/Printer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Printer.cpp
@@ -353,7 +353,7 @@ size_t Printer::doPrint(bool justDoIt)
 			printPage = false;		 
 
 		TCHAR pageString[32];
-		wsprintf(pageString, TEXT("%0d"), pageNum);
+		wsprintf(pageString, TEXT("%0ld"), static_cast<long>(pageNum));
 		
 		if (printPage) 
 		{

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -2113,7 +2113,7 @@ INT_PTR CALLBACK PrintSettingsDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 			TCHAR intStr[5];
 			for(size_t i = 6 ; i < 15 ; ++i)
 			{
-				wsprintf(intStr, TEXT("%d"), i);
+				wsprintf(intStr, TEXT("%ld"), static_cast<long>(i));
 				::SendDlgItemMessage(_hSelf, IDC_COMBO_HFONTSIZE, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(intStr));
 				::SendDlgItemMessage(_hSelf, IDC_COMBO_FFONTSIZE, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(intStr));
 			}

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
@@ -134,7 +134,7 @@ void expandNppEnvironmentStrs(const TCHAR *strSrc, TCHAR *stringDest, size_t str
 					if (internalVar == CURRENT_LINE || internalVar == CURRENT_COLUMN)
 					{
 						auto lineNumber = ::SendMessage(hWnd, RUNCOMMAND_USER + internalVar, 0, 0);
-						wsprintf(expandedStr, TEXT("%d"), lineNumber);
+						wsprintf(expandedStr, TEXT("%ld"), static_cast<long>(lineNumber));
 					}
 					else
 						::SendMessage(hWnd, RUNCOMMAND_USER + internalVar, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(expandedStr));


### PR DESCRIPTION
In several places string functions specified 'int' values but 'long' or 'size_t' was actually being used. I fixed them by specifying 'long' and casting inputs to 'long'. I found these using Visual Studio's Code Analysis feature.