### PR TITLE
Fix folding in user-defined languages for non-windows line endings

### DIFF
--- a/scintilla/lexers/LexUser.cxx
+++ b/scintilla/lexers/LexUser.cxx
@@ -1715,8 +1715,8 @@ static void ColouriseUserDoc(unsigned int startPos, int length, int initStyle, W
                         // for delimiters that end with ((EOL))
                         if (newState != SCE_USER_STYLE_COMMENTLINE || (sc.ch != '\r' && sc.ch != '\n'))
                             sc.Forward(iter->length());
-                        if (sc.atLineStart)
-                            checkEOL = EOL_FORCE_CHECK;
+                        if (sc.atLineEnd)
+                            checkEOL = EOL_SKIP_CHECK;
 
                         // paint end of delimiter sequence
                         sc.SetState(newState);

--- a/scintilla/lexers/LexUser.cxx
+++ b/scintilla/lexers/LexUser.cxx
@@ -2085,6 +2085,8 @@ static void ColouriseUserDoc(unsigned int startPos, int length, int initStyle, W
                         // no closing sequence, start over from default
                         sc.SetState(SCE_USER_STYLE_IDENTIFIER);
                         dontMove = true;
+                        if (sc.atLineEnd)
+                            checkEOL = EOL_SKIP_CHECK;
                         break;
                     }
                 }
@@ -2129,7 +2131,7 @@ static void ColouriseUserDoc(unsigned int startPos, int length, int initStyle, W
                         sc.SetState(SCE_USER_STYLE_IDENTIFIER);
                         dontMove = true;
                         if (sc.atLineEnd)
-                            checkEOL = true;
+                            checkEOL = EOL_SKIP_CHECK;
 
                         levelNext--;
                         if (levelMinCurrent > levelNext)
@@ -2154,7 +2156,7 @@ static void ColouriseUserDoc(unsigned int startPos, int length, int initStyle, W
                         // no closing sequence, start over from default
                         sc.SetState(SCE_USER_STYLE_IDENTIFIER);
                         if (sc.atLineEnd)
-                            checkEOL = true;
+                            checkEOL = EOL_SKIP_CHECK;
 
                         dontMove = true;
                         levelNext--;


### PR DESCRIPTION
fixes #2873 and fixes #350 (duplicate issues)

I also replaced two instances of "true" with EOL_SKIP_CHECK since that's what it evaluates to (and to reduce confusion since "true" would imply EOL_FORCE_CHECK)