### PR TITLE
Remember empty "Replace with" on Notepad++ restart

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -374,6 +374,14 @@ void FindReplaceDlg::fillComboHistory(int id, const vector<generic_string> & str
 	{
 		addText2Combo(i->c_str(), hCombo);
 	}
+
+	//empty string is not added to CB items, so we need to set it manually
+	if (!strings.empty() && strings.begin()->empty())
+	{
+		SetWindowText(hCombo, _T(""));
+		return;
+	}
+
 	::SendMessage(hCombo, CB_SETCURSEL, 0, 0); // select first item
 }
 
@@ -383,13 +391,13 @@ void FindReplaceDlg::saveFindHistory()
 	if (! isCreated()) return;
 	FindHistory& findHistory = (NppParameters::getInstance())->getFindHistory();
 
-	saveComboHistory(IDD_FINDINFILES_DIR_COMBO, findHistory._nbMaxFindHistoryPath, findHistory._findHistoryPaths);
-	saveComboHistory(IDD_FINDINFILES_FILTERS_COMBO, findHistory._nbMaxFindHistoryFilter, findHistory._findHistoryFilters);
-	saveComboHistory(IDFINDWHAT,                    findHistory._nbMaxFindHistoryFind, findHistory._findHistoryFinds);
-	saveComboHistory(IDREPLACEWITH,                 findHistory._nbMaxFindHistoryReplace, findHistory._findHistoryReplaces);
+	saveComboHistory(IDD_FINDINFILES_DIR_COMBO, findHistory._nbMaxFindHistoryPath, findHistory._findHistoryPaths, false);
+	saveComboHistory(IDD_FINDINFILES_FILTERS_COMBO, findHistory._nbMaxFindHistoryFilter, findHistory._findHistoryFilters, true);
+	saveComboHistory(IDFINDWHAT,                    findHistory._nbMaxFindHistoryFind, findHistory._findHistoryFinds, false);
+	saveComboHistory(IDREPLACEWITH,                 findHistory._nbMaxFindHistoryReplace, findHistory._findHistoryReplaces, true);
 }
 
-int FindReplaceDlg::saveComboHistory(int id, int maxcount, vector<generic_string> & strings)
+int FindReplaceDlg::saveComboHistory(int id, int maxcount, vector<generic_string> & strings, bool saveEmpty)
 {
 	TCHAR text[FINDREPLACE_MAXLENGTH];
 	HWND hCombo = ::GetDlgItem(_hSelf, id);
@@ -400,6 +408,14 @@ int FindReplaceDlg::saveComboHistory(int id, int maxcount, vector<generic_string
 
     if (count)
         strings.clear();
+
+	if (saveEmpty)
+	{
+		if (::GetWindowTextLength(hCombo) == 0)
+		{
+			strings.push_back(generic_string());
+		}
+	}
 
     for (int i = 0 ; i < count ; ++i)
 	{

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -401,7 +401,7 @@ private :
 	void updateCombo(int comboID);
 	void fillFindHistory();
     void fillComboHistory(int id, const std::vector<generic_string> & strings);
-	int saveComboHistory(int id, int maxcount, std::vector<generic_string> & strings);
+	int saveComboHistory(int id, int maxcount, std::vector<generic_string> & strings, bool saveEmpty);
 	static const int FR_OP_FIND = 1;
 	static const int FR_OP_REPLACE = 2;
 	static const int FR_OP_FIF = 4;


### PR DESCRIPTION
This PR allows to save to history empty values in Combo Boxes. It's useful for input fields where empty value is valid one and "Replace with" is one of them.

So I'm trying to fix the following condition:
![emptyvaluenotsaved](https://user-images.githubusercontent.com/22025304/27255218-7c53bd34-53a2-11e7-9cb5-a83af12a9ffe.png)
