### PR TITLE
Fix hung UI thread while holding left click on a tab and not moving.

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -598,26 +598,7 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 
             if (_doDragNDrop)
             {
-				// ::DragDetect does not work with TCS_BUTTONS
-				if (::GetWindowLongPtr(_hSelf, GWL_STYLE) & TCS_BUTTONS)
-				{
-					_mightBeDragging = true;
-				}
-				else
-				{
-					_nSrcTab = _nTabDragged = currentTabOn;
-
-					POINT point;
-					point.x = LOWORD(lParam);
-					point.y = HIWORD(lParam);
-					::ClientToScreen(hwnd, &point);
-					if(::DragDetect(hwnd, point))
-					{
-						// Yes, we're beginning to drag, so capture the mouse...
-						_isDragging = true;
-						::SetCapture(hwnd);
-					}
-				}
+				_mightBeDragging = true;
             }
 
 			notify(NM_CLICK, currentTabOn);
@@ -658,6 +639,12 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 
 					_nSrcTab = _nTabDragged = tabFocused;
 					_isDragging = true;
+					
+					// ::SetCapture is required for normal non-TLS_BUTTONS.
+					if (!(::GetWindowLongPtr(_hSelf, GWL_STYLE) & TCS_BUTTONS))
+					{
+						::SetCapture(hwnd);
+					}
 				}
 			}
 


### PR DESCRIPTION
::DragDetect seems to being blocking UI updates for up to 2 seconds if you hold left click on a tab and don't move. This manifests itself as two issues depending on OS environment. Either [all the tabs completely disappear for 2 seconds](https://media.giphy.com/media/l0Iyldxa0P4StXTyM/giphy.gif) or the tab is selected but the document contents don't reflect the tab change.

To reproduce, enable drag and drop and either disable Multi-line or have only 1 row of tabs, then don't move while holding left click on a tab.

[Fixes issue reported here](https://notepad-plus-plus.org/community/topic/13881/tab-bar-flashes-when-dragging-tabs)