### PR TITLE
functionParser.h: add virtual destructor into abstract class.

### DIFF
--- a/PowerEditor/src/WinControls/FunctionList/functionParser.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.h
@@ -49,6 +49,7 @@ public:
 	virtual void parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT("")) = 0;
 	void funcParse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT(""), const std::vector< std::pair<int, int> > * commentZones = NULL);
 	bool isInZones(int pos2Test, const std::vector< std::pair<int, int> > & zones);
+	virtual ~FunctionParser() {};
 protected:
 	generic_string _id;
 	generic_string _displayName;


### PR DESCRIPTION
We have found and fixed a bug using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) analyzer. 

Analyzer warning: [V599](https://www.viva64.com/en/w/V599/) The virtual destructor is not present, although the 'FunctionParser' class contains virtual functions.
