### PR TITLE
Do not treat strings with spaces as file extensions in the save dialog.

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -481,7 +481,7 @@ generic_string changeExt(generic_string fn, generic_string ext, bool forceReplac
 	auto index = fnExt.find_last_of(TEXT("."));
 	generic_string extension = TEXT(".");
 	extension += ext;
-	if (index == generic_string::npos)
+	if (index == generic_string::npos || fnExt.find_first_of(' ', index + 1) != generic_string::npos)
 	{
 		fnExt += extension;
 	}


### PR DESCRIPTION
Fixes #3390.

A file name extension is now only considered valid when there is no space in the string following the last "." in the file name.