### PR TITLE
Fixed CWE-476 (NULL Pointer Dereference).

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1283,7 +1283,7 @@ public:
 	{
 		for (int i = 0 ; i < _nbLang ; ++i)
 		{
-			if ((_langList[i]->_langID == langID) || (!_langList[i]))
+			if ( _langList[i] && _langList[i]->_langID == langID )
 				return _langList[i];
 		}
 		return nullptr;

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -343,7 +343,7 @@ LRESULT CALLBACK ScintillaEditView::scintillaStatic_Proc(HWND hwnd, UINT Message
 		bool isSynpnatic = std::string(synapticsHack) == "SynTrackCursorWindowClass";
 		bool makeTouchPadCompetible = ((NppParameters::getInstance())->getSVP())._disableAdvancedScrolling;
 
-		if (isSynpnatic || makeTouchPadCompetible)
+		if (pScint && (isSynpnatic || makeTouchPadCompetible))
 			return (pScint->scintillaNew_Proc(hwnd, Message, wParam, lParam));
 
 		ScintillaEditView *pScintillaOnMouse = (ScintillaEditView *)(::GetWindowLongPtr(hwndOnMouse, GWLP_USERDATA));


### PR DESCRIPTION
We have found and fixed a weakness using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) analyzer. 

Analyzer warnings:

- [V595](https://www.viva64.com/en/w/V595/) The 'pScint' pointer was utilized before it was verified against nullptr. Check lines: 347, 353. scintillaeditview.cpp 347
- [V713](https://www.viva64.com/en/w/V713/) The pointer _langList[i] was utilized in the logical expression before it was verified against nullptr in the same logical expression. parameters.h 1286
