### PR TITLE
Installer shows installation size as 0 for minimalist

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -91,6 +91,7 @@ page Custom ExtraOptions
 Var diffArchDir2Remove
 Function .onInit
 
+	SectionSetSize ${mainSection} 4500		; This is rough estimation of files present in function copyCommonFiles
 	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
 	Call preventInstallInWin9x
 		


### PR DESCRIPTION
Nsis calculates the required space for installation automatically, but the installation should be done via section. **FILE command should be used in sections in order to get exact required size.**

N++ installer used to show proper required size till V6.9.2. Later on few files were moved into function and problem arises.

Issue: (scrrenshots from V7.4.1)
![image](https://user-images.githubusercontent.com/14791461/26844813-497414d8-4b12-11e7-9404-eb34d0f88678.png)

To overcome this issue, there are few ways:
1. Move code from function "copyCommonFiles" to section "mainSection" instead of calling "copyCommonFiles". **This is recommended way.**
2. Do not show required size at all.
3. or set size of section "mainSection" manually.
This PR uses third approach due to less code.

![image](https://user-images.githubusercontent.com/14791461/26844980-cea4aafa-4b12-11e7-86c3-3dd86c0c40d2.png)

Reference: 
[nsis doc](http://nsis.sourceforge.net/Docs/Chapter4.html) section 4.9.13.7 SectionSetSize
[NSIS Discussion](http://forums.winamp.com/showthread.php?p=3084022)

