### PR TITLE
Fixed cppChecker reported issues

### DIFF
--- a/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
@@ -130,7 +130,6 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 
 	// Determine mode for SmartHighlighting
 	bool isWordOnly = true;
-	bool isCaseSensentive = true;
 
 	if (nppGUI._smartHiliteUseFindSettings)
 	{
@@ -138,12 +137,10 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 		NppParameters *nppParams = NppParameters::getInstance();
 		FindHistory &findHistory = nppParams->getFindHistory();
 		isWordOnly = findHistory._isMatchWord;
-		isCaseSensentive = findHistory._isMatchCase;
 	}
 	else
 	{
 		isWordOnly = nppGUI._smartHiliteWordOnly;
-		isCaseSensentive = nppGUI._smartHiliteCaseSensitive;
 	}
 
 	// additional checks for wordOnly mode

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -172,7 +172,7 @@ public:
 
 protected:
 	TreeView _treeView;
-	HIMAGELIST _hImaLst;
+	HIMAGELIST _hImaLst = nullptr;
 
 	HMENU _hGlobalMenu = NULL;
 	HMENU _hRootMenu = NULL;

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -1299,19 +1299,10 @@ void SizeGrid(HWND hWnd,int /*SI*/)
 
 int FindLongestLine(HDC hdc,TCHAR* text,SIZE* size)
 {
-	int longest, lines;
+	int longest = 0;
      TCHAR temptext[1000];
      TCHAR *p;
-     longest=0;
-     lines=1;
 
-     for(size_t j=0, len=lstrlen(text); j<len; j++)
-     {
-      if(text[j]=='\n')
-          {
-           lines++;
-          }
-     }
      lstrcpy(temptext,text);
      p = generic_strtok(temptext, TEXT("\n"));
      while(p)
@@ -1324,7 +1315,7 @@ int FindLongestLine(HDC hdc,TCHAR* text,SIZE* size)
           p = generic_strtok('\0', TEXT("\n"));
          }
      return longest;
-    }
+}
 
 
 LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
@@ -78,7 +78,7 @@ private:
 	ContextMenu _rightClickMenu;
 
 	GridState _currentState;
-	HWND _hTabCtrl;
+	HWND _hTabCtrl = nullptr;
 
 	TCHAR tabNames[5][maxTabName];
 

--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
@@ -111,7 +111,6 @@ public :
 	};
 
 	unsigned int getNbCommand() const {return _nbCmd;};
-	int getCommandAt(int index) const {return _cmdArray[index];};
 	void resizeIcon(int size) {
 		reInit(size);
 	};
@@ -134,7 +133,6 @@ public :
 
 private :
 	ToolBarIconIDs _tbiis;
-	int _cmdArray[nbMax];
 	unsigned int _nbCmd;
 };
 

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
@@ -106,7 +106,7 @@ public:
 
 protected:
 	TreeView _treeView;
-	HIMAGELIST _hImaLst;
+	HIMAGELIST _hImaLst = nullptr;
 	HWND _hToolbarMenu = nullptr;
 	HMENU _hWorkSpaceMenu = nullptr;
 	HMENU _hProjectMenu = nullptr;

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -77,7 +77,7 @@ protected :
 private :
 	TaskList _taskList;
 	TaskListInfo _taskListInfo;
-	HIMAGELIST _hImalist;
+	HIMAGELIST _hImalist = nullptr;
 	bool _initDir = false;
 	HHOOK _hHooker = nullptr;
 

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
@@ -104,6 +104,6 @@ protected:
 
 private:
 	VerticalFileSwitcherListView _fileListView;
-	HIMAGELIST _hImaLst;
+	HIMAGELIST _hImaLst = nullptr;
 };
 #endif // VERTICALFILESWITCHER_H

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
@@ -116,6 +116,6 @@ public:
 	void initPopupMenu(HMENU hMenu, DocTabView *pTab);
 
 private:
-	HMENU _hMenu;
+	HMENU _hMenu = nullptr;
 };
 

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -388,7 +388,6 @@ public:
 	ScintillaAccelerator() {};
 	void init(std::vector<HWND> * vScintillas, HMENU hMenu, HWND menuParent);
 	void updateKeys();
-	void updateKey(ScintillaKeyMap skmOld, ScintillaKeyMap skm);
 	size_t nbScintillas() { return _vScintillas.size(); };
 private:
 	HMENU _hAccelMenu = nullptr;

--- a/PowerEditor/src/lastRecentFileList.h
+++ b/PowerEditor/src/lastRecentFileList.h
@@ -44,6 +44,8 @@ class LastRecentFileList
 public:
 	LastRecentFileList() {
 		_userMax = (NppParameters::getInstance())->getNbMaxRecentFile();
+		for (int i = 0; i < NB_MAX_LRF_FILE; i++)
+			_idFreeArray[i] = false;
 	};
 
 	void initMenu(HMENU hMenu, int idBase, int posBase, Accelerator *accelerator, bool doSubMenu = false);


### PR DESCRIPTION
1. Removed unused variable/code
	- smarthighlighter.cpp, Babtgrid.cpp, shortcut.h, ImageListSet.h

2. Member variable not initialised in ctor
	- ShortcutMapper.h, FileBrowser.h, ProjectPanel.h, TaskList.h, VerticalFileSwitcher.h, WindowDlg.h, lastRecentFileList.h