### PR TITLE
Fixed issue: Tab closing error

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -788,6 +788,17 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 				{
 					notify(TCN_TABDELETE, currentTabOn);
 					_whichCloseClickDown = -1;
+
+					// Get the next tab at same position
+					// If valid tab is found then
+					//	 update the current hover tab RECT (_currentHoverTabRect)
+					//	 update close hover flag (_isCloseHover), so that x will be highlighted or not based on new _currentHoverTabRect
+					int nextTab = getTabIndexAt(xPos, yPos);
+					if (nextTab != -1)
+					{
+						::SendMessage(_hSelf, TCM_GETITEMRECT, nextTab, reinterpret_cast<LPARAM>(&_currentHoverTabRect));
+						_isCloseHover = _closeButtonZone.isHit(xPos, yPos, _currentHoverTabRect, _isVertical);
+					}
 					return TRUE;
 				}
 				_whichCloseClickDown = -1;


### PR DESCRIPTION
Fixed issue #3004 
If the previous tab size is small then next tab is being closed without clicking on 'x' image.