### PR TITLE
Fixed potential memory leak, found by Cppcheck.

### DIFF
--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -589,13 +589,9 @@ void Accelerator::updateShortcuts()
 	if (_hFindAccTab)
 		::DestroyAcceleratorTable(_hFindAccTab);
 	ACCEL *tmpFindAccelArray = new ACCEL[1];
-	if (pSearchFindAccel != nullptr)
-	{
-		tmpFindAccelArray[0] = *pSearchFindAccel;
-		_hFindAccTab = ::CreateAcceleratorTable(tmpFindAccelArray, 1);
-		delete[] tmpFindAccelArray;
-	}
-
+	tmpFindAccelArray[0] = *pSearchFindAccel;
+	_hFindAccTab = ::CreateAcceleratorTable(tmpFindAccelArray, 1);
+	delete[] tmpFindAccelArray;
 	return;
 }
 


### PR DESCRIPTION
This PR fixes a potential memory leak found by the static code analysis tool [Cppcheck](http://cppcheck.sourceforge.net/devinfo/).

The potential memory leak happens, because new (by default) never returns a nullptr and therefore, the if-branch gets never executed. In order to catch memory allocation issues in C++, use try-catch or use (std::nothrow). 

Reference:
http://www.cplusplus.com/reference/new/operator%20new[]/