### PR TITLE
verifySignedfile.cpp: PVS-Studio: fixed identical sub-expressions.

### DIFF
--- a/PowerEditor/src/MISC/Common/verifySignedfile.cpp
+++ b/PowerEditor/src/MISC/Common/verifySignedfile.cpp
@@ -247,7 +247,7 @@ bool VerifySignedLibrary(const wstring& filepath,
 		OutputDebugString(TEXT("VerifyLibrary: Invalid certificate display name\n"));
 	}
 
-	if ( status && !cert_subject.empty() && subject != subject)
+	if ( status && !cert_subject.empty() && cert_subject != subject)
 	{
 		status = false;
 		OutputDebugString(TEXT("VerifyLibrary: Invalid certificate subject\n"));


### PR DESCRIPTION
We have found and fixed a bug using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) analyzer. 

Analyzer warning: [V501](https://www.viva64.com/en/w/V501/) There are identical sub-expressions to the left and to the right of the '!=' operator: subject != subject.
