### PR TITLE
Fixed PVS-Studio static analyser reported issues

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -1601,29 +1601,30 @@ bool FindReplaceDlg::processReplace(const TCHAR *txt2find, const TCHAR *txt2repl
 		// If the next find is the same as the last, then perform the replacement
 		if (nextFind.cpMin == currentSelection.cpMin && nextFind.cpMax == currentSelection.cpMax)
 		{
-			int stringSizeFind = lstrlen(txt2find);
-			int stringSizeReplace = lstrlen(txt2replace);
-
-			TCHAR *pTextFind = new TCHAR[stringSizeFind + 1];
-			TCHAR *pTextReplace = new TCHAR[stringSizeReplace + 1];
-			lstrcpy(pTextFind, txt2find);
-			lstrcpy(pTextReplace, txt2replace);
-		
 			bool isRegExp = replaceOptions._searchType == FindRegex;
 
 			int start = currentSelection.cpMin;
 			int replacedLen = 0;
 			if (isRegExp)
 			{
-				replacedLen = (*_ppEditView)->replaceTargetRegExMode(pTextReplace);
+				replacedLen = (*_ppEditView)->replaceTargetRegExMode(txt2replace);
 			}
 			else
 			{
 				if (replaceOptions._searchType == FindExtended)
 				{
-					Searching::convertExtendedToString(pTextReplace, pTextReplace, stringSizeReplace);
+					int stringSizeReplace = lstrlen(txt2replace);
+					TCHAR *pText2ReplaceExtended = new TCHAR[stringSizeReplace + 1];
+					Searching::convertExtendedToString(txt2replace, pText2ReplaceExtended, stringSizeReplace);
+
+					replacedLen = (*_ppEditView)->replaceTarget(pText2ReplaceExtended);
+
+					delete[] pText2ReplaceExtended;
 				}
-				replacedLen = (*_ppEditView)->replaceTarget(pTextReplace);
+				else
+				{
+					replacedLen = (*_ppEditView)->replaceTarget(txt2replace);
+				}
 			}
 			(*_ppEditView)->execute(SCI_SETSEL, start + replacedLen, start + replacedLen);
 						

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -3113,7 +3113,6 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             }
             break; */
 		case WM_CREATE:
-			  lpcs = &cs;
 			  lpcs = (LPCREATESTRUCT)lParam;
 
 			  hInst = lpcs->hInstance;

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -323,19 +323,31 @@ bool ProjectPanel::openWorkSpace(const TCHAR *projectFileName)
 	TiXmlDocument *pXmlDocProject = new TiXmlDocument(projectFileName);
 	bool loadOkay = pXmlDocProject->LoadFile();
 	if (!loadOkay)
+	{
+		delete pXmlDocProject;
 		return false;
+	}
 
 	TiXmlNode *root = pXmlDocProject->FirstChild(TEXT("NotepadPlus"));
 	if (!root) 
+	{
+		delete pXmlDocProject;
 		return false;
+	}
 
 
 	TiXmlNode *childNode = root->FirstChildElement(TEXT("Project"));
 	if (!childNode) 
+	{
+		delete pXmlDocProject;
 		return false;
+	}
 
 	if (!::PathFileExists(projectFileName))
+	{
+		delete pXmlDocProject;
 		return false;
+	}
 
 	_treeView.removeAllItems();
 	_workSpaceFilePath = projectFileName;

--- a/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
@@ -118,7 +118,7 @@ LPARAM TreeView::getItemParam(HTREEITEM Item2Get) const
 generic_string TreeView::getItemDisplayName(HTREEITEM Item2Set) const
 {
 	if (not Item2Set)
-		return false;
+		return TEXT("");
 	TCHAR textBuffer[MAX_PATH];
 	TVITEM tvItem;
 	tvItem.hItem = Item2Set;


### PR DESCRIPTION
FindReplaceDlg.cpp: Release dynamically allocated memory.
BabyGrid.cpp: lpcs variable assigned twice successively.
ProjectPanel.cpp: A memory leak is possible.
TreeView.cpp: Wrong value is returned.