### PR TITLE
lang: Cleanup strange "&amp;" for both [en] [de] and finally fix "sea…

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -421,7 +421,7 @@
 
             <StyleConfig title="Style Configurator">
                 <Item id="2"    name="Cancel"/>
-                <Item id="2301" name="Save && Close"/>
+                <Item id="2301" name="Save & Close"/>
                 <Item id="2303" name="Transparency"/>
                 <Item id="2306" name="Select theme: "/>
                 <SubDialog>
@@ -497,7 +497,7 @@
                     <Item id="1" name="OK"/>
                     <Item id="2" name="Cancel"/>
                 </StylerDialog>
-                <Folder title="Folder && Default">
+                <Folder title="Folder & Default">
                     <Item id="21101" name="Default style"/>
                     <Item id="21102" name="Styler"/>
                     <Item id="21105" name="Documentation:"/>
@@ -545,7 +545,7 @@
                     <Item id="22572" name="Styler"/>
                     <Item id="22622" name="Styler"/>
                 </Keywords>
-                <Comment title="Comment && Number">
+                <Comment title="Comment & Number">
                     <Item id="23003" name="Line comment position"/>
                     <Item id="23004" name="Allow anywhere"/>
                     <Item id="23005" name="Force at beginning of line"/>
@@ -574,7 +574,7 @@
                     <Item id="23246" name="Comma"/>
                     <Item id="23247" name="Both"/>
                 </Comment>
-                <Operator title="Operators && Delimiter">
+                <Operator title="Operators & Delimiter">
                     <Item id="24101" name="Operators style"/>
                     <Item id="24113" name="Styler"/>
                     <Item id="24116" name="Operators 1"/>
@@ -675,7 +675,7 @@
                     <Item id="6207" name="Display bookmarks"/>
                     <Item id="6208" name="Show vertical edge"/>
                     <Item id="6209" name="Number of columns: "/>
-                    <Item id="6234" name="Disable advanced scrolling feature&#x0a;(if you have touchpad problem)"/>
+                    <Item id="6234" name="Disable advanced scrolling feature&#x0D;(if you have touchpad problem)"/>
 
                     <Item id="6211" name="Vertical Edge Settings"/>
                     <Item id="6212" name="Line mode"/>
@@ -830,7 +830,7 @@
                     <Item id="6256" name="Allow on several lines"/>
                     <Item id="6161" name="Word character list"/>
                     <Item id="6162" name="Use default Word character list as it is"/>
-                    <Item id="6163" name="Add your character as part of word&#x0a;(don't choose it unless you know what you're doing)"/>
+                    <Item id="6163" name="Add your character as part of word&#x0D;(don't choose, unless you know what you're doing)"/>
                 </Delimiter>
 
                 <Cloud title="Cloud">
@@ -906,10 +906,10 @@
             </ColumnEditor>
         </Dialog>
         <MessageBox>
-            <ContextMenuXmlEditWarning title="Editing contextMenu" message="Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.\rYou have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
-            <NppHelpAbsentWarning title="File does not exist" message="\rdoesn't exist. Please download it on Notepad++ site."/>
-            <SaveCurrentModifWarning title="Save Current Modification" message="You should save the current modification.\rAll the saved modifications can not be undone.\r\rContinue?"/>
-            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message="You should save the current modification.\rAll the saved modifications can not be undone.\r\rContinue?"/>
+            <ContextMenuXmlEditWarning title="Editing contextMenu" message="Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.&#x0D;You have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
+            <NppHelpAbsentWarning title="File does not exist" message="&#x0D;doesn't exist. Please download it on Notepad++ site."/>
+            <SaveCurrentModifWarning title="Save Current Modification" message="You should save the current modification.&#x0D;All the saved modifications can not be undone.&#x0D;&#x0D;Continue?"/>
+            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message="You should save the current modification.&#x0D;All the saved modifications can not be undone.&#x0D;&#x0D;Continue?"/>
             <CannotMoveDoc title="Move to new Notepad++ Instance" message="Document is modified, save it then try again."/>
             <DocReloadWarning title="Reload" message="Are you sure you want to reload the current file and lose the changes made in Notepad++?"/>
             <FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
@@ -917,8 +917,8 @@
             <DeleteFileFailed title="Delete File" message="Delete File failed"/>
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.\rAre you sure to open them?"/>
-            <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,\ror on a folder needed privilege right for writing access.\rYour settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
+            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.&#x0D;Are you sure to open them?"/>
+            <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,&#x0D;or on a folder needed privilege right for writing access.&#x0D;Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
             <FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
         <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
         </MessageBox>
@@ -997,10 +997,10 @@
             <word-chars-list-space-warning value="$INT_REPLACE$ space(s)"/>
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-tab-warning value="$INT_REPLACE$ TAB(s)"/>
-            <word-chars-list-warning-end value="  in your character list."/>
+            <word-chars-list-warning-end value=" in your character list."/>
             <cloud-invalid-warning value="Invalid path."/>
             <cloud-restart-warning value="Please restart Notepad++ to take effect."/>
-            <shift-change-direction-tip value="Enter: Find Next&#x0a;Shift+Enter: Find Previous"/>
+            <shift-change-direction-tip value="Enter: Find Next&#x0D;Shift+Enter: Find Previous"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -63,7 +63,7 @@
                     <Item subMenuId="encoding-westernEuropean" name="Western European"/>
                     <Item subMenuId="encoding-vietnamese" name="Vietnamese"/>
                     <Item subMenuId="settings-import" name="Import"/>
-					<Item subMenuId="tools-md5" name="MD5"/>
+                    <Item subMenuId="tools-md5" name="MD5"/>
                 </SubEntries>
 
                 <!-- all menu item -->
@@ -79,16 +79,16 @@
                     <Item id="41018" name="Close All to the Right"/>
                     <Item id="41006" name="Save"/>
                     <Item id="41007" name="Save All"/>
-                    <Item id="41008" name="Save As..."/>
-                    <Item id="41010" name="Print..."/>
+                    <Item id="41008" name="Save As…"/>
+                    <Item id="41010" name="Print…"/>
                     <Item id="1001"  name="Print Now"/>
                     <Item id="41011" name="Exit"/>
-                    <Item id="41012" name="Load Session..."/>
-                    <Item id="41013" name="Save Session..."/>
+                    <Item id="41012" name="Load Session…"/>
+                    <Item id="41013" name="Save Session…"/>
                     <Item id="41014" name="Reload from Disk"/>
-                    <Item id="41015" name="Save a Copy As..."/>
+                    <Item id="41015" name="Save a Copy As…"/>
                     <Item id="41016" name="Delete from Disk"/>
-                    <Item id="41017" name="Rename..."/>
+                    <Item id="41017" name="Rename…"/>
                     <Item id="41021" name="Restore Recent Closed File"/>
                     <Item id="41022" name="Open Folder as Workspace"/>
 
@@ -123,10 +123,10 @@
                     <Item id="42070" name="Sentence case (blend)"/>
                     <Item id="42071" name="iNVERT cASE"/>
                     <Item id="42072" name="ranDOm CasE"/>
-					<Item id="42073" name="Open File"/>
-					<Item id="42074" name="Open Containing Folder in Explorer"/>
-					<Item id="42075" name="Search on Internet"/>
-					<Item id="42076" name="Change Search Engine..."/>
+                    <Item id="42073" name="Open File"/>
+                    <Item id="42074" name="Open Containing Folder in Explorer"/>
+                    <Item id="42075" name="Search on Internet"/>
+                    <Item id="42076" name="Change Search Engine…"/>
                     <Item id="42018" name="Start Recording"/>
                     <Item id="42019" name="Stop Recording"/>
                     <Item id="42021" name="Playback"/>
@@ -146,8 +146,8 @@
                     <Item id="42048" name="Copy Binary Content"/>
                     <Item id="42049" name="Cut Binary Content"/>
                     <Item id="42050" name="Paste Binary Content"/>
-                    <Item id="42037" name="Column Mode..."/>
-                    <Item id="42034" name="Column Editor..."/>
+                    <Item id="42037" name="Column Mode…"/>
+                    <Item id="42034" name="Column Editor…"/>
                     <Item id="42051" name="Character Panel"/>
                     <Item id="42052" name="Clipboard History"/>
                     <Item id="42025" name="Save Currently Recorded Macro"/>
@@ -157,7 +157,7 @@
                     <Item id="42029" name="Current File Path to Clipboard"/>
                     <Item id="42030" name="Current Filename to Clipboard"/>
                     <Item id="42031" name="Current Dir. Path to Clipboard"/>
-                    <Item id="42032" name="Run a Macro Multiple Times..."/>
+                    <Item id="42032" name="Run a Macro Multiple Times…"/>
                     <Item id="42033" name="Clear Read-Only Flag"/>
                     <Item id="42035" name="Single Line Comment"/>
                     <Item id="42036" name="Single Line Uncomment"/>
@@ -165,10 +165,10 @@
                     <Item id="42056" name="Remove Empty Lines (Containing Blank characters)"/>
                     <Item id="42057" name="Insert Blank Line Above Current"/>
                     <Item id="42058" name="Insert Blank Line Below Current"/>
-                    <Item id="43001" name="Find..."/>
+                    <Item id="43001" name="Find…"/>
                     <Item id="43002" name="Find Next"/>
-                    <Item id="43003" name="Replace..."/>
-                    <Item id="43004" name="Go to..."/>
+                    <Item id="43003" name="Replace…"/>
+                    <Item id="43004" name="Go to…"/>
                     <Item id="43005" name="Toggle Bookmark"/>
                     <Item id="43006" name="Next Bookmark"/>
                     <Item id="43007" name="Previous Bookmark"/>
@@ -179,7 +179,7 @@
                     <Item id="43021" name="Remove Bookmarked Lines"/>
                     <Item id="43051" name="Remove Unmarked Lines"/>
                     <Item id="43050" name="Inverse Bookmark"/>
-                    <Item id="43052" name="Find characters in range..."/>
+                    <Item id="43052" name="Find characters in range…"/>
                     <Item id="43053" name="Select All Between Matching Braces"/>
                     <Item id="43009" name="Go to Matching Brace"/>
                     <Item id="43010" name="Find Previous"/>
@@ -215,7 +215,7 @@
                     <Item id="43047" name="Previous Search Result"/>
                     <Item id="43048" name="Select and Find Next"/>
                     <Item id="43049" name="Select and Find Previous"/>
-					<Item id="43054" name="Mark..."/>
+                    <Item id="43054" name="Mark…"/>
                     <Item id="44009" name="Post-It"/>
                     <Item id="44010" name="Fold All"/>
                     <Item id="44019" name="Show All Characters"/>
@@ -228,7 +228,7 @@
                     <Item id="44029" name="Unfold All"/>
                     <Item id="44030" name="Collapse Current Level"/>
                     <Item id="44031" name="Uncollapse Current Level"/>
-                    <Item id="44049" name="Summary..."/>
+                    <Item id="44049" name="Summary…"/>
                     <Item id="44080" name="Document Map"/>
                     <Item id="44084" name="Function List"/>
                     <Item id="44085" name="Folder as Workspace"/>
@@ -275,29 +275,29 @@
                     <Item id="10003" name="Move to New Instance"/>
                     <Item id="10004" name="Open in New Instance"/>
 
-                    <Item id="46001" name="Style Configurator..."/>
-                    <Item id="46150" name="Define your language..."/>
+                    <Item id="46001" name="Style Configurator…"/>
+                    <Item id="46150" name="Define your language…"/>
                     <Item id="46080" name="User-Defined"/>
-                    <Item id="47000" name="About Notepad++..."/>
-                    <Item id="47010" name="Command Line Arguments..."/>
+                    <Item id="47000" name="About Notepad++…"/>
+                    <Item id="47010" name="Command Line Arguments…"/>
                     <Item id="47001" name="Notepad++ Home"/>
                     <Item id="47002" name="Notepad++ Project Page"/>
                     <Item id="47003" name="Online Documentation"/>
-					<Item id="47004" name="Notepad++ Community (Forum)"/>
+                    <Item id="47004" name="Notepad++ Community (Forum)"/>
                     <Item id="47011" name="Live Support"/>
-                    <Item id="47012" name="Debug Info..."/>
+                    <Item id="47012" name="Debug Info…"/>
                     <Item id="47005" name="Get More Plugins"/>
                     <Item id="47006" name="Update Notepad++"/>
-                    <Item id="47009" name="Set Updater Proxy..."/>
-                    <Item id="48005" name="Import Plugin(s) ..."/>
-                    <Item id="48006" name="Import Theme(s) ..."/>
+                    <Item id="47009" name="Set Updater Proxy…"/>
+                    <Item id="48005" name="Import Plugin(s) …"/>
+                    <Item id="48006" name="Import Theme(s) …"/>
                     <Item id="48018" name="Edit Popup ContextMenu"/>
-                    <Item id="48009" name="Shortcut Mapper..."/>
-                    <Item id="48011" name="Preferences..."/>
-                    <Item id="48501" name="Generate..."/>
-                    <Item id="48502" name="Generate from files..."/>
+                    <Item id="48009" name="Shortcut Mapper…"/>
+                    <Item id="48011" name="Preferences…"/>
+                    <Item id="48501" name="Generate…"/>
+                    <Item id="48502" name="Generate from files…"/>
                     <Item id="48503" name="Generate into clipboard"/>
-                    <Item id="49000" name="Run..."/>
+                    <Item id="49000" name="Run…"/>
 
                     <Item id="50000" name="Function Completion"/>
                     <Item id="50001" name="Word Completion"/>
@@ -306,8 +306,8 @@
                     <Item id="44042" name="Hide Lines"/>
                     <Item id="42040" name="Open All Recent Files"/>
                     <Item id="42041" name="Empty Recent Files List"/>
-                    <Item id="48016" name="Modify Shortcut/Delete Macro..."/>
-                    <Item id="48017" name="Modify Shortcut/Delete Command..."/>
+                    <Item id="48016" name="Modify Shortcut/Delete Macro…"/>
+                    <Item id="48017" name="Modify Shortcut/Delete Command…"/>
                 </Commands>
             </Main>
             <Splitter>
@@ -316,7 +316,7 @@
                     <Item CMID="0" name="Close"/>
                     <Item CMID="1" name="Close All BUT This"/>
                     <Item CMID="2" name="Save"/>
-                    <Item CMID="3" name="Save As..."/>
+                    <Item CMID="3" name="Save As…"/>
                     <Item CMID="4" name="Print"/>
                     <Item CMID="5" name="Move to Other View"/>
                     <Item CMID="6" name="Clone to Other View"/>
@@ -340,7 +340,7 @@
         <Dialog>
             <Find title="" titleFind="Find" titleReplace="Replace" titleFindInFiles="Find in Files" titleMark="Mark">
                 <Item id="1"    name="Find  ›"/>
-				<Item id="1721" name="‹  Find"/>
+                <Item id="1721" name="‹  Find"/>
                 <Item id="2"    name="Close"/>
                 <Item id="1620" name="Find what:"/>
                 <Item id="1603" name="Match whole word only"/>
@@ -370,7 +370,7 @@
                 <Item id="1659" name="In hidden folders"/>
                 <Item id="1624" name="Search mode"/>
                 <Item id="1625" name="Normal"/>
-                <Item id="1626" name="Extended (\n, \r, \t, \0, \x...)"/>
+                <Item id="1626" name="Extended (\n, \r, \t, \0, \x…)"/>
                 <Item id="1660" name="Replace in Files"/>
                 <Item id="1661" name="Follow current doc."/>
                 <Item id="1641" name="Find All in Current Document"/>
@@ -378,7 +378,7 @@
                 <Item id="1703" name=". matches newline"/>
             </Find>
 
-            <FindCharsInRange title="Find Characters in Range...">
+            <FindCharsInRange title="Find Characters in Range…">
                 <Item id="2" name="Close"/>
                 <Item id="2901" name="Non-ASCII Characters (128-255)"/>
                 <Item id="2902" name="ASCII Characters (0-127)"/>
@@ -390,7 +390,7 @@
                 <Item id="2910" name="Find"/>
             </FindCharsInRange>
 
-            <GoToLine title="Go to...">
+            <GoToLine title="Go to…">
                 <Item id="2007" name="Line"/>
                 <Item id="2008" name="Offset"/>
                 <Item id="1"    name="Go"/>
@@ -400,15 +400,15 @@
                 <Item id="2006" name="You can't go further than:"/>
             </GoToLine>
 
-            <Run title="Run...">
+            <Run title="Run…">
                 <Item id="1903" name="The Program to Run"/>
                 <Item id="1"    name="Run"/>
                 <Item id="2"    name="Cancel"/>
-                <Item id="1904" name="Save..."/>
+                <Item id="1904" name="Save…"/>
             </Run>
 
             <MD5FromFilesDlg title="Generate MD5 digest from files">
-                <Item id="1922" name="Choose files to generate MD5..."/>
+                <Item id="1922" name="Choose files to generate MD5…"/>
                 <Item id="1924" name="Copy to Clipboard"/>
                 <Item id="2"    name="Close"/>
             </MD5FromFilesDlg>
@@ -454,15 +454,15 @@
             <UserDefine title="User-Defined">
                 <Item id="20001" name="Dock"/>
                 <Item id="20002" name="Rename"/>
-                <Item id="20003" name="Create New..."/>
+                <Item id="20003" name="Create New…"/>
                 <Item id="20004" name="Remove"/>
-                <Item id="20005" name="Save As..."/>
+                <Item id="20005" name="Save As…"/>
                 <Item id="20007" name="User language: "/>
                 <Item id="20009" name="Ext.:"/>
                 <Item id="20012" name="Ignore case"/>
                 <Item id="20011" name="Transparency"/>
-                <Item id="20015" name="Import..."/>
-                <Item id="20016" name="Export..."/>
+                <Item id="20015" name="Import…"/>
+                <Item id="20016" name="Export…"/>
                 <StylerDialog title="Styler Dialog">
                     <Item id="25030" name="Font options:"/>
                     <Item id="25006" name="Foreground colour"/>
@@ -494,7 +494,7 @@
                     <Item id="25026" name="Operator 1"/>
                     <Item id="25027" name="Operator 2"/>
                     <Item id="25028" name="Numbers"/>
-					<Item id="1" name="OK"/>
+                    <Item id="1" name="OK"/>
                     <Item id="2" name="Cancel"/>
                 </StylerDialog>
                 <Folder title="Folder && Default">
@@ -681,7 +681,7 @@
                     <Item id="6212" name="Line mode"/>
                     <Item id="6213" name="Background mode"/>
                     <Item id="6214" name="Enable current line highlighting"/>
-					<Item id="6215" name="Enable smooth font"/>
+                    <Item id="6215" name="Enable smooth font"/>
                     <Item id="6231" name="Border Width"/>
                     <Item id="6235" name="No edge"/>
                     <Item id="6236" name="Enable scrolling beyond last line"/>
@@ -720,7 +720,7 @@
                     <Item id="6506" name="Disabled items"/>
                     <Item id="6507" name="Make language menu compact"/>
                     <Item id="6508" name="Language Menu"/>
-					<Item id="6301" name="Tab Settings"/>
+                    <Item id="6301" name="Tab Settings"/>
                     <Item id="6302" name="Replace by space"/>
                     <Item id="6303" name="Tab size: "/>
                     <Item id="6510" name="Use default value"/>
@@ -729,9 +729,9 @@
                 <Highlighting title="Highlighting">
                     <Item id="6333" name="Smart Highlighting"/>
                     <Item id="6326" name="Enable smart highlighting"/>
-					<Item id="6332" name="Match case"/>
-					<Item id="6338" name="Match whole word only"/>
-					<Item id="6339" name="Use Find dialog settings"/>
+                    <Item id="6332" name="Match case"/>
+                    <Item id="6338" name="Match whole word only"/>
+                    <Item id="6339" name="Use Find dialog settings"/>
                     <Item id="6340" name="Highlight another view"/>
                     <Item id="6329" name="Highlight Matching Tags"/>
                     <Item id="6327" name="Enable"/>
@@ -828,7 +828,7 @@
                     <Item id="6252" name="Open"/>
                     <Item id="6255" name="Close"/>
                     <Item id="6256" name="Allow on several lines"/>
-					<Item id="6161" name="Word character list"/>
+                    <Item id="6161" name="Word character list"/>
                     <Item id="6162" name="Use default Word character list as it is"/>
                     <Item id="6163" name="Add your character as part of word&#x0a;(don't choose it unless you know what you're doing)"/>
                 </Delimiter>
@@ -838,7 +838,7 @@
                     <Item id="6263" name="No Cloud"/>
                     <Item id="6267" name="Set your cloud location path here:"/>
                 </Cloud>
-				
+                
                 <SearchEngine title="Search Engine">
                     <Item id="6271" name="Search Engine (for command &quot;Search on Internet&quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
@@ -918,9 +918,9 @@
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.\rAre you sure to open them?"/>
-			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,\ror on a folder needed privilege right for writing access.\rYour settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
-			<FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
-	    <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
+            <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,\ror on a folder needed privilege right for writing access.\rYour settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
+            <FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
+        <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Clipboard History"/>
@@ -959,15 +959,15 @@
                     <Item id="3123" name="Open Workspace"/>
                     <Item id="3124" name="Reload Workspace"/>
                     <Item id="3125" name="Save"/>
-                    <Item id="3126" name="Save As..."/>
-                    <Item id="3127" name="Save a Copy As..."/>
+                    <Item id="3126" name="Save As…"/>
+                    <Item id="3127" name="Save a Copy As…"/>
                     <Item id="3121" name="Add New Project"/>
                 </WorkspaceMenu>
                 <ProjectMenu>
                     <Item id="3111" name="Rename"/>
                     <Item id="3112" name="Add Folder"/>
-                    <Item id="3113" name="Add Files..."/>
-                    <Item id="3117" name="Add Files from Directory..."/>
+                    <Item id="3113" name="Add Files…"/>
+                    <Item id="3117" name="Add Files from Directory…"/>
                     <Item id="3114" name="Remove"/>
                     <Item id="3118" name="Move Up"/>
                     <Item id="3119" name="Move Down"/>
@@ -975,8 +975,8 @@
                 <FolderMenu>
                     <Item id="3111" name="Rename"/>
                     <Item id="3112" name="Add Folder"/>
-                    <Item id="3113" name="Add Files..."/>
-                    <Item id="3117" name="Add Files from Directory..."/>
+                    <Item id="3113" name="Add Files…"/>
+                    <Item id="3117" name="Add Files from Directory…"/>
                     <Item id="3114" name="Remove"/>
                     <Item id="3118" name="Move Up"/>
                     <Item id="3119" name="Move Down"/>
@@ -991,16 +991,16 @@
             </Menus>
         </ProjectManager>
         <MiscStrings>
-			<word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &quot;Match whole word only&quot; option checked."/>
+            <word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &quot;Match whole word only&quot; option checked."/>
             <word-chars-list-warning-begin value="Be aware: "/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ space(s)"/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-tab-warning value="$INT_REPLACE$ TAB(s)"/>
-			<word-chars-list-warning-end value="  in your character list."/>
-			<cloud-invalid-warning value="Invalid path."/>
-			<cloud-restart-warning value="Please restart Notepad++ to take effect."/>
-			<shift-change-direction-tip value="Enter: Find Next&#x0a;Shift+Enter: Find Previous"/>
+            <word-chars-list-warning-end value="  in your character list."/>
+            <cloud-invalid-warning value="Invalid path."/>
+            <cloud-restart-warning value="Please restart Notepad++ to take effect."/>
+            <shift-change-direction-tip value="Enter: Find Next&#x0a;Shift+Enter: Find Previous"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -675,7 +675,7 @@
                     <Item id="6207" name="Display bookmarks"/>
                     <Item id="6208" name="Show vertical edge"/>
                     <Item id="6209" name="Number of columns: "/>
-                    <Item id="6234" name="Disable advanced scrolling feature&amp;#x0D;(if you have touchpad problem)"/>
+                    <Item id="6234" name="Disable advanced scrolling feature&#x0D;(if you have touchpad problem)"/>
 
                     <Item id="6211" name="Vertical Edge Settings"/>
                     <Item id="6212" name="Line mode"/>
@@ -830,7 +830,7 @@
                     <Item id="6256" name="Allow on several lines"/>
                     <Item id="6161" name="Word character list"/>
                     <Item id="6162" name="Use default Word character list as it is"/>
-                    <Item id="6163" name="Add your character as part of word&amp;#x0D;(don't choose, unless you know what you're doing)"/>
+                    <Item id="6163" name="Add your character as part of word&#x0D;(don't choose, unless you know what you're doing)"/>
                 </Delimiter>
 
                 <Cloud title="Cloud">
@@ -906,10 +906,10 @@
             </ColumnEditor>
         </Dialog>
         <MessageBox>
-            <ContextMenuXmlEditWarning title="Editing contextMenu" message="Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.&amp;#x0D;You have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
-            <NppHelpAbsentWarning title="File does not exist" message="&amp;#x0D;doesn't exist. Please download it on Notepad++ site."/>
-            <SaveCurrentModifWarning title="Save Current Modification" message="You should save the current modification.&amp;#x0D;All the saved modifications can not be undone.&amp;#x0D;&amp;#x0D;Continue?"/>
-            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message="You should save the current modification.&amp;#x0D;All the saved modifications can not be undone.&amp;#x0D;&amp;#x0D;Continue?"/>
+            <ContextMenuXmlEditWarning title="Editing contextMenu" message="Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.&#x0D;You have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
+            <NppHelpAbsentWarning title="File does not exist" message="&#x0D;doesn't exist. Please download it on Notepad++ site."/>
+            <SaveCurrentModifWarning title="Save Current Modification" message="You should save the current modification.&#x0D;All the saved modifications can not be undone.&#x0D;&#x0D;Continue?"/>
+            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message="You should save the current modification.&#x0D;All the saved modifications can not be undone.&#x0D;&#x0D;Continue?"/>
             <CannotMoveDoc title="Move to new Notepad++ Instance" message="Document is modified, save it then try again."/>
             <DocReloadWarning title="Reload" message="Are you sure you want to reload the current file and lose the changes made in Notepad++?"/>
             <FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
@@ -917,8 +917,8 @@
             <DeleteFileFailed title="Delete File" message="Delete File failed"/>
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.&amp;#x0D;Are you sure to open them?"/>
-            <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,&amp;#x0D;or on a folder needed privilege right for writing access.&amp;#x0D;Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
+            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.&#x0D;Are you sure to open them?"/>
+            <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,&#x0D;or on a folder needed privilege right for writing access.&#x0D;Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
             <FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
             <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
         </MessageBox>
@@ -1000,7 +1000,7 @@
             <word-chars-list-warning-end value=" in your character list."/>
             <cloud-invalid-warning value="Invalid path."/>
             <cloud-restart-warning value="Please restart Notepad++ to take effect."/>
-            <shift-change-direction-tip value="Enter: Find Next&amp;#x0D;Shift+Enter: Find Previous"/>
+            <shift-change-direction-tip value="Enter: Find Next&#x0D;Shift+Enter: Find Previous"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -5,14 +5,14 @@
             <Main>
                 <!-- Main Menu Entries -->
                 <Entries>
-                    <Item menuId="file" name="&amp;File"/>
-                    <Item menuId="edit" name="&amp;Edit"/>
-                    <Item menuId="search" name="&amp;Search"/>
-                    <Item menuId="view" name="&amp;View"/>
-                    <Item menuId="encoding" name="E&amp;ncoding"/>
-                    <Item menuId="language" name="&amp;Language"/>
-                    <Item menuId="settings" name="Se&amp;ttings"/>
-                    <Item menuId="tools" name="To&amp;ols"/>
+                    <Item menuId="file" name="File"/>
+                    <Item menuId="edit" name="Edit"/>
+                    <Item menuId="search" name="Search"/>
+                    <Item menuId="view" name="View"/>
+                    <Item menuId="encoding" name="Encoding"/>
+                    <Item menuId="language" name="Language"/>
+                    <Item menuId="settings" name="Settings"/>
+                    <Item menuId="tools" name="Tools"/>
                     <Item menuId="macro" name="Macro"/>
                     <Item menuId="run" name="Run"/>
                     <Item idName="Plugins" name="Plugins"/>
@@ -23,7 +23,7 @@
                     <Item subMenuId="file-openFolder" name="Open Containing Folder"/>
                     <Item subMenuId="file-closeMore" name="Close More"/>
                     <Item subMenuId="file-recentFiles" name="Recent Files"/>
-                    <Item subMenuId="edit-copyToClipboard"  name="Copy to Clipboard"/>
+                    <Item subMenuId="edit-copyToClipboard" name="Copy to Clipboard"/>
                     <Item subMenuId="edit-indent" name="Indent"/>
                     <Item subMenuId="edit-convertCaseTo" name="Convert Case to"/>
                     <Item subMenuId="edit-lineOperations" name="Line Operations"/>
@@ -38,51 +38,51 @@
                     <Item subMenuId="search-jumpUp" name="Jump Up"/>
                     <Item subMenuId="search-jumpDown" name="Jump Down"/>
                     <Item subMenuId="search-bookmark" name="Bookmark"/>
-                    <Item subMenuId="view-showSymbol"  name="Show Symbol"/>
-                    <Item subMenuId="view-zoom"  name="Zoom"/>
-                    <Item subMenuId="view-moveCloneDocument"  name="Move/Clone Current Document"/>
-                    <Item subMenuId="view-tab"  name="Tab"/>
+                    <Item subMenuId="view-showSymbol" name="Show Symbol"/>
+                    <Item subMenuId="view-zoom" name="Zoom"/>
+                    <Item subMenuId="view-moveCloneDocument" name="Move/Clone Current Document"/>
+                    <Item subMenuId="view-tab" name="Tab"/>
                     <Item subMenuId="view-collapseLevel" name="Collapse Level"/>
                     <Item subMenuId="view-uncollapseLevel" name="Uncollapse Level"/>
                     <Item subMenuId="view-project" name="Project"/>
-                    <Item subMenuId="encoding-characterSets"  name="Character Set"/>
-                    <Item subMenuId="encoding-arabic"  name="Arabic"/>
-                    <Item subMenuId="encoding-baltic"  name="Baltic"/>
-                    <Item subMenuId="encoding-celtic"  name="Celtic"/>
-                    <Item subMenuId="encoding-cyrillic"  name="Cyrillic"/>
-                    <Item subMenuId="encoding-centralEuropean"  name="Central European"/>
-                    <Item subMenuId="encoding-chinese"  name="Chinese"/>
-                    <Item subMenuId="encoding-easternEuropean"  name="Eastern European"/>
-                    <Item subMenuId="encoding-greek"  name="Greek"/>
-                    <Item subMenuId="encoding-hebrew"  name="Hebrew"/>
-                    <Item subMenuId="encoding-japanese"  name="Japanese"/>
+                    <Item subMenuId="encoding-characterSets" name="Character Set"/>
+                    <Item subMenuId="encoding-arabic" name="Arabic"/>
+                    <Item subMenuId="encoding-baltic" name="Baltic"/>
+                    <Item subMenuId="encoding-celtic" name="Celtic"/>
+                    <Item subMenuId="encoding-cyrillic" name="Cyrillic"/>
+                    <Item subMenuId="encoding-centralEuropean" name="Central European"/>
+                    <Item subMenuId="encoding-chinese" name="Chinese"/>
+                    <Item subMenuId="encoding-easternEuropean" name="Eastern European"/>
+                    <Item subMenuId="encoding-greek" name="Greek"/>
+                    <Item subMenuId="encoding-hebrew" name="Hebrew"/>
+                    <Item subMenuId="encoding-japanese" name="Japanese"/>
                     <Item subMenuId="encoding-korean" name="Korean"/>
                     <Item subMenuId="encoding-northEuropean" name="North European"/>
                     <Item subMenuId="encoding-thai" name="Thai"/>
                     <Item subMenuId="encoding-turkish" name="Turkish"/>
                     <Item subMenuId="encoding-westernEuropean" name="Western European"/>
                     <Item subMenuId="encoding-vietnamese" name="Vietnamese"/>
-                    <Item subMenuId="settings-import"  name="Import"/>
-					<Item subMenuId="tools-md5"  name="MD5"/>
+                    <Item subMenuId="settings-import" name="Import"/>
+					<Item subMenuId="tools-md5" name="MD5"/>
                 </SubEntries>
 
                 <!-- all menu item -->
                 <Commands>
-                    <Item id="41001" name="&amp;New"/>
-                    <Item id="41002" name="&amp;Open"/>
+                    <Item id="41001" name="New"/>
+                    <Item id="41002" name="Open"/>
                     <Item id="41019" name="Explorer"/>
                     <Item id="41020" name="cmd"/>
                     <Item id="41003" name="Close"/>
-                    <Item id="41004" name="C&amp;lose All"/>
+                    <Item id="41004" name="Close All"/>
                     <Item id="41005" name="Close All BUT Current Document"/>
                     <Item id="41009" name="Close All to the Left"/>
                     <Item id="41018" name="Close All to the Right"/>
-                    <Item id="41006" name="&amp;Save"/>
-                    <Item id="41007" name="Sav&amp;e All"/>
-                    <Item id="41008" name="Save &amp;As..."/>
+                    <Item id="41006" name="Save"/>
+                    <Item id="41007" name="Save All"/>
+                    <Item id="41008" name="Save As..."/>
                     <Item id="41010" name="Print..."/>
                     <Item id="1001"  name="Print Now"/>
-                    <Item id="41011" name="E&amp;xit"/>
+                    <Item id="41011" name="Exit"/>
                     <Item id="41012" name="Load Session..."/>
                     <Item id="41013" name="Save Session..."/>
                     <Item id="41014" name="Reload from Disk"/>
@@ -90,15 +90,15 @@
                     <Item id="41016" name="Delete from Disk"/>
                     <Item id="41017" name="Rename..."/>
                     <Item id="41021" name="Restore Recent Closed File"/>
-                    <Item id="41022" name="Open Folder as &amp;Workspace"/>
+                    <Item id="41022" name="Open Folder as Workspace"/>
 
-                    <Item id="42001" name="Cu&amp;t"/>
-                    <Item id="42002" name="&amp;Copy"/>
-                    <Item id="42003" name="&amp;Undo"/>
-                    <Item id="42004" name="&amp;Redo"/>
-                    <Item id="42005" name="&amp;Paste"/>
-                    <Item id="42006" name="&amp;Delete"/>
-                    <Item id="42007" name="Select A&amp;ll"/>
+                    <Item id="42001" name="Cut"/>
+                    <Item id="42002" name="Copy"/>
+                    <Item id="42003" name="Undo"/>
+                    <Item id="42004" name="Redo"/>
+                    <Item id="42005" name="Paste"/>
+                    <Item id="42006" name="Delete"/>
+                    <Item id="42007" name="Select All"/>
                     <Item id="42020" name="Begin/End Select"/>
                     <Item id="42008" name="Increase Line Indent"/>
                     <Item id="42009" name="Decrease Line Indent"/>
@@ -127,9 +127,9 @@
 					<Item id="42074" name="Open Containing Folder in Explorer"/>
 					<Item id="42075" name="Search on Internet"/>
 					<Item id="42076" name="Change Search Engine..."/>
-                    <Item id="42018" name="&amp;Start Recording"/>
-                    <Item id="42019" name="&amp;Stop Recording"/>
-                    <Item id="42021" name="&amp;Playback"/>
+                    <Item id="42018" name="Start Recording"/>
+                    <Item id="42019" name="Stop Recording"/>
+                    <Item id="42021" name="Playback"/>
                     <Item id="42022" name="Toggle Single Line Comment"/>
                     <Item id="42023" name="Block Comment"/>
                     <Item id="42047" name="Block Uncomment"/>
@@ -165,8 +165,8 @@
                     <Item id="42056" name="Remove Empty Lines (Containing Blank characters)"/>
                     <Item id="42057" name="Insert Blank Line Above Current"/>
                     <Item id="42058" name="Insert Blank Line Below Current"/>
-                    <Item id="43001" name="&amp;Find..."/>
-                    <Item id="43002" name="Find &amp;Next"/>
+                    <Item id="43001" name="Find..."/>
+                    <Item id="43002" name="Find Next"/>
                     <Item id="43003" name="Replace..."/>
                     <Item id="43004" name="Go to..."/>
                     <Item id="43005" name="Toggle Bookmark"/>
@@ -183,7 +183,7 @@
                     <Item id="43053" name="Select All Between Matching Braces"/>
                     <Item id="43009" name="Go to Matching Brace"/>
                     <Item id="43010" name="Find Previous"/>
-                    <Item id="43011" name="&amp;Incremental Search"/>
+                    <Item id="43011" name="Incremental Search"/>
                     <Item id="43013" name="Find in Files"/>
                     <Item id="43014" name="Find (Volatile) Next"/>
                     <Item id="43015" name="Find (Volatile) Previous"/>
@@ -221,8 +221,8 @@
                     <Item id="44019" name="Show All Characters"/>
                     <Item id="44020" name="Show Indent Guide"/>
                     <Item id="44022" name="Wrap"/>
-                    <Item id="44023" name="Zoom &amp;In Ctrl+Mouse Wheel Up"/>
-                    <Item id="44024" name="Zoom &amp;Out    Ctrl+Mouse Wheel Down"/>
+                    <Item id="44023" name="Zoom In Ctrl+Mouse Wheel Up"/>
+                    <Item id="44024" name="Zoom Out    Ctrl+Mouse Wheel Down"/>
                     <Item id="44025" name="Show White Space and TAB"/>
                     <Item id="44026" name="Show End of Line"/>
                     <Item id="44029" name="Unfold All"/>
@@ -231,7 +231,7 @@
                     <Item id="44049" name="Summary..."/>
                     <Item id="44080" name="Document Map"/>
                     <Item id="44084" name="Function List"/>
-                    <Item id="44085" name="Folder as &amp;Workspace"/>
+                    <Item id="44085" name="Folder as Workspace"/>
                     <Item id="44086" name="1st Tab"/>
                     <Item id="44087" name="2nd Tab"/>
                     <Item id="44088" name="3rd Tab"/>
@@ -297,7 +297,7 @@
                     <Item id="48501" name="Generate..."/>
                     <Item id="48502" name="Generate from files..."/>
                     <Item id="48503" name="Generate into clipboard"/>
-                    <Item id="49000" name="&amp;Run..."/>
+                    <Item id="49000" name="Run..."/>
 
                     <Item id="50000" name="Function Completion"/>
                     <Item id="50001" name="Word Completion"/>
@@ -339,24 +339,24 @@
 
         <Dialog>
             <Find title="" titleFind="Find" titleReplace="Replace" titleFindInFiles="Find in Files" titleMark="Mark">
-                <Item id="1"    name="Find  >>"/>
-                <Item id="1721" name="<<  Find"/>
+                <Item id="1"    name="Find  ›"/>
+				<Item id="1721" name="‹  Find"/>
                 <Item id="2"    name="Close"/>
                 <Item id="1620" name="Find what:"/>
-                <Item id="1603" name="Match &amp;whole word only"/>
-                <Item id="1604" name="Match &amp;case"/>
-                <Item id="1605" name="Regular &amp;expression"/>
-                <Item id="1606" name="Wrap aroun&amp;d"/>
-                <Item id="1612" name="&amp;Up"/>
-                <Item id="1613" name="&amp;Down"/>
+                <Item id="1603" name="Match whole word only"/>
+                <Item id="1604" name="Match case"/>
+                <Item id="1605" name="Regular expression"/>
+                <Item id="1606" name="Wrap around"/>
+                <Item id="1612" name="Up"/>
+                <Item id="1613" name="Down"/>
                 <Item id="1614" name="Count"/>
                 <Item id="1615" name="Find All"/>
                 <Item id="1616" name="Mark line"/>
                 <Item id="1618" name="Purge for each search"/>
                 <Item id="1621" name="Direction"/>
-                <Item id="1611" name="Re&amp;place with:"/>
-                <Item id="1608" name="&amp;Replace"/>
-                <Item id="1609" name="Replace &amp;All"/>
+                <Item id="1611" name="Replace with:"/>
+                <Item id="1608" name="Replace"/>
+                <Item id="1609" name="Replace All"/>
                 <Item id="1687" name="On losing focus"/>
                 <Item id="1688" name="Always"/>
                 <Item id="1632" name="In selection"/>
@@ -375,7 +375,7 @@
                 <Item id="1661" name="Follow current doc."/>
                 <Item id="1641" name="Find All in Current Document"/>
                 <Item id="1686" name="Transparency"/>
-                <Item id="1703" name="&amp;. matches newline"/>
+                <Item id="1703" name=". matches newline"/>
             </Find>
 
             <FindCharsInRange title="Find Characters in Range...">
@@ -383,17 +383,17 @@
                 <Item id="2901" name="Non-ASCII Characters (128-255)"/>
                 <Item id="2902" name="ASCII Characters (0-127)"/>
                 <Item id="2903" name="My range:"/>
-                <Item id="2906" name="&amp;Up"/>
-                <Item id="2907" name="&amp;Down"/>
+                <Item id="2906" name="Up"/>
+                <Item id="2907" name="Down"/>
                 <Item id="2908" name="Direction"/>
-                <Item id="2909" name="Wra&amp;p around"/>
+                <Item id="2909" name="Wrap around"/>
                 <Item id="2910" name="Find"/>
             </FindCharsInRange>
 
             <GoToLine title="Go to...">
                 <Item id="2007" name="Line"/>
                 <Item id="2008" name="Offset"/>
-                <Item id="1"    name="&amp;Go"/>
+                <Item id="1"    name="Go"/>
                 <Item id="2"    name="I'm going nowhere"/>
                 <Item id="2004" name="You are here:"/>
                 <Item id="2005" name="You want to go to:"/>
@@ -421,7 +421,7 @@
 
             <StyleConfig title="Style Configurator">
                 <Item id="2"    name="Cancel"/>
-                <Item id="2301" name="Save &amp;&amp; Close"/>
+                <Item id="2301" name="Save && Close"/>
                 <Item id="2303" name="Transparency"/>
                 <Item id="2306" name="Select theme: "/>
                 <SubDialog>
@@ -497,7 +497,7 @@
 					<Item id="1" name="OK"/>
                     <Item id="2" name="Cancel"/>
                 </StylerDialog>
-                <Folder title="Folder &amp;&amp; Default">
+                <Folder title="Folder && Default">
                     <Item id="21101" name="Default style"/>
                     <Item id="21102" name="Styler"/>
                     <Item id="21105" name="Documentation:"/>
@@ -545,7 +545,7 @@
                     <Item id="22572" name="Styler"/>
                     <Item id="22622" name="Styler"/>
                 </Keywords>
-                <Comment title="Comment &amp;&amp; Number">
+                <Comment title="Comment && Number">
                     <Item id="23003" name="Line comment position"/>
                     <Item id="23004" name="Allow anywhere"/>
                     <Item id="23005" name="Force at beginning of line"/>
@@ -574,7 +574,7 @@
                     <Item id="23246" name="Comma"/>
                     <Item id="23247" name="Both"/>
                 </Comment>
-                <Operator title="Operators &amp;&amp; Delimiter">
+                <Operator title="Operators && Delimiter">
                     <Item id="24101" name="Operators style"/>
                     <Item id="24113" name="Styler"/>
                     <Item id="24116" name="Operators 1"/>
@@ -675,8 +675,7 @@
                     <Item id="6207" name="Display bookmarks"/>
                     <Item id="6208" name="Show vertical edge"/>
                     <Item id="6209" name="Number of columns: "/>
-                    <Item id="6234" name="Disable advanced scrolling feature
-(if you have touchpad problem)"/>
+                    <Item id="6234" name="Disable advanced scrolling feature&#x0a;(if you have touchpad problem)"/>
 
                     <Item id="6211" name="Vertical Edge Settings"/>
                     <Item id="6212" name="Line mode"/>
@@ -831,8 +830,7 @@
                     <Item id="6256" name="Allow on several lines"/>
 					<Item id="6161" name="Word character list"/>
                     <Item id="6162" name="Use default Word character list as it is"/>
-                    <Item id="6163" name="Add your character as part of word
-(don't choose it unless you know what you're doing)"/>
+                    <Item id="6163" name="Add your character as part of word&#x0a;(don't choose it unless you know what you're doing)"/>
                 </Delimiter>
 
                 <Cloud title="Cloud">
@@ -1002,8 +1000,7 @@
 			<word-chars-list-warning-end value="  in your character list."/>
 			<cloud-invalid-warning value="Invalid path."/>
 			<cloud-restart-warning value="Please restart Notepad++ to take effect."/>
-			<shift-change-direction-tip value="Enter: Find Next
-Shift+Enter: Find Previous"/>
+			<shift-change-direction-tip value="Enter: Find Next&#x0a;Shift+Enter: Find Previous"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -98,7 +98,7 @@
                     <Item id="42004" name="&amp;Redo"/>
                     <Item id="42005" name="&amp;Paste"/>
                     <Item id="42006" name="&amp;Delete"/>
-                    <Item id="42007" name="Select &amp;All"/>
+                    <Item id="42007" name="Select A&amp;ll"/>
                     <Item id="42020" name="Begin/End Select"/>
                     <Item id="42008" name="Increase Line Indent"/>
                     <Item id="42009" name="Decrease Line Indent"/>
@@ -840,7 +840,7 @@
                 </Cloud>
                 
                 <SearchEngine title="Search Engine">
-                    <Item id="6271" name="Search Engine (for command &amp;quot;Search on Internet&amp;quot;)"/>
+                    <Item id="6271" name="Search Engine (for command &quot;Search on Internet&quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
                     <Item id="6273" name="Google"/>
                     <Item id="6274" name="Bing"/>
@@ -991,7 +991,7 @@
             </Menus>
         </ProjectManager>
         <MiscStrings>
-            <word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &amp;quot;Match whole word only&amp;quot; option checked."/>
+            <word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &quot;Match whole word only&quot; option checked."/>
             <word-chars-list-warning-begin value="Be aware: "/>
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ space(s)"/>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -5,14 +5,14 @@
             <Main>
                 <!-- Main Menu Entries -->
                 <Entries>
-                    <Item menuId="file" name="&File"/>
-                    <Item menuId="edit" name="&Edit"/>
-                    <Item menuId="search" name="&Search"/>
-                    <Item menuId="view" name="&View"/>
-                    <Item menuId="encoding" name="E&ncoding"/>
-                    <Item menuId="language" name="&Language"/>
-                    <Item menuId="settings" name="Se&ttings"/>
-                    <Item menuId="tools" name="To&ols"/>
+                    <Item menuId="file" name="&amp;File"/>
+                    <Item menuId="edit" name="&amp;Edit"/>
+                    <Item menuId="search" name="&amp;Search"/>
+                    <Item menuId="view" name="&amp;View"/>
+                    <Item menuId="encoding" name="E&amp;ncoding"/>
+                    <Item menuId="language" name="&amp;Language"/>
+                    <Item menuId="settings" name="Se&amp;ttings"/>
+                    <Item menuId="tools" name="To&amp;ols"/>
                     <Item menuId="macro" name="Macro"/>
                     <Item menuId="run" name="Run"/>
                     <Item idName="Plugins" name="Plugins"/>
@@ -68,21 +68,21 @@
 
                 <!-- all menu item -->
                 <Commands>
-                    <Item id="41001" name="&New"/>
-                    <Item id="41002" name="&Open"/>
+                    <Item id="41001" name="&amp;New"/>
+                    <Item id="41002" name="&amp;Open"/>
                     <Item id="41019" name="Explorer"/>
                     <Item id="41020" name="cmd"/>
                     <Item id="41003" name="Close"/>
-                    <Item id="41004" name="C&lose All"/>
+                    <Item id="41004" name="C&amp;lose All"/>
                     <Item id="41005" name="Close All BUT Current Document"/>
                     <Item id="41009" name="Close All to the Left"/>
                     <Item id="41018" name="Close All to the Right"/>
-                    <Item id="41006" name="&Save"/>
-                    <Item id="41007" name="Sav&e All"/>
-                    <Item id="41008" name="Save &As…"/>
+                    <Item id="41006" name="&amp;Save"/>
+                    <Item id="41007" name="Sav&amp;e All"/>
+                    <Item id="41008" name="Save &amp;As…"/>
                     <Item id="41010" name="Print…"/>
                     <Item id="1001"  name="Print Now"/>
-                    <Item id="41011" name="E&xit"/>
+                    <Item id="41011" name="E&amp;xit"/>
                     <Item id="41012" name="Load Session…"/>
                     <Item id="41013" name="Save Session…"/>
                     <Item id="41014" name="Reload from Disk"/>
@@ -90,15 +90,15 @@
                     <Item id="41016" name="Delete from Disk"/>
                     <Item id="41017" name="Rename…"/>
                     <Item id="41021" name="Restore Recent Closed File"/>
-                    <Item id="41022" name="Open Folder as &Workspace"/>
+                    <Item id="41022" name="Open Folder as &amp;Workspace"/>
 
-                    <Item id="42001" name="Cu&t"/>
-                    <Item id="42002" name="&Copy"/>
-                    <Item id="42003" name="&Undo"/>
-                    <Item id="42004" name="&Redo"/>
-                    <Item id="42005" name="&Paste"/>
-                    <Item id="42006" name="&Delete"/>
-                    <Item id="42007" name="Select &All"/>
+                    <Item id="42001" name="Cu&amp;t"/>
+                    <Item id="42002" name="&amp;Copy"/>
+                    <Item id="42003" name="&amp;Undo"/>
+                    <Item id="42004" name="&amp;Redo"/>
+                    <Item id="42005" name="&amp;Paste"/>
+                    <Item id="42006" name="&amp;Delete"/>
+                    <Item id="42007" name="Select &amp;All"/>
                     <Item id="42020" name="Begin/End Select"/>
                     <Item id="42008" name="Increase Line Indent"/>
                     <Item id="42009" name="Decrease Line Indent"/>
@@ -127,9 +127,9 @@
                     <Item id="42074" name="Open Containing Folder in Explorer"/>
                     <Item id="42075" name="Search on Internet"/>
                     <Item id="42076" name="Change Search Engine…"/>
-                    <Item id="42018" name="&Start Recording"/>
-                    <Item id="42019" name="&Stop Recording"/>
-                    <Item id="42021" name="&Playback"/>
+                    <Item id="42018" name="&amp;Start Recording"/>
+                    <Item id="42019" name="&amp;Stop Recording"/>
+                    <Item id="42021" name="&amp;Playback"/>
                     <Item id="42022" name="Toggle Single Line Comment"/>
                     <Item id="42023" name="Block Comment"/>
                     <Item id="42047" name="Block Uncomment"/>
@@ -165,8 +165,8 @@
                     <Item id="42056" name="Remove Empty Lines (Containing Blank characters)"/>
                     <Item id="42057" name="Insert Blank Line Above Current"/>
                     <Item id="42058" name="Insert Blank Line Below Current"/>
-                    <Item id="43001" name="&Find…"/>
-                    <Item id="43002" name="Find &Next"/>
+                    <Item id="43001" name="&amp;Find…"/>
+                    <Item id="43002" name="Find &amp;Next"/>
                     <Item id="43003" name="Replace…"/>
                     <Item id="43004" name="Go to…"/>
                     <Item id="43005" name="Toggle Bookmark"/>
@@ -183,7 +183,7 @@
                     <Item id="43053" name="Select All Between Matching Braces"/>
                     <Item id="43009" name="Go to Matching Brace"/>
                     <Item id="43010" name="Find Previous"/>
-                    <Item id="43011" name="&Incremental Search"/>
+                    <Item id="43011" name="&amp;Incremental Search"/>
                     <Item id="43013" name="Find in Files"/>
                     <Item id="43014" name="Find (Volatile) Next"/>
                     <Item id="43015" name="Find (Volatile) Previous"/>
@@ -221,8 +221,8 @@
                     <Item id="44019" name="Show All Characters"/>
                     <Item id="44020" name="Show Indent Guide"/>
                     <Item id="44022" name="Wrap"/>
-                    <Item id="44023" name="Zoom &In Ctrl+Mouse Wheel Up"/>
-                    <Item id="44024" name="Zoom &Out    Ctrl+Mouse Wheel Down"/>
+                    <Item id="44023" name="Zoom &amp;In Ctrl+Mouse Wheel Up"/>
+                    <Item id="44024" name="Zoom &amp;Out    Ctrl+Mouse Wheel Down"/>
                     <Item id="44025" name="Show White Space and TAB"/>
                     <Item id="44026" name="Show End of Line"/>
                     <Item id="44029" name="Unfold All"/>
@@ -231,7 +231,7 @@
                     <Item id="44049" name="Summary…"/>
                     <Item id="44080" name="Document Map"/>
                     <Item id="44084" name="Function List"/>
-                    <Item id="44085" name="Folder as &Workspace"/>
+                    <Item id="44085" name="Folder as &amp;Workspace"/>
                     <Item id="44086" name="1st Tab"/>
                     <Item id="44087" name="2nd Tab"/>
                     <Item id="44088" name="3rd Tab"/>
@@ -297,7 +297,7 @@
                     <Item id="48501" name="Generate…"/>
                     <Item id="48502" name="Generate from files…"/>
                     <Item id="48503" name="Generate into clipboard"/>
-                    <Item id="49000" name="&Run…"/>
+                    <Item id="49000" name="&amp;Run…"/>
 
                     <Item id="50000" name="Function Completion"/>
                     <Item id="50001" name="Word Completion"/>
@@ -343,20 +343,20 @@
                 <Item id="1721" name="‹  Find"/>
                 <Item id="2"    name="Close"/>
                 <Item id="1620" name="Find what:"/>
-                <Item id="1603" name="Match &whole word only"/>
-                <Item id="1604" name="Match &case"/>
-                <Item id="1605" name="Regular &expression"/>
-                <Item id="1606" name="Wrap aroun&d"/>
-                <Item id="1612" name="&Up"/>
-                <Item id="1613" name="&Down"/>
+                <Item id="1603" name="Match &amp;whole word only"/>
+                <Item id="1604" name="Match &amp;case"/>
+                <Item id="1605" name="Regular &amp;expression"/>
+                <Item id="1606" name="Wrap aroun&amp;d"/>
+                <Item id="1612" name="&amp;Up"/>
+                <Item id="1613" name="&amp;Down"/>
                 <Item id="1614" name="Count"/>
                 <Item id="1615" name="Find All"/>
                 <Item id="1616" name="Mark line"/>
                 <Item id="1618" name="Purge for each search"/>
                 <Item id="1621" name="Direction"/>
-                <Item id="1611" name="Re&place with:"/>
-                <Item id="1608" name="&Replace"/>
-                <Item id="1609" name="Replace &All"/>
+                <Item id="1611" name="Re&amp;place with:"/>
+                <Item id="1608" name="&amp;Replace"/>
+                <Item id="1609" name="Replace &amp;All"/>
                 <Item id="1687" name="On losing focus"/>
                 <Item id="1688" name="Always"/>
                 <Item id="1632" name="In selection"/>
@@ -375,7 +375,7 @@
                 <Item id="1661" name="Follow current doc."/>
                 <Item id="1641" name="Find All in Current Document"/>
                 <Item id="1686" name="Transparency"/>
-                <Item id="1703" name="&. matches newline"/>
+                <Item id="1703" name="&amp;. matches newline"/>
             </Find>
 
             <FindCharsInRange title="Find Characters in Range…">
@@ -383,17 +383,17 @@
                 <Item id="2901" name="Non-ASCII Characters (128-255)"/>
                 <Item id="2902" name="ASCII Characters (0-127)"/>
                 <Item id="2903" name="My range:"/>
-                <Item id="2906" name="&Up"/>
-                <Item id="2907" name="&Down"/>
+                <Item id="2906" name="&amp;Up"/>
+                <Item id="2907" name="&amp;Down"/>
                 <Item id="2908" name="Direction"/>
-                <Item id="2909" name="Wra&p around"/>
+                <Item id="2909" name="Wra&amp;p around"/>
                 <Item id="2910" name="Find"/>
             </FindCharsInRange>
 
             <GoToLine title="Go to…">
                 <Item id="2007" name="Line"/>
                 <Item id="2008" name="Offset"/>
-                <Item id="1"    name="&Go"/>
+                <Item id="1"    name="&amp;Go"/>
                 <Item id="2"    name="I'm going nowhere"/>
                 <Item id="2004" name="You are here:"/>
                 <Item id="2005" name="You want to go to:"/>
@@ -421,7 +421,7 @@
 
             <StyleConfig title="Style Configurator">
                 <Item id="2"    name="Cancel"/>
-                <Item id="2301" name="Save && Close"/>
+                <Item id="2301" name="Save &amp;&amp; Close"/>
                 <Item id="2303" name="Transparency"/>
                 <Item id="2306" name="Select theme: "/>
                 <SubDialog>
@@ -497,7 +497,7 @@
                     <Item id="1" name="OK"/>
                     <Item id="2" name="Cancel"/>
                 </StylerDialog>
-                <Folder title="Folder && Default">
+                <Folder title="Folder &amp;&amp; Default">
                     <Item id="21101" name="Default style"/>
                     <Item id="21102" name="Styler"/>
                     <Item id="21105" name="Documentation:"/>
@@ -545,7 +545,7 @@
                     <Item id="22572" name="Styler"/>
                     <Item id="22622" name="Styler"/>
                 </Keywords>
-                <Comment title="Comment && Number">
+                <Comment title="Comment &amp;&amp; Number">
                     <Item id="23003" name="Line comment position"/>
                     <Item id="23004" name="Allow anywhere"/>
                     <Item id="23005" name="Force at beginning of line"/>
@@ -574,7 +574,7 @@
                     <Item id="23246" name="Comma"/>
                     <Item id="23247" name="Both"/>
                 </Comment>
-                <Operator title="Operators && Delimiter">
+                <Operator title="Operators &amp;&amp; Delimiter">
                     <Item id="24101" name="Operators style"/>
                     <Item id="24113" name="Styler"/>
                     <Item id="24116" name="Operators 1"/>
@@ -675,7 +675,7 @@
                     <Item id="6207" name="Display bookmarks"/>
                     <Item id="6208" name="Show vertical edge"/>
                     <Item id="6209" name="Number of columns: "/>
-                    <Item id="6234" name="Disable advanced scrolling feature&#x0D;(if you have touchpad problem)"/>
+                    <Item id="6234" name="Disable advanced scrolling feature&amp;#x0D;(if you have touchpad problem)"/>
 
                     <Item id="6211" name="Vertical Edge Settings"/>
                     <Item id="6212" name="Line mode"/>
@@ -830,7 +830,7 @@
                     <Item id="6256" name="Allow on several lines"/>
                     <Item id="6161" name="Word character list"/>
                     <Item id="6162" name="Use default Word character list as it is"/>
-                    <Item id="6163" name="Add your character as part of word&#x0D;(don't choose, unless you know what you're doing)"/>
+                    <Item id="6163" name="Add your character as part of word&amp;#x0D;(don't choose, unless you know what you're doing)"/>
                 </Delimiter>
 
                 <Cloud title="Cloud">
@@ -840,7 +840,7 @@
                 </Cloud>
                 
                 <SearchEngine title="Search Engine">
-                    <Item id="6271" name="Search Engine (for command &quot;Search on Internet&quot;)"/>
+                    <Item id="6271" name="Search Engine (for command &amp;quot;Search on Internet&amp;quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
                     <Item id="6273" name="Google"/>
                     <Item id="6274" name="Bing"/>
@@ -906,10 +906,10 @@
             </ColumnEditor>
         </Dialog>
         <MessageBox>
-            <ContextMenuXmlEditWarning title="Editing contextMenu" message="Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.&#x0D;You have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
-            <NppHelpAbsentWarning title="File does not exist" message="&#x0D;doesn't exist. Please download it on Notepad++ site."/>
-            <SaveCurrentModifWarning title="Save Current Modification" message="You should save the current modification.&#x0D;All the saved modifications can not be undone.&#x0D;&#x0D;Continue?"/>
-            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message="You should save the current modification.&#x0D;All the saved modifications can not be undone.&#x0D;&#x0D;Continue?"/>
+            <ContextMenuXmlEditWarning title="Editing contextMenu" message="Editing contextMenu.xml allows you to modify your Notepad++ popup context menu.&amp;#x0D;You have to restart your Notepad++ to take effect after modifying contextMenu.xml."/>
+            <NppHelpAbsentWarning title="File does not exist" message="&amp;#x0D;doesn't exist. Please download it on Notepad++ site."/>
+            <SaveCurrentModifWarning title="Save Current Modification" message="You should save the current modification.&amp;#x0D;All the saved modifications can not be undone.&amp;#x0D;&amp;#x0D;Continue?"/>
+            <LoseUndoAbilityWarning title="Lose Undo Ability Warning" message="You should save the current modification.&amp;#x0D;All the saved modifications can not be undone.&amp;#x0D;&amp;#x0D;Continue?"/>
             <CannotMoveDoc title="Move to new Notepad++ Instance" message="Document is modified, save it then try again."/>
             <DocReloadWarning title="Reload" message="Are you sure you want to reload the current file and lose the changes made in Notepad++?"/>
             <FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
@@ -917,8 +917,8 @@
             <DeleteFileFailed title="Delete File" message="Delete File failed"/>
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.&#x0D;Are you sure to open them?"/>
-            <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,&#x0D;or on a folder needed privilege right for writing access.&#x0D;Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
+            <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.&amp;#x0D;Are you sure to open them?"/>
+            <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,&amp;#x0D;or on a folder needed privilege right for writing access.&amp;#x0D;Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
             <FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
             <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
         </MessageBox>
@@ -991,7 +991,7 @@
             </Menus>
         </ProjectManager>
         <MiscStrings>
-            <word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &quot;Match whole word only&quot; option checked."/>
+            <word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &amp;quot;Match whole word only&amp;quot; option checked."/>
             <word-chars-list-warning-begin value="Be aware: "/>
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ space(s)"/>
@@ -1000,7 +1000,7 @@
             <word-chars-list-warning-end value=" in your character list."/>
             <cloud-invalid-warning value="Invalid path."/>
             <cloud-restart-warning value="Please restart Notepad++ to take effect."/>
-            <shift-change-direction-tip value="Enter: Find Next&#x0D;Shift+Enter: Find Previous"/>
+            <shift-change-direction-tip value="Enter: Find Next&amp;#x0D;Shift+Enter: Find Previous"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -5,14 +5,14 @@
             <Main>
                 <!-- Main Menu Entries -->
                 <Entries>
-                    <Item menuId="file" name="File"/>
-                    <Item menuId="edit" name="Edit"/>
-                    <Item menuId="search" name="Search"/>
-                    <Item menuId="view" name="View"/>
-                    <Item menuId="encoding" name="Encoding"/>
-                    <Item menuId="language" name="Language"/>
-                    <Item menuId="settings" name="Settings"/>
-                    <Item menuId="tools" name="Tools"/>
+                    <Item menuId="file" name="&File"/>
+                    <Item menuId="edit" name="&Edit"/>
+                    <Item menuId="search" name="&Search"/>
+                    <Item menuId="view" name="&View"/>
+                    <Item menuId="encoding" name="E&ncoding"/>
+                    <Item menuId="language" name="&Language"/>
+                    <Item menuId="settings" name="Se&ttings"/>
+                    <Item menuId="tools" name="To&ols"/>
                     <Item menuId="macro" name="Macro"/>
                     <Item menuId="run" name="Run"/>
                     <Item idName="Plugins" name="Plugins"/>
@@ -68,21 +68,21 @@
 
                 <!-- all menu item -->
                 <Commands>
-                    <Item id="41001" name="New"/>
-                    <Item id="41002" name="Open"/>
+                    <Item id="41001" name="&New"/>
+                    <Item id="41002" name="&Open"/>
                     <Item id="41019" name="Explorer"/>
                     <Item id="41020" name="cmd"/>
                     <Item id="41003" name="Close"/>
-                    <Item id="41004" name="Close All"/>
+                    <Item id="41004" name="C&lose All"/>
                     <Item id="41005" name="Close All BUT Current Document"/>
                     <Item id="41009" name="Close All to the Left"/>
                     <Item id="41018" name="Close All to the Right"/>
-                    <Item id="41006" name="Save"/>
-                    <Item id="41007" name="Save All"/>
-                    <Item id="41008" name="Save As…"/>
+                    <Item id="41006" name="&Save"/>
+                    <Item id="41007" name="Sav&e All"/>
+                    <Item id="41008" name="Save &As…"/>
                     <Item id="41010" name="Print…"/>
                     <Item id="1001"  name="Print Now"/>
-                    <Item id="41011" name="Exit"/>
+                    <Item id="41011" name="E&xit"/>
                     <Item id="41012" name="Load Session…"/>
                     <Item id="41013" name="Save Session…"/>
                     <Item id="41014" name="Reload from Disk"/>
@@ -90,15 +90,15 @@
                     <Item id="41016" name="Delete from Disk"/>
                     <Item id="41017" name="Rename…"/>
                     <Item id="41021" name="Restore Recent Closed File"/>
-                    <Item id="41022" name="Open Folder as Workspace"/>
+                    <Item id="41022" name="Open Folder as &Workspace"/>
 
-                    <Item id="42001" name="Cut"/>
-                    <Item id="42002" name="Copy"/>
-                    <Item id="42003" name="Undo"/>
-                    <Item id="42004" name="Redo"/>
-                    <Item id="42005" name="Paste"/>
-                    <Item id="42006" name="Delete"/>
-                    <Item id="42007" name="Select All"/>
+                    <Item id="42001" name="Cu&t"/>
+                    <Item id="42002" name="&Copy"/>
+                    <Item id="42003" name="&Undo"/>
+                    <Item id="42004" name="&Redo"/>
+                    <Item id="42005" name="&Paste"/>
+                    <Item id="42006" name="&Delete"/>
+                    <Item id="42007" name="Select &All"/>
                     <Item id="42020" name="Begin/End Select"/>
                     <Item id="42008" name="Increase Line Indent"/>
                     <Item id="42009" name="Decrease Line Indent"/>
@@ -127,9 +127,9 @@
                     <Item id="42074" name="Open Containing Folder in Explorer"/>
                     <Item id="42075" name="Search on Internet"/>
                     <Item id="42076" name="Change Search Engine…"/>
-                    <Item id="42018" name="Start Recording"/>
-                    <Item id="42019" name="Stop Recording"/>
-                    <Item id="42021" name="Playback"/>
+                    <Item id="42018" name="&Start Recording"/>
+                    <Item id="42019" name="&Stop Recording"/>
+                    <Item id="42021" name="&Playback"/>
                     <Item id="42022" name="Toggle Single Line Comment"/>
                     <Item id="42023" name="Block Comment"/>
                     <Item id="42047" name="Block Uncomment"/>
@@ -165,8 +165,8 @@
                     <Item id="42056" name="Remove Empty Lines (Containing Blank characters)"/>
                     <Item id="42057" name="Insert Blank Line Above Current"/>
                     <Item id="42058" name="Insert Blank Line Below Current"/>
-                    <Item id="43001" name="Find…"/>
-                    <Item id="43002" name="Find Next"/>
+                    <Item id="43001" name="&Find…"/>
+                    <Item id="43002" name="Find &Next"/>
                     <Item id="43003" name="Replace…"/>
                     <Item id="43004" name="Go to…"/>
                     <Item id="43005" name="Toggle Bookmark"/>
@@ -183,7 +183,7 @@
                     <Item id="43053" name="Select All Between Matching Braces"/>
                     <Item id="43009" name="Go to Matching Brace"/>
                     <Item id="43010" name="Find Previous"/>
-                    <Item id="43011" name="Incremental Search"/>
+                    <Item id="43011" name="&Incremental Search"/>
                     <Item id="43013" name="Find in Files"/>
                     <Item id="43014" name="Find (Volatile) Next"/>
                     <Item id="43015" name="Find (Volatile) Previous"/>
@@ -221,8 +221,8 @@
                     <Item id="44019" name="Show All Characters"/>
                     <Item id="44020" name="Show Indent Guide"/>
                     <Item id="44022" name="Wrap"/>
-                    <Item id="44023" name="Zoom In Ctrl+Mouse Wheel Up"/>
-                    <Item id="44024" name="Zoom Out    Ctrl+Mouse Wheel Down"/>
+                    <Item id="44023" name="Zoom &In Ctrl+Mouse Wheel Up"/>
+                    <Item id="44024" name="Zoom &Out    Ctrl+Mouse Wheel Down"/>
                     <Item id="44025" name="Show White Space and TAB"/>
                     <Item id="44026" name="Show End of Line"/>
                     <Item id="44029" name="Unfold All"/>
@@ -231,7 +231,7 @@
                     <Item id="44049" name="Summary…"/>
                     <Item id="44080" name="Document Map"/>
                     <Item id="44084" name="Function List"/>
-                    <Item id="44085" name="Folder as Workspace"/>
+                    <Item id="44085" name="Folder as &Workspace"/>
                     <Item id="44086" name="1st Tab"/>
                     <Item id="44087" name="2nd Tab"/>
                     <Item id="44088" name="3rd Tab"/>
@@ -297,7 +297,7 @@
                     <Item id="48501" name="Generate…"/>
                     <Item id="48502" name="Generate from files…"/>
                     <Item id="48503" name="Generate into clipboard"/>
-                    <Item id="49000" name="Run…"/>
+                    <Item id="49000" name="&Run…"/>
 
                     <Item id="50000" name="Function Completion"/>
                     <Item id="50001" name="Word Completion"/>
@@ -343,20 +343,20 @@
                 <Item id="1721" name="‹  Find"/>
                 <Item id="2"    name="Close"/>
                 <Item id="1620" name="Find what:"/>
-                <Item id="1603" name="Match whole word only"/>
-                <Item id="1604" name="Match case"/>
-                <Item id="1605" name="Regular expression"/>
-                <Item id="1606" name="Wrap around"/>
-                <Item id="1612" name="Up"/>
-                <Item id="1613" name="Down"/>
+                <Item id="1603" name="Match &whole word only"/>
+                <Item id="1604" name="Match &case"/>
+                <Item id="1605" name="Regular &expression"/>
+                <Item id="1606" name="Wrap aroun&d"/>
+                <Item id="1612" name="&Up"/>
+                <Item id="1613" name="&Down"/>
                 <Item id="1614" name="Count"/>
                 <Item id="1615" name="Find All"/>
                 <Item id="1616" name="Mark line"/>
                 <Item id="1618" name="Purge for each search"/>
                 <Item id="1621" name="Direction"/>
-                <Item id="1611" name="Replace with:"/>
-                <Item id="1608" name="Replace"/>
-                <Item id="1609" name="Replace All"/>
+                <Item id="1611" name="Re&place with:"/>
+                <Item id="1608" name="&Replace"/>
+                <Item id="1609" name="Replace &All"/>
                 <Item id="1687" name="On losing focus"/>
                 <Item id="1688" name="Always"/>
                 <Item id="1632" name="In selection"/>
@@ -375,7 +375,7 @@
                 <Item id="1661" name="Follow current doc."/>
                 <Item id="1641" name="Find All in Current Document"/>
                 <Item id="1686" name="Transparency"/>
-                <Item id="1703" name=". matches newline"/>
+                <Item id="1703" name="&. matches newline"/>
             </Find>
 
             <FindCharsInRange title="Find Characters in Range…">
@@ -383,17 +383,17 @@
                 <Item id="2901" name="Non-ASCII Characters (128-255)"/>
                 <Item id="2902" name="ASCII Characters (0-127)"/>
                 <Item id="2903" name="My range:"/>
-                <Item id="2906" name="Up"/>
-                <Item id="2907" name="Down"/>
+                <Item id="2906" name="&Up"/>
+                <Item id="2907" name="&Down"/>
                 <Item id="2908" name="Direction"/>
-                <Item id="2909" name="Wrap around"/>
+                <Item id="2909" name="Wra&p around"/>
                 <Item id="2910" name="Find"/>
             </FindCharsInRange>
 
             <GoToLine title="Go to…">
                 <Item id="2007" name="Line"/>
                 <Item id="2008" name="Offset"/>
-                <Item id="1"    name="Go"/>
+                <Item id="1"    name="&Go"/>
                 <Item id="2"    name="I'm going nowhere"/>
                 <Item id="2004" name="You are here:"/>
                 <Item id="2005" name="You want to go to:"/>
@@ -421,7 +421,7 @@
 
             <StyleConfig title="Style Configurator">
                 <Item id="2"    name="Cancel"/>
-                <Item id="2301" name="Save & Close"/>
+                <Item id="2301" name="Save && Close"/>
                 <Item id="2303" name="Transparency"/>
                 <Item id="2306" name="Select theme: "/>
                 <SubDialog>
@@ -497,7 +497,7 @@
                     <Item id="1" name="OK"/>
                     <Item id="2" name="Cancel"/>
                 </StylerDialog>
-                <Folder title="Folder & Default">
+                <Folder title="Folder && Default">
                     <Item id="21101" name="Default style"/>
                     <Item id="21102" name="Styler"/>
                     <Item id="21105" name="Documentation:"/>
@@ -545,7 +545,7 @@
                     <Item id="22572" name="Styler"/>
                     <Item id="22622" name="Styler"/>
                 </Keywords>
-                <Comment title="Comment & Number">
+                <Comment title="Comment && Number">
                     <Item id="23003" name="Line comment position"/>
                     <Item id="23004" name="Allow anywhere"/>
                     <Item id="23005" name="Force at beginning of line"/>
@@ -574,7 +574,7 @@
                     <Item id="23246" name="Comma"/>
                     <Item id="23247" name="Both"/>
                 </Comment>
-                <Operator title="Operators & Delimiter">
+                <Operator title="Operators && Delimiter">
                     <Item id="24101" name="Operators style"/>
                     <Item id="24113" name="Styler"/>
                     <Item id="24116" name="Operators 1"/>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -920,7 +920,7 @@
             <NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.&#x0D;Are you sure to open them?"/>
             <SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,&#x0D;or on a folder needed privilege right for writing access.&#x0D;Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
             <FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/>
-        <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
+            <SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Clipboard History"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -17,118 +17,118 @@
             <Main>
                 <!-- Main Menu Entries -->
                 <Entries>
-                    <Item menuId="file" name="&Datei"/>
-                    <Item menuId="edit" name="&Bearbeiten"/>
-                    <Item menuId="search" name="&Suchen"/>
-                    <Item menuId="view" name="&Ansicht"/>
-                    <Item menuId="encoding" name="&Kodierung"/>
-                    <Item menuId="language" name="S&prachen"/>
-                    <Item menuId="settings" name="&Einstellungen"/>
-                    <Item menuId="tools" name="Werk&zeuge"/>
-                    <Item menuId="macro" name="&Makro"/>
-                    <Item menuId="run" name="Ausfüh&ren"/>
-                    <Item idName="Plugins" name="Er&weiterungen"/>
-                    <Item idName="Window" name="Fe&nster"/>
+                    <Item menuId="file" name="&amp;Datei"/>
+                    <Item menuId="edit" name="&amp;Bearbeiten"/>
+                    <Item menuId="search" name="&amp;Suchen"/>
+                    <Item menuId="view" name="&amp;Ansicht"/>
+                    <Item menuId="encoding" name="&amp;Kodierung"/>
+                    <Item menuId="language" name="S&amp;prachen"/>
+                    <Item menuId="settings" name="&amp;Einstellungen"/>
+                    <Item menuId="tools" name="Werk&amp;zeuge"/>
+                    <Item menuId="macro" name="&amp;Makro"/>
+                    <Item menuId="run" name="Ausfüh&amp;ren"/>
+                    <Item idName="Plugins" name="Er&amp;weiterungen"/>
+                    <Item idName="Window" name="Fe&amp;nster"/>
                 </Entries>
                 <!-- Sub Menu Entries -->
                 <SubEntries>
-                    <Item subMenuId="file-openFolder" name="Aktuellen &Ordner öffnen"/>
-                    <Item subMenuId="file-closeMore" name="&Mehrere schließen"/>
-                    <Item subMenuId="file-recentFiles" name="Zuletzt &verwendet"/>
-                    <Item subMenuId="edit-copyToClipboard" name="Datei&pfad kopieren"/>
-                    <Item subMenuId="edit-indent" name="E&inrückung"/>
-                    <Item subMenuId="edit-convertCaseTo" name="&Groß-/Kleinschreibung"/>
-                    <Item subMenuId="edit-lineOperations" name="&Zeilenoperationen"/>
-                    <Item subMenuId="edit-comment" name="K&ommentare"/>
-                    <Item subMenuId="edit-autoCompletion" name="Autovervollst&ändigung"/>
-                    <Item subMenuId="edit-eolConversion" name="Format Zeile&nende"/>
-                    <Item subMenuId="edit-blankOperations" name="Nicht &druckbare Zeichen"/>
-                    <Item subMenuId="edit-pasteSpecial" name= "Einf&ügen spezial"/>
+                    <Item subMenuId="file-openFolder" name="Aktuellen &amp;Ordner öffnen"/>
+                    <Item subMenuId="file-closeMore" name="&amp;Mehrere schließen"/>
+                    <Item subMenuId="file-recentFiles" name="Zuletzt &amp;verwendet"/>
+                    <Item subMenuId="edit-copyToClipboard" name="Datei&amp;pfad kopieren"/>
+                    <Item subMenuId="edit-indent" name="E&amp;inrückung"/>
+                    <Item subMenuId="edit-convertCaseTo" name="&amp;Groß-/Kleinschreibung"/>
+                    <Item subMenuId="edit-lineOperations" name="&amp;Zeilenoperationen"/>
+                    <Item subMenuId="edit-comment" name="K&amp;ommentare"/>
+                    <Item subMenuId="edit-autoCompletion" name="Autovervollst&amp;ändigung"/>
+                    <Item subMenuId="edit-eolConversion" name="Format Zeile&amp;nende"/>
+                    <Item subMenuId="edit-blankOperations" name="Nicht &amp;druckbare Zeichen"/>
+                    <Item subMenuId="edit-pasteSpecial" name= "Einf&amp;ügen spezial"/>
                     <Item subMenuId="edit-onSelection" name="Bei Auswahl"/>
-                    <Item subMenuId="search-markAll" name="Alle &Vorkommnisse hervorheben"/>
-                    <Item subMenuId="search-unmarkAll" name="Alle Hervorhe&bungen löschen"/>
-                    <Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung s&pringen"/>
-                    <Item subMenuId="search-jumpDown" name="Zur &nächsten Hervorhebung springen"/>
-                    <Item subMenuId="search-bookmark" name="&Lesezeichen"/>
-                    <Item subMenuId="view-showSymbol" name="Nicht &druckbare Zeichen"/>
-                    <Item subMenuId="view-zoom" name="Z&oom"/>
-                    <Item subMenuId="view-moveCloneDocument" name="Datei &verschieben/duplizieren"/>
-                    <Item subMenuId="view-tab" name="&Tabs"/>
-                    <Item subMenuId="view-collapseLevel" name="T&extblöcke schließen"/>
-                    <Item subMenuId="view-uncollapseLevel" name="Te&xtblöcke öffnen"/>
-                    <Item subMenuId="view-project" name="Projektver&waltung"/>
-                    <Item subMenuId="encoding-characterSets" name="&Weitere"/>
-                    <Item subMenuId="encoding-arabic" name="&Arabisch"/>
-                    <Item subMenuId="encoding-baltic" name="&Baltisch"/>
-                    <Item subMenuId="encoding-celtic" name="&Keltisch"/>
-                    <Item subMenuId="encoding-cyrillic" name="K&yrillisch"/>
-                    <Item subMenuId="encoding-centralEuropean" name="&Mitteleuropäisch"/>
-                    <Item subMenuId="encoding-chinese" name="&Chinesisch"/>
-                    <Item subMenuId="encoding-easternEuropean" name="&Osteuropäisch"/>
-                    <Item subMenuId="encoding-greek" name="&Griechisch"/>
-                    <Item subMenuId="encoding-hebrew" name="&Hebräisch"/>
-                    <Item subMenuId="encoding-japanese" name="&Japanisch"/>
-                    <Item subMenuId="encoding-korean" name="Ko&reanisch"/>
-                    <Item subMenuId="encoding-northEuropean" name="&Nordeuropäisch"/>
-                    <Item subMenuId="encoding-thai" name="&Thai"/>
-                    <Item subMenuId="encoding-turkish" name="T&ürkisch"/>
-                    <Item subMenuId="encoding-westernEuropean" name="&Westeuropäisch"/>
-                    <Item subMenuId="encoding-vietnamese" name="&Vietnamesisch"/>
-                    <Item subMenuId="settings-import" name="&Import"/>
+                    <Item subMenuId="search-markAll" name="Alle &amp;Vorkommnisse hervorheben"/>
+                    <Item subMenuId="search-unmarkAll" name="Alle Hervorhe&amp;bungen löschen"/>
+                    <Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung s&amp;pringen"/>
+                    <Item subMenuId="search-jumpDown" name="Zur &amp;nächsten Hervorhebung springen"/>
+                    <Item subMenuId="search-bookmark" name="&amp;Lesezeichen"/>
+                    <Item subMenuId="view-showSymbol" name="Nicht &amp;druckbare Zeichen"/>
+                    <Item subMenuId="view-zoom" name="Z&amp;oom"/>
+                    <Item subMenuId="view-moveCloneDocument" name="Datei &amp;verschieben/duplizieren"/>
+                    <Item subMenuId="view-tab" name="&amp;Tabs"/>
+                    <Item subMenuId="view-collapseLevel" name="T&amp;extblöcke schließen"/>
+                    <Item subMenuId="view-uncollapseLevel" name="Te&amp;xtblöcke öffnen"/>
+                    <Item subMenuId="view-project" name="Projektver&amp;waltung"/>
+                    <Item subMenuId="encoding-characterSets" name="&amp;Weitere"/>
+                    <Item subMenuId="encoding-arabic" name="&amp;Arabisch"/>
+                    <Item subMenuId="encoding-baltic" name="&amp;Baltisch"/>
+                    <Item subMenuId="encoding-celtic" name="&amp;Keltisch"/>
+                    <Item subMenuId="encoding-cyrillic" name="K&amp;yrillisch"/>
+                    <Item subMenuId="encoding-centralEuropean" name="&amp;Mitteleuropäisch"/>
+                    <Item subMenuId="encoding-chinese" name="&amp;Chinesisch"/>
+                    <Item subMenuId="encoding-easternEuropean" name="&amp;Osteuropäisch"/>
+                    <Item subMenuId="encoding-greek" name="&amp;Griechisch"/>
+                    <Item subMenuId="encoding-hebrew" name="&amp;Hebräisch"/>
+                    <Item subMenuId="encoding-japanese" name="&amp;Japanisch"/>
+                    <Item subMenuId="encoding-korean" name="Ko&amp;reanisch"/>
+                    <Item subMenuId="encoding-northEuropean" name="&amp;Nordeuropäisch"/>
+                    <Item subMenuId="encoding-thai" name="&amp;Thai"/>
+                    <Item subMenuId="encoding-turkish" name="T&amp;ürkisch"/>
+                    <Item subMenuId="encoding-westernEuropean" name="&amp;Westeuropäisch"/>
+                    <Item subMenuId="encoding-vietnamese" name="&amp;Vietnamesisch"/>
+                    <Item subMenuId="settings-import" name="&amp;Import"/>
                     <Item subMenuId="tools-md5" name="MD5"/>
                 </SubEntries>
 
                 <!-- all menu item -->
                 <Commands>
-                    <Item id="41001" name="&Neu"/>
-                    <Item id="41002" name="&Öffnen …"/>
-                    <Item id="41019" name="E&xplorer"/>
-                    <Item id="41020" name="&Eingabeaufforderung"/>
-                    <Item id="41003" name="Schlie&ßen"/>
-                    <Item id="41004" name="Alle s&chließen"/>
-                    <Item id="41005" name="Alle s&chließen bis auf aktuelle Datei"/>
-                    <Item id="41009" name="Dateien &links schließen"/>
-                    <Item id="41018" name="Dateien &rechts schließen"/>
-                    <Item id="41006" name="&Speichern"/>
-                    <Item id="41007" name="&Alle speichern"/>
-                    <Item id="41008" name="Speichern &unter …"/>
-                    <Item id="41010" name="&Drucken …"/>
-                    <Item id="1001"  name="So&fort drucken"/>
-                    <Item id="41011" name="B&eenden"/>
-                    <Item id="41012" name="Sit&zung öffnen …"/>
-                    <Item id="41013" name="Sitzung speiche&rn …"/>
-                    <Item id="41014" name="Neu &laden"/>
-                    <Item id="41015" name="&Kopie speichern unter …"/>
-                    <Item id="41016" name="Von Datentr&äger löschen"/>
-                    <Item id="41017" name="Um&benennen …"/>
+                    <Item id="41001" name="&amp;Neu"/>
+                    <Item id="41002" name="&amp;Öffnen …"/>
+                    <Item id="41019" name="E&amp;xplorer"/>
+                    <Item id="41020" name="&amp;Eingabeaufforderung"/>
+                    <Item id="41003" name="Schlie&amp;ßen"/>
+                    <Item id="41004" name="Alle s&amp;chließen"/>
+                    <Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
+                    <Item id="41009" name="Dateien &amp;links schließen"/>
+                    <Item id="41018" name="Dateien &amp;rechts schließen"/>
+                    <Item id="41006" name="&amp;Speichern"/>
+                    <Item id="41007" name="&amp;Alle speichern"/>
+                    <Item id="41008" name="Speichern &amp;unter …"/>
+                    <Item id="41010" name="&amp;Drucken …"/>
+                    <Item id="1001"  name="So&amp;fort drucken"/>
+                    <Item id="41011" name="B&amp;eenden"/>
+                    <Item id="41012" name="Sit&amp;zung öffnen …"/>
+                    <Item id="41013" name="Sitzung speiche&amp;rn …"/>
+                    <Item id="41014" name="Neu &amp;laden"/>
+                    <Item id="41015" name="&amp;Kopie speichern unter …"/>
+                    <Item id="41016" name="Von Datentr&amp;äger löschen"/>
+                    <Item id="41017" name="Um&amp;benennen …"/>
                     <Item id="41021" name="Zuletzt geschlossene Datei wieder öffnen"/>
                     <Item id="41022" name="Verzeichnis als Arbeitsbereich öffnen"/>
 
-                    <Item id="42001" name="Aus&schneiden"/>
-                    <Item id="42002" name="&Kopieren"/>
-                    <Item id="42003" name="&Rückgängig"/>
-                    <Item id="42004" name="&Wiederherstellen"/>
-                    <Item id="42005" name="&Einfügen"/>
-                    <Item id="42006" name="&Löschen"/>
-                    <Item id="42007" name="&Alles auswählen"/>
-                    <Item id="42020" name="Auswa&hl beginnen/beenden"/>
-                    <Item id="42008" name="Zeileneinzug v&ergrößern"/>
-                    <Item id="42009" name="Zeileneinzug ver&kleinern"/>
-                    <Item id="42010" name="Zeile &duplizieren"/>
-                    <Item id="42012" name="Zeile am Fensterrand &teilen"/>
-                    <Item id="42013" name="&Zeilen zusammenfassen"/>
-                    <Item id="42014" name="Zeile nach &oben verschieben"/>
-                    <Item id="42015" name="Zeile nach &unten verschieben"/>
-                    <Item id="42059" name="Zeilen alphabetisch au&fsteigend sortieren"/>
-                    <Item id="42060" name="Zeilen alphabetisch a&bsteigend sortieren"/>
+                    <Item id="42001" name="Aus&amp;schneiden"/>
+                    <Item id="42002" name="&amp;Kopieren"/>
+                    <Item id="42003" name="&amp;Rückgängig"/>
+                    <Item id="42004" name="&amp;Wiederherstellen"/>
+                    <Item id="42005" name="&amp;Einfügen"/>
+                    <Item id="42006" name="&amp;Löschen"/>
+                    <Item id="42007" name="&amp;Alles auswählen"/>
+                    <Item id="42020" name="Auswa&amp;hl beginnen/beenden"/>
+                    <Item id="42008" name="Zeileneinzug v&amp;ergrößern"/>
+                    <Item id="42009" name="Zeileneinzug ver&amp;kleinern"/>
+                    <Item id="42010" name="Zeile &amp;duplizieren"/>
+                    <Item id="42012" name="Zeile am Fensterrand &amp;teilen"/>
+                    <Item id="42013" name="&amp;Zeilen zusammenfassen"/>
+                    <Item id="42014" name="Zeile nach &amp;oben verschieben"/>
+                    <Item id="42015" name="Zeile nach &amp;unten verschieben"/>
+                    <Item id="42059" name="Zeilen alphabetisch au&amp;fsteigend sortieren"/>
+                    <Item id="42060" name="Zeilen alphabetisch a&amp;bsteigend sortieren"/>
                     <Item id="42061" name="Zeilen als Ganzzahlen aufsteigend sortieren"/>
                     <Item id="42062" name="Zeilen als Ganzzahlen absteigend sortieren"/>
                     <Item id="42063" name="Zeilen als Dezimalzahlen (Komma) aufsteigend sortieren"/>
                     <Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
                     <Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
                     <Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-                    <Item id="42016" name="In &GROSSBUCHSTABEN umwandeln"/>
-                    <Item id="42017" name="In &kleinbuchstaben umwandeln"/>
+                    <Item id="42016" name="In &amp;GROSSBUCHSTABEN umwandeln"/>
+                    <Item id="42017" name="In &amp;kleinbuchstaben umwandeln"/>
                     <Item id="42067" name="Überschriftenstil"/>
                     <Item id="42068" name="Gemischter Überschriftenstil"/>
                     <Item id="42069" name="Normaler Wortstil"/>
@@ -139,158 +139,158 @@
                     <Item id="42074" name="Ordner im Explorer öffnen"/>
                     <Item id="42075" name="Suche im Internet"/>
                     <Item id="42076" name="Andere Suchmaschine wählen …"/>
-                    <Item id="42018" name="Aufzeichnung &starten"/>
-                    <Item id="42019" name="Aufzeichnung st&oppen"/>
-                    <Item id="42021" name="Makro ausfüh&ren"/>
-                    <Item id="42022" name="&Zeilenweise Auskommentierung umschalten"/>
-                    <Item id="42023" name="Auswahl &auskommentieren"/>
-                    <Item id="42047" name="Auskommentierung der Auswahl au&fheben"/>
-                    <Item id="42024" name="Leerzeichen und Tabulatoren am Zeilen&ende löschen"/>
-                    <Item id="42042" name="Leerzeichen und Tabulatoren am Zeilen&anfang löschen"/>
-                    <Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang &und -ende löschen"/>
-                    <Item id="42044" name="Zeilenumbrüche in Leerzeichen &konvertieren"/>
-                    <Item id="42045" name="&Mehrfachen Whitespace und Umbrüche entfernen"/>
-                    <Item id="42046" name="Tabulatoren in &Leerzeichen umwandeln"/>
-                    <Item id="42054" name="Leerzeichen in &Tabulatoren umwandeln (alle)"/>
-                    <Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am &Zeilenanfang)"/>
-                    <Item id="42038" name="&HTML-Inhalt einfügen"/>
-                    <Item id="42039" name="&RTF-Inhalt einfügen"/>
-                    <Item id="42048" name="Binär-Inhalt &kopieren"/>
-                    <Item id="42049" name="Binär-Inhalt &ausschneiden"/>
-                    <Item id="42050" name="Binär-Inhalt &einfügen"/>
-                    <Item id="42037" name="Spalten-&Modus …"/>
-                    <Item id="42034" name="&Block-Editor …"/>
-                    <Item id="42051" name="Zeichen&tabelle"/>
-                    <Item id="42052" name="Zwis&chenablage"/>
-                    <Item id="42025" name="Aufgenommenes Makro s&peichern"/>
-                    <Item id="42026" name="Schreib&richtung von rechts nach links"/>
-                    <Item id="42027" name="Schreibrichtung von lin&ks nach rechts"/>
-                    <Item id="42028" name="Schreibsch&utz"/>
-                    <Item id="42029" name="Vollständigen &Pfad kopieren"/>
-                    <Item id="42030" name="Nur Datei&namen kopieren"/>
-                    <Item id="42031" name="Nur &Verzeichnispfad kopieren"/>
-                    <Item id="42032" name="Makro &mehrfach ausführen …"/>
-                    <Item id="42033" name="Schreibschutz-Attribut l&öschen"/>
-                    <Item id="42035" name="Zeilen aus&kommentieren"/>
-                    <Item id="42036" name="Auskommentierung der Zeilen a&ufheben"/>
-                    <Item id="42055" name="&Leerzeilen (nur völlig leere) löschen"/>
-                    <Item id="42056" name="Leerzeilen (auch mit &Whitespace) löschen"/>
-                    <Item id="42057" name="Leerzeile &über aktueller Zeile einfügen"/>
-                    <Item id="42058" name="Leerzeile u&nter aktueller Zeile einfügen"/>
-                    <Item id="43001" name="&Suchen …"/>
-                    <Item id="43002" name="&Vorwärts Suchen"/>
-                    <Item id="43003" name="&Ersetzen …"/>
-                    <Item id="43004" name="&Gehe zu …"/>
-                    <Item id="43005" name="&Lesezeichen setzen/löschen"/>
-                    <Item id="43006" name="&Nächstes Lesezeichen"/>
-                    <Item id="43007" name="&Vorheriges Lesezeichen"/>
-                    <Item id="43008" name="Alle Lesezeichen l&öschen"/>
-                    <Item id="43018" name="Zeilen mit Lesezeichen &ausschneiden"/>
-                    <Item id="43019" name="Zeilen mit Lesezeichen &kopieren"/>
-                    <Item id="43020" name="&Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
-                    <Item id="43021" name="Zeilen mit Lesezeichen lös&chen"/>
-                    <Item id="43051" name="Zeilen &ohne Lesezeichen löschen"/>
-                    <Item id="43050" name="Lesezeichen inver&tieren"/>
-                    <Item id="43052" name="Suche nach &Zeichencodes …"/>
-                    <Item id="43053" name="&Alles zwischen Klammern auswählen"/>
-                    <Item id="43009" name="Suche zugehörige &Klammer"/>
-                    <Item id="43010" name="&Rückwärts suchen"/>
-                    <Item id="43011" name="&Inkrementelle Suche"/>
-                    <Item id="43013" name="In &Dateien suchen …"/>
-                    <Item id="43014" name="Wort am Cursor suchen (&ohne Verlauf)"/>
-                    <Item id="43015" name="Wor&t am Cursor rückwärts suchen (ohne Verlauf)"/>
-                    <Item id="43022" name="Hervorhebung &1"/>
-                    <Item id="43023" name="Hervorhebung &1 entfernen"/>
-                    <Item id="43024" name="Hervorhebung &2"/>
-                    <Item id="43025" name="Hervorhebung &2 entfernen"/>
-                    <Item id="43026" name="Hervorhebung &3"/>
-                    <Item id="43027" name="Hervorhebung &3 entfernen"/>
-                    <Item id="43028" name="Hervorhebung &4"/>
-                    <Item id="43029" name="Hervorhebung &4 entfernen"/>
-                    <Item id="43030" name="Hervorhebung &5"/>
-                    <Item id="43031" name="Hervorhebung &5 entfernen"/>
-                    <Item id="43032" name="&Alle entfernen"/>
-                    <Item id="43033" name="Hervorhebung &1"/>
-                    <Item id="43034" name="Hervorhebung &2"/>
-                    <Item id="43035" name="Hervorhebung &3"/>
-                    <Item id="43036" name="Hervorhebung &4"/>
-                    <Item id="43037" name="Hervorhebung &5"/>
-                    <Item id="43038" name="Hervorhebung aus &Suche"/>
-                    <Item id="43039" name="Hervorhebung &1"/>
-                    <Item id="43040" name="Hervorhebung &2"/>
-                    <Item id="43041" name="Hervorhebung &3"/>
-                    <Item id="43042" name="Hervorhebung &4"/>
-                    <Item id="43043" name="Hervorhebung &5"/>
-                    <Item id="43044" name="Hervorhebung aus &Suche"/>
-                    <Item id="43045" name="Suchergebnis-&Fenster"/>
-                    <Item id="43046" name="Zum n&ächsten Suchergebnis springen"/>
-                    <Item id="43047" name="Zum vorherigen S&uchergebnis springen"/>
-                    <Item id="43048" name="Auswahl oder Wort am &Cursor suchen"/>
-                    <Item id="43049" name="Wort am Cursor r&ückwärts suchen"/>
-                    <Item id="43054" name="&Hervorheben …"/>
-                    <Item id="44009" name="&Post-It"/>
-                    <Item id="44010" name="A&lle Textblöcke schließen"/>
-                    <Item id="44019" name="&Alle Zeichen anzeigen"/>
-                    <Item id="44020" name="&Einrückung anzeigen"/>
-                    <Item id="44022" name="Automatischer Zeilen&umbruch"/>
-                    <Item id="44023" name="Schrift ver&größern"/>
-                    <Item id="44024" name="Schrift ver&kleinern"/>
-                    <Item id="44025" name="&Leerzeichen und Tabulatoren anzeigen"/>
-                    <Item id="44026" name="Zeilenende anze&igen"/>
-                    <Item id="44029" name="Alle Textblöcke &öffnen"/>
-                    <Item id="44030" name="Textblock schlie&ßen"/>
-                    <Item id="44031" name="Textblock öff&nen"/>
-                    <Item id="44049" name="Datei-&Info …"/>
-                    <Item id="44080" name="&Miniaturansicht"/>
-                    <Item id="44084" name="&Funktionsliste"/>
+                    <Item id="42018" name="Aufzeichnung &amp;starten"/>
+                    <Item id="42019" name="Aufzeichnung st&amp;oppen"/>
+                    <Item id="42021" name="Makro ausfüh&amp;ren"/>
+                    <Item id="42022" name="&amp;Zeilenweise Auskommentierung umschalten"/>
+                    <Item id="42023" name="Auswahl &amp;auskommentieren"/>
+                    <Item id="42047" name="Auskommentierung der Auswahl au&amp;fheben"/>
+                    <Item id="42024" name="Leerzeichen und Tabulatoren am Zeilen&amp;ende löschen"/>
+                    <Item id="42042" name="Leerzeichen und Tabulatoren am Zeilen&amp;anfang löschen"/>
+                    <Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang &amp;und -ende löschen"/>
+                    <Item id="42044" name="Zeilenumbrüche in Leerzeichen &amp;konvertieren"/>
+                    <Item id="42045" name="&amp;Mehrfachen Whitespace und Umbrüche entfernen"/>
+                    <Item id="42046" name="Tabulatoren in &amp;Leerzeichen umwandeln"/>
+                    <Item id="42054" name="Leerzeichen in &amp;Tabulatoren umwandeln (alle)"/>
+                    <Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am &amp;Zeilenanfang)"/>
+                    <Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
+                    <Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
+                    <Item id="42048" name="Binär-Inhalt &amp;kopieren"/>
+                    <Item id="42049" name="Binär-Inhalt &amp;ausschneiden"/>
+                    <Item id="42050" name="Binär-Inhalt &amp;einfügen"/>
+                    <Item id="42037" name="Spalten-&amp;Modus …"/>
+                    <Item id="42034" name="&amp;Block-Editor …"/>
+                    <Item id="42051" name="Zeichen&amp;tabelle"/>
+                    <Item id="42052" name="Zwis&amp;chenablage"/>
+                    <Item id="42025" name="Aufgenommenes Makro s&amp;peichern"/>
+                    <Item id="42026" name="Schreib&amp;richtung von rechts nach links"/>
+                    <Item id="42027" name="Schreibrichtung von lin&amp;ks nach rechts"/>
+                    <Item id="42028" name="Schreibsch&amp;utz"/>
+                    <Item id="42029" name="Vollständigen &amp;Pfad kopieren"/>
+                    <Item id="42030" name="Nur Datei&amp;namen kopieren"/>
+                    <Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
+                    <Item id="42032" name="Makro &amp;mehrfach ausführen …"/>
+                    <Item id="42033" name="Schreibschutz-Attribut l&amp;öschen"/>
+                    <Item id="42035" name="Zeilen aus&amp;kommentieren"/>
+                    <Item id="42036" name="Auskommentierung der Zeilen a&amp;ufheben"/>
+                    <Item id="42055" name="&amp;Leerzeilen (nur völlig leere) löschen"/>
+                    <Item id="42056" name="Leerzeilen (auch mit &amp;Whitespace) löschen"/>
+                    <Item id="42057" name="Leerzeile &amp;über aktueller Zeile einfügen"/>
+                    <Item id="42058" name="Leerzeile u&amp;nter aktueller Zeile einfügen"/>
+                    <Item id="43001" name="&amp;Suchen …"/>
+                    <Item id="43002" name="&amp;Vorwärts Suchen"/>
+                    <Item id="43003" name="&amp;Ersetzen …"/>
+                    <Item id="43004" name="&amp;Gehe zu …"/>
+                    <Item id="43005" name="&amp;Lesezeichen setzen/löschen"/>
+                    <Item id="43006" name="&amp;Nächstes Lesezeichen"/>
+                    <Item id="43007" name="&amp;Vorheriges Lesezeichen"/>
+                    <Item id="43008" name="Alle Lesezeichen l&amp;öschen"/>
+                    <Item id="43018" name="Zeilen mit Lesezeichen &amp;ausschneiden"/>
+                    <Item id="43019" name="Zeilen mit Lesezeichen &amp;kopieren"/>
+                    <Item id="43020" name="&amp;Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
+                    <Item id="43021" name="Zeilen mit Lesezeichen lös&amp;chen"/>
+                    <Item id="43051" name="Zeilen &amp;ohne Lesezeichen löschen"/>
+                    <Item id="43050" name="Lesezeichen inver&amp;tieren"/>
+                    <Item id="43052" name="Suche nach &amp;Zeichencodes …"/>
+                    <Item id="43053" name="&amp;Alles zwischen Klammern auswählen"/>
+                    <Item id="43009" name="Suche zugehörige &amp;Klammer"/>
+                    <Item id="43010" name="&amp;Rückwärts suchen"/>
+                    <Item id="43011" name="&amp;Inkrementelle Suche"/>
+                    <Item id="43013" name="In &amp;Dateien suchen …"/>
+                    <Item id="43014" name="Wort am Cursor suchen (&amp;ohne Verlauf)"/>
+                    <Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne Verlauf)"/>
+                    <Item id="43022" name="Hervorhebung &amp;1"/>
+                    <Item id="43023" name="Hervorhebung &amp;1 entfernen"/>
+                    <Item id="43024" name="Hervorhebung &amp;2"/>
+                    <Item id="43025" name="Hervorhebung &amp;2 entfernen"/>
+                    <Item id="43026" name="Hervorhebung &amp;3"/>
+                    <Item id="43027" name="Hervorhebung &amp;3 entfernen"/>
+                    <Item id="43028" name="Hervorhebung &amp;4"/>
+                    <Item id="43029" name="Hervorhebung &amp;4 entfernen"/>
+                    <Item id="43030" name="Hervorhebung &amp;5"/>
+                    <Item id="43031" name="Hervorhebung &amp;5 entfernen"/>
+                    <Item id="43032" name="&amp;Alle entfernen"/>
+                    <Item id="43033" name="Hervorhebung &amp;1"/>
+                    <Item id="43034" name="Hervorhebung &amp;2"/>
+                    <Item id="43035" name="Hervorhebung &amp;3"/>
+                    <Item id="43036" name="Hervorhebung &amp;4"/>
+                    <Item id="43037" name="Hervorhebung &amp;5"/>
+                    <Item id="43038" name="Hervorhebung aus &amp;Suche"/>
+                    <Item id="43039" name="Hervorhebung &amp;1"/>
+                    <Item id="43040" name="Hervorhebung &amp;2"/>
+                    <Item id="43041" name="Hervorhebung &amp;3"/>
+                    <Item id="43042" name="Hervorhebung &amp;4"/>
+                    <Item id="43043" name="Hervorhebung &amp;5"/>
+                    <Item id="43044" name="Hervorhebung aus &amp;Suche"/>
+                    <Item id="43045" name="Suchergebnis-&amp;Fenster"/>
+                    <Item id="43046" name="Zum n&amp;ächsten Suchergebnis springen"/>
+                    <Item id="43047" name="Zum vorherigen S&amp;uchergebnis springen"/>
+                    <Item id="43048" name="Auswahl oder Wort am &amp;Cursor suchen"/>
+                    <Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
+                    <Item id="43054" name="&amp;Hervorheben …"/>
+                    <Item id="44009" name="&amp;Post-It"/>
+                    <Item id="44010" name="A&amp;lle Textblöcke schließen"/>
+                    <Item id="44019" name="&amp;Alle Zeichen anzeigen"/>
+                    <Item id="44020" name="&amp;Einrückung anzeigen"/>
+                    <Item id="44022" name="Automatischer Zeilen&amp;umbruch"/>
+                    <Item id="44023" name="Schrift ver&amp;größern"/>
+                    <Item id="44024" name="Schrift ver&amp;kleinern"/>
+                    <Item id="44025" name="&amp;Leerzeichen und Tabulatoren anzeigen"/>
+                    <Item id="44026" name="Zeilenende anze&amp;igen"/>
+                    <Item id="44029" name="Alle Textblöcke &amp;öffnen"/>
+                    <Item id="44030" name="Textblock schlie&amp;ßen"/>
+                    <Item id="44031" name="Textblock öff&amp;nen"/>
+                    <Item id="44049" name="Datei-&amp;Info …"/>
+                    <Item id="44080" name="&amp;Miniaturansicht"/>
+                    <Item id="44084" name="&amp;Funktionsliste"/>
                     <Item id="44085" name="Verzeichnis als Arbeitsbereich"/>
-                    <Item id="44086" name="&1. Tab"/>
-                    <Item id="44087" name="&2. Tab"/>
-                    <Item id="44088" name="&3. Tab"/>
-                    <Item id="44089" name="&4. Tab"/>
-                    <Item id="44090" name="&5. Tab"/>
-                    <Item id="44091" name="&6. Tab"/>
-                    <Item id="44092" name="&7. Tab"/>
-                    <Item id="44093" name="&8. Tab"/>
-                    <Item id="44094" name="&9. Tab"/>
-                    <Item id="44095" name="&Nächster Tab"/>
-                    <Item id="44096" name="&Vorheriger Tab"/>
+                    <Item id="44086" name="&amp;1. Tab"/>
+                    <Item id="44087" name="&amp;2. Tab"/>
+                    <Item id="44088" name="&amp;3. Tab"/>
+                    <Item id="44089" name="&amp;4. Tab"/>
+                    <Item id="44090" name="&amp;5. Tab"/>
+                    <Item id="44091" name="&amp;6. Tab"/>
+                    <Item id="44092" name="&amp;7. Tab"/>
+                    <Item id="44093" name="&amp;8. Tab"/>
+                    <Item id="44094" name="&amp;9. Tab"/>
+                    <Item id="44095" name="&amp;Nächster Tab"/>
+                    <Item id="44096" name="&amp;Vorheriger Tab"/>
                     <Item id="44097" name="Überwachen (tail -f)"/>
                     <Item id="44098" name="Tab vorwärts bewegen"/>
                     <Item id="44099" name="Tab rückwärts bewegen"/>
-                    <Item id="44032" name="Voll&bild"/>
-                    <Item id="44033" name="&Standardgröße"/>
-                    <Item id="44034" name="Immer im Vorder&grund halten"/>
-                    <Item id="44035" name="S&ynchrones vertikales Scrollen"/>
-                    <Item id="44036" name="Synchrones &horizontales Scrollen"/>
-                    <Item id="44041" name="Symbol bei automatischem &Umbruch"/>
-                    <Item id="44072" name="&Zur anderen Ansicht wechseln"/>
-                    <Item id="44081" name="Projektfenster &1"/>
-                    <Item id="44082" name="Projektfenster &2"/>
-                    <Item id="44083" name="Projektfenster &3"/>
-                    <Item id="45001" name="Konvertiere zu &Windows (CR+LF)"/>
-                    <Item id="45002" name="Konvertiere zu &UNIX (LF)"/>
-                    <Item id="45003" name="Konvertiere zu &Mac (CR)"/>
-                    <Item id="45004" name="&ANSI"/>
-                    <Item id="45005" name="UTF-&8"/>
-                    <Item id="45006" name="UCS-2 &Big Endian"/>
-                    <Item id="45007" name="UCS-2 &Little Endian"/>
-                    <Item id="45008" name="UTF-8 &ohne BOM"/>
-                    <Item id="45009" name="Ko&nvertiere zu ANSI"/>
-                    <Item id="45010" name="Kon&vertiere zu UTF-8 ohne BOM"/>
-                    <Item id="45011" name="Konv&ertiere zu UTF-8"/>
-                    <Item id="45012" name="Konve&rtiere zu UCS-2 Big Endian"/>
-                    <Item id="45013" name="Konver&tiere zu UCS-2 Little Endian"/>
-                    <Item id="44011" name="Benutzerdefinierte Spra&che …"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="44012" name="Zeilennummernrand ausb&lenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="44013" name="Lesezeichenrand ausb&lenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="44014" name="Codefaltung ausb&lenden"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="47008" name="In&halt …"/>                    <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44032" name="Voll&amp;bild"/>
+                    <Item id="44033" name="&amp;Standardgröße"/>
+                    <Item id="44034" name="Immer im Vorder&amp;grund halten"/>
+                    <Item id="44035" name="S&amp;ynchrones vertikales Scrollen"/>
+                    <Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
+                    <Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
+                    <Item id="44072" name="&amp;Zur anderen Ansicht wechseln"/>
+                    <Item id="44081" name="Projektfenster &amp;1"/>
+                    <Item id="44082" name="Projektfenster &amp;2"/>
+                    <Item id="44083" name="Projektfenster &amp;3"/>
+                    <Item id="45001" name="Konvertiere zu &amp;Windows (CR+LF)"/>
+                    <Item id="45002" name="Konvertiere zu &amp;UNIX (LF)"/>
+                    <Item id="45003" name="Konvertiere zu &amp;Mac (CR)"/>
+                    <Item id="45004" name="&amp;ANSI"/>
+                    <Item id="45005" name="UTF-&amp;8"/>
+                    <Item id="45006" name="UCS-2 &amp;Big Endian"/>
+                    <Item id="45007" name="UCS-2 &amp;Little Endian"/>
+                    <Item id="45008" name="UTF-8 &amp;ohne BOM"/>
+                    <Item id="45009" name="Ko&amp;nvertiere zu ANSI"/>
+                    <Item id="45010" name="Kon&amp;vertiere zu UTF-8 ohne BOM"/>
+                    <Item id="45011" name="Konv&amp;ertiere zu UTF-8"/>
+                    <Item id="45012" name="Konve&amp;rtiere zu UCS-2 Big Endian"/>
+                    <Item id="45013" name="Konver&amp;tiere zu UCS-2 Little Endian"/>
+                    <Item id="44011" name="Benutzerdefinierte Spra&amp;che …"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44014" name="Codefaltung ausb&amp;lenden"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="47008" name="In&amp;halt …"/>                    <!-- kommt im englischen nicht oder nicht mehr vor -->
 
-                    <Item id="10001" name="In zweite Ansicht &verschieben"/>
-                    <Item id="10002" name="In zweite Ansicht &duplizieren"/>
-                    <Item id="10003" name="In &neue Instanz verschieben"/>
-                    <Item id="10004" name="In neue Instan&z duplizieren"/>
+                    <Item id="10001" name="In zweite Ansicht &amp;verschieben"/>
+                    <Item id="10002" name="In zweite Ansicht &amp;duplizieren"/>
+                    <Item id="10003" name="In &amp;neue Instanz verschieben"/>
+                    <Item id="10004" name="In neue Instan&amp;z duplizieren"/>
 
                     <Item id="45060" name="Big5 (Traditionell)"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
                     <Item id="45061" name="GB2312 (Vereinfacht)"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
@@ -305,30 +305,30 @@
                     <Item id="46016" name="Normaler Text"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
                     <Item id="46017" name="Ressourcen-Datei"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
 
-                    <Item id="46001" name="&Stile …"/>
-                    <Item id="46150" name="Eigene Sprache &definieren …"/>
+                    <Item id="46001" name="&amp;Stile …"/>
+                    <Item id="46150" name="Eigene Sprache &amp;definieren …"/>
                     <Item id="46080" name="Benutzerdefiniert"/>
-                    <Item id="47000" name="&Info …"/>
-                    <Item id="47010" name="&Kommandozeilenparameter …"/>
-                    <Item id="47001" name="Notepad++ im &Web"/>
-                    <Item id="47002" name="Notepad++ bei &GitHub"/>
+                    <Item id="47000" name="&amp;Info …"/>
+                    <Item id="47010" name="&amp;Kommandozeilenparameter …"/>
+                    <Item id="47001" name="Notepad++ im &amp;Web"/>
+                    <Item id="47002" name="Notepad++ bei &amp;GitHub"/>
                     <Item id="47003" name="Online-Dokumentation"/>
                     <Item id="47004" name="Notepad++ Online-Forum"/>
-                    <Item id="47011" name="&Support im Chat"/>
+                    <Item id="47011" name="&amp;Support im Chat"/>
                     <Item id="47012" name="Debug-Info"/>
-                    <Item id="47005" name="&Erweiterungen"/>
-                    <Item id="47006" name="Notepad++ &aktualisieren"/>
-                    <Item id="47009" name="&Proxy für Updater einstellen …"/>
-                    <Item id="48005" name="&Plugin(s) importieren …"/>
-                    <Item id="48006" name="&Design(s) importieren …"/>
-                    <Item id="48018" name="&Kontextmenü anpassen …"/>
-                    <Item id="48009" name="&Tastatur …"/>
-                    <Item id="48011" name="&Optionen …"/>
+                    <Item id="47005" name="&amp;Erweiterungen"/>
+                    <Item id="47006" name="Notepad++ &amp;aktualisieren"/>
+                    <Item id="47009" name="&amp;Proxy für Updater einstellen …"/>
+                    <Item id="48005" name="&amp;Plugin(s) importieren …"/>
+                    <Item id="48006" name="&amp;Design(s) importieren …"/>
+                    <Item id="48018" name="&amp;Kontextmenü anpassen …"/>
+                    <Item id="48009" name="&amp;Tastatur …"/>
+                    <Item id="48011" name="&amp;Optionen …"/>
                     <Item id="48501" name="Erstelle …"/>
                     <Item id="48502" name="Erstelle aus Dateien …"/>
                     <Item id="48503" name="Erstelle in die Zwischenablage"/>
 
-                    <Item id="49000" name="Externes Programm &ausführen …"/>
+                    <Item id="49000" name="Externes Programm &amp;ausführen …"/>
 
                     <Item id="50000" name="Funktionsvervollständigung"/>
                     <Item id="50001" name="Wortvervollständigung"/>
@@ -344,69 +344,69 @@
             <Splitter>
             </Splitter>
             <TabBar>
-                <Item CMID="0"  name="S&chließen"/>
-                <Item CMID="1"  name="&Alle anderen schließen"/>
-                <Item CMID="2"  name="&Speichern"/>
-                <Item CMID="3"  name="Speichern &unter …"/>
-                <Item CMID="4"  name="&Drucken"/>
-                <Item CMID="5"  name="In zweite Ansicht &verschieben"/>
-                <Item CMID="6"  name="In zw&eite Ansicht duplizieren"/>
-                <Item CMID="7"  name="Vollständigen Pfad &kopieren"/>
-                <Item CMID="8"  name="Nur Datei&namen kopieren"/>
-                <Item CMID="9"  name="Nur Verzeichnis&pfad kopieren"/>
-                <Item CMID="10" name="Um&benennen …"/>
-                <Item CMID="11" name="L&öschen"/>
-                <Item CMID="12" name="Sch&reibschutz"/>
-                <Item CMID="13" name="Schreibschutz au&fheben"/>
-                <Item CMID="14" name="In neue &Instanz verschieben"/>
-                <Item CMID="15" name="In neue Instan&z duplizieren"/>
-                <Item CMID="16" name="Neu &laden"/>
-                <Item CMID="17" name="Dateien links schlie&ßen"/>
-                <Item CMID="18" name="Dateien rech&ts schließen"/>
-                <Item CMID="19" name="Ordner im E&xplorer öffnen"/>
-                <Item CMID="20" name="Kommandozeile im aktuellen &Ordner öffnen"/>
+                <Item CMID="0"  name="S&amp;chließen"/>
+                <Item CMID="1"  name="&amp;Alle anderen schließen"/>
+                <Item CMID="2"  name="&amp;Speichern"/>
+                <Item CMID="3"  name="Speichern &amp;unter …"/>
+                <Item CMID="4"  name="&amp;Drucken"/>
+                <Item CMID="5"  name="In zweite Ansicht &amp;verschieben"/>
+                <Item CMID="6"  name="In zw&amp;eite Ansicht duplizieren"/>
+                <Item CMID="7"  name="Vollständigen Pfad &amp;kopieren"/>
+                <Item CMID="8"  name="Nur Datei&amp;namen kopieren"/>
+                <Item CMID="9"  name="Nur Verzeichnis&amp;pfad kopieren"/>
+                <Item CMID="10" name="Um&amp;benennen …"/>
+                <Item CMID="11" name="L&amp;öschen"/>
+                <Item CMID="12" name="Sch&amp;reibschutz"/>
+                <Item CMID="13" name="Schreibschutz au&amp;fheben"/>
+                <Item CMID="14" name="In neue &amp;Instanz verschieben"/>
+                <Item CMID="15" name="In neue Instan&amp;z duplizieren"/>
+                <Item CMID="16" name="Neu &amp;laden"/>
+                <Item CMID="17" name="Dateien links schlie&amp;ßen"/>
+                <Item CMID="18" name="Dateien rech&amp;ts schließen"/>
+                <Item CMID="19" name="Ordner im E&amp;xplorer öffnen"/>
+                <Item CMID="20" name="Kommandozeile im aktuellen &amp;Ordner öffnen"/>
             </TabBar>
         </Menu>
 
         <Dialog>
             <Find title="Suchen und ersetzen" titleFind="Suchen" titleReplace="Ersetzen" titleFindInFiles="In Dateien suchen" titleMark="Hervorheben">
-                <Item id="1"    name="&Suchen  ›"/>
-                <Item id="1721" name="‹  S&uchen"/>
-                <Item id="2"    name="S&chließen"/>
-                <Item id="1620" name="Suchen &nach:"/>
-                <Item id="1603" name="Nur &ganze Wörter suchen"/>
-                <Item id="1604" name="Groß-/&Kleinschreibung beachten"/>
-                <Item id="1605" name="&Reguläre Ausdrücke"/>
-                <Item id="1606" name="Am Ende von vorne &beginnen"/>
-                <Item id="1612" name="R&ückwärts"/>
-                <Item id="1613" name="&Vorwärts"/>
-                <Item id="1614" name="Z&ählen"/>
-                <Item id="1615" name="&Alle suchen"/>
-                <Item id="1616" name="&Lesezeichen setzen"/>
-                <Item id="1618" name="Für &jede Suche löschen"/>
+                <Item id="1"    name="&amp;Suchen  ›"/>
+                <Item id="1721" name="‹  S&amp;uchen"/>
+                <Item id="2"    name="S&amp;chließen"/>
+                <Item id="1620" name="Suchen &amp;nach:"/>
+                <Item id="1603" name="Nur &amp;ganze Wörter suchen"/>
+                <Item id="1604" name="Groß-/&amp;Kleinschreibung beachten"/>
+                <Item id="1605" name="&amp;Reguläre Ausdrücke"/>
+                <Item id="1606" name="Am Ende von vorne &amp;beginnen"/>
+                <Item id="1612" name="R&amp;ückwärts"/>
+                <Item id="1613" name="&amp;Vorwärts"/>
+                <Item id="1614" name="Z&amp;ählen"/>
+                <Item id="1615" name="&amp;Alle suchen"/>
+                <Item id="1616" name="&amp;Lesezeichen setzen"/>
+                <Item id="1618" name="Für &amp;jede Suche löschen"/>
                 <Item id="1621" name="Suchrichtung"/>
-                <Item id="1611" name="Erset&zen durch:"/>
-                <Item id="1608" name="&Ersetzen"/>
-                <Item id="1609" name="Alle erse&tzen"/>
+                <Item id="1611" name="Erset&amp;zen durch:"/>
+                <Item id="1608" name="&amp;Ersetzen"/>
+                <Item id="1609" name="Alle erse&amp;tzen"/>
                 <Item id="1687" name="Wenn inaktiv"/>
                 <Item id="1688" name="Immer"/>
-                <Item id="1632" name="In &Auswahl"/>
+                <Item id="1632" name="In &amp;Auswahl"/>
                 <Item id="1633" name="Zurücksetzen"/>
                 <Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
-                <Item id="1636" name="In &offenen Dateien suchen"/>
+                <Item id="1636" name="In &amp;offenen Dateien suchen"/>
                 <Item id="1654" name="Filter:"/>
                 <Item id="1655" name="Verzeichnis:"/>
-                <Item id="1656" name="Alle su&chen"/>
-                <Item id="1658" name="&Unterverzeichnisse"/>
-                <Item id="1659" name="&Versteckte Ordner"/>
+                <Item id="1656" name="Alle su&amp;chen"/>
+                <Item id="1658" name="&amp;Unterverzeichnisse"/>
+                <Item id="1659" name="&amp;Versteckte Ordner"/>
                 <Item id="1624" name="Suchmodus"/>
-                <Item id="1625" name="Norma&l"/>
-                <Item id="1626" name="Erwe&itert (\n, \r, \t, \0, \x…)"/>
+                <Item id="1625" name="Norma&amp;l"/>
+                <Item id="1626" name="Erwe&amp;itert (\n, \r, \t, \0, \x…)"/>
                 <Item id="1660" name="Ersetzen in Dateien"/>
-                <Item id="1661" name="&Ordner der akt. Datei"/>
-                <Item id="1641" name="Alle in aktiver &Datei suchen"/>
+                <Item id="1661" name="&amp;Ordner der akt. Datei"/>
+                <Item id="1641" name="Alle in aktiver &amp;Datei suchen"/>
                 <Item id="1686" name="Transparenz"/>
-                <Item id="1703" name="&. findet \r und \n"/>
+                <Item id="1703" name="&amp;. findet \r und \n"/>
                 <Item id="1627" name="Unten"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
                 <Item id="1637" name="In Dateien suchen"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
                 <Item id="1640" name="Umschaltdialog"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
@@ -414,22 +414,22 @@
 
             <FindCharsInRange title="Suche nach Zeichencodes">
                 <Item id="-1"   name="–"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
-                <Item id="2"    name="S&chließen"/>
-                <Item id="2901" name="&Nicht-ASCII-Zeichen (128–255)"/>
-                <Item id="2902" name="&ASCII-Zeichen (0–127)"/>
-                <Item id="2903" name="&Benutzerdefiniert:"/>
-                <Item id="2906" name="&Aufwärts"/>
-                <Item id="2907" name="&Abwärts"/>
+                <Item id="2"    name="S&amp;chließen"/>
+                <Item id="2901" name="&amp;Nicht-ASCII-Zeichen (128–255)"/>
+                <Item id="2902" name="&amp;ASCII-Zeichen (0–127)"/>
+                <Item id="2903" name="&amp;Benutzerdefiniert:"/>
+                <Item id="2906" name="&amp;Aufwärts"/>
+                <Item id="2907" name="&amp;Abwärts"/>
                 <Item id="2908" name="Suchrichtung"/>
-                <Item id="2909" name="Am Ende von &vorne beginnen"/>
-                <Item id="2910" name="&Suchen"/>
+                <Item id="2909" name="Am Ende von &amp;vorne beginnen"/>
+                <Item id="2910" name="&amp;Suchen"/>
             </FindCharsInRange>
 
             <GoToLine title="Gehe zu">
-                <Item id="2007" name="&Zeile"/>
-                <Item id="2008" name="Z&eichen"/>
-                <Item id="1"    name="&Gehe zu"/>
-                <Item id="2"    name="&Abbrechen"/>
+                <Item id="2007" name="&amp;Zeile"/>
+                <Item id="2008" name="Z&amp;eichen"/>
+                <Item id="1"    name="&amp;Gehe zu"/>
+                <Item id="2"    name="&amp;Abbrechen"/>
                 <Item id="2004" name="Aktuell:"/>
                 <Item id="2005" name="Ziel:"/>
                 <Item id="2006" name="Insgesamt in der Datei:"/>
@@ -437,10 +437,10 @@
 
             <Run title="Ausführen …">
                 <Item id="1903" name="Auszuführendes Programm hier eingeben"/>
-                <Item id="1"    name="&Ausführen"/>
-                <Item id="2"    name="A&bbrechen"/>
-                <Item id="1904" name="&Speichern"/>
-                <Item id="1901" name=".&.."/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
+                <Item id="1"    name="&amp;Ausführen"/>
+                <Item id="2"    name="A&amp;bbrechen"/>
+                <Item id="1904" name="&amp;Speichern"/>
+                <Item id="1901" name=".&amp;.."/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
             </Run>
 
             <MD5FromFilesDlg title="Erstelle MD5-Hashwert aus Dateien">
@@ -458,7 +458,7 @@
             <StyleConfig title="Stile">
                 <Item id="1"    name="Übernehmen"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
                 <Item id="2"    name="Abbrechen"/>
-                <Item id="2301" name="Speichern && Schließen"/>
+                <Item id="2301" name="Speichern &amp;&amp; Schließen"/>
                 <Item id="2303" name="Transparenz"/>
                 <Item id="2306" name="Design:"/>
                 <SubDialog>
@@ -531,10 +531,10 @@
                     <Item id="25026" name="Operatoren 1"/>
                     <Item id="25027" name="Operatoren 2"/>
                     <Item id="25028" name="Zahlen"/>
-                    <Item id="1"     name="&OK"/>
-                    <Item id="2"     name="A&bbrechen"/>
+                    <Item id="1"     name="&amp;OK"/>
+                    <Item id="2"     name="A&amp;bbrechen"/>
                 </StylerDialog>
-                <Folder title="Textblöcke && Voreinstellung">
+                <Folder title="Textblöcke &amp;&amp; Voreinstellung">
                     <Item id="21101" name="Standardschrift"/>
                     <Item id="21102" name="Stil"/>
                     <Item id="21105" name="Dokumentation"/>
@@ -582,7 +582,7 @@
                     <Item id="22572" name="Stil"/>
                     <Item id="22622" name="Stil"/>
                 </Keywords>
-                <Comment title="Kommentare && Zahlen">
+                <Comment title="Kommentare &amp;&amp; Zahlen">
                     <Item id="23002" name="Am Zeilenanfang Zeilenkommentar erzwingen"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
                     <Item id="23003" name="Position von Zeilenkommentaren"/>
                     <Item id="23004" name="Überall erlauben"/>
@@ -612,7 +612,7 @@
                     <Item id="23246" name="Komma"/>
                     <Item id="23247" name="Beides"/>
                 </Comment>
-                <Operator title="Operatoren && Trenner">
+                <Operator title="Operatoren &amp;&amp; Trenner">
                     <Item id="24101" name="Operatoren"/>
                     <Item id="24113" name="Stil"/>
                     <Item id="24116" name="Operatoren 1"/>
@@ -660,7 +660,7 @@
                 </Operator>
             </UserDefine>
             <Preference title="Optionen">
-                <Item id="6001" name="S&chließen"/>
+                <Item id="6001" name="S&amp;chließen"/>
                 <Global title="Oberfläche 1">
                     <Item id="6101" name="Symbolleiste"/>
                     <Item id="6102" name="Ausblenden"/>
@@ -713,7 +713,7 @@
                     <Item id="6207" name="Lesezeichenrand"/>
                     <Item id="6208" name="Randbegrenzung anzeigen"/>
                     <Item id="6209" name="Anzahl der Spalten:"/>
-                    <Item id="6234" name="Flüssiges Scrollen deaktivieren&#x0D;(bei Touchpad-Problemen)"/>
+                    <Item id="6234" name="Flüssiges Scrollen deaktivieren&amp;#x0D;(bei Touchpad-Problemen)"/>
 
                     <Item id="6211" name="Rechter Rand"/>
                     <Item id="6212" name="Vertikale Linie"/>
@@ -870,7 +870,7 @@
                     <Item id="6256" name="Über mehrere Zeilen"/>
                     <Item id="6161" name="Liste der Wortzeichen (Word character list)"/>
                     <Item id="6162" name="Verwende die ursprüngliche Liste der Wortzeichen"/>
-                    <Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0D;(nicht verwenden, wenn man nicht sicher ist)"/>
+                    <Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&amp;#x0D;(nicht verwenden, wenn man nicht sicher ist)"/>
                     </Delimiter>
 
                 <Cloud title="Cloud-Einstellungen">
@@ -880,7 +880,7 @@
                 </Cloud>
 
                 <SearchEngine title="Suchmaschine">
-                    <Item id="6271" name="Suchmaschine (für das Kommando &quot;Suche im Internet&quot;)"/>
+                    <Item id="6271" name="Suchmaschine (für das Kommando &amp;quot;Suche im Internet&amp;quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
                     <Item id="6273" name="Google"/>
                     <Item id="6274" name="Bing"/>
@@ -914,61 +914,61 @@
                     <Item id="6346" name="Momentaufnahme in Miniaturansicht"/></MISC>
             </Preference>
             <MultiMacro title="Makro mehrfach ausführen">
-                <Item id="1"    name="Ausfüh&ren"/>
-                <Item id="2"    name="A&bbrechen"/>
+                <Item id="1"    name="Ausfüh&amp;ren"/>
+                <Item id="2"    name="A&amp;bbrechen"/>
                 <Item id="8006" name="Makro:"/>
-                <Item id="8001" name="&Makro"/>
+                <Item id="8001" name="&amp;Makro"/>
                 <Item id="8005" name="mal ausführen"/>
-                <Item id="8002" name="Bis zum &Ende der Datei ausführen"/>
+                <Item id="8002" name="Bis zum &amp;Ende der Datei ausführen"/>
             </MultiMacro>
             <Window title="Fenster">
-                <Item id="1"    name="&Aktivieren"/>
-                <Item id="2"    name="&OK"/>
-                <Item id="7002" name="S&peichern"/>
-                <Item id="7003" name="Tab s&chließen"/>
-                <Item id="7004" name="&Sortiere Tabs"/>
+                <Item id="1"    name="&amp;Aktivieren"/>
+                <Item id="2"    name="&amp;OK"/>
+                <Item id="7002" name="S&amp;peichern"/>
+                <Item id="7003" name="Tab s&amp;chließen"/>
+                <Item id="7004" name="&amp;Sortiere Tabs"/>
             </Window>
             <ColumnEditor title="Block-Editor">
                 <Item id="2023" name="Text einfügen"/>
                 <Item id="2033" name="Zahlen einfügen"/>
                 <Item id="2030" name="Beginnen mit:"/>
                 <Item id="2031" name="Erhöhen um:"/>
-                <Item id="2035" name="Führende &Nullen"/>
+                <Item id="2035" name="Führende &amp;Nullen"/>
                 <Item id="2036" name="Wiederholen:"/>
                 <Item id="2032" name="Format"/>
-                <Item id="2024" name="&Dezimal"/>
-                <Item id="2025" name="&Oktal"/>
-                <Item id="2026" name="&Hexadezimal"/>
-                <Item id="2027" name="&Binär"/>
-                <Item id="1"    name="Ausfüh&ren"/>
-                <Item id="2"    name="Abbre&chen"/>
+                <Item id="2024" name="&amp;Dezimal"/>
+                <Item id="2025" name="&amp;Oktal"/>
+                <Item id="2026" name="&amp;Hexadezimal"/>
+                <Item id="2027" name="&amp;Binär"/>
+                <Item id="1"    name="Ausfüh&amp;ren"/>
+                <Item id="2"    name="Abbre&amp;chen"/>
             </ColumnEditor>
         </Dialog>
         <MessageBox>
-            <ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&#x0D;das Kontextmenü von Notepad++ anpassen.&#x0D;Nach dem Bearbeiten müssen Sie Notepad++ neu&#x0D;starten, damit die Änderungen wirksam werden."/>
-            <NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&#x0D;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&#x0D;von der Notepad++-Website herunter."/>
-            <SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&#x0D;&#x0D;Fortfahren?"/>
-            <LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&#x0D;&#x0D;Fortfahren?"/>
-            <CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&#x0D;Bitte zuerst speichern und erneut versuchen."/>
-            <DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&#x0D;gespeicherten Version erneut laden und die&#x0D;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
-            <FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &#x0D;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
+            <ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&amp;#x0D;das Kontextmenü von Notepad++ anpassen.&amp;#x0D;Nach dem Bearbeiten müssen Sie Notepad++ neu&amp;#x0D;starten, damit die Änderungen wirksam werden."/>
+            <NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&amp;#x0D;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&amp;#x0D;von der Notepad++-Website herunter."/>
+            <SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&amp;#x0D;&amp;#x0D;Fortfahren?"/>
+            <LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&amp;#x0D;&amp;#x0D;Fortfahren?"/>
+            <CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&amp;#x0D;Bitte zuerst speichern und erneut versuchen."/>
+            <DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&amp;#x0D;gespeicherten Version erneut laden und die&amp;#x0D;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
+            <FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &amp;#x0D;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
             <FileAlreadyOpenedInNpp title="Datei bereits geöffnet" message="Die Datei ist bereits in Notepad++ geöffnet."/>
             <DeleteFileFailed title="Löschen fehlgeschlagen!" message="Datei konnte nicht gelöscht werden."/>
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&#x0D;Sind Sie sicher?"/>
-            <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&#x0D;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&#x0D;ohne die erforderlichen Schreibrechte zeigen.&#x0D;Die Einstellungen in der Cloud werden abgebrochen.&#x0D;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
+            <NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&amp;#x0D;Sind Sie sicher?"/>
+            <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&amp;#x0D;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&amp;#x0D;ohne die erforderlichen Schreibrechte zeigen.&amp;#x0D;Die Einstellungen in der Cloud werden abgebrochen.&amp;#x0D;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
             <FilePathNotFoundWarning title="Datei öffnen" message="Die Datei zum Öffnen existiert nicht."/>
             <SessionFileInvalidError title="Konnte Sitzung nicht laden" message="Sitzungsdatei ist entweder beschädigt oder ungültig."/>
-            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&#x0D;um in den Spalten-Modus zu wechseln."/>
+            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &amp;quot;ALT+Maus Auswahl&amp;quot; oder &amp;quot;Alt+Shift+Pfeiltaste&amp;quot;&amp;#x0D;um in den Spalten-Modus zu wechseln."/>
 
             <!-- $STR_REPLACE$ is a place holder, don't translate it -->
             <SortingError title="Sortierung fehlgeschlagen" message="Kann aufgrund der Zeile $STR_REPLACE$ keine numerische Sortierung durchführen."/>
             <BufferInvalidWarning title="Speichern fehlgeschlagen" message="Kann nicht speichern: Puffer ist ungültig."/>
-            <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&amp;#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
             <OpenInAdminModeFailed title="Starten im Administrator-Modus fehlgeschlagen" message="Notepad++ kann nicht im Administrator-Modus gestartet werden."/>
-            <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
-            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&#x0D;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
+            <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&amp;#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&amp;#x0D;Dafür muss &amp;quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&amp;quot; im Bereich &amp;quot;Standardverzeichnis&amp;quot; der Einstellungen ausgewählt werden."/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Zwischenablage"/>
@@ -1039,7 +1039,7 @@
             </Menus>
         </ProjectManager>
         <MiscStrings>
-            <word-chars-list-tip value="Erlaubt ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick zur Auswahl hinzuzufügen, oder als Suche mit der aktivierten Option &quot;Übereinstimmung mit ganzem Wort&quot;."/>
+            <word-chars-list-tip value="Erlaubt ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick zur Auswahl hinzuzufügen, oder als Suche mit der aktivierten Option &amp;quot;Übereinstimmung mit ganzem Wort&amp;quot;."/>
             <word-chars-list-warning-begin value="Achtung: "/>
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ Leerzeichen"/>
@@ -1048,7 +1048,7 @@
             <word-chars-list-warning-end value=" in der Liste der Wortzeichen."/>
             <cloud-invalid-warning value="Ungültiger Pfad."/>
             <cloud-restart-warning value="Zum Übernehmen Notepad++ bitte neu starten."/>
-            <shift-change-direction-tip value="Enter: Suche vorwärts&#x0D;Shift+Enter: Suche rückwärts"/>
+            <shift-change-direction-tip value="Enter: Suche vorwärts&amp;#x0D;Shift+Enter: Suche rückwärts"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -178,7 +178,7 @@
                     <Item id="42057" name="Leerzeile über aktueller Zeile einfügen"/>
                     <Item id="42058" name="Leerzeile unter aktueller Zeile einfügen"/>
                     <Item id="43001" name="Suchen …"/>
-                    <Item id="43002" name="Vorwärts Suchen"/>
+                    <Item id="43002" name="Vorwärts suchen"/>
                     <Item id="43003" name="Ersetzen …"/>
                     <Item id="43004" name="Gehe zu …"/>
                     <Item id="43005" name="Lesezeichen setzen/löschen"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -135,7 +135,7 @@
                     <Item id="42070" name="Gemischter Wortstil"/>
                     <Item id="42071" name="iNVERTIERTER wORTSTIL"/>
                     <Item id="42072" name="zUFäLlIGeR WortSTiL"/>
-                    <Item id="42073" name="Datei Öffnen"/>
+                    <Item id="42073" name="Datei öffnen"/>
                     <Item id="42074" name="Ordner im Explorer öffnen"/>
                     <Item id="42075" name="Suche im Internet"/>
                     <Item id="42076" name="Andere Suchmaschine wählen …"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -419,7 +419,7 @@
                 <Item id="2902" name="&amp;ASCII-Zeichen (0–127)"/>
                 <Item id="2903" name="&amp;Benutzerdefiniert:"/>
                 <Item id="2906" name="A&amp;ufwärts"/>
-                <Item id="2907" name="A&amp;bwärts"/>
+                <Item id="2907" name="Ab&amp;wärts"/>
                 <Item id="2908" name="Suchrichtung"/>
                 <Item id="2909" name="Am Ende von &amp;vorne beginnen"/>
                 <Item id="2910" name="&amp;Suchen"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -17,118 +17,118 @@
             <Main>
                 <!-- Main Menu Entries -->
                 <Entries>
-                    <Item menuId="file" name="Datei"/>
-                    <Item menuId="edit" name="Bearbeiten"/>
-                    <Item menuId="search" name="Suchen"/>
-                    <Item menuId="view" name="Ansicht"/>
-                    <Item menuId="encoding" name="Kodierung"/>
-                    <Item menuId="language" name="Sprachen"/>
-                    <Item menuId="settings" name="Einstellungen"/>
-                    <Item menuId="tools" name="Werkzeuge"/>
-                    <Item menuId="macro" name="Makro"/>
-                    <Item menuId="run" name="Ausführen"/>
-                    <Item idName="Plugins" name="Erweiterungen"/>
-                    <Item idName="Window" name="Fenster"/>
+                    <Item menuId="file" name="&Datei"/>
+                    <Item menuId="edit" name="&Bearbeiten"/>
+                    <Item menuId="search" name="&Suchen"/>
+                    <Item menuId="view" name="&Ansicht"/>
+                    <Item menuId="encoding" name="&Kodierung"/>
+                    <Item menuId="language" name="S&prachen"/>
+                    <Item menuId="settings" name="&Einstellungen"/>
+                    <Item menuId="tools" name="Werk&zeuge"/>
+                    <Item menuId="macro" name="&Makro"/>
+                    <Item menuId="run" name="Ausfüh&ren"/>
+                    <Item idName="Plugins" name="Er&weiterungen"/>
+                    <Item idName="Window" name="Fe&nster"/>
                 </Entries>
                 <!-- Sub Menu Entries -->
                 <SubEntries>
-                    <Item subMenuId="file-openFolder" name="Aktuellen Ordner öffnen"/>
-                    <Item subMenuId="file-closeMore" name="Mehrere schließen"/>
-                    <Item subMenuId="file-recentFiles" name="Zuletzt verwendet"/>
-                    <Item subMenuId="edit-copyToClipboard" name="Dateipfad kopieren"/>
-                    <Item subMenuId="edit-indent" name="Einrückung"/>
-                    <Item subMenuId="edit-convertCaseTo" name="Groß-/Kleinschreibung"/>
-                    <Item subMenuId="edit-lineOperations" name="Zeilenoperationen"/>
-                    <Item subMenuId="edit-comment" name="Kommentare"/>
-                    <Item subMenuId="edit-autoCompletion" name="Autovervollständigung"/>
-                    <Item subMenuId="edit-eolConversion" name="Format Zeilenende"/>
-                    <Item subMenuId="edit-blankOperations" name="Nicht druckbare Zeichen"/>
-                    <Item subMenuId="edit-pasteSpecial" name= "Einfügen spezial"/>
+                    <Item subMenuId="file-openFolder" name="Aktuellen &Ordner öffnen"/>
+                    <Item subMenuId="file-closeMore" name="&Mehrere schließen"/>
+                    <Item subMenuId="file-recentFiles" name="Zuletzt &verwendet"/>
+                    <Item subMenuId="edit-copyToClipboard" name="Datei&pfad kopieren"/>
+                    <Item subMenuId="edit-indent" name="E&inrückung"/>
+                    <Item subMenuId="edit-convertCaseTo" name="&Groß-/Kleinschreibung"/>
+                    <Item subMenuId="edit-lineOperations" name="&Zeilenoperationen"/>
+                    <Item subMenuId="edit-comment" name="K&ommentare"/>
+                    <Item subMenuId="edit-autoCompletion" name="Autovervollst&ändigung"/>
+                    <Item subMenuId="edit-eolConversion" name="Format Zeile&nende"/>
+                    <Item subMenuId="edit-blankOperations" name="Nicht &druckbare Zeichen"/>
+                    <Item subMenuId="edit-pasteSpecial" name= "Einf&ügen spezial"/>
                     <Item subMenuId="edit-onSelection" name="Bei Auswahl"/>
-                    <Item subMenuId="search-markAll" name="Alle Vorkommnisse hervorheben"/>
-                    <Item subMenuId="search-unmarkAll" name="Alle Hervorhebungen löschen"/>
-                    <Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung springen"/>
-                    <Item subMenuId="search-jumpDown" name="Zur nächsten Hervorhebung springen"/>
-                    <Item subMenuId="search-bookmark" name="Lesezeichen"/>
-                    <Item subMenuId="view-showSymbol" name="Nicht druckbare Zeichen"/>
-                    <Item subMenuId="view-zoom" name="Zoom"/>
-                    <Item subMenuId="view-moveCloneDocument" name="Datei verschieben/duplizieren"/>
-                    <Item subMenuId="view-tab" name="Tabs"/>
-                    <Item subMenuId="view-collapseLevel" name="Textblöcke schließen"/>
-                    <Item subMenuId="view-uncollapseLevel" name="Textblöcke öffnen"/>
-                    <Item subMenuId="view-project" name="Projektverwaltung"/>
-                    <Item subMenuId="encoding-characterSets" name="Weitere"/>
-                    <Item subMenuId="encoding-arabic" name="Arabisch"/>
-                    <Item subMenuId="encoding-baltic" name="Baltisch"/>
-                    <Item subMenuId="encoding-celtic" name="Keltisch"/>
-                    <Item subMenuId="encoding-cyrillic" name="Kyrillisch"/>
-                    <Item subMenuId="encoding-centralEuropean" name="Mitteleuropäisch"/>
-                    <Item subMenuId="encoding-chinese" name="Chinesisch"/>
-                    <Item subMenuId="encoding-easternEuropean" name="Osteuropäisch"/>
-                    <Item subMenuId="encoding-greek" name="Griechisch"/>
-                    <Item subMenuId="encoding-hebrew" name="Hebräisch"/>
-                    <Item subMenuId="encoding-japanese" name="Japanisch"/>
-                    <Item subMenuId="encoding-korean" name="Koreanisch"/>
-                    <Item subMenuId="encoding-northEuropean" name="Nordeuropäisch"/>
-                    <Item subMenuId="encoding-thai" name="Thai"/>
-                    <Item subMenuId="encoding-turkish" name="Türkisch"/>
-                    <Item subMenuId="encoding-westernEuropean" name="Westeuropäisch"/>
-                    <Item subMenuId="encoding-vietnamese" name="Vietnamesisch"/>
-                    <Item subMenuId="settings-import" name="Import"/>
+                    <Item subMenuId="search-markAll" name="Alle &Vorkommnisse hervorheben"/>
+                    <Item subMenuId="search-unmarkAll" name="Alle Hervorhe&bungen löschen"/>
+                    <Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung s&pringen"/>
+                    <Item subMenuId="search-jumpDown" name="Zur &nächsten Hervorhebung springen"/>
+                    <Item subMenuId="search-bookmark" name="&Lesezeichen"/>
+                    <Item subMenuId="view-showSymbol" name="Nicht &druckbare Zeichen"/>
+                    <Item subMenuId="view-zoom" name="Z&oom"/>
+                    <Item subMenuId="view-moveCloneDocument" name="Datei &verschieben/duplizieren"/>
+                    <Item subMenuId="view-tab" name="&Tabs"/>
+                    <Item subMenuId="view-collapseLevel" name="T&extblöcke schließen"/>
+                    <Item subMenuId="view-uncollapseLevel" name="Te&xtblöcke öffnen"/>
+                    <Item subMenuId="view-project" name="Projektver&waltung"/>
+                    <Item subMenuId="encoding-characterSets" name="&Weitere"/>
+                    <Item subMenuId="encoding-arabic" name="&Arabisch"/>
+                    <Item subMenuId="encoding-baltic" name="&Baltisch"/>
+                    <Item subMenuId="encoding-celtic" name="&Keltisch"/>
+                    <Item subMenuId="encoding-cyrillic" name="K&yrillisch"/>
+                    <Item subMenuId="encoding-centralEuropean" name="&Mitteleuropäisch"/>
+                    <Item subMenuId="encoding-chinese" name="&Chinesisch"/>
+                    <Item subMenuId="encoding-easternEuropean" name="&Osteuropäisch"/>
+                    <Item subMenuId="encoding-greek" name="&Griechisch"/>
+                    <Item subMenuId="encoding-hebrew" name="&Hebräisch"/>
+                    <Item subMenuId="encoding-japanese" name="&Japanisch"/>
+                    <Item subMenuId="encoding-korean" name="Ko&reanisch"/>
+                    <Item subMenuId="encoding-northEuropean" name="&Nordeuropäisch"/>
+                    <Item subMenuId="encoding-thai" name="&Thai"/>
+                    <Item subMenuId="encoding-turkish" name="T&ürkisch"/>
+                    <Item subMenuId="encoding-westernEuropean" name="&Westeuropäisch"/>
+                    <Item subMenuId="encoding-vietnamese" name="&Vietnamesisch"/>
+                    <Item subMenuId="settings-import" name="&Import"/>
                     <Item subMenuId="tools-md5" name="MD5"/>
                 </SubEntries>
 
                 <!-- all menu item -->
                 <Commands>
-                    <Item id="41001" name="Neu"/>
-                    <Item id="41002" name="Öffnen …"/>
-                    <Item id="41019" name="Explorer"/>
-                    <Item id="41020" name="Eingabeaufforderung"/>
-                    <Item id="41003" name="Schließen"/>
-                    <Item id="41004" name="Alle schließen"/>
-                    <Item id="41005" name="Alle schließen bis auf aktuelle Datei"/>
-                    <Item id="41009" name="Dateien links schließen"/>
-                    <Item id="41018" name="Dateien rechts schließen"/>
-                    <Item id="41006" name="Speichern"/>
-                    <Item id="41007" name="Alle speichern"/>
-                    <Item id="41008" name="Speichern unter …"/>
-                    <Item id="41010" name="Drucken …"/>
-                    <Item id="1001"  name="Sofort drucken"/>
-                    <Item id="41011" name="Beenden"/>
-                    <Item id="41012" name="Sitzung öffnen …"/>
-                    <Item id="41013" name="Sitzung speichern …"/>
-                    <Item id="41014" name="Neu laden"/>
-                    <Item id="41015" name="Kopie speichern unter …"/>
-                    <Item id="41016" name="Von Datenträger löschen"/>
-                    <Item id="41017" name="Umbenennen …"/>
+                    <Item id="41001" name="&Neu"/>
+                    <Item id="41002" name="&Öffnen …"/>
+                    <Item id="41019" name="E&xplorer"/>
+                    <Item id="41020" name="&Eingabeaufforderung"/>
+                    <Item id="41003" name="Schlie&ßen"/>
+                    <Item id="41004" name="Alle s&chließen"/>
+                    <Item id="41005" name="Alle s&chließen bis auf aktuelle Datei"/>
+                    <Item id="41009" name="Dateien &links schließen"/>
+                    <Item id="41018" name="Dateien &rechts schließen"/>
+                    <Item id="41006" name="&Speichern"/>
+                    <Item id="41007" name="&Alle speichern"/>
+                    <Item id="41008" name="Speichern &unter …"/>
+                    <Item id="41010" name="&Drucken …"/>
+                    <Item id="1001"  name="So&fort drucken"/>
+                    <Item id="41011" name="B&eenden"/>
+                    <Item id="41012" name="Sit&zung öffnen …"/>
+                    <Item id="41013" name="Sitzung speiche&rn …"/>
+                    <Item id="41014" name="Neu &laden"/>
+                    <Item id="41015" name="&Kopie speichern unter …"/>
+                    <Item id="41016" name="Von Datentr&äger löschen"/>
+                    <Item id="41017" name="Um&benennen …"/>
                     <Item id="41021" name="Zuletzt geschlossene Datei wieder öffnen"/>
                     <Item id="41022" name="Verzeichnis als Arbeitsbereich öffnen"/>
 
-                    <Item id="42001" name="Ausschneiden"/>
-                    <Item id="42002" name="Kopieren"/>
-                    <Item id="42003" name="Rückgängig"/>
-                    <Item id="42004" name="Wiederherstellen"/>
-                    <Item id="42005" name="Einfügen"/>
-                    <Item id="42006" name="Löschen"/>
-                    <Item id="42007" name="Alles auswählen"/>
-                    <Item id="42020" name="Auswahl beginnen/beenden"/>
-                    <Item id="42008" name="Zeileneinzug vergrößern"/>
-                    <Item id="42009" name="Zeileneinzug verkleinern"/>
-                    <Item id="42010" name="Zeile duplizieren"/>
-                    <Item id="42012" name="Zeile am Fensterrand teilen"/>
-                    <Item id="42013" name="Zeilen zusammenfassen"/>
-                    <Item id="42014" name="Zeile nach oben verschieben"/>
-                    <Item id="42015" name="Zeile nach unten verschieben"/>
-                    <Item id="42059" name="Zeilen alphabetisch aufsteigend sortieren"/>
-                    <Item id="42060" name="Zeilen alphabetisch absteigend sortieren"/>
+                    <Item id="42001" name="Aus&schneiden"/>
+                    <Item id="42002" name="&Kopieren"/>
+                    <Item id="42003" name="&Rückgängig"/>
+                    <Item id="42004" name="&Wiederherstellen"/>
+                    <Item id="42005" name="&Einfügen"/>
+                    <Item id="42006" name="&Löschen"/>
+                    <Item id="42007" name="&Alles auswählen"/>
+                    <Item id="42020" name="Auswa&hl beginnen/beenden"/>
+                    <Item id="42008" name="Zeileneinzug v&ergrößern"/>
+                    <Item id="42009" name="Zeileneinzug ver&kleinern"/>
+                    <Item id="42010" name="Zeile &duplizieren"/>
+                    <Item id="42012" name="Zeile am Fensterrand &teilen"/>
+                    <Item id="42013" name="&Zeilen zusammenfassen"/>
+                    <Item id="42014" name="Zeile nach &oben verschieben"/>
+                    <Item id="42015" name="Zeile nach &unten verschieben"/>
+                    <Item id="42059" name="Zeilen alphabetisch au&fsteigend sortieren"/>
+                    <Item id="42060" name="Zeilen alphabetisch a&bsteigend sortieren"/>
                     <Item id="42061" name="Zeilen als Ganzzahlen aufsteigend sortieren"/>
                     <Item id="42062" name="Zeilen als Ganzzahlen absteigend sortieren"/>
                     <Item id="42063" name="Zeilen als Dezimalzahlen (Komma) aufsteigend sortieren"/>
                     <Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
                     <Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
                     <Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-                    <Item id="42016" name="In GROSSBUCHSTABEN umwandeln"/>
-                    <Item id="42017" name="In kleinbuchstaben umwandeln"/>
+                    <Item id="42016" name="In &GROSSBUCHSTABEN umwandeln"/>
+                    <Item id="42017" name="In &kleinbuchstaben umwandeln"/>
                     <Item id="42067" name="Überschriftenstil"/>
                     <Item id="42068" name="Gemischter Überschriftenstil"/>
                     <Item id="42069" name="Normaler Wortstil"/>
@@ -139,158 +139,158 @@
                     <Item id="42074" name="Ordner im Explorer öffnen"/>
                     <Item id="42075" name="Suche im Internet"/>
                     <Item id="42076" name="Andere Suchmaschine wählen …"/>
-                    <Item id="42018" name="Aufzeichnung starten"/>
-                    <Item id="42019" name="Aufzeichnung stoppen"/>
-                    <Item id="42021" name="Makro ausführen"/>
-                    <Item id="42022" name="Zeilenweise Auskommentierung umschalten"/>
-                    <Item id="42023" name="Auswahl auskommentieren"/>
-                    <Item id="42047" name="Auskommentierung der Auswahl aufheben"/>
-                    <Item id="42024" name="Leerzeichen und Tabulatoren am Zeilenende löschen"/>
-                    <Item id="42042" name="Leerzeichen und Tabulatoren am Zeilenanfang löschen"/>
-                    <Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang und -ende löschen"/>
-                    <Item id="42044" name="Zeilenumbrüche in Leerzeichen konvertieren"/>
-                    <Item id="42045" name="Mehrfachen Whitespace und Umbrüche entfernen"/>
-                    <Item id="42046" name="Tabulatoren in Leerzeichen umwandeln"/>
-                    <Item id="42054" name="Leerzeichen in Tabulatoren umwandeln (alle)"/>
-                    <Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am Zeilenanfang)"/>
-                    <Item id="42038" name="HTML-Inhalt einfügen"/>
-                    <Item id="42039" name="RTF-Inhalt einfügen"/>
-                    <Item id="42048" name="Binär-Inhalt kopieren"/>
-                    <Item id="42049" name="Binär-Inhalt ausschneiden"/>
-                    <Item id="42050" name="Binär-Inhalt einfügen"/>
-                    <Item id="42037" name="Spalten-Modus …"/>
-                    <Item id="42034" name="Block-Editor …"/>
-                    <Item id="42051" name="Zeichentabelle"/>
-                    <Item id="42052" name="Zwischenablage"/>
-                    <Item id="42025" name="Aufgenommenes Makro speichern"/>
-                    <Item id="42026" name="Schreibrichtung von rechts nach links"/>
-                    <Item id="42027" name="Schreibrichtung von links nach rechts"/>
-                    <Item id="42028" name="Schreibschutz"/>
-                    <Item id="42029" name="Vollständigen Pfad kopieren"/>
-                    <Item id="42030" name="Nur Dateinamen kopieren"/>
-                    <Item id="42031" name="Nur Verzeichnispfad kopieren"/>
-                    <Item id="42032" name="Makro mehrfach ausführen …"/>
-                    <Item id="42033" name="Schreibschutz-Attribut löschen"/>
-                    <Item id="42035" name="Zeilen auskommentieren"/>
-                    <Item id="42036" name="Auskommentierung der Zeilen aufheben"/>
-                    <Item id="42055" name="Leerzeilen (nur völlig leere) löschen"/>
-                    <Item id="42056" name="Leerzeilen (auch mit Whitespace) löschen"/>
-                    <Item id="42057" name="Leerzeile über aktueller Zeile einfügen"/>
-                    <Item id="42058" name="Leerzeile unter aktueller Zeile einfügen"/>
-                    <Item id="43001" name="Suchen …"/>
-                    <Item id="43002" name="Vorwärts suchen"/>
-                    <Item id="43003" name="Ersetzen …"/>
-                    <Item id="43004" name="Gehe zu …"/>
-                    <Item id="43005" name="Lesezeichen setzen/löschen"/>
-                    <Item id="43006" name="Nächstes Lesezeichen"/>
-                    <Item id="43007" name="Vorheriges Lesezeichen"/>
-                    <Item id="43008" name="Alle Lesezeichen löschen"/>
-                    <Item id="43018" name="Zeilen mit Lesezeichen ausschneiden"/>
-                    <Item id="43019" name="Zeilen mit Lesezeichen kopieren"/>
-                    <Item id="43020" name="Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
-                    <Item id="43021" name="Zeilen mit Lesezeichen löschen"/>
-                    <Item id="43051" name="Zeilen ohne Lesezeichen löschen"/>
-                    <Item id="43050" name="Lesezeichen invertieren"/>
-                    <Item id="43052" name="Suche nach Zeichencodes …"/>
-                    <Item id="43053" name="Alles zwischen Klammern auswählen"/>
-                    <Item id="43009" name="Suche zugehörige Klammer"/>
-                    <Item id="43010" name="Rückwärts suchen"/>
-                    <Item id="43011" name="Inkrementelle Suche"/>
-                    <Item id="43013" name="In Dateien suchen …"/>
-                    <Item id="43014" name="Wort am Cursor suchen (ohne Verlauf)"/>
-                    <Item id="43015" name="Wort am Cursor rückwärts suchen (ohne Verlauf)"/>
-                    <Item id="43022" name="Hervorhebung 1"/>
-                    <Item id="43023" name="Hervorhebung 1 entfernen"/>
-                    <Item id="43024" name="Hervorhebung 2"/>
-                    <Item id="43025" name="Hervorhebung 2 entfernen"/>
-                    <Item id="43026" name="Hervorhebung 3"/>
-                    <Item id="43027" name="Hervorhebung 3 entfernen"/>
-                    <Item id="43028" name="Hervorhebung 4"/>
-                    <Item id="43029" name="Hervorhebung 4 entfernen"/>
-                    <Item id="43030" name="Hervorhebung 5"/>
-                    <Item id="43031" name="Hervorhebung 5 entfernen"/>
-                    <Item id="43032" name="Alle entfernen"/>
-                    <Item id="43033" name="Hervorhebung 1"/>
-                    <Item id="43034" name="Hervorhebung 2"/>
-                    <Item id="43035" name="Hervorhebung 3"/>
-                    <Item id="43036" name="Hervorhebung 4"/>
-                    <Item id="43037" name="Hervorhebung 5"/>
-                    <Item id="43038" name="Hervorhebung aus Suche"/>
-                    <Item id="43039" name="Hervorhebung 1"/>
-                    <Item id="43040" name="Hervorhebung 2"/>
-                    <Item id="43041" name="Hervorhebung 3"/>
-                    <Item id="43042" name="Hervorhebung 4"/>
-                    <Item id="43043" name="Hervorhebung 5"/>
-                    <Item id="43044" name="Hervorhebung aus Suche"/>
-                    <Item id="43045" name="Suchergebnis-Fenster"/>
-                    <Item id="43046" name="Zum nächsten Suchergebnis springen"/>
-                    <Item id="43047" name="Zum vorherigen Suchergebnis springen"/>
-                    <Item id="43048" name="Auswahl oder Wort am Cursor suchen"/>
-                    <Item id="43049" name="Wort am Cursor rückwärts suchen"/>
-                    <Item id="43054" name="Hervorheben …"/>
-                    <Item id="44009" name="Post-It"/>
-                    <Item id="44010" name="Alle Textblöcke schließen"/>
-                    <Item id="44019" name="Alle Zeichen anzeigen"/>
-                    <Item id="44020" name="Einrückung anzeigen"/>
-                    <Item id="44022" name="Automatischer Zeilenumbruch"/>
-                    <Item id="44023" name="Schrift vergrößern"/>
-                    <Item id="44024" name="Schrift verkleinern"/>
-                    <Item id="44025" name="Leerzeichen und Tabulatoren anzeigen"/>
-                    <Item id="44026" name="Zeilenende anzeigen"/>
-                    <Item id="44029" name="Alle Textblöcke öffnen"/>
-                    <Item id="44030" name="Textblock schließen"/>
-                    <Item id="44031" name="Textblock öffnen"/>
-                    <Item id="44049" name="Datei-Info …"/>
-                    <Item id="44080" name="Miniaturansicht"/>
-                    <Item id="44084" name="Funktionsliste"/>
+                    <Item id="42018" name="Aufzeichnung &starten"/>
+                    <Item id="42019" name="Aufzeichnung st&oppen"/>
+                    <Item id="42021" name="Makro ausfüh&ren"/>
+                    <Item id="42022" name="&Zeilenweise Auskommentierung umschalten"/>
+                    <Item id="42023" name="Auswahl &auskommentieren"/>
+                    <Item id="42047" name="Auskommentierung der Auswahl au&fheben"/>
+                    <Item id="42024" name="Leerzeichen und Tabulatoren am Zeilen&ende löschen"/>
+                    <Item id="42042" name="Leerzeichen und Tabulatoren am Zeilen&anfang löschen"/>
+                    <Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang &und -ende löschen"/>
+                    <Item id="42044" name="Zeilenumbrüche in Leerzeichen &konvertieren"/>
+                    <Item id="42045" name="&Mehrfachen Whitespace und Umbrüche entfernen"/>
+                    <Item id="42046" name="Tabulatoren in &Leerzeichen umwandeln"/>
+                    <Item id="42054" name="Leerzeichen in &Tabulatoren umwandeln (alle)"/>
+                    <Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am &Zeilenanfang)"/>
+                    <Item id="42038" name="&HTML-Inhalt einfügen"/>
+                    <Item id="42039" name="&RTF-Inhalt einfügen"/>
+                    <Item id="42048" name="Binär-Inhalt &kopieren"/>
+                    <Item id="42049" name="Binär-Inhalt &ausschneiden"/>
+                    <Item id="42050" name="Binär-Inhalt &einfügen"/>
+                    <Item id="42037" name="Spalten-&Modus …"/>
+                    <Item id="42034" name="&Block-Editor …"/>
+                    <Item id="42051" name="Zeichen&tabelle"/>
+                    <Item id="42052" name="Zwis&chenablage"/>
+                    <Item id="42025" name="Aufgenommenes Makro s&peichern"/>
+                    <Item id="42026" name="Schreib&richtung von rechts nach links"/>
+                    <Item id="42027" name="Schreibrichtung von lin&ks nach rechts"/>
+                    <Item id="42028" name="Schreibsch&utz"/>
+                    <Item id="42029" name="Vollständigen &Pfad kopieren"/>
+                    <Item id="42030" name="Nur Datei&namen kopieren"/>
+                    <Item id="42031" name="Nur &Verzeichnispfad kopieren"/>
+                    <Item id="42032" name="Makro &mehrfach ausführen …"/>
+                    <Item id="42033" name="Schreibschutz-Attribut l&öschen"/>
+                    <Item id="42035" name="Zeilen aus&kommentieren"/>
+                    <Item id="42036" name="Auskommentierung der Zeilen a&ufheben"/>
+                    <Item id="42055" name="&Leerzeilen (nur völlig leere) löschen"/>
+                    <Item id="42056" name="Leerzeilen (auch mit &Whitespace) löschen"/>
+                    <Item id="42057" name="Leerzeile &über aktueller Zeile einfügen"/>
+                    <Item id="42058" name="Leerzeile u&nter aktueller Zeile einfügen"/>
+                    <Item id="43001" name="&Suchen …"/>
+                    <Item id="43002" name="&Vorwärts Suchen"/>
+                    <Item id="43003" name="&Ersetzen …"/>
+                    <Item id="43004" name="&Gehe zu …"/>
+                    <Item id="43005" name="&Lesezeichen setzen/löschen"/>
+                    <Item id="43006" name="&Nächstes Lesezeichen"/>
+                    <Item id="43007" name="&Vorheriges Lesezeichen"/>
+                    <Item id="43008" name="Alle Lesezeichen l&öschen"/>
+                    <Item id="43018" name="Zeilen mit Lesezeichen &ausschneiden"/>
+                    <Item id="43019" name="Zeilen mit Lesezeichen &kopieren"/>
+                    <Item id="43020" name="&Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
+                    <Item id="43021" name="Zeilen mit Lesezeichen lös&chen"/>
+                    <Item id="43051" name="Zeilen &ohne Lesezeichen löschen"/>
+                    <Item id="43050" name="Lesezeichen inver&tieren"/>
+                    <Item id="43052" name="Suche nach &Zeichencodes …"/>
+                    <Item id="43053" name="&Alles zwischen Klammern auswählen"/>
+                    <Item id="43009" name="Suche zugehörige &Klammer"/>
+                    <Item id="43010" name="&Rückwärts suchen"/>
+                    <Item id="43011" name="&Inkrementelle Suche"/>
+                    <Item id="43013" name="In &Dateien suchen …"/>
+                    <Item id="43014" name="Wort am Cursor suchen (&ohne Verlauf)"/>
+                    <Item id="43015" name="Wor&t am Cursor rückwärts suchen (ohne Verlauf)"/>
+                    <Item id="43022" name="Hervorhebung &1"/>
+                    <Item id="43023" name="Hervorhebung &1 entfernen"/>
+                    <Item id="43024" name="Hervorhebung &2"/>
+                    <Item id="43025" name="Hervorhebung &2 entfernen"/>
+                    <Item id="43026" name="Hervorhebung &3"/>
+                    <Item id="43027" name="Hervorhebung &3 entfernen"/>
+                    <Item id="43028" name="Hervorhebung &4"/>
+                    <Item id="43029" name="Hervorhebung &4 entfernen"/>
+                    <Item id="43030" name="Hervorhebung &5"/>
+                    <Item id="43031" name="Hervorhebung &5 entfernen"/>
+                    <Item id="43032" name="&Alle entfernen"/>
+                    <Item id="43033" name="Hervorhebung &1"/>
+                    <Item id="43034" name="Hervorhebung &2"/>
+                    <Item id="43035" name="Hervorhebung &3"/>
+                    <Item id="43036" name="Hervorhebung &4"/>
+                    <Item id="43037" name="Hervorhebung &5"/>
+                    <Item id="43038" name="Hervorhebung aus &Suche"/>
+                    <Item id="43039" name="Hervorhebung &1"/>
+                    <Item id="43040" name="Hervorhebung &2"/>
+                    <Item id="43041" name="Hervorhebung &3"/>
+                    <Item id="43042" name="Hervorhebung &4"/>
+                    <Item id="43043" name="Hervorhebung &5"/>
+                    <Item id="43044" name="Hervorhebung aus &Suche"/>
+                    <Item id="43045" name="Suchergebnis-&Fenster"/>
+                    <Item id="43046" name="Zum n&ächsten Suchergebnis springen"/>
+                    <Item id="43047" name="Zum vorherigen S&uchergebnis springen"/>
+                    <Item id="43048" name="Auswahl oder Wort am &Cursor suchen"/>
+                    <Item id="43049" name="Wort am Cursor r&ückwärts suchen"/>
+                    <Item id="43054" name="&Hervorheben …"/>
+                    <Item id="44009" name="&Post-It"/>
+                    <Item id="44010" name="A&lle Textblöcke schließen"/>
+                    <Item id="44019" name="&Alle Zeichen anzeigen"/>
+                    <Item id="44020" name="&Einrückung anzeigen"/>
+                    <Item id="44022" name="Automatischer Zeilen&umbruch"/>
+                    <Item id="44023" name="Schrift ver&größern"/>
+                    <Item id="44024" name="Schrift ver&kleinern"/>
+                    <Item id="44025" name="&Leerzeichen und Tabulatoren anzeigen"/>
+                    <Item id="44026" name="Zeilenende anze&igen"/>
+                    <Item id="44029" name="Alle Textblöcke &öffnen"/>
+                    <Item id="44030" name="Textblock schlie&ßen"/>
+                    <Item id="44031" name="Textblock öff&nen"/>
+                    <Item id="44049" name="Datei-&Info …"/>
+                    <Item id="44080" name="&Miniaturansicht"/>
+                    <Item id="44084" name="&Funktionsliste"/>
                     <Item id="44085" name="Verzeichnis als Arbeitsbereich"/>
-                    <Item id="44086" name="1. Tab"/>
-                    <Item id="44087" name="2. Tab"/>
-                    <Item id="44088" name="3. Tab"/>
-                    <Item id="44089" name="4. Tab"/>
-                    <Item id="44090" name="5. Tab"/>
-                    <Item id="44091" name="6. Tab"/>
-                    <Item id="44092" name="7. Tab"/>
-                    <Item id="44093" name="8. Tab"/>
-                    <Item id="44094" name="9. Tab"/>
-                    <Item id="44095" name="Nächster Tab"/>
-                    <Item id="44096" name="Vorheriger Tab"/>
+                    <Item id="44086" name="&1. Tab"/>
+                    <Item id="44087" name="&2. Tab"/>
+                    <Item id="44088" name="&3. Tab"/>
+                    <Item id="44089" name="&4. Tab"/>
+                    <Item id="44090" name="&5. Tab"/>
+                    <Item id="44091" name="&6. Tab"/>
+                    <Item id="44092" name="&7. Tab"/>
+                    <Item id="44093" name="&8. Tab"/>
+                    <Item id="44094" name="&9. Tab"/>
+                    <Item id="44095" name="&Nächster Tab"/>
+                    <Item id="44096" name="&Vorheriger Tab"/>
                     <Item id="44097" name="Überwachen (tail -f)"/>
                     <Item id="44098" name="Tab vorwärts bewegen"/>
                     <Item id="44099" name="Tab rückwärts bewegen"/>
-                    <Item id="44032" name="Vollbild"/>
-                    <Item id="44033" name="Standardgröße"/>
-                    <Item id="44034" name="Immer im Vordergrund halten"/>
-                    <Item id="44035" name="Synchrones vertikales Scrollen"/>
-                    <Item id="44036" name="Synchrones horizontales Scrollen"/>
-                    <Item id="44041" name="Symbol bei automatischem Umbruch"/>
-                    <Item id="44072" name="Zur anderen Ansicht wechseln"/>
-                    <Item id="44081" name="Projektfenster 1"/>
-                    <Item id="44082" name="Projektfenster 2"/>
-                    <Item id="44083" name="Projektfenster 3"/>
-                    <Item id="45001" name="Konvertiere zu Windows (CR+LF)"/>
-                    <Item id="45002" name="Konvertiere zu UNIX (LF)"/>
-                    <Item id="45003" name="Konvertiere zu Mac (CR)"/>
-                    <Item id="45004" name="ANSI"/>
-                    <Item id="45005" name="UTF-8"/>
-                    <Item id="45006" name="UCS-2 Big Endian"/>
-                    <Item id="45007" name="UCS-2 Little Endian"/>
-                    <Item id="45008" name="UTF-8 ohne BOM"/>
-                    <Item id="45009" name="Konvertiere zu ANSI"/>
-                    <Item id="45010" name="Konvertiere zu UTF-8 ohne BOM"/>
-                    <Item id="45011" name="Konvertiere zu UTF-8"/>
-                    <Item id="45012" name="Konvertiere zu UCS-2 Big Endian"/>
-                    <Item id="45013" name="Konvertiere zu UCS-2 Little Endian"/>
-                    <Item id="44011" name="Benutzerdefinierte Sprache …"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="44012" name="Zeilennummernrand ausblenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="44013" name="Lesezeichenrand ausblenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="44014" name="Codefaltung ausblenden"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
-                    <Item id="47008" name="Inhalt …"/>                    <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44032" name="Voll&bild"/>
+                    <Item id="44033" name="&Standardgröße"/>
+                    <Item id="44034" name="Immer im Vorder&grund halten"/>
+                    <Item id="44035" name="S&ynchrones vertikales Scrollen"/>
+                    <Item id="44036" name="Synchrones &horizontales Scrollen"/>
+                    <Item id="44041" name="Symbol bei automatischem &Umbruch"/>
+                    <Item id="44072" name="&Zur anderen Ansicht wechseln"/>
+                    <Item id="44081" name="Projektfenster &1"/>
+                    <Item id="44082" name="Projektfenster &2"/>
+                    <Item id="44083" name="Projektfenster &3"/>
+                    <Item id="45001" name="Konvertiere zu &Windows (CR+LF)"/>
+                    <Item id="45002" name="Konvertiere zu &UNIX (LF)"/>
+                    <Item id="45003" name="Konvertiere zu &Mac (CR)"/>
+                    <Item id="45004" name="&ANSI"/>
+                    <Item id="45005" name="UTF-&8"/>
+                    <Item id="45006" name="UCS-2 &Big Endian"/>
+                    <Item id="45007" name="UCS-2 &Little Endian"/>
+                    <Item id="45008" name="UTF-8 &ohne BOM"/>
+                    <Item id="45009" name="Ko&nvertiere zu ANSI"/>
+                    <Item id="45010" name="Kon&vertiere zu UTF-8 ohne BOM"/>
+                    <Item id="45011" name="Konv&ertiere zu UTF-8"/>
+                    <Item id="45012" name="Konve&rtiere zu UCS-2 Big Endian"/>
+                    <Item id="45013" name="Konver&tiere zu UCS-2 Little Endian"/>
+                    <Item id="44011" name="Benutzerdefinierte Spra&che …"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44012" name="Zeilennummernrand ausb&lenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44013" name="Lesezeichenrand ausb&lenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44014" name="Codefaltung ausb&lenden"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="47008" name="In&halt …"/>                    <!-- kommt im englischen nicht oder nicht mehr vor -->
 
-                    <Item id="10001" name="In zweite Ansicht verschieben"/>
-                    <Item id="10002" name="In zweite Ansicht duplizieren"/>
-                    <Item id="10003" name="In neue Instanz verschieben"/>
-                    <Item id="10004" name="In neue Instanz duplizieren"/>
+                    <Item id="10001" name="In zweite Ansicht &verschieben"/>
+                    <Item id="10002" name="In zweite Ansicht &duplizieren"/>
+                    <Item id="10003" name="In &neue Instanz verschieben"/>
+                    <Item id="10004" name="In neue Instan&z duplizieren"/>
 
                     <Item id="45060" name="Big5 (Traditionell)"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
                     <Item id="45061" name="GB2312 (Vereinfacht)"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
@@ -305,30 +305,30 @@
                     <Item id="46016" name="Normaler Text"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
                     <Item id="46017" name="Ressourcen-Datei"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
 
-                    <Item id="46001" name="Stile …"/>
-                    <Item id="46150" name="Eigene Sprache definieren …"/>
+                    <Item id="46001" name="&Stile …"/>
+                    <Item id="46150" name="Eigene Sprache &definieren …"/>
                     <Item id="46080" name="Benutzerdefiniert"/>
-                    <Item id="47000" name="Info …"/>
-                    <Item id="47010" name="Kommandozeilenparameter …"/>
-                    <Item id="47001" name="Notepad++ im Web"/>
-                    <Item id="47002" name="Notepad++ bei GitHub"/>
+                    <Item id="47000" name="&Info …"/>
+                    <Item id="47010" name="&Kommandozeilenparameter …"/>
+                    <Item id="47001" name="Notepad++ im &Web"/>
+                    <Item id="47002" name="Notepad++ bei &GitHub"/>
                     <Item id="47003" name="Online-Dokumentation"/>
                     <Item id="47004" name="Notepad++ Online-Forum"/>
-                    <Item id="47011" name="Support im Chat"/>
+                    <Item id="47011" name="&Support im Chat"/>
                     <Item id="47012" name="Debug-Info"/>
-                    <Item id="47005" name="Erweiterungen"/>
-                    <Item id="47006" name="Notepad++ aktualisieren"/>
-                    <Item id="47009" name="Proxy für Updater einstellen …"/>
-                    <Item id="48005" name="Plugin(s) importieren …"/>
-                    <Item id="48006" name="Design(s) importieren …"/>
-                    <Item id="48018" name="Kontextmenü anpassen …"/>
-                    <Item id="48009" name="Tastatur …"/>
-                    <Item id="48011" name="Optionen …"/>
+                    <Item id="47005" name="&Erweiterungen"/>
+                    <Item id="47006" name="Notepad++ &aktualisieren"/>
+                    <Item id="47009" name="&Proxy für Updater einstellen …"/>
+                    <Item id="48005" name="&Plugin(s) importieren …"/>
+                    <Item id="48006" name="&Design(s) importieren …"/>
+                    <Item id="48018" name="&Kontextmenü anpassen …"/>
+                    <Item id="48009" name="&Tastatur …"/>
+                    <Item id="48011" name="&Optionen …"/>
                     <Item id="48501" name="Erstelle …"/>
                     <Item id="48502" name="Erstelle aus Dateien …"/>
                     <Item id="48503" name="Erstelle in die Zwischenablage"/>
 
-                    <Item id="49000" name="Externes Programm ausführen …"/>
+                    <Item id="49000" name="Externes Programm &ausführen …"/>
 
                     <Item id="50000" name="Funktionsvervollständigung"/>
                     <Item id="50001" name="Wortvervollständigung"/>
@@ -344,69 +344,69 @@
             <Splitter>
             </Splitter>
             <TabBar>
-                <Item CMID="0"  name="Schließen"/>
-                <Item CMID="1"  name="Alle anderen schließen"/>
-                <Item CMID="2"  name="Speichern"/>
-                <Item CMID="3"  name="Speichern unter …"/>
-                <Item CMID="4"  name="Drucken"/>
-                <Item CMID="5"  name="In zweite Ansicht verschieben"/>
-                <Item CMID="6"  name="In zweite Ansicht duplizieren"/>
-                <Item CMID="7"  name="Vollständigen Pfad kopieren"/>
-                <Item CMID="8"  name="Nur Dateinamen kopieren"/>
-                <Item CMID="9"  name="Nur Verzeichnispfad kopieren"/>
-                <Item CMID="10" name="Umbenennen …"/>
-                <Item CMID="11" name="Löschen"/>
-                <Item CMID="12" name="Schreibschutz"/>
-                <Item CMID="13" name="Schreibschutz aufheben"/>
-                <Item CMID="14" name="In neue Instanz verschieben"/>
-                <Item CMID="15" name="In neue Instanz duplizieren"/>
-                <Item CMID="16" name="Neu laden"/>
-                <Item CMID="17" name="Dateien links schließen"/>
-                <Item CMID="18" name="Dateien rechts schließen"/>
-                <Item CMID="19" name="Ordner im Explorer öffnen"/>
-                <Item CMID="20" name="Kommandozeile im aktuellen Ordner öffnen"/>
+                <Item CMID="0"  name="S&chließen"/>
+                <Item CMID="1"  name="&Alle anderen schließen"/>
+                <Item CMID="2"  name="&Speichern"/>
+                <Item CMID="3"  name="Speichern &unter …"/>
+                <Item CMID="4"  name="&Drucken"/>
+                <Item CMID="5"  name="In zweite Ansicht &verschieben"/>
+                <Item CMID="6"  name="In zw&eite Ansicht duplizieren"/>
+                <Item CMID="7"  name="Vollständigen Pfad &kopieren"/>
+                <Item CMID="8"  name="Nur Datei&namen kopieren"/>
+                <Item CMID="9"  name="Nur Verzeichnis&pfad kopieren"/>
+                <Item CMID="10" name="Um&benennen …"/>
+                <Item CMID="11" name="L&öschen"/>
+                <Item CMID="12" name="Sch&reibschutz"/>
+                <Item CMID="13" name="Schreibschutz au&fheben"/>
+                <Item CMID="14" name="In neue &Instanz verschieben"/>
+                <Item CMID="15" name="In neue Instan&z duplizieren"/>
+                <Item CMID="16" name="Neu &laden"/>
+                <Item CMID="17" name="Dateien links schlie&ßen"/>
+                <Item CMID="18" name="Dateien rech&ts schließen"/>
+                <Item CMID="19" name="Ordner im E&xplorer öffnen"/>
+                <Item CMID="20" name="Kommandozeile im aktuellen &Ordner öffnen"/>
             </TabBar>
         </Menu>
 
         <Dialog>
             <Find title="Suchen und ersetzen" titleFind="Suchen" titleReplace="Ersetzen" titleFindInFiles="In Dateien suchen" titleMark="Hervorheben">
-                <Item id="1"    name="Suchen  ›"/>
-                <Item id="1721" name="‹  Suchen"/>
-                <Item id="2"    name="Schließen"/>
-                <Item id="1620" name="Suchen nach:"/>
-                <Item id="1603" name="Nur ganze Wörter suchen"/>
-                <Item id="1604" name="Groß-/Kleinschreibung beachten"/>
-                <Item id="1605" name="Reguläre Ausdrücke"/>
-                <Item id="1606" name="Am Ende von vorne beginnen"/>
-                <Item id="1612" name="Rückwärts"/>
-                <Item id="1613" name="Vorwärts"/>
-                <Item id="1614" name="Zählen"/>
-                <Item id="1615" name="Alle suchen"/>
-                <Item id="1616" name="Lesezeichen setzen"/>
-                <Item id="1618" name="Für jede Suche löschen"/>
+                <Item id="1"    name="&Suchen  ›"/>
+                <Item id="1721" name="‹  S&uchen"/>
+                <Item id="2"    name="S&chließen"/>
+                <Item id="1620" name="Suchen &nach:"/>
+                <Item id="1603" name="Nur &ganze Wörter suchen"/>
+                <Item id="1604" name="Groß-/&Kleinschreibung beachten"/>
+                <Item id="1605" name="&Reguläre Ausdrücke"/>
+                <Item id="1606" name="Am Ende von vorne &beginnen"/>
+                <Item id="1612" name="R&ückwärts"/>
+                <Item id="1613" name="&Vorwärts"/>
+                <Item id="1614" name="Z&ählen"/>
+                <Item id="1615" name="&Alle suchen"/>
+                <Item id="1616" name="&Lesezeichen setzen"/>
+                <Item id="1618" name="Für &jede Suche löschen"/>
                 <Item id="1621" name="Suchrichtung"/>
-                <Item id="1611" name="Ersetzen durch:"/>
-                <Item id="1608" name="Ersetzen"/>
-                <Item id="1609" name="Alle ersetzen"/>
+                <Item id="1611" name="Erset&zen durch:"/>
+                <Item id="1608" name="&Ersetzen"/>
+                <Item id="1609" name="Alle erse&tzen"/>
                 <Item id="1687" name="Wenn inaktiv"/>
                 <Item id="1688" name="Immer"/>
-                <Item id="1632" name="In Auswahl"/>
+                <Item id="1632" name="In &Auswahl"/>
                 <Item id="1633" name="Zurücksetzen"/>
                 <Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
-                <Item id="1636" name="In offenen Dateien suchen"/>
+                <Item id="1636" name="In &offenen Dateien suchen"/>
                 <Item id="1654" name="Filter:"/>
                 <Item id="1655" name="Verzeichnis:"/>
-                <Item id="1656" name="Alle suchen"/>
-                <Item id="1658" name="Unterverzeichnisse"/>
-                <Item id="1659" name="Versteckte Ordner"/>
+                <Item id="1656" name="Alle su&chen"/>
+                <Item id="1658" name="&Unterverzeichnisse"/>
+                <Item id="1659" name="&Versteckte Ordner"/>
                 <Item id="1624" name="Suchmodus"/>
-                <Item id="1625" name="Normal"/>
-                <Item id="1626" name="Erweitert (\n, \r, \t, \0, \x…)"/>
+                <Item id="1625" name="Norma&l"/>
+                <Item id="1626" name="Erwe&itert (\n, \r, \t, \0, \x…)"/>
                 <Item id="1660" name="Ersetzen in Dateien"/>
-                <Item id="1661" name="Ordner der akt. Datei"/>
-                <Item id="1641" name="Alle in aktiver Datei suchen"/>
+                <Item id="1661" name="&Ordner der akt. Datei"/>
+                <Item id="1641" name="Alle in aktiver &Datei suchen"/>
                 <Item id="1686" name="Transparenz"/>
-                <Item id="1703" name=". findet \r und \n"/>
+                <Item id="1703" name="&. findet \r und \n"/>
                 <Item id="1627" name="Unten"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
                 <Item id="1637" name="In Dateien suchen"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
                 <Item id="1640" name="Umschaltdialog"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
@@ -414,22 +414,22 @@
 
             <FindCharsInRange title="Suche nach Zeichencodes">
                 <Item id="-1"   name="–"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
-                <Item id="2"    name="Schließen"/>
-                <Item id="2901" name="Nicht-ASCII-Zeichen (128–255)"/>
-                <Item id="2902" name="ASCII-Zeichen (0–127)"/>
-                <Item id="2903" name="Benutzerdefiniert:"/>
-                <Item id="2906" name="Aufwärts"/>
-                <Item id="2907" name="Abwärts"/>
+                <Item id="2"    name="S&chließen"/>
+                <Item id="2901" name="&Nicht-ASCII-Zeichen (128–255)"/>
+                <Item id="2902" name="&ASCII-Zeichen (0–127)"/>
+                <Item id="2903" name="&Benutzerdefiniert:"/>
+                <Item id="2906" name="&Aufwärts"/>
+                <Item id="2907" name="&Abwärts"/>
                 <Item id="2908" name="Suchrichtung"/>
-                <Item id="2909" name="Am Ende von vorne beginnen"/>
-                <Item id="2910" name="Suchen"/>
+                <Item id="2909" name="Am Ende von &vorne beginnen"/>
+                <Item id="2910" name="&Suchen"/>
             </FindCharsInRange>
 
             <GoToLine title="Gehe zu">
-                <Item id="2007" name="Zeile"/>
-                <Item id="2008" name="Zeichen"/>
-                <Item id="1"    name="Gehe zu"/>
-                <Item id="2"    name="Abbrechen"/>
+                <Item id="2007" name="&Zeile"/>
+                <Item id="2008" name="Z&eichen"/>
+                <Item id="1"    name="&Gehe zu"/>
+                <Item id="2"    name="&Abbrechen"/>
                 <Item id="2004" name="Aktuell:"/>
                 <Item id="2005" name="Ziel:"/>
                 <Item id="2006" name="Insgesamt in der Datei:"/>
@@ -437,10 +437,10 @@
 
             <Run title="Ausführen …">
                 <Item id="1903" name="Auszuführendes Programm hier eingeben"/>
-                <Item id="1"    name="Ausführen"/>
-                <Item id="2"    name="Abbrechen"/>
-                <Item id="1904" name="Speichern"/>
-                <Item id="1901" name="..."/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
+                <Item id="1"    name="&Ausführen"/>
+                <Item id="2"    name="A&bbrechen"/>
+                <Item id="1904" name="&Speichern"/>
+                <Item id="1901" name=".&.."/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
             </Run>
 
             <MD5FromFilesDlg title="Erstelle MD5-Hashwert aus Dateien">
@@ -458,7 +458,7 @@
             <StyleConfig title="Stile">
                 <Item id="1"    name="Übernehmen"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
                 <Item id="2"    name="Abbrechen"/>
-                <Item id="2301" name="Speichern & Schließen"/>
+                <Item id="2301" name="Speichern && Schließen"/>
                 <Item id="2303" name="Transparenz"/>
                 <Item id="2306" name="Design:"/>
                 <SubDialog>
@@ -531,10 +531,10 @@
                     <Item id="25026" name="Operatoren 1"/>
                     <Item id="25027" name="Operatoren 2"/>
                     <Item id="25028" name="Zahlen"/>
-                    <Item id="1"     name="OK"/>
-                    <Item id="2"     name="Abbrechen"/>
+                    <Item id="1"     name="&OK"/>
+                    <Item id="2"     name="A&bbrechen"/>
                 </StylerDialog>
-                <Folder title="Textblöcke & Voreinstellung">
+                <Folder title="Textblöcke && Voreinstellung">
                     <Item id="21101" name="Standardschrift"/>
                     <Item id="21102" name="Stil"/>
                     <Item id="21105" name="Dokumentation"/>
@@ -582,7 +582,7 @@
                     <Item id="22572" name="Stil"/>
                     <Item id="22622" name="Stil"/>
                 </Keywords>
-                <Comment title="Kommentare & Zahlen">
+                <Comment title="Kommentare && Zahlen">
                     <Item id="23002" name="Am Zeilenanfang Zeilenkommentar erzwingen"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
                     <Item id="23003" name="Position von Zeilenkommentaren"/>
                     <Item id="23004" name="Überall erlauben"/>
@@ -612,7 +612,7 @@
                     <Item id="23246" name="Komma"/>
                     <Item id="23247" name="Beides"/>
                 </Comment>
-                <Operator title="Operatoren & Trenner">
+                <Operator title="Operatoren && Trenner">
                     <Item id="24101" name="Operatoren"/>
                     <Item id="24113" name="Stil"/>
                     <Item id="24116" name="Operatoren 1"/>
@@ -660,7 +660,7 @@
                 </Operator>
             </UserDefine>
             <Preference title="Optionen">
-                <Item id="6001" name="Schließen"/>
+                <Item id="6001" name="S&chließen"/>
                 <Global title="Oberfläche 1">
                     <Item id="6101" name="Symbolleiste"/>
                     <Item id="6102" name="Ausblenden"/>
@@ -914,34 +914,34 @@
                     <Item id="6346" name="Momentaufnahme in Miniaturansicht"/></MISC>
             </Preference>
             <MultiMacro title="Makro mehrfach ausführen">
-                <Item id="1"    name="Ausführen"/>
-                <Item id="2"    name="Abbrechen"/>
+                <Item id="1"    name="Ausfüh&ren"/>
+                <Item id="2"    name="A&bbrechen"/>
                 <Item id="8006" name="Makro:"/>
-                <Item id="8001" name="Makro"/>
+                <Item id="8001" name="&Makro"/>
                 <Item id="8005" name="mal ausführen"/>
-                <Item id="8002" name="Bis zum Ende der Datei ausführen"/>
+                <Item id="8002" name="Bis zum &Ende der Datei ausführen"/>
             </MultiMacro>
             <Window title="Fenster">
-                <Item id="1"    name="Aktivieren"/>
-                <Item id="2"    name="OK"/>
-                <Item id="7002" name="Speichern"/>
-                <Item id="7003" name="Tab schließen"/>
-                <Item id="7004" name="Sortiere Tabs"/>
+                <Item id="1"    name="&Aktivieren"/>
+                <Item id="2"    name="&OK"/>
+                <Item id="7002" name="S&peichern"/>
+                <Item id="7003" name="Tab s&chließen"/>
+                <Item id="7004" name="&Sortiere Tabs"/>
             </Window>
             <ColumnEditor title="Block-Editor">
                 <Item id="2023" name="Text einfügen"/>
                 <Item id="2033" name="Zahlen einfügen"/>
                 <Item id="2030" name="Beginnen mit:"/>
                 <Item id="2031" name="Erhöhen um:"/>
-                <Item id="2035" name="Führende Nullen"/>
+                <Item id="2035" name="Führende &Nullen"/>
                 <Item id="2036" name="Wiederholen:"/>
                 <Item id="2032" name="Format"/>
-                <Item id="2024" name="Dezimal"/>
-                <Item id="2025" name="Oktal"/>
-                <Item id="2026" name="Hexadezimal"/>
-                <Item id="2027" name="Binär"/>
-                <Item id="1"    name="Ausführen"/>
-                <Item id="2"    name="Abbrechen"/>
+                <Item id="2024" name="&Dezimal"/>
+                <Item id="2025" name="&Oktal"/>
+                <Item id="2026" name="&Hexadezimal"/>
+                <Item id="2027" name="&Binär"/>
+                <Item id="1"    name="Ausfüh&ren"/>
+                <Item id="2"    name="Abbre&chen"/>
             </ColumnEditor>
         </Dialog>
         <MessageBox>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
+<!--
     German localization for Notepad++ 7.4.2
     last modified: 2017-07-02 by schnurlos (schnurlos@gmail.com)
-
 
     Please e-mail errors, suggestions etc. to schnurlos(at)gmail.com or janschreiber(at)users.sf.net
 

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
 <!--
-	German localization for Notepad++ 7.4
-	last modified: 2017-05-27 by schnurlos (schnurlos@gmail.com)
+	German localization for Notepad++ 7.4.2
+	last modified: 2017-07-02 by schnurlos (schnurlos@gmail.com)
 
 	Please e-mail errors, suggestions etc. to schnurlos(at)gmail.com or janschreiber(at)users.sf.net
 
@@ -12,124 +12,123 @@
 -->
 
 <NotepadPlus>
-	<Native-Langue name="Deutsch" filename="german.xml" version="7.4">
+	<Native-Langue name="Deutsch" filename="german.xml" version="7.4.2">
 		<Menu>
 			<Main>
                 <!-- Main Menu Entries -->
 				<Entries>
-					<Item menuId="file" name="&amp;Datei"/>
-					<Item menuId="edit" name="&amp;Bearbeiten"/>
-					<Item menuId="search" name="&amp;Suchen"/>
-					<Item menuId="view" name="&amp;Ansicht"/>
-					<Item menuId="encoding" name="&amp;Kodierung"/>
-					<Item menuId="language" name="S&amp;prachen"/>
-					<Item menuId="settings" name="&amp;Einstellungen"/>
-					<Item menuId="tools" name="Werk&amp;zeuge"/>
-					<Item menuId="macro" name="&amp;Makro"/>
-					<Item menuId="run" name="Ausfüh&amp;ren"/>
-					<Item idName="Plugins" name="Er&amp;weiterungen"/>
-					<Item idName="Window" name="Fe&amp;nster"/>
+					<Item menuId="file" name="Datei"/>
+					<Item menuId="edit" name="Bearbeiten"/>
+					<Item menuId="search" name="Suchen"/>
+					<Item menuId="view" name="Ansicht"/>
+					<Item menuId="encoding" name="Kodierung"/>
+					<Item menuId="language" name="Sprachen"/>
+					<Item menuId="settings" name="Einstellungen"/>
+					<Item menuId="tools" name="Werkzeuge"/>
+					<Item menuId="macro" name="Makro"/>
+					<Item menuId="run" name="Ausführen"/>
+					<Item idName="Plugins" name="Erweiterungen"/>
+					<Item idName="Window" name="Fenster"/>
 				</Entries>
                 <!-- Sub Menu Entries -->
 				<SubEntries>
-					<Item subMenuId="file-openFolder" name="Aktuellen &amp;Ordner öffnen"/>
-					<Item subMenuId="file-closeMore" name="&amp;Mehrere schließen"/>
-					<Item subMenuId="file-recentFiles" name="Zuletzt &amp;verwendet"/>
-					<Item subMenuId="edit-copyToClipboard" name="Datei&amp;pfad kopieren"/>
-					<Item subMenuId="edit-indent" name="E&amp;inrückung"/>
-					<Item subMenuId="edit-convertCaseTo" name="&amp;Groß-/Kleinschreibung"/>
-					<Item subMenuId="edit-lineOperations" name="&amp;Zeilenoperationen"/>
-					<Item subMenuId="edit-comment" name="K&amp;ommentare"/>
-					<Item subMenuId="edit-autoCompletion" name="Autovervollst&amp;ändigung"/>
-					<Item subMenuId="edit-eolConversion" name="Format Zeile&amp;nende"/>
-					<Item subMenuId="edit-blankOperations" name="Nicht &amp;druckbare Zeichen"/>
-					<Item subMenuId="edit-pasteSpecial" name= "Einf&amp;ügen spezial"/>
+					<Item subMenuId="file-openFolder" name="Aktuellen Ordner öffnen"/>
+					<Item subMenuId="file-closeMore" name="Mehrere schließen"/>
+					<Item subMenuId="file-recentFiles" name="Zuletzt verwendet"/>
+					<Item subMenuId="edit-copyToClipboard" name="Dateipfad kopieren"/>
+					<Item subMenuId="edit-indent" name="Einrückung"/>
+					<Item subMenuId="edit-convertCaseTo" name="Groß-/Kleinschreibung"/>
+					<Item subMenuId="edit-lineOperations" name="Zeilenoperationen"/>
+					<Item subMenuId="edit-comment" name="Kommentare"/>
+					<Item subMenuId="edit-autoCompletion" name="Autovervollständigung"/>
+					<Item subMenuId="edit-eolConversion" name="Format Zeilenende"/>
+					<Item subMenuId="edit-blankOperations" name="Nicht druckbare Zeichen"/>
+					<Item subMenuId="edit-pasteSpecial" name= "Einfügen spezial"/>
 					<Item subMenuId="edit-onSelection" name="Bei Auswahl"/>
-					<Item subMenuId="search-markAll" name="Alle &amp;Vorkommnisse hervorheben"/>
-					<Item subMenuId="search-unmarkAll" name="Alle Hervorhe&amp;bungen löschen"/>
-					<Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung s&amp;pringen"/>
-					<Item subMenuId="search-jumpDown" name="Zur &amp;nächsten Hervorhebung springen"/>
-					<Item subMenuId="search-bookmark" name="&amp;Lesezeichen"/>
-					<Item subMenuId="view-showSymbol" name="Nicht &amp;druckbare Zeichen"/>
-					<Item subMenuId="view-zoom" name="Z&amp;oom"/>
-					<Item subMenuId="view-moveCloneDocument" name="Datei &amp;verschieben/duplizieren"/>
-					<Item subMenuId="view-tab" name="&amp;Tabs"/>
-					<Item subMenuId="view-collapseLevel" name="T&amp;extblöcke schließen"/>
-					<Item subMenuId="view-uncollapseLevel" name="Te&amp;xtblöcke öffnen"/>
-					<Item subMenuId="view-project" name="Projektver&amp;waltung"/>
-					<Item subMenuId="encoding-characterSets" name="&amp;Weitere"/>
-					<Item subMenuId="encoding-arabic" name="&amp;Arabisch"/>
-					<Item subMenuId="encoding-baltic" name="&amp;Baltisch"/>
-					<Item subMenuId="encoding-celtic" name="&amp;Keltisch"/>
-					<Item subMenuId="encoding-cyrillic" name="K&amp;yrillisch"/>
-					<Item subMenuId="encoding-centralEuropean" name="&amp;Mitteleuropäisch"/>
-					<Item subMenuId="encoding-chinese" name="&amp;Chinesisch"/>
-					<Item subMenuId="encoding-easternEuropean" name="&amp;Osteuropäisch"/>
-					<Item subMenuId="encoding-greek" name="&amp;Griechisch"/>
-					<Item subMenuId="encoding-hebrew" name="&amp;Hebräisch"/>
-					<Item subMenuId="encoding-japanese" name="&amp;Japanisch"/>
-					<Item subMenuId="encoding-korean" name="Ko&amp;reanisch"/>
-					<Item subMenuId="encoding-northEuropean" name="&amp;Nordeuropäisch"/>
-					<Item subMenuId="encoding-thai" name="&amp;Thai"/>
-					<Item subMenuId="encoding-turkish" name="T&amp;ürkisch"/>
-					<Item subMenuId="encoding-westernEuropean" name="&amp;Westeuropäisch"/>
-					<Item subMenuId="encoding-vietnamese" name="&amp;Vietnamesisch"/>
-					<Item subMenuId="settings-import" name="&amp;Import"/>
+					<Item subMenuId="search-markAll" name="Alle Vorkommnisse hervorheben"/>
+					<Item subMenuId="search-unmarkAll" name="Alle Hervorhebungen löschen"/>
+					<Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung springen"/>
+					<Item subMenuId="search-jumpDown" name="Zur nächsten Hervorhebung springen"/>
+					<Item subMenuId="search-bookmark" name="Lesezeichen"/>
+					<Item subMenuId="view-showSymbol" name="Nicht druckbare Zeichen"/>
+					<Item subMenuId="view-zoom" name="Zoom"/>
+					<Item subMenuId="view-moveCloneDocument" name="Datei verschieben/duplizieren"/>
+					<Item subMenuId="view-tab" name="Tabs"/>
+					<Item subMenuId="view-collapseLevel" name="Textblöcke schließen"/>
+					<Item subMenuId="view-uncollapseLevel" name="Textblöcke öffnen"/>
+					<Item subMenuId="view-project" name="Projektverwaltung"/>
+					<Item subMenuId="encoding-characterSets" name="Weitere"/>
+					<Item subMenuId="encoding-arabic" name="Arabisch"/>
+					<Item subMenuId="encoding-baltic" name="Baltisch"/>
+					<Item subMenuId="encoding-celtic" name="Keltisch"/>
+					<Item subMenuId="encoding-cyrillic" name="Kyrillisch"/>
+					<Item subMenuId="encoding-centralEuropean" name="Mitteleuropäisch"/>
+					<Item subMenuId="encoding-chinese" name="Chinesisch"/>
+					<Item subMenuId="encoding-easternEuropean" name="Osteuropäisch"/>
+					<Item subMenuId="encoding-greek" name="Griechisch"/>
+					<Item subMenuId="encoding-hebrew" name="Hebräisch"/>
+					<Item subMenuId="encoding-japanese" name="Japanisch"/>
+					<Item subMenuId="encoding-korean" name="Koreanisch"/>
+					<Item subMenuId="encoding-northEuropean" name="Nordeuropäisch"/>
+					<Item subMenuId="encoding-thai" name="Thai"/>
+					<Item subMenuId="encoding-turkish" name="Türkisch"/>
+					<Item subMenuId="encoding-westernEuropean" name="Westeuropäisch"/>
+					<Item subMenuId="encoding-vietnamese" name="Vietnamesisch"/>
+					<Item subMenuId="settings-import" name="Import"/>
 					<Item subMenuId="tools-md5" name="MD5"/>
-
 				</SubEntries>
 
                 <!-- all menu item -->
 				<Commands>
-					<Item id="41001" name="&amp;Neu"/>
-					<Item id="41002" name="&amp;Öffnen …"/>
-					<Item id="41019" name="E&amp;xplorer"/>
-					<Item id="41020" name="&amp;Eingabeaufforderung"/>
-					<Item id="41003" name="Schlie&amp;ßen"/>
-					<Item id="41004" name="Alle s&amp;chließen"/>
-					<Item id="41005" name="Alle s&amp;chließen bis auf aktuelle Datei"/>
-					<Item id="41009" name="Dateien &amp;links schließen"/>
-					<Item id="41018" name="Dateien &amp;rechts schließen"/>
-					<Item id="41006" name="&amp;Speichern"/>
-					<Item id="41007" name="&amp;Alle speichern"/>
-					<Item id="41008" name="Speichern &amp;unter …"/>
-					<Item id="41010" name="&amp;Drucken …"/>
-					<Item id="1001"  name="So&amp;fort drucken"/>
-					<Item id="41011" name="B&amp;eenden"/>
-					<Item id="41012" name="Sit&amp;zung öffnen …"/>
-					<Item id="41013" name="Sitzung speiche&amp;rn …"/>
-					<Item id="41014" name="Neu &amp;laden"/>
-					<Item id="41015" name="&amp;Kopie speichern unter …"/>
-					<Item id="41016" name="Von Datentr&amp;äger löschen"/>
-					<Item id="41017" name="Um&amp;benennen …"/>
+					<Item id="41001" name="Neu"/>
+					<Item id="41002" name="Öffnen …"/>
+					<Item id="41019" name="Explorer"/>
+					<Item id="41020" name="Eingabeaufforderung"/>
+					<Item id="41003" name="Schließen"/>
+					<Item id="41004" name="Alle schließen"/>
+					<Item id="41005" name="Alle schließen bis auf aktuelle Datei"/>
+					<Item id="41009" name="Dateien links schließen"/>
+					<Item id="41018" name="Dateien rechts schließen"/>
+					<Item id="41006" name="Speichern"/>
+					<Item id="41007" name="Alle speichern"/>
+					<Item id="41008" name="Speichern unter …"/>
+					<Item id="41010" name="Drucken …"/>
+					<Item id="1001"  name="Sofort drucken"/>
+					<Item id="41011" name="Beenden"/>
+					<Item id="41012" name="Sitzung öffnen …"/>
+					<Item id="41013" name="Sitzung speichern …"/>
+					<Item id="41014" name="Neu laden"/>
+					<Item id="41015" name="Kopie speichern unter …"/>
+					<Item id="41016" name="Von Datenträger löschen"/>
+					<Item id="41017" name="Umbenennen …"/>
 					<Item id="41021" name="Zuletzt geschlossene Datei wieder öffnen"/>
 					<Item id="41022" name="Verzeichnis als Arbeitsbereich öffnen"/>
 
-					<Item id="42001" name="Aus&amp;schneiden"/>
-					<Item id="42002" name="&amp;Kopieren"/>
-					<Item id="42003" name="&amp;Rückgängig"/>
-					<Item id="42004" name="&amp;Wiederherstellen"/>
-					<Item id="42005" name="&amp;Einfügen"/>
-					<Item id="42006" name="&amp;Löschen"/>
-					<Item id="42007" name="&amp;Alles auswählen"/>
-					<Item id="42020" name="Auswa&amp;hl beginnen/beenden"/>
-					<Item id="42008" name="Zeileneinzug v&amp;ergrößern"/>
-					<Item id="42009" name="Zeileneinzug ver&amp;kleinern"/>
-					<Item id="42010" name="Zeile &amp;duplizieren"/>
-					<Item id="42012" name="Zeile am Fensterrand &amp;teilen"/>
-					<Item id="42013" name="&amp;Zeilen zusammenfassen"/>
-					<Item id="42014" name="Zeile nach &amp;oben verschieben"/>
-					<Item id="42015" name="Zeile nach &amp;unten verschieben"/>
-					<Item id="42059" name="Zeilen alphabetisch au&amp;fsteigend sortieren"/>
-					<Item id="42060" name="Zeilen alphabetisch a&amp;bsteigend sortieren"/>
+					<Item id="42001" name="Ausschneiden"/>
+					<Item id="42002" name="Kopieren"/>
+					<Item id="42003" name="Rückgängig"/>
+					<Item id="42004" name="Wiederherstellen"/>
+					<Item id="42005" name="Einfügen"/>
+					<Item id="42006" name="Löschen"/>
+					<Item id="42007" name="Alles auswählen"/>
+					<Item id="42020" name="Auswahl beginnen/beenden"/>
+					<Item id="42008" name="Zeileneinzug vergrößern"/>
+					<Item id="42009" name="Zeileneinzug verkleinern"/>
+					<Item id="42010" name="Zeile duplizieren"/>
+					<Item id="42012" name="Zeile am Fensterrand teilen"/>
+					<Item id="42013" name="Zeilen zusammenfassen"/>
+					<Item id="42014" name="Zeile nach oben verschieben"/>
+					<Item id="42015" name="Zeile nach unten verschieben"/>
+					<Item id="42059" name="Zeilen alphabetisch aufsteigend sortieren"/>
+					<Item id="42060" name="Zeilen alphabetisch absteigend sortieren"/>
 					<Item id="42061" name="Zeilen als Ganzzahlen aufsteigend sortieren"/>
 					<Item id="42062" name="Zeilen als Ganzzahlen absteigend sortieren"/>
 					<Item id="42063" name="Zeilen als Dezimalzahlen (Komma) aufsteigend sortieren"/>
 					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
 					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
 					<Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-					<Item id="42016" name="In &amp;GROSSBUCHSTABEN umwandeln"/>
-					<Item id="42017" name="In &amp;kleinbuchstaben umwandeln"/>
+					<Item id="42016" name="In GROSSBUCHSTABEN umwandeln"/>
+					<Item id="42017" name="In kleinbuchstaben umwandeln"/>
 					<Item id="42067" name="Überschriftenstil"/>
 					<Item id="42068" name="Gemischter Überschriftenstil"/>
 					<Item id="42069" name="Normaler Wortstil"/>
@@ -140,158 +139,158 @@
 					<Item id="42074" name="Ordner im Explorer öffnen"/>
 					<Item id="42075" name="Suche im Internet"/>
 					<Item id="42076" name="Andere Suchmaschine wählen …"/>
-					<Item id="42018" name="Aufzeichnung s&amp;tarten"/>
-					<Item id="42019" name="Aufzeichnung st&amp;oppen"/>
-					<Item id="42021" name="Makro ausfüh&amp;ren"/>
-					<Item id="42022" name="&amp;Zeilenweise Auskommentierung umschalten"/>
-					<Item id="42023" name="Auswahl &amp;auskommentieren"/>
-					<Item id="42047" name="Auskommentierung der Auswahl au&amp;fheben"/>
-					<Item id="42024" name="Leerzeichen und Tabulatoren am Zeilen&amp;ende löschen"/>
-					<Item id="42042" name="Leerzeichen und Tabulatoren am Zeilen&amp;anfang löschen"/>
-					<Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang &amp;und -ende löschen"/>
-					<Item id="42044" name="Zeilenumbrüche in Leerzeichen &amp;konvertieren"/>
-					<Item id="42045" name="&amp;Mehrfachen Whitespace und Umbrüche entfernen"/>
-					<Item id="42046" name="Tabulatoren in &amp;Leerzeichen umwandeln"/>
-					<Item id="42054" name="Leerzeichen in &amp;Tabulatoren umwandeln (alle)"/>
-					<Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am &amp;Zeilenanfang)"/>
-					<Item id="42038" name="&amp;HTML-Inhalt einfügen"/>
-					<Item id="42039" name="&amp;RTF-Inhalt einfügen"/>
-					<Item id="42048" name="Binär-Inhalt &amp;kopieren"/>
-					<Item id="42049" name="Binär-Inhalt &amp;ausschneiden"/>
-					<Item id="42050" name="Binär-Inhalt &amp;einfügen"/>
-					<Item id="42037" name="Spalten-&amp;Modus …"/>
-					<Item id="42034" name="&amp;Block-Editor …"/>
-					<Item id="42051" name="Zeichen&amp;tabelle"/>
-					<Item id="42052" name="Zwis&amp;chenablage"/>
-					<Item id="42025" name="Aufgenommenes Makro s&amp;peichern"/>
-					<Item id="42026" name="Schreib&amp;richtung von rechts nach links"/>
-					<Item id="42027" name="Schreibrichtung von lin&amp;ks nach rechts"/>
-					<Item id="42028" name="Schreibsch&amp;utz"/>
-					<Item id="42029" name="Vollständigen &amp;Pfad kopieren"/>
-					<Item id="42030" name="Nur Datei&amp;namen kopieren"/>
-					<Item id="42031" name="Nur &amp;Verzeichnispfad kopieren"/>
-					<Item id="42032" name="Makro &amp;mehrfach ausführen …"/>
-					<Item id="42033" name="Schreibschutz-Attribut l&amp;öschen"/>
-					<Item id="42035" name="Zeilen aus&amp;kommentieren"/>
-					<Item id="42036" name="Auskommentierung der Zeilen a&amp;ufheben"/>
-					<Item id="42055" name="&amp;Leerzeilen (nur völlig leere) löschen"/>
-					<Item id="42056" name="Leerzeilen (auch mit &amp;Whitespace) löschen"/>
-					<Item id="42057" name="Leerzeile &amp;über aktueller Zeile einfügen"/>
-					<Item id="42058" name="Leerzeile u&amp;nter aktueller Zeile einfügen"/>
-					<Item id="43001" name="&amp;Suchen …"/>
-					<Item id="43002" name="&amp;Weitersuchen"/>
-					<Item id="43003" name="&amp;Ersetzen …"/>
-					<Item id="43004" name="&amp;Gehe zu …"/>
-					<Item id="43005" name="&amp;Lesezeichen setzen/löschen"/>
-					<Item id="43006" name="&amp;Nächstes Lesezeichen"/>
-					<Item id="43007" name="&amp;Vorheriges Lesezeichen"/>
-					<Item id="43008" name="Alle Lesezeichen l&amp;öschen"/>
-					<Item id="43018" name="Zeilen mit Lesezeichen &amp;ausschneiden"/>
-					<Item id="43019" name="Zeilen mit Lesezeichen &amp;kopieren"/>
-					<Item id="43020" name="&amp;Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
-					<Item id="43021" name="Zeilen mit Lesezeichen lös&amp;chen"/>
-					<Item id="43051" name="Zeilen &amp;ohne Lesezeichen löschen"/>
-					<Item id="43050" name="Lesezeichen inver&amp;tieren"/>
-					<Item id="43052" name="Suche nach &amp;Zeichencodes …"/>
-					<Item id="43053" name="&amp;Alles zwischen Klammern auswählen"/>
-					<Item id="43009" name="Suche zugehörige &amp;Klammer"/>
-					<Item id="43010" name="&amp;Rückwärts suchen"/>
-					<Item id="43011" name="&amp;Inkrementelle Suche"/>
-					<Item id="43013" name="In &amp;Dateien suchen …"/>
-					<Item id="43014" name="Wort am Cursor suchen (&amp;ohne Verlauf)"/>
-					<Item id="43015" name="Wor&amp;t am Cursor rückwärts suchen (ohne Verlauf)"/>
-					<Item id="43022" name="Hervorhebung &amp;1"/>
-					<Item id="43023" name="Hervorhebung &amp;1 entfernen"/>
-					<Item id="43024" name="Hervorhebung &amp;2"/>
-					<Item id="43025" name="Hervorhebung &amp;2 entfernen"/>
-					<Item id="43026" name="Hervorhebung &amp;3"/>
-					<Item id="43027" name="Hervorhebung &amp;3 entfernen"/>
-					<Item id="43028" name="Hervorhebung &amp;4"/>
-					<Item id="43029" name="Hervorhebung &amp;4 entfernen"/>
-					<Item id="43030" name="Hervorhebung &amp;5"/>
-					<Item id="43031" name="Hervorhebung &amp;5 entfernen"/>
-					<Item id="43032" name="&amp;Alle entfernen"/>
-					<Item id="43033" name="Hervorhebung &amp;1"/>
-					<Item id="43034" name="Hervorhebung &amp;2"/>
-					<Item id="43035" name="Hervorhebung &amp;3"/>
-					<Item id="43036" name="Hervorhebung &amp;4"/>
-					<Item id="43037" name="Hervorhebung &amp;5"/>
-					<Item id="43038" name="Hervorhebung aus &amp;Suche"/>
-					<Item id="43039" name="Hervorhebung &amp;1"/>
-					<Item id="43040" name="Hervorhebung &amp;2"/>
-					<Item id="43041" name="Hervorhebung &amp;3"/>
-					<Item id="43042" name="Hervorhebung &amp;4"/>
-					<Item id="43043" name="Hervorhebung &amp;5"/>
-					<Item id="43044" name="Hervorhebung aus &amp;Suche"/>
-					<Item id="43045" name="Suchergebnis-&amp;Fenster"/>
-					<Item id="43046" name="Zum n&amp;ächsten Suchergebnis springen"/>
-					<Item id="43047" name="Zum vorherigen S&amp;uchergebnis springen"/>
-					<Item id="43048" name="Auswahl oder Wort am &amp;Cursor suchen"/>
-					<Item id="43049" name="Wort am Cursor r&amp;ückwärts suchen"/>
-					<Item id="43054" name="&amp;Hervorheben …"/>
-					<Item id="44009" name="&amp;Post-It"/>
-					<Item id="44010" name="A&amp;lle Textblöcke schließen"/>
-					<Item id="44019" name="&amp;Alle Zeichen anzeigen"/>
-					<Item id="44020" name="&amp;Einrückung anzeigen"/>
-					<Item id="44022" name="Automatischer Zeilen&amp;umbruch"/>
-					<Item id="44023" name="Schrift ver&amp;größern"/>
-					<Item id="44024" name="Schrift ver&amp;kleinern"/>
-					<Item id="44025" name="&amp;Leerzeichen und Tabulatoren anzeigen"/>
-					<Item id="44026" name="Zeilenende anze&amp;igen"/>
-					<Item id="44029" name="Alle Textblöcke &amp;öffnen"/>
-					<Item id="44030" name="Textblock schlie&amp;ßen"/>
-					<Item id="44031" name="Textblock öff&amp;nen"/>
-					<Item id="44049" name="Datei-&amp;Info …"/>
-					<Item id="44080" name="&amp;Miniaturansicht"/>
-					<Item id="44084" name="&amp;Funktionsliste"/>
+					<Item id="42018" name="Aufzeichnung starten"/>
+					<Item id="42019" name="Aufzeichnung stoppen"/>
+					<Item id="42021" name="Makro ausführen"/>
+					<Item id="42022" name="Zeilenweise Auskommentierung umschalten"/>
+					<Item id="42023" name="Auswahl auskommentieren"/>
+					<Item id="42047" name="Auskommentierung der Auswahl aufheben"/>
+					<Item id="42024" name="Leerzeichen und Tabulatoren am Zeilenende löschen"/>
+					<Item id="42042" name="Leerzeichen und Tabulatoren am Zeilenanfang löschen"/>
+					<Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang und -ende löschen"/>
+					<Item id="42044" name="Zeilenumbrüche in Leerzeichen konvertieren"/>
+					<Item id="42045" name="Mehrfachen Whitespace und Umbrüche entfernen"/>
+					<Item id="42046" name="Tabulatoren in Leerzeichen umwandeln"/>
+					<Item id="42054" name="Leerzeichen in Tabulatoren umwandeln (alle)"/>
+					<Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am Zeilenanfang)"/>
+					<Item id="42038" name="HTML-Inhalt einfügen"/>
+					<Item id="42039" name="RTF-Inhalt einfügen"/>
+					<Item id="42048" name="Binär-Inhalt kopieren"/>
+					<Item id="42049" name="Binär-Inhalt ausschneiden"/>
+					<Item id="42050" name="Binär-Inhalt einfügen"/>
+					<Item id="42037" name="Spalten-Modus …"/>
+					<Item id="42034" name="Block-Editor …"/>
+					<Item id="42051" name="Zeichentabelle"/>
+					<Item id="42052" name="Zwischenablage"/>
+					<Item id="42025" name="Aufgenommenes Makro speichern"/>
+					<Item id="42026" name="Schreibrichtung von rechts nach links"/>
+					<Item id="42027" name="Schreibrichtung von links nach rechts"/>
+					<Item id="42028" name="Schreibschutz"/>
+					<Item id="42029" name="Vollständigen Pfad kopieren"/>
+					<Item id="42030" name="Nur Dateinamen kopieren"/>
+					<Item id="42031" name="Nur Verzeichnispfad kopieren"/>
+					<Item id="42032" name="Makro mehrfach ausführen …"/>
+					<Item id="42033" name="Schreibschutz-Attribut löschen"/>
+					<Item id="42035" name="Zeilen auskommentieren"/>
+					<Item id="42036" name="Auskommentierung der Zeilen aufheben"/>
+					<Item id="42055" name="Leerzeilen (nur völlig leere) löschen"/>
+					<Item id="42056" name="Leerzeilen (auch mit Whitespace) löschen"/>
+					<Item id="42057" name="Leerzeile über aktueller Zeile einfügen"/>
+					<Item id="42058" name="Leerzeile unter aktueller Zeile einfügen"/>
+					<Item id="43001" name="Suchen …"/>
+					<Item id="43002" name="Vorwärts Suchen"/>
+					<Item id="43003" name="Ersetzen …"/>
+					<Item id="43004" name="Gehe zu …"/>
+					<Item id="43005" name="Lesezeichen setzen/löschen"/>
+					<Item id="43006" name="Nächstes Lesezeichen"/>
+					<Item id="43007" name="Vorheriges Lesezeichen"/>
+					<Item id="43008" name="Alle Lesezeichen löschen"/>
+					<Item id="43018" name="Zeilen mit Lesezeichen ausschneiden"/>
+					<Item id="43019" name="Zeilen mit Lesezeichen kopieren"/>
+					<Item id="43020" name="Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
+					<Item id="43021" name="Zeilen mit Lesezeichen löschen"/>
+					<Item id="43051" name="Zeilen ohne Lesezeichen löschen"/>
+					<Item id="43050" name="Lesezeichen invertieren"/>
+					<Item id="43052" name="Suche nach Zeichencodes …"/>
+					<Item id="43053" name="Alles zwischen Klammern auswählen"/>
+					<Item id="43009" name="Suche zugehörige Klammer"/>
+					<Item id="43010" name="Rückwärts suchen"/>
+					<Item id="43011" name="Inkrementelle Suche"/>
+					<Item id="43013" name="In Dateien suchen …"/>
+					<Item id="43014" name="Wort am Cursor suchen (ohne Verlauf)"/>
+					<Item id="43015" name="Wort am Cursor rückwärts suchen (ohne Verlauf)"/>
+					<Item id="43022" name="Hervorhebung 1"/>
+					<Item id="43023" name="Hervorhebung 1 entfernen"/>
+					<Item id="43024" name="Hervorhebung 2"/>
+					<Item id="43025" name="Hervorhebung 2 entfernen"/>
+					<Item id="43026" name="Hervorhebung 3"/>
+					<Item id="43027" name="Hervorhebung 3 entfernen"/>
+					<Item id="43028" name="Hervorhebung 4"/>
+					<Item id="43029" name="Hervorhebung 4 entfernen"/>
+					<Item id="43030" name="Hervorhebung 5"/>
+					<Item id="43031" name="Hervorhebung 5 entfernen"/>
+					<Item id="43032" name="Alle entfernen"/>
+					<Item id="43033" name="Hervorhebung 1"/>
+					<Item id="43034" name="Hervorhebung 2"/>
+					<Item id="43035" name="Hervorhebung 3"/>
+					<Item id="43036" name="Hervorhebung 4"/>
+					<Item id="43037" name="Hervorhebung 5"/>
+					<Item id="43038" name="Hervorhebung aus Suche"/>
+					<Item id="43039" name="Hervorhebung 1"/>
+					<Item id="43040" name="Hervorhebung 2"/>
+					<Item id="43041" name="Hervorhebung 3"/>
+					<Item id="43042" name="Hervorhebung 4"/>
+					<Item id="43043" name="Hervorhebung 5"/>
+					<Item id="43044" name="Hervorhebung aus Suche"/>
+					<Item id="43045" name="Suchergebnis-Fenster"/>
+					<Item id="43046" name="Zum nächsten Suchergebnis springen"/>
+					<Item id="43047" name="Zum vorherigen Suchergebnis springen"/>
+					<Item id="43048" name="Auswahl oder Wort am Cursor suchen"/>
+					<Item id="43049" name="Wort am Cursor rückwärts suchen"/>
+					<Item id="43054" name="Hervorheben …"/>
+					<Item id="44009" name="Post-It"/>
+					<Item id="44010" name="Alle Textblöcke schließen"/>
+					<Item id="44019" name="Alle Zeichen anzeigen"/>
+					<Item id="44020" name="Einrückung anzeigen"/>
+					<Item id="44022" name="Automatischer Zeilenumbruch"/>
+					<Item id="44023" name="Schrift vergrößern"/>
+					<Item id="44024" name="Schrift verkleinern"/>
+					<Item id="44025" name="Leerzeichen und Tabulatoren anzeigen"/>
+					<Item id="44026" name="Zeilenende anzeigen"/>
+					<Item id="44029" name="Alle Textblöcke öffnen"/>
+					<Item id="44030" name="Textblock schließen"/>
+					<Item id="44031" name="Textblock öffnen"/>
+					<Item id="44049" name="Datei-Info …"/>
+					<Item id="44080" name="Miniaturansicht"/>
+					<Item id="44084" name="Funktionsliste"/>
 					<Item id="44085" name="Verzeichnis als Arbeitsbereich"/>
-					<Item id="44086" name="&amp;1. Tab"/>
-					<Item id="44087" name="&amp;2. Tab"/>
-					<Item id="44088" name="&amp;3. Tab"/>
-					<Item id="44089" name="&amp;4. Tab"/>
-					<Item id="44090" name="&amp;5. Tab"/>
-					<Item id="44091" name="&amp;6. Tab"/>
-					<Item id="44092" name="&amp;7. Tab"/>
-					<Item id="44093" name="&amp;8. Tab"/>
-					<Item id="44094" name="&amp;9. Tab"/>
-					<Item id="44095" name="&amp;Nächster Tab"/>
-					<Item id="44096" name="&amp;Vorheriger Tab"/>
+					<Item id="44086" name="1. Tab"/>
+					<Item id="44087" name="2. Tab"/>
+					<Item id="44088" name="3. Tab"/>
+					<Item id="44089" name="4. Tab"/>
+					<Item id="44090" name="5. Tab"/>
+					<Item id="44091" name="6. Tab"/>
+					<Item id="44092" name="7. Tab"/>
+					<Item id="44093" name="8. Tab"/>
+					<Item id="44094" name="9. Tab"/>
+					<Item id="44095" name="Nächster Tab"/>
+					<Item id="44096" name="Vorheriger Tab"/>
 					<Item id="44097" name="Überwachen (tail -f)"/>
 					<Item id="44098" name="Tab vorwärts bewegen"/>
 					<Item id="44099" name="Tab rückwärts bewegen"/>
-					<Item id="44032" name="Voll&amp;bild"/>
-					<Item id="44033" name="&amp;Standardgröße"/>
-					<Item id="44034" name="Immer im Vorder&amp;grund halten"/>
-					<Item id="44035" name="S&amp;ynchrones vertikales Scrollen"/>
-					<Item id="44036" name="Synchrones &amp;horizontales Scrollen"/>
-					<Item id="44041" name="Symbol bei automatischem &amp;Umbruch"/>
-					<Item id="44072" name="&amp;Zur anderen Ansicht wechseln"/>
-					<Item id="44081" name="Projektfenster &amp;1"/>
-					<Item id="44082" name="Projektfenster &amp;2"/>
-					<Item id="44083" name="Projektfenster &amp;3"/>
-					<Item id="45001" name="Konvertiere zu &amp;Windows (CR+LF)"/>
-					<Item id="45002" name="Konvertiere zu &amp;UNIX (LF)"/>
-					<Item id="45003" name="Konvertiere zu &amp;Mac (CR)"/>
-					<Item id="45004" name="&amp;ANSI"/>
-					<Item id="45005" name="UTF-&amp;8"/>
-					<Item id="45006" name="UCS-2 &amp;Big Endian"/>
-					<Item id="45007" name="UCS-2 &amp;Little Endian"/>
-					<Item id="45008" name="UTF-8 &amp;ohne BOM"/>
-					<Item id="45009" name="Ko&amp;nvertiere zu ANSI"/>
-					<Item id="45010" name="Kon&amp;vertiere zu UTF-8 ohne BOM"/>
-					<Item id="45011" name="Konv&amp;ertiere zu UTF-8"/>
-					<Item id="45012" name="Konve&amp;rtiere zu UCS-2 Big Endian"/>
-					<Item id="45013" name="Konver&amp;tiere zu UCS-2 Little Endian"/>
-					<Item id="44011" name="Benutzerdefinierte Spra&amp;che …"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="44012" name="Zeilennummernrand ausb&amp;lenden"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="44013" name="Lesezeichenrand ausb&amp;lenden"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="44014" name="Codefaltung ausb&amp;lenden"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="47008" name="In&amp;halt …"/>					<!-- kommt im englischen nicht oder nicht mehr vor -->
+					<Item id="44032" name="Vollbild"/>
+					<Item id="44033" name="Standardgröße"/>
+					<Item id="44034" name="Immer im Vordergrund halten"/>
+					<Item id="44035" name="Synchrones vertikales Scrollen"/>
+					<Item id="44036" name="Synchrones horizontales Scrollen"/>
+					<Item id="44041" name="Symbol bei automatischem Umbruch"/>
+					<Item id="44072" name="Zur anderen Ansicht wechseln"/>
+					<Item id="44081" name="Projektfenster 1"/>
+					<Item id="44082" name="Projektfenster 2"/>
+					<Item id="44083" name="Projektfenster 3"/>
+					<Item id="45001" name="Konvertiere zu Windows (CR+LF)"/>
+					<Item id="45002" name="Konvertiere zu UNIX (LF)"/>
+					<Item id="45003" name="Konvertiere zu Mac (CR)"/>
+					<Item id="45004" name="ANSI"/>
+					<Item id="45005" name="UTF-8"/>
+					<Item id="45006" name="UCS-2 Big Endian"/>
+					<Item id="45007" name="UCS-2 Little Endian"/>
+					<Item id="45008" name="UTF-8 ohne BOM"/>
+					<Item id="45009" name="Konvertiere zu ANSI"/>
+					<Item id="45010" name="Konvertiere zu UTF-8 ohne BOM"/>
+					<Item id="45011" name="Konvertiere zu UTF-8"/>
+					<Item id="45012" name="Konvertiere zu UCS-2 Big Endian"/>
+					<Item id="45013" name="Konvertiere zu UCS-2 Little Endian"/>
+					<Item id="44011" name="Benutzerdefinierte Sprache …"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
+					<Item id="44012" name="Zeilennummernrand ausblenden"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
+					<Item id="44013" name="Lesezeichenrand ausblenden"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
+					<Item id="44014" name="Codefaltung ausblenden"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
+					<Item id="47008" name="Inhalt …"/>					<!-- kommt im englischen nicht oder nicht mehr vor -->
 
-					<Item id="10001" name="In zweite Ansicht &amp;verschieben"/>
-					<Item id="10002" name="In zweite Ansicht &amp;duplizieren"/>
-					<Item id="10003" name="In &amp;neue Instanz verschieben"/>
-					<Item id="10004" name="In neue Instan&amp;z duplizieren"/>
+					<Item id="10001" name="In zweite Ansicht verschieben"/>
+					<Item id="10002" name="In zweite Ansicht duplizieren"/>
+					<Item id="10003" name="In neue Instanz verschieben"/>
+					<Item id="10004" name="In neue Instanz duplizieren"/>
 
 					<Item id="45060" name="Big5 (Traditionell)"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
 					<Item id="45061" name="GB2312 (Vereinfacht)"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
@@ -306,107 +305,108 @@
 					<Item id="46016" name="Normaler Text"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
 					<Item id="46017" name="Ressourcen-Datei"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
 
-					<Item id="46001" name="&amp;Stile …"/>
-					<Item id="46150" name="Eigene Sprache &amp;definieren …"/>
+					<Item id="46001" name="Stile …"/>
+					<Item id="46150" name="Eigene Sprache definieren …"/>
 					<Item id="46080" name="Benutzerdefiniert"/>
-					<Item id="47000" name="&amp;Info …"/>
-					<Item id="47010" name="&amp;Kommandozeilenparameter …"/>
-					<Item id="47001" name="Notepad++ im &amp;Web"/>
-					<Item id="47002" name="Notepad++ bei &amp;GitHub"/>
+					<Item id="47000" name="Info …"/>
+					<Item id="47010" name="Kommandozeilenparameter …"/>
+					<Item id="47001" name="Notepad++ im Web"/>
+					<Item id="47002" name="Notepad++ bei GitHub"/>
 					<Item id="47003" name="Online-Dokumentation"/>
 					<Item id="47004" name="Notepad++ Online-Forum"/>
-					<Item id="47011" name="&amp;Support im Chat"/>
+					<Item id="47011" name="Support im Chat"/>
 					<Item id="47012" name="Debug-Info"/>
-					<Item id="47005" name="&amp;Erweiterungen"/>
-					<Item id="47006" name="Notepad++ &amp;aktualisieren"/>
-					<Item id="47009" name="&amp;Proxy für Updater einstellen …"/>
-					<Item id="48005" name="&amp;Plugin(s) importieren …"/>
-					<Item id="48006" name="&amp;Design(s) importieren …"/>
-					<Item id="48018" name="&amp;Kontextmenü anpassen …"/>
-					<Item id="48009" name="&amp;Tastatur …"/>
-					<Item id="48011" name="&amp;Optionen …"/>
+					<Item id="47005" name="Erweiterungen"/>
+					<Item id="47006" name="Notepad++ aktualisieren"/>
+					<Item id="47009" name="Proxy für Updater einstellen …"/>
+					<Item id="48005" name="Plugin(s) importieren …"/>
+					<Item id="48006" name="Design(s) importieren …"/>
+					<Item id="48018" name="Kontextmenü anpassen …"/>
+					<Item id="48009" name="Tastatur …"/>
+					<Item id="48011" name="Optionen …"/>
 					<Item id="48501" name="Erstelle …"/>
 					<Item id="48502" name="Erstelle aus Dateien …"/>
 					<Item id="48503" name="Erstelle in die Zwischenablage"/>
 
-					<Item id="49000" name="Externes Programm &amp;ausführen …"/>
+					<Item id="49000" name="Externes Programm ausführen …"/>
 
-					<Item id="50000" name="&amp;Funktionsvervollständigung"/>
-					<Item id="50001" name="&amp;Wortvervollständigung"/>
-					<Item id="50002" name="Funktions&amp;parameter anzeigen"/>
-					<Item id="50006" name="&amp;Dateipfad vervollständigen"/>
-					<Item id="44042" name="Zeilen &amp;ausblenden"/>
-					<Item id="42040" name="Alle zule&amp;tzt verwendeten Dateien öffnen"/>
-					<Item id="42041" name="L&amp;iste löschen"/>
-					<Item id="48016" name="Shortcut &amp;ändern/Makro löschen …"/>
-					<Item id="48017" name="Shortcut &amp;ändern/Befehl löschen …"/>
+					<Item id="50000" name="Funktionsvervollständigung"/>
+					<Item id="50001" name="Wortvervollständigung"/>
+					<Item id="50002" name="Funktionsparameter anzeigen"/>
+					<Item id="50006" name="Dateipfad vervollständigen"/>
+					<Item id="44042" name="Zeilen ausblenden"/>
+					<Item id="42040" name="Alle zuletzt verwendeten Dateien öffnen"/>
+					<Item id="42041" name="Liste löschen"/>
+					<Item id="48016" name="Shortcut ändern/Makro löschen …"/>
+					<Item id="48017" name="Shortcut ändern/Befehl löschen …"/>
 				</Commands>
 			</Main>
 			<Splitter>
 			</Splitter>
 			<TabBar>
-				<Item CMID="0"  name="S&amp;chließen"/>
-				<Item CMID="1"  name="&amp;Alle anderen schließen"/>
-				<Item CMID="2"  name="&amp;Speichern"/>
-				<Item CMID="3"  name="Speichern &amp;unter …"/>
-				<Item CMID="4"  name="&amp;Drucken"/>
-				<Item CMID="5"  name="In zweite Ansicht &amp;verschieben"/>
-				<Item CMID="6"  name="In zw&amp;eite Ansicht duplizieren"/>
-				<Item CMID="7"  name="Vollständigen Pfad &amp;kopieren"/>
-				<Item CMID="8"  name="Nur Datei&amp;namen kopieren"/>
-				<Item CMID="9"  name="Nur Verzeichnis&amp;pfad kopieren"/>
-				<Item CMID="10" name="Um&amp;benennen …"/>
-				<Item CMID="11" name="L&amp;öschen"/>
-				<Item CMID="12" name="Sch&amp;reibschutz"/>
-				<Item CMID="13" name="Schreibschutz au&amp;fheben"/>
-				<Item CMID="14" name="In neue &amp;Instanz verschieben"/>
-				<Item CMID="15" name="In neue Instan&amp;z duplizieren"/>
-				<Item CMID="16" name="Neu &amp;laden"/>
-				<Item CMID="17" name="Dateien links schlie&amp;ßen"/>
-				<Item CMID="18" name="Dateien rech&amp;ts schließen"/>
-				<Item CMID="19" name="Ordner im E&amp;xplorer öffnen"/>
-				<Item CMID="20" name="Kommandozeile im aktuellen &amp;Ordner öffnen"/>
+				<Item CMID="0"  name="Schließen"/>
+				<Item CMID="1"  name="Alle anderen schließen"/>
+				<Item CMID="2"  name="Speichern"/>
+				<Item CMID="3"  name="Speichern unter …"/>
+				<Item CMID="4"  name="Drucken"/>
+				<Item CMID="5"  name="In zweite Ansicht verschieben"/>
+				<Item CMID="6"  name="In zweite Ansicht duplizieren"/>
+				<Item CMID="7"  name="Vollständigen Pfad kopieren"/>
+				<Item CMID="8"  name="Nur Dateinamen kopieren"/>
+				<Item CMID="9"  name="Nur Verzeichnispfad kopieren"/>
+				<Item CMID="10" name="Umbenennen …"/>
+				<Item CMID="11" name="Löschen"/>
+				<Item CMID="12" name="Schreibschutz"/>
+				<Item CMID="13" name="Schreibschutz aufheben"/>
+				<Item CMID="14" name="In neue Instanz verschieben"/>
+				<Item CMID="15" name="In neue Instanz duplizieren"/>
+				<Item CMID="16" name="Neu laden"/>
+				<Item CMID="17" name="Dateien links schließen"/>
+				<Item CMID="18" name="Dateien rechts schließen"/>
+				<Item CMID="19" name="Ordner im Explorer öffnen"/>
+				<Item CMID="20" name="Kommandozeile im aktuellen Ordner öffnen"/>
 			</TabBar>
 		</Menu>
 
 		<Dialog>
 			<Find title="Suchen und ersetzen" titleFind="Suchen" titleReplace="Ersetzen" titleFindInFiles="In Dateien suchen" titleMark="Hervorheben">
-				<Item id="1"    name="&amp;Weitersuchen"/>
-				<Item id="2"    name="&amp;Schließen"/>
-				<Item id="1620" name="Suchen &amp;nach:"/>
-				<Item id="1603" name="Nur &amp;ganze Wörter suchen"/>
-				<Item id="1604" name="Groß-/&amp;Kleinschreibung beachten"/>
-				<Item id="1605" name="&amp;Reguläre Ausdrücke"/>
-				<Item id="1606" name="Am Ende von vorne &amp;beginnen"/>
-				<Item id="1612" name="R&amp;ückwärts"/>
-				<Item id="1613" name="&amp;Vorwärts"/>
-				<Item id="1614" name="Z&amp;ählen"/>
-				<Item id="1615" name="&amp;Alle suchen"/>
-				<Item id="1616" name="&amp;Lesezeichen setzen"/>
-				<Item id="1618" name="Für &amp;jede Suche löschen"/>
+				<Item id="1"    name="Suchen  ›"/>
+				<Item id="1721" name="‹  Suchen"/>
+                <Item id="2"    name="Schließen"/>
+				<Item id="1620" name="Suchen nach:"/>
+				<Item id="1603" name="Nur ganze Wörter suchen"/>
+				<Item id="1604" name="Groß-/Kleinschreibung beachten"/>
+				<Item id="1605" name="Reguläre Ausdrücke"/>
+				<Item id="1606" name="Am Ende von vorne beginnen"/>
+				<Item id="1612" name="Rückwärts"/>
+				<Item id="1613" name="Vorwärts"/>
+				<Item id="1614" name="Zählen"/>
+				<Item id="1615" name="Alle suchen"/>
+				<Item id="1616" name="Lesezeichen setzen"/>
+				<Item id="1618" name="Für jede Suche löschen"/>
 				<Item id="1621" name="Suchrichtung"/>
-				<Item id="1611" name="Erset&amp;zen durch:"/>
-				<Item id="1608" name="&amp;Ersetzen"/>
-				<Item id="1609" name="Alle erse&amp;tzen"/>
+				<Item id="1611" name="Ersetzen durch:"/>
+				<Item id="1608" name="Ersetzen"/>
+				<Item id="1609" name="Alle ersetzen"/>
 				<Item id="1687" name="Wenn inaktiv"/>
 				<Item id="1688" name="Immer"/>
-				<Item id="1632" name="In &amp;Auswahl"/>
+				<Item id="1632" name="In Auswahl"/>
 				<Item id="1633" name="Zurücksetzen"/>
 				<Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
-				<Item id="1636" name="In &amp;offenen Dateien suchen"/>
+				<Item id="1636" name="In offenen Dateien suchen"/>
 				<Item id="1654" name="Filter:"/>
 				<Item id="1655" name="Verzeichnis:"/>
-				<Item id="1656" name="Alle su&amp;chen"/>
-				<Item id="1658" name="&amp;Unterverzeichnisse"/>
-				<Item id="1659" name="&amp;Versteckte Ordner"/>
+				<Item id="1656" name="Alle suchen"/>
+				<Item id="1658" name="Unterverzeichnisse"/>
+				<Item id="1659" name="Versteckte Ordner"/>
 				<Item id="1624" name="Suchmodus"/>
-				<Item id="1625" name="Norma&amp;l"/>
-				<Item id="1626" name="Erwe&amp;itert (\n, \r, \t, \0, \x…)"/>
+				<Item id="1625" name="Normal"/>
+				<Item id="1626" name="Erweitert (\n, \r, \t, \0, \x…)"/>
 				<Item id="1660" name="Ersetzen in Dateien"/>
-				<Item id="1661" name="&amp;Ordner der akt. Datei"/>
-				<Item id="1641" name="Alle in aktiver &amp;Datei suchen"/>
+				<Item id="1661" name="Ordner der akt. Datei"/>
+				<Item id="1641" name="Alle in aktiver Datei suchen"/>
 				<Item id="1686" name="Transparenz"/>
-				<Item id="1703" name="&amp;. findet \r und \n"/>
+				<Item id="1703" name=". findet \r und \n"/>
 				<Item id="1627" name="Unten"/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
 				<Item id="1637" name="In Dateien suchen"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
 				<Item id="1640" name="Umschaltdialog"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
@@ -414,22 +414,22 @@
 
 			<FindCharsInRange title="Suche nach Zeichencodes">
 				<Item id="-1"   name="–"/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
-				<Item id="2"    name="S&amp;chließen"/>
-				<Item id="2901" name="&amp;Nicht-ASCII-Zeichen (128–255)"/>
-				<Item id="2902" name="&amp;ASCII-Zeichen (0–127)"/>
-				<Item id="2903" name="&amp;Benutzerdefiniert:"/>
-				<Item id="2906" name="A&amp;ufwärts"/>
-				<Item id="2907" name="Ab&amp;wärts"/>
+				<Item id="2"    name="Schließen"/>
+				<Item id="2901" name="Nicht-ASCII-Zeichen (128–255)"/>
+				<Item id="2902" name="ASCII-Zeichen (0–127)"/>
+				<Item id="2903" name="Benutzerdefiniert:"/>
+				<Item id="2906" name="Aufwärts"/>
+				<Item id="2907" name="Abwärts"/>
 				<Item id="2908" name="Suchrichtung"/>
-				<Item id="2909" name="Am Ende von &amp;vorne beginnen"/>
-				<Item id="2910" name="&amp;Suchen"/>
+				<Item id="2909" name="Am Ende von vorne beginnen"/>
+				<Item id="2910" name="Suchen"/>
 			</FindCharsInRange>
 
 			<GoToLine title="Gehe zu">
-				<Item id="2007" name="&amp;Zeile"/>
-				<Item id="2008" name="Z&amp;eichen"/>
-				<Item id="1"    name="&amp;Gehe zu"/>
-				<Item id="2"    name="&amp;Abbrechen"/>
+				<Item id="2007" name="Zeile"/>
+				<Item id="2008" name="Zeichen"/>
+				<Item id="1"    name="Gehe zu"/>
+				<Item id="2"    name="Abbrechen"/>
 				<Item id="2004" name="Aktuell:"/>
 				<Item id="2005" name="Ziel:"/>
 				<Item id="2006" name="Insgesamt in der Datei:"/>
@@ -437,10 +437,10 @@
 
 			<Run title="Ausführen …">
 				<Item id="1903" name="Auszuführendes Programm hier eingeben"/>
-				<Item id="1"    name="&amp;Ausführen"/>
-				<Item id="2"    name="A&amp;bbrechen"/>
-				<Item id="1904" name="&amp;Speichern"/>
-				<Item id="1901" name=".&amp;.."/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
+				<Item id="1"    name="Ausführen"/>
+				<Item id="2"    name="Abbrechen"/>
+				<Item id="1904" name="Speichern"/>
+				<Item id="1901" name="..."/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
 			</Run>
 
 			<MD5FromFilesDlg title="Erstelle MD5-Hashwert aus Dateien">
@@ -458,7 +458,7 @@
 			<StyleConfig title="Stile">
 				<Item id="1"    name="Übernehmen"/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
 				<Item id="2"    name="Abbrechen"/>
-				<Item id="2301" name="Speichern &amp;&amp; Schließen"/>
+				<Item id="2301" name="Speichern && Schließen"/>
 				<Item id="2303" name="Transparenz"/>
 				<Item id="2306" name="Design:"/>
 				<SubDialog>
@@ -531,10 +531,10 @@
 					<Item id="25026" name="Operatoren 1"/>
 					<Item id="25027" name="Operatoren 2"/>
 					<Item id="25028" name="Zahlen"/>
-					<Item id="1"     name="&amp;OK"/>
-					<Item id="2"     name="A&amp;bbrechen"/>
+					<Item id="1"     name="OK"/>
+					<Item id="2"     name="Abbrechen"/>
 				</StylerDialog>
-				<Folder title="Textblöcke &amp;&amp; Voreinstellung">
+				<Folder title="Textblöcke && Voreinstellung">
 					<Item id="21101" name="Standardschrift"/>
 					<Item id="21102" name="Stil"/>
 					<Item id="21105" name="Dokumentation"/>
@@ -582,7 +582,7 @@
 					<Item id="22572" name="Stil"/>
 					<Item id="22622" name="Stil"/>
 				</Keywords>
-				<Comment title="Kommentare &amp;&amp; Zahlen">
+				<Comment title="Kommentare && Zahlen">
 					<Item id="23002" name="Am Zeilenanfang Zeilenkommentar erzwingen"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
 					<Item id="23003" name="Position von Zeilenkommentaren"/>
 					<Item id="23004" name="Überall erlauben"/>
@@ -612,7 +612,7 @@
 					<Item id="23246" name="Komma"/>
 					<Item id="23247" name="Beides"/>
 				</Comment>
-				<Operator title="Operatoren &amp;&amp; Trenner">
+				<Operator title="Operatoren && Trenner">
 					<Item id="24101" name="Operatoren"/>
 					<Item id="24113" name="Stil"/>
 					<Item id="24116" name="Operatoren 1"/>
@@ -660,7 +660,7 @@
 				</Operator>
 			</UserDefine>
 			<Preference title="Optionen">
-				<Item id="6001" name="S&amp;chließen"/>
+				<Item id="6001" name="Schließen"/>
 				<Global title="Oberfläche 1">
 					<Item id="6101" name="Symbolleiste"/>
 					<Item id="6102" name="Ausblenden"/>
@@ -868,11 +868,10 @@
 					<Item id="6252" name="Anfang"/>
 					<Item id="6255" name="Ende"/>
 					<Item id="6256" name="Über mehrere Zeilen"/>
-					<Item id="6257" name="bla bla bla bla bla bla"/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="6258" name="bla bla bla bla bla bla bla bla bla bla bla bla"/>	<!-- kommt im englischen nicht oder nicht mehr vor -->
 					<Item id="6161" name="Liste der Wortzeichen (Word character list)"/>
 					<Item id="6162" name="Verwende die ursprüngliche Liste der Wortzeichen"/>
-					<Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0a;(nicht verwenden wenn man nicht sicher ist)"/>				</Delimiter>
+					<Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0a;(nicht verwenden wenn man nicht sicher ist)"/>
+                    </Delimiter>
 
 				<Cloud title="Cloud-Einstellungen">
 					<Item id="6262" name="Einstellungen in der Cloud speichern"/>
@@ -915,34 +914,34 @@
 					<Item id="6346" name="Momentaufnahme in Miniaturansicht"/></MISC>
 			</Preference>
 			<MultiMacro title="Makro mehrfach ausführen">
-				<Item id="1"    name="Ausfüh&amp;ren"/>
-				<Item id="2"    name="A&amp;bbrechen"/>
+				<Item id="1"    name="Ausführen"/>
+				<Item id="2"    name="Abbrechen"/>
 				<Item id="8006" name="Makro:"/>
-				<Item id="8001" name="&amp;Makro"/>
+				<Item id="8001" name="Makro"/>
 				<Item id="8005" name="mal ausführen"/>
-				<Item id="8002" name="Bis zum &amp;Ende der Datei ausführen"/>
+				<Item id="8002" name="Bis zum Ende der Datei ausführen"/>
 			</MultiMacro>
 			<Window title="Fenster">
-				<Item id="1"    name="&amp;Aktivieren"/>
-				<Item id="2"    name="&amp;OK"/>
-				<Item id="7002" name="S&amp;peichern"/>
-				<Item id="7003" name="Tab s&amp;chließen"/>
-				<Item id="7004" name="&amp;Sortiere Tabs"/>
+				<Item id="1"    name="Aktivieren"/>
+				<Item id="2"    name="OK"/>
+				<Item id="7002" name="Speichern"/>
+				<Item id="7003" name="Tab schließen"/>
+				<Item id="7004" name="Sortiere Tabs"/>
 			</Window>
 			<ColumnEditor title="Block-Editor">
 				<Item id="2023" name="Text einfügen"/>
 				<Item id="2033" name="Zahlen einfügen"/>
 				<Item id="2030" name="Beginnen mit:"/>
 				<Item id="2031" name="Erhöhen um:"/>
-				<Item id="2035" name="Führende &amp;Nullen"/>
+				<Item id="2035" name="Führende Nullen"/>
 				<Item id="2036" name="Wiederholen:"/>
 				<Item id="2032" name="Format"/>
-				<Item id="2024" name="&amp;Dezimal"/>
-				<Item id="2025" name="&amp;Oktal"/>
-				<Item id="2026" name="&amp;Hexadezimal"/>
-				<Item id="2027" name="&amp;Binär"/>
-				<Item id="1"    name="Ausfüh&amp;ren"/>
-				<Item id="2"    name="Abbre&amp;chen"/>
+				<Item id="2024" name="Dezimal"/>
+				<Item id="2025" name="Oktal"/>
+				<Item id="2026" name="Hexadezimal"/>
+				<Item id="2027" name="Binär"/>
+				<Item id="1"    name="Ausführen"/>
+				<Item id="2"    name="Abbrechen"/>
 			</ColumnEditor>
 		</Dialog>
 		<MessageBox>
@@ -1049,7 +1048,7 @@
 			<word-chars-list-warning-end value=" in der Liste der Wortzeichen."/>
 			<cloud-invalid-warning value="Ungültiger Pfad."/>
 			<cloud-restart-warning value="Zum Übernehmen Notepad++ bitte neu starten."/>
-			<shift-change-direction-tip value="Verwende Shift+Enter um die Suchrichtung zu ändern."/>
+			<shift-change-direction-tip value="Enter: Suche vorwärts&#x0a;Shift+Enter: Suche rückwärts"/>
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -139,7 +139,7 @@
                     <Item id="42074" name="Ordner im Explorer öffnen"/>
                     <Item id="42075" name="Suche im Internet"/>
                     <Item id="42076" name="Andere Suchmaschine wählen …"/>
-                    <Item id="42018" name="Aufzeichnung &amp;starten"/>
+                    <Item id="42018" name="Aufzeichnung s&amp;tarten"/>
                     <Item id="42019" name="Aufzeichnung st&amp;oppen"/>
                     <Item id="42021" name="Makro ausfüh&amp;ren"/>
                     <Item id="42022" name="&amp;Zeilenweise Auskommentierung umschalten"/>
@@ -330,15 +330,15 @@
 
                     <Item id="49000" name="Externes Programm &amp;ausführen …"/>
 
-                    <Item id="50000" name="Funktionsvervollständigung"/>
-                    <Item id="50001" name="Wortvervollständigung"/>
-                    <Item id="50002" name="Funktionsparameter anzeigen"/>
-                    <Item id="50006" name="Dateipfad vervollständigen"/>
-                    <Item id="44042" name="Zeilen ausblenden"/>
-                    <Item id="42040" name="Alle zuletzt verwendeten Dateien öffnen"/>
-                    <Item id="42041" name="Liste löschen"/>
-                    <Item id="48016" name="Shortcut ändern/Makro löschen …"/>
-                    <Item id="48017" name="Shortcut ändern/Befehl löschen …"/>
+                    <Item id="50000" name="&amp;Funktionsvervollständigung"/>
+                    <Item id="50001" name="&amp;Wortvervollständigung"/>
+                    <Item id="50002" name="Funktions&amp;parameter anzeigen"/>
+                    <Item id="50006" name="&amp;Dateipfad vervollständigen"/>
+                    <Item id="44042" name="Zeilen &amp;ausblenden"/>
+                    <Item id="42040" name="Alle zule&amp;tzt verwendeten Dateien öffnen"/>
+                    <Item id="42041" name="L&amp;iste löschen"/>
+                    <Item id="48016" name="Shortcut &amp;ändern/Makro löschen …"/>
+                    <Item id="48017" name="Shortcut &amp;ändern/Befehl löschen …"/>
                 </Commands>
             </Main>
             <Splitter>
@@ -418,8 +418,8 @@
                 <Item id="2901" name="&amp;Nicht-ASCII-Zeichen (128–255)"/>
                 <Item id="2902" name="&amp;ASCII-Zeichen (0–127)"/>
                 <Item id="2903" name="&amp;Benutzerdefiniert:"/>
-                <Item id="2906" name="&amp;Aufwärts"/>
-                <Item id="2907" name="&amp;Abwärts"/>
+                <Item id="2906" name="A&amp;ufwärts"/>
+                <Item id="2907" name="A&amp;bwärts"/>
                 <Item id="2908" name="Suchrichtung"/>
                 <Item id="2909" name="Am Ende von &amp;vorne beginnen"/>
                 <Item id="2910" name="&amp;Suchen"/>
@@ -880,7 +880,7 @@
                 </Cloud>
 
                 <SearchEngine title="Suchmaschine">
-                    <Item id="6271" name="Suchmaschine (für das Kommando &amp;quot;Suche im Internet&amp;quot;)"/>
+                    <Item id="6271" name="Suchmaschine (für das Kommando &quot;Suche im Internet&quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
                     <Item id="6273" name="Google"/>
                     <Item id="6274" name="Bing"/>
@@ -960,7 +960,7 @@
             <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&amp;#x0D;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&amp;#x0D;ohne die erforderlichen Schreibrechte zeigen.&amp;#x0D;Die Einstellungen in der Cloud werden abgebrochen.&amp;#x0D;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
             <FilePathNotFoundWarning title="Datei öffnen" message="Die Datei zum Öffnen existiert nicht."/>
             <SessionFileInvalidError title="Konnte Sitzung nicht laden" message="Sitzungsdatei ist entweder beschädigt oder ungültig."/>
-            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &amp;quot;ALT+Maus Auswahl&amp;quot; oder &amp;quot;Alt+Shift+Pfeiltaste&amp;quot;&amp;#x0D;um in den Spalten-Modus zu wechseln."/>
+            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&amp;#x0D;um in den Spalten-Modus zu wechseln."/>
 
             <!-- $STR_REPLACE$ is a place holder, don't translate it -->
             <SortingError title="Sortierung fehlgeschlagen" message="Kann aufgrund der Zeile $STR_REPLACE$ keine numerische Sortierung durchführen."/>
@@ -968,7 +968,7 @@
             <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&amp;#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
             <OpenInAdminModeFailed title="Starten im Administrator-Modus fehlgeschlagen" message="Notepad++ kann nicht im Administrator-Modus gestartet werden."/>
             <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&amp;#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
-            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&amp;#x0D;Dafür muss &amp;quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&amp;quot; im Bereich &amp;quot;Standardverzeichnis&amp;quot; der Einstellungen ausgewählt werden."/>
+            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&amp;#x0D;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Zwischenablage"/>
@@ -1039,7 +1039,7 @@
             </Menus>
         </ProjectManager>
         <MiscStrings>
-            <word-chars-list-tip value="Erlaubt ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick zur Auswahl hinzuzufügen, oder als Suche mit der aktivierten Option &amp;quot;Übereinstimmung mit ganzem Wort&amp;quot;."/>
+            <word-chars-list-tip value="Erlaubt ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick zur Auswahl hinzuzufügen, oder als Suche mit der aktivierten Option &quot;Übereinstimmung mit ganzem Wort&quot;."/>
             <word-chars-list-warning-begin value="Achtung: "/>
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ Leerzeichen"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -713,7 +713,7 @@
                     <Item id="6207" name="Lesezeichenrand"/>
                     <Item id="6208" name="Randbegrenzung anzeigen"/>
                     <Item id="6209" name="Anzahl der Spalten:"/>
-                    <Item id="6234" name="Flüssiges Scrollen deaktivieren&amp;#x0D;(bei Touchpad-Problemen)"/>
+                    <Item id="6234" name="Flüssiges Scrollen deaktivieren&#x0D;(bei Touchpad-Problemen)"/>
 
                     <Item id="6211" name="Rechter Rand"/>
                     <Item id="6212" name="Vertikale Linie"/>
@@ -870,7 +870,7 @@
                     <Item id="6256" name="Über mehrere Zeilen"/>
                     <Item id="6161" name="Liste der Wortzeichen (Word character list)"/>
                     <Item id="6162" name="Verwende die ursprüngliche Liste der Wortzeichen"/>
-                    <Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&amp;#x0D;(nicht verwenden, wenn man nicht sicher ist)"/>
+                    <Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0D;(nicht verwenden, wenn man nicht sicher ist)"/>
                     </Delimiter>
 
                 <Cloud title="Cloud-Einstellungen">
@@ -945,30 +945,30 @@
             </ColumnEditor>
         </Dialog>
         <MessageBox>
-            <ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&amp;#x0D;das Kontextmenü von Notepad++ anpassen.&amp;#x0D;Nach dem Bearbeiten müssen Sie Notepad++ neu&amp;#x0D;starten, damit die Änderungen wirksam werden."/>
-            <NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&amp;#x0D;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&amp;#x0D;von der Notepad++-Website herunter."/>
-            <SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&amp;#x0D;&amp;#x0D;Fortfahren?"/>
-            <LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&amp;#x0D;&amp;#x0D;Fortfahren?"/>
-            <CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&amp;#x0D;Bitte zuerst speichern und erneut versuchen."/>
-            <DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&amp;#x0D;gespeicherten Version erneut laden und die&amp;#x0D;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
-            <FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &amp;#x0D;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
+            <ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&#x0D;das Kontextmenü von Notepad++ anpassen.&#x0D;Nach dem Bearbeiten müssen Sie Notepad++ neu&#x0D;starten, damit die Änderungen wirksam werden."/>
+            <NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&#x0D;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&#x0D;von der Notepad++-Website herunter."/>
+            <SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&#x0D;&#x0D;Fortfahren?"/>
+            <LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&#x0D;&#x0D;Fortfahren?"/>
+            <CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&#x0D;Bitte zuerst speichern und erneut versuchen."/>
+            <DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&#x0D;gespeicherten Version erneut laden und die&#x0D;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
+            <FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &#x0D;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
             <FileAlreadyOpenedInNpp title="Datei bereits geöffnet" message="Die Datei ist bereits in Notepad++ geöffnet."/>
             <DeleteFileFailed title="Löschen fehlgeschlagen!" message="Datei konnte nicht gelöscht werden."/>
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&amp;#x0D;Sind Sie sicher?"/>
-            <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&amp;#x0D;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&amp;#x0D;ohne die erforderlichen Schreibrechte zeigen.&amp;#x0D;Die Einstellungen in der Cloud werden abgebrochen.&amp;#x0D;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
+            <NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&#x0D;Sind Sie sicher?"/>
+            <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&#x0D;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&#x0D;ohne die erforderlichen Schreibrechte zeigen.&#x0D;Die Einstellungen in der Cloud werden abgebrochen.&#x0D;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
             <FilePathNotFoundWarning title="Datei öffnen" message="Die Datei zum Öffnen existiert nicht."/>
             <SessionFileInvalidError title="Konnte Sitzung nicht laden" message="Sitzungsdatei ist entweder beschädigt oder ungültig."/>
-            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&amp;#x0D;um in den Spalten-Modus zu wechseln."/>
+            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&#x0D;um in den Spalten-Modus zu wechseln."/>
 
             <!-- $STR_REPLACE$ is a place holder, don't translate it -->
             <SortingError title="Sortierung fehlgeschlagen" message="Kann aufgrund der Zeile $STR_REPLACE$ keine numerische Sortierung durchführen."/>
             <BufferInvalidWarning title="Speichern fehlgeschlagen" message="Kann nicht speichern: Puffer ist ungültig."/>
-            <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&amp;#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
             <OpenInAdminModeFailed title="Starten im Administrator-Modus fehlgeschlagen" message="Notepad++ kann nicht im Administrator-Modus gestartet werden."/>
-            <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&amp;#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
-            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&amp;#x0D;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
+            <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&#x0D;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Zwischenablage"/>
@@ -1048,7 +1048,7 @@
             <word-chars-list-warning-end value=" in der Liste der Wortzeichen."/>
             <cloud-invalid-warning value="Ungültiger Pfad."/>
             <cloud-restart-warning value="Zum Übernehmen Notepad++ bitte neu starten."/>
-            <shift-change-direction-tip value="Enter: Suche vorwärts&amp;#x0D;Shift+Enter: Suche rückwärts"/>
+            <shift-change-direction-tip value="Enter: Suche vorwärts&#x0D;Shift+Enter: Suche rückwärts"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -1,1054 +1,1054 @@
 <?xml version="1.0" encoding="utf-8" ?>
 
 <!--
-	German localization for Notepad++ 7.4.2
-	last modified: 2017-07-02 by schnurlos (schnurlos@gmail.com)
+    German localization for Notepad++ 7.4.2
+    last modified: 2017-07-02 by schnurlos (schnurlos@gmail.com)
 
-	Please e-mail errors, suggestions etc. to schnurlos(at)gmail.com or janschreiber(at)users.sf.net
+    Please e-mail errors, suggestions etc. to schnurlos(at)gmail.com or janschreiber(at)users.sf.net
 
-	The most recent version of this file can usually be downloaded from
-	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/german.xml
-	http://www.should.keepfree.de/N++/german.xml.txt (rename to german.xml)
+    The most recent version of this file can usually be downloaded from
+    https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/german.xml
+    http://www.should.keepfree.de/N++/german.xml.txt (rename to german.xml)
 -->
 
 <NotepadPlus>
-	<Native-Langue name="Deutsch" filename="german.xml" version="7.4.2">
-		<Menu>
-			<Main>
+    <Native-Langue name="Deutsch" filename="german.xml" version="7.4.2">
+        <Menu>
+            <Main>
                 <!-- Main Menu Entries -->
-				<Entries>
-					<Item menuId="file" name="Datei"/>
-					<Item menuId="edit" name="Bearbeiten"/>
-					<Item menuId="search" name="Suchen"/>
-					<Item menuId="view" name="Ansicht"/>
-					<Item menuId="encoding" name="Kodierung"/>
-					<Item menuId="language" name="Sprachen"/>
-					<Item menuId="settings" name="Einstellungen"/>
-					<Item menuId="tools" name="Werkzeuge"/>
-					<Item menuId="macro" name="Makro"/>
-					<Item menuId="run" name="Ausführen"/>
-					<Item idName="Plugins" name="Erweiterungen"/>
-					<Item idName="Window" name="Fenster"/>
-				</Entries>
+                <Entries>
+                    <Item menuId="file" name="Datei"/>
+                    <Item menuId="edit" name="Bearbeiten"/>
+                    <Item menuId="search" name="Suchen"/>
+                    <Item menuId="view" name="Ansicht"/>
+                    <Item menuId="encoding" name="Kodierung"/>
+                    <Item menuId="language" name="Sprachen"/>
+                    <Item menuId="settings" name="Einstellungen"/>
+                    <Item menuId="tools" name="Werkzeuge"/>
+                    <Item menuId="macro" name="Makro"/>
+                    <Item menuId="run" name="Ausführen"/>
+                    <Item idName="Plugins" name="Erweiterungen"/>
+                    <Item idName="Window" name="Fenster"/>
+                </Entries>
                 <!-- Sub Menu Entries -->
-				<SubEntries>
-					<Item subMenuId="file-openFolder" name="Aktuellen Ordner öffnen"/>
-					<Item subMenuId="file-closeMore" name="Mehrere schließen"/>
-					<Item subMenuId="file-recentFiles" name="Zuletzt verwendet"/>
-					<Item subMenuId="edit-copyToClipboard" name="Dateipfad kopieren"/>
-					<Item subMenuId="edit-indent" name="Einrückung"/>
-					<Item subMenuId="edit-convertCaseTo" name="Groß-/Kleinschreibung"/>
-					<Item subMenuId="edit-lineOperations" name="Zeilenoperationen"/>
-					<Item subMenuId="edit-comment" name="Kommentare"/>
-					<Item subMenuId="edit-autoCompletion" name="Autovervollständigung"/>
-					<Item subMenuId="edit-eolConversion" name="Format Zeilenende"/>
-					<Item subMenuId="edit-blankOperations" name="Nicht druckbare Zeichen"/>
-					<Item subMenuId="edit-pasteSpecial" name= "Einfügen spezial"/>
-					<Item subMenuId="edit-onSelection" name="Bei Auswahl"/>
-					<Item subMenuId="search-markAll" name="Alle Vorkommnisse hervorheben"/>
-					<Item subMenuId="search-unmarkAll" name="Alle Hervorhebungen löschen"/>
-					<Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung springen"/>
-					<Item subMenuId="search-jumpDown" name="Zur nächsten Hervorhebung springen"/>
-					<Item subMenuId="search-bookmark" name="Lesezeichen"/>
-					<Item subMenuId="view-showSymbol" name="Nicht druckbare Zeichen"/>
-					<Item subMenuId="view-zoom" name="Zoom"/>
-					<Item subMenuId="view-moveCloneDocument" name="Datei verschieben/duplizieren"/>
-					<Item subMenuId="view-tab" name="Tabs"/>
-					<Item subMenuId="view-collapseLevel" name="Textblöcke schließen"/>
-					<Item subMenuId="view-uncollapseLevel" name="Textblöcke öffnen"/>
-					<Item subMenuId="view-project" name="Projektverwaltung"/>
-					<Item subMenuId="encoding-characterSets" name="Weitere"/>
-					<Item subMenuId="encoding-arabic" name="Arabisch"/>
-					<Item subMenuId="encoding-baltic" name="Baltisch"/>
-					<Item subMenuId="encoding-celtic" name="Keltisch"/>
-					<Item subMenuId="encoding-cyrillic" name="Kyrillisch"/>
-					<Item subMenuId="encoding-centralEuropean" name="Mitteleuropäisch"/>
-					<Item subMenuId="encoding-chinese" name="Chinesisch"/>
-					<Item subMenuId="encoding-easternEuropean" name="Osteuropäisch"/>
-					<Item subMenuId="encoding-greek" name="Griechisch"/>
-					<Item subMenuId="encoding-hebrew" name="Hebräisch"/>
-					<Item subMenuId="encoding-japanese" name="Japanisch"/>
-					<Item subMenuId="encoding-korean" name="Koreanisch"/>
-					<Item subMenuId="encoding-northEuropean" name="Nordeuropäisch"/>
-					<Item subMenuId="encoding-thai" name="Thai"/>
-					<Item subMenuId="encoding-turkish" name="Türkisch"/>
-					<Item subMenuId="encoding-westernEuropean" name="Westeuropäisch"/>
-					<Item subMenuId="encoding-vietnamese" name="Vietnamesisch"/>
-					<Item subMenuId="settings-import" name="Import"/>
-					<Item subMenuId="tools-md5" name="MD5"/>
-				</SubEntries>
+                <SubEntries>
+                    <Item subMenuId="file-openFolder" name="Aktuellen Ordner öffnen"/>
+                    <Item subMenuId="file-closeMore" name="Mehrere schließen"/>
+                    <Item subMenuId="file-recentFiles" name="Zuletzt verwendet"/>
+                    <Item subMenuId="edit-copyToClipboard" name="Dateipfad kopieren"/>
+                    <Item subMenuId="edit-indent" name="Einrückung"/>
+                    <Item subMenuId="edit-convertCaseTo" name="Groß-/Kleinschreibung"/>
+                    <Item subMenuId="edit-lineOperations" name="Zeilenoperationen"/>
+                    <Item subMenuId="edit-comment" name="Kommentare"/>
+                    <Item subMenuId="edit-autoCompletion" name="Autovervollständigung"/>
+                    <Item subMenuId="edit-eolConversion" name="Format Zeilenende"/>
+                    <Item subMenuId="edit-blankOperations" name="Nicht druckbare Zeichen"/>
+                    <Item subMenuId="edit-pasteSpecial" name= "Einfügen spezial"/>
+                    <Item subMenuId="edit-onSelection" name="Bei Auswahl"/>
+                    <Item subMenuId="search-markAll" name="Alle Vorkommnisse hervorheben"/>
+                    <Item subMenuId="search-unmarkAll" name="Alle Hervorhebungen löschen"/>
+                    <Item subMenuId="search-jumpUp" name="Zur vorherigen Hervorhebung springen"/>
+                    <Item subMenuId="search-jumpDown" name="Zur nächsten Hervorhebung springen"/>
+                    <Item subMenuId="search-bookmark" name="Lesezeichen"/>
+                    <Item subMenuId="view-showSymbol" name="Nicht druckbare Zeichen"/>
+                    <Item subMenuId="view-zoom" name="Zoom"/>
+                    <Item subMenuId="view-moveCloneDocument" name="Datei verschieben/duplizieren"/>
+                    <Item subMenuId="view-tab" name="Tabs"/>
+                    <Item subMenuId="view-collapseLevel" name="Textblöcke schließen"/>
+                    <Item subMenuId="view-uncollapseLevel" name="Textblöcke öffnen"/>
+                    <Item subMenuId="view-project" name="Projektverwaltung"/>
+                    <Item subMenuId="encoding-characterSets" name="Weitere"/>
+                    <Item subMenuId="encoding-arabic" name="Arabisch"/>
+                    <Item subMenuId="encoding-baltic" name="Baltisch"/>
+                    <Item subMenuId="encoding-celtic" name="Keltisch"/>
+                    <Item subMenuId="encoding-cyrillic" name="Kyrillisch"/>
+                    <Item subMenuId="encoding-centralEuropean" name="Mitteleuropäisch"/>
+                    <Item subMenuId="encoding-chinese" name="Chinesisch"/>
+                    <Item subMenuId="encoding-easternEuropean" name="Osteuropäisch"/>
+                    <Item subMenuId="encoding-greek" name="Griechisch"/>
+                    <Item subMenuId="encoding-hebrew" name="Hebräisch"/>
+                    <Item subMenuId="encoding-japanese" name="Japanisch"/>
+                    <Item subMenuId="encoding-korean" name="Koreanisch"/>
+                    <Item subMenuId="encoding-northEuropean" name="Nordeuropäisch"/>
+                    <Item subMenuId="encoding-thai" name="Thai"/>
+                    <Item subMenuId="encoding-turkish" name="Türkisch"/>
+                    <Item subMenuId="encoding-westernEuropean" name="Westeuropäisch"/>
+                    <Item subMenuId="encoding-vietnamese" name="Vietnamesisch"/>
+                    <Item subMenuId="settings-import" name="Import"/>
+                    <Item subMenuId="tools-md5" name="MD5"/>
+                </SubEntries>
 
                 <!-- all menu item -->
-				<Commands>
-					<Item id="41001" name="Neu"/>
-					<Item id="41002" name="Öffnen …"/>
-					<Item id="41019" name="Explorer"/>
-					<Item id="41020" name="Eingabeaufforderung"/>
-					<Item id="41003" name="Schließen"/>
-					<Item id="41004" name="Alle schließen"/>
-					<Item id="41005" name="Alle schließen bis auf aktuelle Datei"/>
-					<Item id="41009" name="Dateien links schließen"/>
-					<Item id="41018" name="Dateien rechts schließen"/>
-					<Item id="41006" name="Speichern"/>
-					<Item id="41007" name="Alle speichern"/>
-					<Item id="41008" name="Speichern unter …"/>
-					<Item id="41010" name="Drucken …"/>
-					<Item id="1001"  name="Sofort drucken"/>
-					<Item id="41011" name="Beenden"/>
-					<Item id="41012" name="Sitzung öffnen …"/>
-					<Item id="41013" name="Sitzung speichern …"/>
-					<Item id="41014" name="Neu laden"/>
-					<Item id="41015" name="Kopie speichern unter …"/>
-					<Item id="41016" name="Von Datenträger löschen"/>
-					<Item id="41017" name="Umbenennen …"/>
-					<Item id="41021" name="Zuletzt geschlossene Datei wieder öffnen"/>
-					<Item id="41022" name="Verzeichnis als Arbeitsbereich öffnen"/>
+                <Commands>
+                    <Item id="41001" name="Neu"/>
+                    <Item id="41002" name="Öffnen …"/>
+                    <Item id="41019" name="Explorer"/>
+                    <Item id="41020" name="Eingabeaufforderung"/>
+                    <Item id="41003" name="Schließen"/>
+                    <Item id="41004" name="Alle schließen"/>
+                    <Item id="41005" name="Alle schließen bis auf aktuelle Datei"/>
+                    <Item id="41009" name="Dateien links schließen"/>
+                    <Item id="41018" name="Dateien rechts schließen"/>
+                    <Item id="41006" name="Speichern"/>
+                    <Item id="41007" name="Alle speichern"/>
+                    <Item id="41008" name="Speichern unter …"/>
+                    <Item id="41010" name="Drucken …"/>
+                    <Item id="1001"  name="Sofort drucken"/>
+                    <Item id="41011" name="Beenden"/>
+                    <Item id="41012" name="Sitzung öffnen …"/>
+                    <Item id="41013" name="Sitzung speichern …"/>
+                    <Item id="41014" name="Neu laden"/>
+                    <Item id="41015" name="Kopie speichern unter …"/>
+                    <Item id="41016" name="Von Datenträger löschen"/>
+                    <Item id="41017" name="Umbenennen …"/>
+                    <Item id="41021" name="Zuletzt geschlossene Datei wieder öffnen"/>
+                    <Item id="41022" name="Verzeichnis als Arbeitsbereich öffnen"/>
 
-					<Item id="42001" name="Ausschneiden"/>
-					<Item id="42002" name="Kopieren"/>
-					<Item id="42003" name="Rückgängig"/>
-					<Item id="42004" name="Wiederherstellen"/>
-					<Item id="42005" name="Einfügen"/>
-					<Item id="42006" name="Löschen"/>
-					<Item id="42007" name="Alles auswählen"/>
-					<Item id="42020" name="Auswahl beginnen/beenden"/>
-					<Item id="42008" name="Zeileneinzug vergrößern"/>
-					<Item id="42009" name="Zeileneinzug verkleinern"/>
-					<Item id="42010" name="Zeile duplizieren"/>
-					<Item id="42012" name="Zeile am Fensterrand teilen"/>
-					<Item id="42013" name="Zeilen zusammenfassen"/>
-					<Item id="42014" name="Zeile nach oben verschieben"/>
-					<Item id="42015" name="Zeile nach unten verschieben"/>
-					<Item id="42059" name="Zeilen alphabetisch aufsteigend sortieren"/>
-					<Item id="42060" name="Zeilen alphabetisch absteigend sortieren"/>
-					<Item id="42061" name="Zeilen als Ganzzahlen aufsteigend sortieren"/>
-					<Item id="42062" name="Zeilen als Ganzzahlen absteigend sortieren"/>
-					<Item id="42063" name="Zeilen als Dezimalzahlen (Komma) aufsteigend sortieren"/>
-					<Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
-					<Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
-					<Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
-					<Item id="42016" name="In GROSSBUCHSTABEN umwandeln"/>
-					<Item id="42017" name="In kleinbuchstaben umwandeln"/>
-					<Item id="42067" name="Überschriftenstil"/>
-					<Item id="42068" name="Gemischter Überschriftenstil"/>
-					<Item id="42069" name="Normaler Wortstil"/>
-					<Item id="42070" name="Gemischter Wortstil"/>
-					<Item id="42071" name="iNVERTIERTER wORTSTIL"/>
-					<Item id="42072" name="zUFäLlIGeR WortSTiL"/>
-					<Item id="42073" name="Datei Öffnen"/>
-					<Item id="42074" name="Ordner im Explorer öffnen"/>
-					<Item id="42075" name="Suche im Internet"/>
-					<Item id="42076" name="Andere Suchmaschine wählen …"/>
-					<Item id="42018" name="Aufzeichnung starten"/>
-					<Item id="42019" name="Aufzeichnung stoppen"/>
-					<Item id="42021" name="Makro ausführen"/>
-					<Item id="42022" name="Zeilenweise Auskommentierung umschalten"/>
-					<Item id="42023" name="Auswahl auskommentieren"/>
-					<Item id="42047" name="Auskommentierung der Auswahl aufheben"/>
-					<Item id="42024" name="Leerzeichen und Tabulatoren am Zeilenende löschen"/>
-					<Item id="42042" name="Leerzeichen und Tabulatoren am Zeilenanfang löschen"/>
-					<Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang und -ende löschen"/>
-					<Item id="42044" name="Zeilenumbrüche in Leerzeichen konvertieren"/>
-					<Item id="42045" name="Mehrfachen Whitespace und Umbrüche entfernen"/>
-					<Item id="42046" name="Tabulatoren in Leerzeichen umwandeln"/>
-					<Item id="42054" name="Leerzeichen in Tabulatoren umwandeln (alle)"/>
-					<Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am Zeilenanfang)"/>
-					<Item id="42038" name="HTML-Inhalt einfügen"/>
-					<Item id="42039" name="RTF-Inhalt einfügen"/>
-					<Item id="42048" name="Binär-Inhalt kopieren"/>
-					<Item id="42049" name="Binär-Inhalt ausschneiden"/>
-					<Item id="42050" name="Binär-Inhalt einfügen"/>
-					<Item id="42037" name="Spalten-Modus …"/>
-					<Item id="42034" name="Block-Editor …"/>
-					<Item id="42051" name="Zeichentabelle"/>
-					<Item id="42052" name="Zwischenablage"/>
-					<Item id="42025" name="Aufgenommenes Makro speichern"/>
-					<Item id="42026" name="Schreibrichtung von rechts nach links"/>
-					<Item id="42027" name="Schreibrichtung von links nach rechts"/>
-					<Item id="42028" name="Schreibschutz"/>
-					<Item id="42029" name="Vollständigen Pfad kopieren"/>
-					<Item id="42030" name="Nur Dateinamen kopieren"/>
-					<Item id="42031" name="Nur Verzeichnispfad kopieren"/>
-					<Item id="42032" name="Makro mehrfach ausführen …"/>
-					<Item id="42033" name="Schreibschutz-Attribut löschen"/>
-					<Item id="42035" name="Zeilen auskommentieren"/>
-					<Item id="42036" name="Auskommentierung der Zeilen aufheben"/>
-					<Item id="42055" name="Leerzeilen (nur völlig leere) löschen"/>
-					<Item id="42056" name="Leerzeilen (auch mit Whitespace) löschen"/>
-					<Item id="42057" name="Leerzeile über aktueller Zeile einfügen"/>
-					<Item id="42058" name="Leerzeile unter aktueller Zeile einfügen"/>
-					<Item id="43001" name="Suchen …"/>
-					<Item id="43002" name="Vorwärts Suchen"/>
-					<Item id="43003" name="Ersetzen …"/>
-					<Item id="43004" name="Gehe zu …"/>
-					<Item id="43005" name="Lesezeichen setzen/löschen"/>
-					<Item id="43006" name="Nächstes Lesezeichen"/>
-					<Item id="43007" name="Vorheriges Lesezeichen"/>
-					<Item id="43008" name="Alle Lesezeichen löschen"/>
-					<Item id="43018" name="Zeilen mit Lesezeichen ausschneiden"/>
-					<Item id="43019" name="Zeilen mit Lesezeichen kopieren"/>
-					<Item id="43020" name="Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
-					<Item id="43021" name="Zeilen mit Lesezeichen löschen"/>
-					<Item id="43051" name="Zeilen ohne Lesezeichen löschen"/>
-					<Item id="43050" name="Lesezeichen invertieren"/>
-					<Item id="43052" name="Suche nach Zeichencodes …"/>
-					<Item id="43053" name="Alles zwischen Klammern auswählen"/>
-					<Item id="43009" name="Suche zugehörige Klammer"/>
-					<Item id="43010" name="Rückwärts suchen"/>
-					<Item id="43011" name="Inkrementelle Suche"/>
-					<Item id="43013" name="In Dateien suchen …"/>
-					<Item id="43014" name="Wort am Cursor suchen (ohne Verlauf)"/>
-					<Item id="43015" name="Wort am Cursor rückwärts suchen (ohne Verlauf)"/>
-					<Item id="43022" name="Hervorhebung 1"/>
-					<Item id="43023" name="Hervorhebung 1 entfernen"/>
-					<Item id="43024" name="Hervorhebung 2"/>
-					<Item id="43025" name="Hervorhebung 2 entfernen"/>
-					<Item id="43026" name="Hervorhebung 3"/>
-					<Item id="43027" name="Hervorhebung 3 entfernen"/>
-					<Item id="43028" name="Hervorhebung 4"/>
-					<Item id="43029" name="Hervorhebung 4 entfernen"/>
-					<Item id="43030" name="Hervorhebung 5"/>
-					<Item id="43031" name="Hervorhebung 5 entfernen"/>
-					<Item id="43032" name="Alle entfernen"/>
-					<Item id="43033" name="Hervorhebung 1"/>
-					<Item id="43034" name="Hervorhebung 2"/>
-					<Item id="43035" name="Hervorhebung 3"/>
-					<Item id="43036" name="Hervorhebung 4"/>
-					<Item id="43037" name="Hervorhebung 5"/>
-					<Item id="43038" name="Hervorhebung aus Suche"/>
-					<Item id="43039" name="Hervorhebung 1"/>
-					<Item id="43040" name="Hervorhebung 2"/>
-					<Item id="43041" name="Hervorhebung 3"/>
-					<Item id="43042" name="Hervorhebung 4"/>
-					<Item id="43043" name="Hervorhebung 5"/>
-					<Item id="43044" name="Hervorhebung aus Suche"/>
-					<Item id="43045" name="Suchergebnis-Fenster"/>
-					<Item id="43046" name="Zum nächsten Suchergebnis springen"/>
-					<Item id="43047" name="Zum vorherigen Suchergebnis springen"/>
-					<Item id="43048" name="Auswahl oder Wort am Cursor suchen"/>
-					<Item id="43049" name="Wort am Cursor rückwärts suchen"/>
-					<Item id="43054" name="Hervorheben …"/>
-					<Item id="44009" name="Post-It"/>
-					<Item id="44010" name="Alle Textblöcke schließen"/>
-					<Item id="44019" name="Alle Zeichen anzeigen"/>
-					<Item id="44020" name="Einrückung anzeigen"/>
-					<Item id="44022" name="Automatischer Zeilenumbruch"/>
-					<Item id="44023" name="Schrift vergrößern"/>
-					<Item id="44024" name="Schrift verkleinern"/>
-					<Item id="44025" name="Leerzeichen und Tabulatoren anzeigen"/>
-					<Item id="44026" name="Zeilenende anzeigen"/>
-					<Item id="44029" name="Alle Textblöcke öffnen"/>
-					<Item id="44030" name="Textblock schließen"/>
-					<Item id="44031" name="Textblock öffnen"/>
-					<Item id="44049" name="Datei-Info …"/>
-					<Item id="44080" name="Miniaturansicht"/>
-					<Item id="44084" name="Funktionsliste"/>
-					<Item id="44085" name="Verzeichnis als Arbeitsbereich"/>
-					<Item id="44086" name="1. Tab"/>
-					<Item id="44087" name="2. Tab"/>
-					<Item id="44088" name="3. Tab"/>
-					<Item id="44089" name="4. Tab"/>
-					<Item id="44090" name="5. Tab"/>
-					<Item id="44091" name="6. Tab"/>
-					<Item id="44092" name="7. Tab"/>
-					<Item id="44093" name="8. Tab"/>
-					<Item id="44094" name="9. Tab"/>
-					<Item id="44095" name="Nächster Tab"/>
-					<Item id="44096" name="Vorheriger Tab"/>
-					<Item id="44097" name="Überwachen (tail -f)"/>
-					<Item id="44098" name="Tab vorwärts bewegen"/>
-					<Item id="44099" name="Tab rückwärts bewegen"/>
-					<Item id="44032" name="Vollbild"/>
-					<Item id="44033" name="Standardgröße"/>
-					<Item id="44034" name="Immer im Vordergrund halten"/>
-					<Item id="44035" name="Synchrones vertikales Scrollen"/>
-					<Item id="44036" name="Synchrones horizontales Scrollen"/>
-					<Item id="44041" name="Symbol bei automatischem Umbruch"/>
-					<Item id="44072" name="Zur anderen Ansicht wechseln"/>
-					<Item id="44081" name="Projektfenster 1"/>
-					<Item id="44082" name="Projektfenster 2"/>
-					<Item id="44083" name="Projektfenster 3"/>
-					<Item id="45001" name="Konvertiere zu Windows (CR+LF)"/>
-					<Item id="45002" name="Konvertiere zu UNIX (LF)"/>
-					<Item id="45003" name="Konvertiere zu Mac (CR)"/>
-					<Item id="45004" name="ANSI"/>
-					<Item id="45005" name="UTF-8"/>
-					<Item id="45006" name="UCS-2 Big Endian"/>
-					<Item id="45007" name="UCS-2 Little Endian"/>
-					<Item id="45008" name="UTF-8 ohne BOM"/>
-					<Item id="45009" name="Konvertiere zu ANSI"/>
-					<Item id="45010" name="Konvertiere zu UTF-8 ohne BOM"/>
-					<Item id="45011" name="Konvertiere zu UTF-8"/>
-					<Item id="45012" name="Konvertiere zu UCS-2 Big Endian"/>
-					<Item id="45013" name="Konvertiere zu UCS-2 Little Endian"/>
-					<Item id="44011" name="Benutzerdefinierte Sprache …"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="44012" name="Zeilennummernrand ausblenden"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="44013" name="Lesezeichenrand ausblenden"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="44014" name="Codefaltung ausblenden"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="47008" name="Inhalt …"/>					<!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="42001" name="Ausschneiden"/>
+                    <Item id="42002" name="Kopieren"/>
+                    <Item id="42003" name="Rückgängig"/>
+                    <Item id="42004" name="Wiederherstellen"/>
+                    <Item id="42005" name="Einfügen"/>
+                    <Item id="42006" name="Löschen"/>
+                    <Item id="42007" name="Alles auswählen"/>
+                    <Item id="42020" name="Auswahl beginnen/beenden"/>
+                    <Item id="42008" name="Zeileneinzug vergrößern"/>
+                    <Item id="42009" name="Zeileneinzug verkleinern"/>
+                    <Item id="42010" name="Zeile duplizieren"/>
+                    <Item id="42012" name="Zeile am Fensterrand teilen"/>
+                    <Item id="42013" name="Zeilen zusammenfassen"/>
+                    <Item id="42014" name="Zeile nach oben verschieben"/>
+                    <Item id="42015" name="Zeile nach unten verschieben"/>
+                    <Item id="42059" name="Zeilen alphabetisch aufsteigend sortieren"/>
+                    <Item id="42060" name="Zeilen alphabetisch absteigend sortieren"/>
+                    <Item id="42061" name="Zeilen als Ganzzahlen aufsteigend sortieren"/>
+                    <Item id="42062" name="Zeilen als Ganzzahlen absteigend sortieren"/>
+                    <Item id="42063" name="Zeilen als Dezimalzahlen (Komma) aufsteigend sortieren"/>
+                    <Item id="42064" name="Zeilen als Dezimalzahlen (Komma) absteigend sortieren"/>
+                    <Item id="42065" name="Zeilen als Dezimalzahlen (Punkt) aufsteigend sortieren"/>
+                    <Item id="42066" name="Zeilen als Dezimalzahlen (Punkt) absteigend sortieren"/>
+                    <Item id="42016" name="In GROSSBUCHSTABEN umwandeln"/>
+                    <Item id="42017" name="In kleinbuchstaben umwandeln"/>
+                    <Item id="42067" name="Überschriftenstil"/>
+                    <Item id="42068" name="Gemischter Überschriftenstil"/>
+                    <Item id="42069" name="Normaler Wortstil"/>
+                    <Item id="42070" name="Gemischter Wortstil"/>
+                    <Item id="42071" name="iNVERTIERTER wORTSTIL"/>
+                    <Item id="42072" name="zUFäLlIGeR WortSTiL"/>
+                    <Item id="42073" name="Datei Öffnen"/>
+                    <Item id="42074" name="Ordner im Explorer öffnen"/>
+                    <Item id="42075" name="Suche im Internet"/>
+                    <Item id="42076" name="Andere Suchmaschine wählen …"/>
+                    <Item id="42018" name="Aufzeichnung starten"/>
+                    <Item id="42019" name="Aufzeichnung stoppen"/>
+                    <Item id="42021" name="Makro ausführen"/>
+                    <Item id="42022" name="Zeilenweise Auskommentierung umschalten"/>
+                    <Item id="42023" name="Auswahl auskommentieren"/>
+                    <Item id="42047" name="Auskommentierung der Auswahl aufheben"/>
+                    <Item id="42024" name="Leerzeichen und Tabulatoren am Zeilenende löschen"/>
+                    <Item id="42042" name="Leerzeichen und Tabulatoren am Zeilenanfang löschen"/>
+                    <Item id="42043" name="Leerzeichen und Tabulatoren am Zeilenanfang und -ende löschen"/>
+                    <Item id="42044" name="Zeilenumbrüche in Leerzeichen konvertieren"/>
+                    <Item id="42045" name="Mehrfachen Whitespace und Umbrüche entfernen"/>
+                    <Item id="42046" name="Tabulatoren in Leerzeichen umwandeln"/>
+                    <Item id="42054" name="Leerzeichen in Tabulatoren umwandeln (alle)"/>
+                    <Item id="42053" name="Leerzeichen in Tabulatoren umwandeln (nur am Zeilenanfang)"/>
+                    <Item id="42038" name="HTML-Inhalt einfügen"/>
+                    <Item id="42039" name="RTF-Inhalt einfügen"/>
+                    <Item id="42048" name="Binär-Inhalt kopieren"/>
+                    <Item id="42049" name="Binär-Inhalt ausschneiden"/>
+                    <Item id="42050" name="Binär-Inhalt einfügen"/>
+                    <Item id="42037" name="Spalten-Modus …"/>
+                    <Item id="42034" name="Block-Editor …"/>
+                    <Item id="42051" name="Zeichentabelle"/>
+                    <Item id="42052" name="Zwischenablage"/>
+                    <Item id="42025" name="Aufgenommenes Makro speichern"/>
+                    <Item id="42026" name="Schreibrichtung von rechts nach links"/>
+                    <Item id="42027" name="Schreibrichtung von links nach rechts"/>
+                    <Item id="42028" name="Schreibschutz"/>
+                    <Item id="42029" name="Vollständigen Pfad kopieren"/>
+                    <Item id="42030" name="Nur Dateinamen kopieren"/>
+                    <Item id="42031" name="Nur Verzeichnispfad kopieren"/>
+                    <Item id="42032" name="Makro mehrfach ausführen …"/>
+                    <Item id="42033" name="Schreibschutz-Attribut löschen"/>
+                    <Item id="42035" name="Zeilen auskommentieren"/>
+                    <Item id="42036" name="Auskommentierung der Zeilen aufheben"/>
+                    <Item id="42055" name="Leerzeilen (nur völlig leere) löschen"/>
+                    <Item id="42056" name="Leerzeilen (auch mit Whitespace) löschen"/>
+                    <Item id="42057" name="Leerzeile über aktueller Zeile einfügen"/>
+                    <Item id="42058" name="Leerzeile unter aktueller Zeile einfügen"/>
+                    <Item id="43001" name="Suchen …"/>
+                    <Item id="43002" name="Vorwärts Suchen"/>
+                    <Item id="43003" name="Ersetzen …"/>
+                    <Item id="43004" name="Gehe zu …"/>
+                    <Item id="43005" name="Lesezeichen setzen/löschen"/>
+                    <Item id="43006" name="Nächstes Lesezeichen"/>
+                    <Item id="43007" name="Vorheriges Lesezeichen"/>
+                    <Item id="43008" name="Alle Lesezeichen löschen"/>
+                    <Item id="43018" name="Zeilen mit Lesezeichen ausschneiden"/>
+                    <Item id="43019" name="Zeilen mit Lesezeichen kopieren"/>
+                    <Item id="43020" name="Zeilen mit Lesezeichen durch Zwischenablage ersetzen"/>
+                    <Item id="43021" name="Zeilen mit Lesezeichen löschen"/>
+                    <Item id="43051" name="Zeilen ohne Lesezeichen löschen"/>
+                    <Item id="43050" name="Lesezeichen invertieren"/>
+                    <Item id="43052" name="Suche nach Zeichencodes …"/>
+                    <Item id="43053" name="Alles zwischen Klammern auswählen"/>
+                    <Item id="43009" name="Suche zugehörige Klammer"/>
+                    <Item id="43010" name="Rückwärts suchen"/>
+                    <Item id="43011" name="Inkrementelle Suche"/>
+                    <Item id="43013" name="In Dateien suchen …"/>
+                    <Item id="43014" name="Wort am Cursor suchen (ohne Verlauf)"/>
+                    <Item id="43015" name="Wort am Cursor rückwärts suchen (ohne Verlauf)"/>
+                    <Item id="43022" name="Hervorhebung 1"/>
+                    <Item id="43023" name="Hervorhebung 1 entfernen"/>
+                    <Item id="43024" name="Hervorhebung 2"/>
+                    <Item id="43025" name="Hervorhebung 2 entfernen"/>
+                    <Item id="43026" name="Hervorhebung 3"/>
+                    <Item id="43027" name="Hervorhebung 3 entfernen"/>
+                    <Item id="43028" name="Hervorhebung 4"/>
+                    <Item id="43029" name="Hervorhebung 4 entfernen"/>
+                    <Item id="43030" name="Hervorhebung 5"/>
+                    <Item id="43031" name="Hervorhebung 5 entfernen"/>
+                    <Item id="43032" name="Alle entfernen"/>
+                    <Item id="43033" name="Hervorhebung 1"/>
+                    <Item id="43034" name="Hervorhebung 2"/>
+                    <Item id="43035" name="Hervorhebung 3"/>
+                    <Item id="43036" name="Hervorhebung 4"/>
+                    <Item id="43037" name="Hervorhebung 5"/>
+                    <Item id="43038" name="Hervorhebung aus Suche"/>
+                    <Item id="43039" name="Hervorhebung 1"/>
+                    <Item id="43040" name="Hervorhebung 2"/>
+                    <Item id="43041" name="Hervorhebung 3"/>
+                    <Item id="43042" name="Hervorhebung 4"/>
+                    <Item id="43043" name="Hervorhebung 5"/>
+                    <Item id="43044" name="Hervorhebung aus Suche"/>
+                    <Item id="43045" name="Suchergebnis-Fenster"/>
+                    <Item id="43046" name="Zum nächsten Suchergebnis springen"/>
+                    <Item id="43047" name="Zum vorherigen Suchergebnis springen"/>
+                    <Item id="43048" name="Auswahl oder Wort am Cursor suchen"/>
+                    <Item id="43049" name="Wort am Cursor rückwärts suchen"/>
+                    <Item id="43054" name="Hervorheben …"/>
+                    <Item id="44009" name="Post-It"/>
+                    <Item id="44010" name="Alle Textblöcke schließen"/>
+                    <Item id="44019" name="Alle Zeichen anzeigen"/>
+                    <Item id="44020" name="Einrückung anzeigen"/>
+                    <Item id="44022" name="Automatischer Zeilenumbruch"/>
+                    <Item id="44023" name="Schrift vergrößern"/>
+                    <Item id="44024" name="Schrift verkleinern"/>
+                    <Item id="44025" name="Leerzeichen und Tabulatoren anzeigen"/>
+                    <Item id="44026" name="Zeilenende anzeigen"/>
+                    <Item id="44029" name="Alle Textblöcke öffnen"/>
+                    <Item id="44030" name="Textblock schließen"/>
+                    <Item id="44031" name="Textblock öffnen"/>
+                    <Item id="44049" name="Datei-Info …"/>
+                    <Item id="44080" name="Miniaturansicht"/>
+                    <Item id="44084" name="Funktionsliste"/>
+                    <Item id="44085" name="Verzeichnis als Arbeitsbereich"/>
+                    <Item id="44086" name="1. Tab"/>
+                    <Item id="44087" name="2. Tab"/>
+                    <Item id="44088" name="3. Tab"/>
+                    <Item id="44089" name="4. Tab"/>
+                    <Item id="44090" name="5. Tab"/>
+                    <Item id="44091" name="6. Tab"/>
+                    <Item id="44092" name="7. Tab"/>
+                    <Item id="44093" name="8. Tab"/>
+                    <Item id="44094" name="9. Tab"/>
+                    <Item id="44095" name="Nächster Tab"/>
+                    <Item id="44096" name="Vorheriger Tab"/>
+                    <Item id="44097" name="Überwachen (tail -f)"/>
+                    <Item id="44098" name="Tab vorwärts bewegen"/>
+                    <Item id="44099" name="Tab rückwärts bewegen"/>
+                    <Item id="44032" name="Vollbild"/>
+                    <Item id="44033" name="Standardgröße"/>
+                    <Item id="44034" name="Immer im Vordergrund halten"/>
+                    <Item id="44035" name="Synchrones vertikales Scrollen"/>
+                    <Item id="44036" name="Synchrones horizontales Scrollen"/>
+                    <Item id="44041" name="Symbol bei automatischem Umbruch"/>
+                    <Item id="44072" name="Zur anderen Ansicht wechseln"/>
+                    <Item id="44081" name="Projektfenster 1"/>
+                    <Item id="44082" name="Projektfenster 2"/>
+                    <Item id="44083" name="Projektfenster 3"/>
+                    <Item id="45001" name="Konvertiere zu Windows (CR+LF)"/>
+                    <Item id="45002" name="Konvertiere zu UNIX (LF)"/>
+                    <Item id="45003" name="Konvertiere zu Mac (CR)"/>
+                    <Item id="45004" name="ANSI"/>
+                    <Item id="45005" name="UTF-8"/>
+                    <Item id="45006" name="UCS-2 Big Endian"/>
+                    <Item id="45007" name="UCS-2 Little Endian"/>
+                    <Item id="45008" name="UTF-8 ohne BOM"/>
+                    <Item id="45009" name="Konvertiere zu ANSI"/>
+                    <Item id="45010" name="Konvertiere zu UTF-8 ohne BOM"/>
+                    <Item id="45011" name="Konvertiere zu UTF-8"/>
+                    <Item id="45012" name="Konvertiere zu UCS-2 Big Endian"/>
+                    <Item id="45013" name="Konvertiere zu UCS-2 Little Endian"/>
+                    <Item id="44011" name="Benutzerdefinierte Sprache …"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44012" name="Zeilennummernrand ausblenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44013" name="Lesezeichenrand ausblenden"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="44014" name="Codefaltung ausblenden"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="47008" name="Inhalt …"/>                    <!-- kommt im englischen nicht oder nicht mehr vor -->
 
-					<Item id="10001" name="In zweite Ansicht verschieben"/>
-					<Item id="10002" name="In zweite Ansicht duplizieren"/>
-					<Item id="10003" name="In neue Instanz verschieben"/>
-					<Item id="10004" name="In neue Instanz duplizieren"/>
+                    <Item id="10001" name="In zweite Ansicht verschieben"/>
+                    <Item id="10002" name="In zweite Ansicht duplizieren"/>
+                    <Item id="10003" name="In neue Instanz verschieben"/>
+                    <Item id="10004" name="In neue Instanz duplizieren"/>
 
-					<Item id="45060" name="Big5 (Traditionell)"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="45061" name="GB2312 (Vereinfacht)"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="45054" name="OEM 861: Isländisch"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="45057" name="OEM 865: Nordisch"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="45053" name="OEM 860: Portugiesisch"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="45056" name="OEM 863: Französisch"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="45060" name="Big5 (Traditionell)"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="45061" name="GB2312 (Vereinfacht)"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="45054" name="OEM 861: Isländisch"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="45057" name="OEM 865: Nordisch"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="45053" name="OEM 860: Portugiesisch"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="45056" name="OEM 863: Französisch"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
 
-                    <Item id="46033" name="Assembler"/>						<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="46019" name="MS-INI-Datei"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="46015" name="MS-DOS-Stil"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="46016" name="Normaler Text"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="46017" name="Ressourcen-Datei"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="46033" name="Assembler"/>                        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="46019" name="MS-INI-Datei"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="46015" name="MS-DOS-Stil"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="46016" name="Normaler Text"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="46017" name="Ressourcen-Datei"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
 
-					<Item id="46001" name="Stile …"/>
-					<Item id="46150" name="Eigene Sprache definieren …"/>
-					<Item id="46080" name="Benutzerdefiniert"/>
-					<Item id="47000" name="Info …"/>
-					<Item id="47010" name="Kommandozeilenparameter …"/>
-					<Item id="47001" name="Notepad++ im Web"/>
-					<Item id="47002" name="Notepad++ bei GitHub"/>
-					<Item id="47003" name="Online-Dokumentation"/>
-					<Item id="47004" name="Notepad++ Online-Forum"/>
-					<Item id="47011" name="Support im Chat"/>
-					<Item id="47012" name="Debug-Info"/>
-					<Item id="47005" name="Erweiterungen"/>
-					<Item id="47006" name="Notepad++ aktualisieren"/>
-					<Item id="47009" name="Proxy für Updater einstellen …"/>
-					<Item id="48005" name="Plugin(s) importieren …"/>
-					<Item id="48006" name="Design(s) importieren …"/>
-					<Item id="48018" name="Kontextmenü anpassen …"/>
-					<Item id="48009" name="Tastatur …"/>
-					<Item id="48011" name="Optionen …"/>
-					<Item id="48501" name="Erstelle …"/>
-					<Item id="48502" name="Erstelle aus Dateien …"/>
-					<Item id="48503" name="Erstelle in die Zwischenablage"/>
+                    <Item id="46001" name="Stile …"/>
+                    <Item id="46150" name="Eigene Sprache definieren …"/>
+                    <Item id="46080" name="Benutzerdefiniert"/>
+                    <Item id="47000" name="Info …"/>
+                    <Item id="47010" name="Kommandozeilenparameter …"/>
+                    <Item id="47001" name="Notepad++ im Web"/>
+                    <Item id="47002" name="Notepad++ bei GitHub"/>
+                    <Item id="47003" name="Online-Dokumentation"/>
+                    <Item id="47004" name="Notepad++ Online-Forum"/>
+                    <Item id="47011" name="Support im Chat"/>
+                    <Item id="47012" name="Debug-Info"/>
+                    <Item id="47005" name="Erweiterungen"/>
+                    <Item id="47006" name="Notepad++ aktualisieren"/>
+                    <Item id="47009" name="Proxy für Updater einstellen …"/>
+                    <Item id="48005" name="Plugin(s) importieren …"/>
+                    <Item id="48006" name="Design(s) importieren …"/>
+                    <Item id="48018" name="Kontextmenü anpassen …"/>
+                    <Item id="48009" name="Tastatur …"/>
+                    <Item id="48011" name="Optionen …"/>
+                    <Item id="48501" name="Erstelle …"/>
+                    <Item id="48502" name="Erstelle aus Dateien …"/>
+                    <Item id="48503" name="Erstelle in die Zwischenablage"/>
 
-					<Item id="49000" name="Externes Programm ausführen …"/>
+                    <Item id="49000" name="Externes Programm ausführen …"/>
 
-					<Item id="50000" name="Funktionsvervollständigung"/>
-					<Item id="50001" name="Wortvervollständigung"/>
-					<Item id="50002" name="Funktionsparameter anzeigen"/>
-					<Item id="50006" name="Dateipfad vervollständigen"/>
-					<Item id="44042" name="Zeilen ausblenden"/>
-					<Item id="42040" name="Alle zuletzt verwendeten Dateien öffnen"/>
-					<Item id="42041" name="Liste löschen"/>
-					<Item id="48016" name="Shortcut ändern/Makro löschen …"/>
-					<Item id="48017" name="Shortcut ändern/Befehl löschen …"/>
-				</Commands>
-			</Main>
-			<Splitter>
-			</Splitter>
-			<TabBar>
-				<Item CMID="0"  name="Schließen"/>
-				<Item CMID="1"  name="Alle anderen schließen"/>
-				<Item CMID="2"  name="Speichern"/>
-				<Item CMID="3"  name="Speichern unter …"/>
-				<Item CMID="4"  name="Drucken"/>
-				<Item CMID="5"  name="In zweite Ansicht verschieben"/>
-				<Item CMID="6"  name="In zweite Ansicht duplizieren"/>
-				<Item CMID="7"  name="Vollständigen Pfad kopieren"/>
-				<Item CMID="8"  name="Nur Dateinamen kopieren"/>
-				<Item CMID="9"  name="Nur Verzeichnispfad kopieren"/>
-				<Item CMID="10" name="Umbenennen …"/>
-				<Item CMID="11" name="Löschen"/>
-				<Item CMID="12" name="Schreibschutz"/>
-				<Item CMID="13" name="Schreibschutz aufheben"/>
-				<Item CMID="14" name="In neue Instanz verschieben"/>
-				<Item CMID="15" name="In neue Instanz duplizieren"/>
-				<Item CMID="16" name="Neu laden"/>
-				<Item CMID="17" name="Dateien links schließen"/>
-				<Item CMID="18" name="Dateien rechts schließen"/>
-				<Item CMID="19" name="Ordner im Explorer öffnen"/>
-				<Item CMID="20" name="Kommandozeile im aktuellen Ordner öffnen"/>
-			</TabBar>
-		</Menu>
+                    <Item id="50000" name="Funktionsvervollständigung"/>
+                    <Item id="50001" name="Wortvervollständigung"/>
+                    <Item id="50002" name="Funktionsparameter anzeigen"/>
+                    <Item id="50006" name="Dateipfad vervollständigen"/>
+                    <Item id="44042" name="Zeilen ausblenden"/>
+                    <Item id="42040" name="Alle zuletzt verwendeten Dateien öffnen"/>
+                    <Item id="42041" name="Liste löschen"/>
+                    <Item id="48016" name="Shortcut ändern/Makro löschen …"/>
+                    <Item id="48017" name="Shortcut ändern/Befehl löschen …"/>
+                </Commands>
+            </Main>
+            <Splitter>
+            </Splitter>
+            <TabBar>
+                <Item CMID="0"  name="Schließen"/>
+                <Item CMID="1"  name="Alle anderen schließen"/>
+                <Item CMID="2"  name="Speichern"/>
+                <Item CMID="3"  name="Speichern unter …"/>
+                <Item CMID="4"  name="Drucken"/>
+                <Item CMID="5"  name="In zweite Ansicht verschieben"/>
+                <Item CMID="6"  name="In zweite Ansicht duplizieren"/>
+                <Item CMID="7"  name="Vollständigen Pfad kopieren"/>
+                <Item CMID="8"  name="Nur Dateinamen kopieren"/>
+                <Item CMID="9"  name="Nur Verzeichnispfad kopieren"/>
+                <Item CMID="10" name="Umbenennen …"/>
+                <Item CMID="11" name="Löschen"/>
+                <Item CMID="12" name="Schreibschutz"/>
+                <Item CMID="13" name="Schreibschutz aufheben"/>
+                <Item CMID="14" name="In neue Instanz verschieben"/>
+                <Item CMID="15" name="In neue Instanz duplizieren"/>
+                <Item CMID="16" name="Neu laden"/>
+                <Item CMID="17" name="Dateien links schließen"/>
+                <Item CMID="18" name="Dateien rechts schließen"/>
+                <Item CMID="19" name="Ordner im Explorer öffnen"/>
+                <Item CMID="20" name="Kommandozeile im aktuellen Ordner öffnen"/>
+            </TabBar>
+        </Menu>
 
-		<Dialog>
-			<Find title="Suchen und ersetzen" titleFind="Suchen" titleReplace="Ersetzen" titleFindInFiles="In Dateien suchen" titleMark="Hervorheben">
-				<Item id="1"    name="Suchen  ›"/>
-				<Item id="1721" name="‹  Suchen"/>
+        <Dialog>
+            <Find title="Suchen und ersetzen" titleFind="Suchen" titleReplace="Ersetzen" titleFindInFiles="In Dateien suchen" titleMark="Hervorheben">
+                <Item id="1"    name="Suchen  ›"/>
+                <Item id="1721" name="‹  Suchen"/>
                 <Item id="2"    name="Schließen"/>
-				<Item id="1620" name="Suchen nach:"/>
-				<Item id="1603" name="Nur ganze Wörter suchen"/>
-				<Item id="1604" name="Groß-/Kleinschreibung beachten"/>
-				<Item id="1605" name="Reguläre Ausdrücke"/>
-				<Item id="1606" name="Am Ende von vorne beginnen"/>
-				<Item id="1612" name="Rückwärts"/>
-				<Item id="1613" name="Vorwärts"/>
-				<Item id="1614" name="Zählen"/>
-				<Item id="1615" name="Alle suchen"/>
-				<Item id="1616" name="Lesezeichen setzen"/>
-				<Item id="1618" name="Für jede Suche löschen"/>
-				<Item id="1621" name="Suchrichtung"/>
-				<Item id="1611" name="Ersetzen durch:"/>
-				<Item id="1608" name="Ersetzen"/>
-				<Item id="1609" name="Alle ersetzen"/>
-				<Item id="1687" name="Wenn inaktiv"/>
-				<Item id="1688" name="Immer"/>
-				<Item id="1632" name="In Auswahl"/>
-				<Item id="1633" name="Zurücksetzen"/>
-				<Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
-				<Item id="1636" name="In offenen Dateien suchen"/>
-				<Item id="1654" name="Filter:"/>
-				<Item id="1655" name="Verzeichnis:"/>
-				<Item id="1656" name="Alle suchen"/>
-				<Item id="1658" name="Unterverzeichnisse"/>
-				<Item id="1659" name="Versteckte Ordner"/>
-				<Item id="1624" name="Suchmodus"/>
-				<Item id="1625" name="Normal"/>
-				<Item id="1626" name="Erweitert (\n, \r, \t, \0, \x…)"/>
-				<Item id="1660" name="Ersetzen in Dateien"/>
-				<Item id="1661" name="Ordner der akt. Datei"/>
-				<Item id="1641" name="Alle in aktiver Datei suchen"/>
-				<Item id="1686" name="Transparenz"/>
-				<Item id="1703" name=". findet \r und \n"/>
-				<Item id="1627" name="Unten"/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
-				<Item id="1637" name="In Dateien suchen"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-				<Item id="1640" name="Umschaltdialog"/>			<!-- kommt im englischen nicht oder nicht mehr vor -->
-			</Find>
+                <Item id="1620" name="Suchen nach:"/>
+                <Item id="1603" name="Nur ganze Wörter suchen"/>
+                <Item id="1604" name="Groß-/Kleinschreibung beachten"/>
+                <Item id="1605" name="Reguläre Ausdrücke"/>
+                <Item id="1606" name="Am Ende von vorne beginnen"/>
+                <Item id="1612" name="Rückwärts"/>
+                <Item id="1613" name="Vorwärts"/>
+                <Item id="1614" name="Zählen"/>
+                <Item id="1615" name="Alle suchen"/>
+                <Item id="1616" name="Lesezeichen setzen"/>
+                <Item id="1618" name="Für jede Suche löschen"/>
+                <Item id="1621" name="Suchrichtung"/>
+                <Item id="1611" name="Ersetzen durch:"/>
+                <Item id="1608" name="Ersetzen"/>
+                <Item id="1609" name="Alle ersetzen"/>
+                <Item id="1687" name="Wenn inaktiv"/>
+                <Item id="1688" name="Immer"/>
+                <Item id="1632" name="In Auswahl"/>
+                <Item id="1633" name="Zurücksetzen"/>
+                <Item id="1635" name="Alle Funde in allen offenen Dateien ersetzen"/>
+                <Item id="1636" name="In offenen Dateien suchen"/>
+                <Item id="1654" name="Filter:"/>
+                <Item id="1655" name="Verzeichnis:"/>
+                <Item id="1656" name="Alle suchen"/>
+                <Item id="1658" name="Unterverzeichnisse"/>
+                <Item id="1659" name="Versteckte Ordner"/>
+                <Item id="1624" name="Suchmodus"/>
+                <Item id="1625" name="Normal"/>
+                <Item id="1626" name="Erweitert (\n, \r, \t, \0, \x…)"/>
+                <Item id="1660" name="Ersetzen in Dateien"/>
+                <Item id="1661" name="Ordner der akt. Datei"/>
+                <Item id="1641" name="Alle in aktiver Datei suchen"/>
+                <Item id="1686" name="Transparenz"/>
+                <Item id="1703" name=". findet \r und \n"/>
+                <Item id="1627" name="Unten"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
+                <Item id="1637" name="In Dateien suchen"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                <Item id="1640" name="Umschaltdialog"/>            <!-- kommt im englischen nicht oder nicht mehr vor -->
+            </Find>
 
-			<FindCharsInRange title="Suche nach Zeichencodes">
-				<Item id="-1"   name="–"/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
-				<Item id="2"    name="Schließen"/>
-				<Item id="2901" name="Nicht-ASCII-Zeichen (128–255)"/>
-				<Item id="2902" name="ASCII-Zeichen (0–127)"/>
-				<Item id="2903" name="Benutzerdefiniert:"/>
-				<Item id="2906" name="Aufwärts"/>
-				<Item id="2907" name="Abwärts"/>
-				<Item id="2908" name="Suchrichtung"/>
-				<Item id="2909" name="Am Ende von vorne beginnen"/>
-				<Item id="2910" name="Suchen"/>
-			</FindCharsInRange>
+            <FindCharsInRange title="Suche nach Zeichencodes">
+                <Item id="-1"   name="–"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
+                <Item id="2"    name="Schließen"/>
+                <Item id="2901" name="Nicht-ASCII-Zeichen (128–255)"/>
+                <Item id="2902" name="ASCII-Zeichen (0–127)"/>
+                <Item id="2903" name="Benutzerdefiniert:"/>
+                <Item id="2906" name="Aufwärts"/>
+                <Item id="2907" name="Abwärts"/>
+                <Item id="2908" name="Suchrichtung"/>
+                <Item id="2909" name="Am Ende von vorne beginnen"/>
+                <Item id="2910" name="Suchen"/>
+            </FindCharsInRange>
 
-			<GoToLine title="Gehe zu">
-				<Item id="2007" name="Zeile"/>
-				<Item id="2008" name="Zeichen"/>
-				<Item id="1"    name="Gehe zu"/>
-				<Item id="2"    name="Abbrechen"/>
-				<Item id="2004" name="Aktuell:"/>
-				<Item id="2005" name="Ziel:"/>
-				<Item id="2006" name="Insgesamt in der Datei:"/>
-			</GoToLine>
+            <GoToLine title="Gehe zu">
+                <Item id="2007" name="Zeile"/>
+                <Item id="2008" name="Zeichen"/>
+                <Item id="1"    name="Gehe zu"/>
+                <Item id="2"    name="Abbrechen"/>
+                <Item id="2004" name="Aktuell:"/>
+                <Item id="2005" name="Ziel:"/>
+                <Item id="2006" name="Insgesamt in der Datei:"/>
+            </GoToLine>
 
-			<Run title="Ausführen …">
-				<Item id="1903" name="Auszuführendes Programm hier eingeben"/>
-				<Item id="1"    name="Ausführen"/>
-				<Item id="2"    name="Abbrechen"/>
-				<Item id="1904" name="Speichern"/>
-				<Item id="1901" name="..."/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
-			</Run>
+            <Run title="Ausführen …">
+                <Item id="1903" name="Auszuführendes Programm hier eingeben"/>
+                <Item id="1"    name="Ausführen"/>
+                <Item id="2"    name="Abbrechen"/>
+                <Item id="1904" name="Speichern"/>
+                <Item id="1901" name="..."/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
+            </Run>
 
-			<MD5FromFilesDlg title="Erstelle MD5-Hashwert aus Dateien">
-				<Item id="1922" name="Wähle Dateien zur Erstellung des MD5-Hashwerts …"/>
-				<Item id="1924" name="In die Zwischenablage kopieren"/>
-				<Item id="2"    name="Schließen"/>
-			</MD5FromFilesDlg>
+            <MD5FromFilesDlg title="Erstelle MD5-Hashwert aus Dateien">
+                <Item id="1922" name="Wähle Dateien zur Erstellung des MD5-Hashwerts …"/>
+                <Item id="1924" name="In die Zwischenablage kopieren"/>
+                <Item id="2"    name="Schließen"/>
+            </MD5FromFilesDlg>
 
-			<MD5FromTextDlg title="Erstelle MD5-Hashwert">
-				<Item id="1932" name="Behandle jede Zeile als eigene Zeichenkette"/>
-				<Item id="1934" name="In die Zwischenablage kopieren"/>
-				<Item id="2"    name="Schließen"/>
-			</MD5FromTextDlg>
+            <MD5FromTextDlg title="Erstelle MD5-Hashwert">
+                <Item id="1932" name="Behandle jede Zeile als eigene Zeichenkette"/>
+                <Item id="1934" name="In die Zwischenablage kopieren"/>
+                <Item id="2"    name="Schließen"/>
+            </MD5FromTextDlg>
 
-			<StyleConfig title="Stile">
-				<Item id="1"    name="Übernehmen"/>				<!-- kommt im englischen nicht oder nicht mehr vor -->
-				<Item id="2"    name="Abbrechen"/>
-				<Item id="2301" name="Speichern && Schließen"/>
-				<Item id="2303" name="Transparenz"/>
-				<Item id="2306" name="Design:"/>
-				<SubDialog>
-					<Item id="2204" name="Fett"/>
-					<Item id="2205" name="Kursiv"/>
-					<Item id="2206" name="Vordergrundfarbe"/>
-					<Item id="2207" name="Hintergrundfarbe"/>
-					<Item id="2208" name="Schriftart"/>
-					<Item id="2209" name="Größe"/>
-					<Item id="2211" name="Stilbeschreibung"/>
-					<Item id="2212" name="Farben"/>
-					<Item id="2213" name="Schriften"/>
-					<Item id="2214" name="Standard-Erw."/>
-					<Item id="2216" name="Benutzer-Erw."/>
-					<Item id="2218" name="Unterstrichen"/>
-					<Item id="2219" name="Standard-Schlüsselwörter"/>
-					<Item id="2221" name="Benutzerdefinierte Schlüsselwörter"/>
-					<Item id="2225" name="Sprache"/>
-					<Item id="2226" name="Standard-Vordergrundfarbe"/>
-					<Item id="2227" name="Standard-Hintergrundfarbe"/>
-					<Item id="2228" name="Schriftart als Standard setzen"/>
-					<Item id="2229" name="Schriftgröße als Standard setzen"/>
-					<Item id="2230" name="Fettschrift als Standard setzen"/>
-					<Item id="2231" name="Kursivschrift als Standard setzen"/>
-					<Item id="2232" name="Unterstrichen als Standard setzen"/>
-				</SubDialog>
+            <StyleConfig title="Stile">
+                <Item id="1"    name="Übernehmen"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
+                <Item id="2"    name="Abbrechen"/>
+                <Item id="2301" name="Speichern && Schließen"/>
+                <Item id="2303" name="Transparenz"/>
+                <Item id="2306" name="Design:"/>
+                <SubDialog>
+                    <Item id="2204" name="Fett"/>
+                    <Item id="2205" name="Kursiv"/>
+                    <Item id="2206" name="Vordergrundfarbe"/>
+                    <Item id="2207" name="Hintergrundfarbe"/>
+                    <Item id="2208" name="Schriftart"/>
+                    <Item id="2209" name="Größe"/>
+                    <Item id="2211" name="Stilbeschreibung"/>
+                    <Item id="2212" name="Farben"/>
+                    <Item id="2213" name="Schriften"/>
+                    <Item id="2214" name="Standard-Erw."/>
+                    <Item id="2216" name="Benutzer-Erw."/>
+                    <Item id="2218" name="Unterstrichen"/>
+                    <Item id="2219" name="Standard-Schlüsselwörter"/>
+                    <Item id="2221" name="Benutzerdefinierte Schlüsselwörter"/>
+                    <Item id="2225" name="Sprache"/>
+                    <Item id="2226" name="Standard-Vordergrundfarbe"/>
+                    <Item id="2227" name="Standard-Hintergrundfarbe"/>
+                    <Item id="2228" name="Schriftart als Standard setzen"/>
+                    <Item id="2229" name="Schriftgröße als Standard setzen"/>
+                    <Item id="2230" name="Fettschrift als Standard setzen"/>
+                    <Item id="2231" name="Kursivschrift als Standard setzen"/>
+                    <Item id="2232" name="Unterstrichen als Standard setzen"/>
+                </SubDialog>
 
-			</StyleConfig>
+            </StyleConfig>
 
-			<UserDefine title="Benutzerdefinierte Sprache">
-				<Item id="20001" name="Andocken"/>
-				<Item id="20002" name="Umbenennen"/>
-				<Item id="20003" name="Neue erstellen …"/>
-				<Item id="20004" name="Löschen"/>
-				<Item id="20005" name="Speichern als …"/>
-				<Item id="20007" name="Benutzer Sprache: "/>
-				<Item id="20009" name="Erw.:"/>
-				<Item id="20012" name="Groß/klein ignorieren"/>
-				<Item id="20011" name="Transparenz"/>
-				<Item id="20015" name="Importieren"/>
-				<Item id="20016" name="Exportieren"/>
-				<StylerDialog title="Stiloptionen für benutzerdefinierte Sprachen">
-					<Item id="25030" name="Schriftoptionen"/>
-					<Item id="25006" name="Vordergrundfarbe:"/>
-					<Item id="25007" name="Hintergrundfarbe:"/>
-					<Item id="25031" name="Schriftart:"/>
-					<Item id="25032" name="Größe:"/>
-					<Item id="25001" name="Fett"/>
-					<Item id="25002" name="Kursiv"/>
-					<Item id="25003" name="Unterstrichen"/>
-					<Item id="25029" name="Eingebettete Stile"/>
-					<Item id="25008" name="Trennzeichen 1"/>
-					<Item id="25009" name="Trennzeichen 2"/>
-					<Item id="25010" name="Trennzeichen 3"/>
-					<Item id="25011" name="Trennzeichen 4"/>
-					<Item id="25012" name="Trennzeichen 5"/>
-					<Item id="25013" name="Trennzeichen 6"/>
-					<Item id="25014" name="Trennzeichen 7"/>
-					<Item id="25015" name="Trennzeichen 8"/>
-					<Item id="25018" name="Schlüsselwörter 1"/>
-					<Item id="25019" name="Schlüsselwörter 2"/>
-					<Item id="25020" name="Schlüsselwörter 3"/>
-					<Item id="25021" name="Schlüsselwörter 4"/>
-					<Item id="25022" name="Schlüsselwörter 5"/>
-					<Item id="25023" name="Schlüsselwörter 6"/>
-					<Item id="25024" name="Schlüsselwörter 7"/>
-					<Item id="25025" name="Schlüsselwörter 8"/>
-					<Item id="25016" name="Kommentare"/>
-					<Item id="25017" name="Zeilenkommentare"/>
-					<Item id="25026" name="Operatoren 1"/>
-					<Item id="25027" name="Operatoren 2"/>
-					<Item id="25028" name="Zahlen"/>
-					<Item id="1"     name="OK"/>
-					<Item id="2"     name="Abbrechen"/>
-				</StylerDialog>
-				<Folder title="Textblöcke && Voreinstellung">
-					<Item id="21101" name="Standardschrift"/>
-					<Item id="21102" name="Stil"/>
-					<Item id="21105" name="Dokumentation"/>
-					<Item id="21104" name="Dokumentation online:"/>
-					<Item id="21106" name="Leerzeilen mit einfalten (kompakte Faltung)"/>
-					<Item id="21220" name="Textblöcke im Code 1"/>
-					<Item id="21224" name="Anfang"/>
-					<Item id="21225" name="Mitte"/>
-					<Item id="21226" name="Ende"/>
-					<Item id="21227" name="Stil"/>
-					<Item id="21320" name="Textblöcke im Code 2 (mit Trennzeichen)"/>
-					<Item id="21324" name="Anfang"/>
-					<Item id="21325" name="Mitte"/>
-					<Item id="21326" name="Ende"/>
-					<Item id="21327" name="Stil"/>
-					<Item id="21420" name="Textblöcke in Kommentaren"/>
-					<Item id="21424" name="Anfang"/>
-					<Item id="21425" name="Mitte"/>
-					<Item id="21426" name="Ende"/>
-					<Item id="21427" name="Stil"/>
-				</Folder>
-				<Keywords title="Schlüsselwörter">
-					<Item id="22101" name="1. Gruppe"/>
-					<Item id="22201" name="2. Gruppe"/>
-					<Item id="22301" name="3. Gruppe"/>
-					<Item id="22401" name="4. Gruppe"/>
-					<Item id="22451" name="5. Gruppe"/>
-					<Item id="22501" name="6. Gruppe"/>
-					<Item id="22551" name="7. Gruppe"/>
-					<Item id="22601" name="8. Gruppe"/>
-					<Item id="22121" name="Präfixmodus"/>
-					<Item id="22221" name="Präfixmodus"/>
-					<Item id="22321" name="Präfixmodus"/>
-					<Item id="22421" name="Präfixmodus"/>
-					<Item id="22471" name="Präfixmodus"/>
-					<Item id="22521" name="Präfixmodus"/>
-					<Item id="22571" name="Präfixmodus"/>
-					<Item id="22621" name="Präfixmodus"/>
-					<Item id="22122" name="Stil"/>
-					<Item id="22222" name="Stil"/>
-					<Item id="22322" name="Stil"/>
-					<Item id="22422" name="Stil"/>
-					<Item id="22472" name="Stil"/>
-					<Item id="22522" name="Stil"/>
-					<Item id="22572" name="Stil"/>
-					<Item id="22622" name="Stil"/>
-				</Keywords>
-				<Comment title="Kommentare && Zahlen">
-					<Item id="23002" name="Am Zeilenanfang Zeilenkommentar erzwingen"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-					<Item id="23003" name="Position von Zeilenkommentaren"/>
-					<Item id="23004" name="Überall erlauben"/>
-					<Item id="23005" name="Nur am Zeilenanfang"/>
-					<Item id="23006" name="Führende Leerzeichen erlauben"/>
-					<Item id="23001" name="Einfalten von Kommentaren erlauben"/>
-					<Item id="23326" name="Stil"/>
-					<Item id="23323" name="Kommentaranfang"/>
-					<Item id="23324" name="Fortsetzungszeichen"/>
-					<Item id="23325" name="Kommentarende"/>
-					<Item id="23301" name="Zeilenkommentare"/>
-					<Item id="23124" name="Stil"/>
-					<Item id="23122" name="Kommentaranfang"/>
-					<Item id="23123" name="Kommentarende"/>
-					<Item id="23101" name="Blockkommentare"/>
-					<Item id="23201" name="Zahlen"/>
-					<Item id="23220" name="Stil"/>
-					<Item id="23230" name="Präfix 1"/>
-					<Item id="23232" name="Präfix 2"/>
-					<Item id="23234" name="Extras 1"/>
-					<Item id="23236" name="Extras 2"/>
-					<Item id="23238" name="Suffix 1"/>
-					<Item id="23240" name="Suffix 2"/>
-					<Item id="23242" name="Bereich"/>
-					<Item id="23244" name="Dezimaltrenner"/>
-					<Item id="23245" name="Punkt"/>
-					<Item id="23246" name="Komma"/>
-					<Item id="23247" name="Beides"/>
-				</Comment>
-				<Operator title="Operatoren && Trenner">
-					<Item id="24101" name="Operatoren"/>
-					<Item id="24113" name="Stil"/>
-					<Item id="24116" name="Operatoren 1"/>
-					<Item id="24117" name="Operatoren 2 (leerzeichengetrennt)"/>
-					<Item id="24201" name="Trennzeichen 1"/>
-					<Item id="24220" name="Anfangszeichen"/>
-					<Item id="24221" name="Escapezeichen"/>
-					<Item id="24222" name="Abschlusszeichen"/>
-					<Item id="24223" name="Stil"/>
-					<Item id="24301" name="Trennzeichen 2"/>
-					<Item id="24320" name="Anfangszeichen"/>
-					<Item id="24321" name="Escapezeichen"/>
-					<Item id="24322" name="Abschlusszeichen"/>
-					<Item id="24323" name="Stil"/>
-					<Item id="24401" name="Trennzeichen 3"/>
-					<Item id="24420" name="Anfangszeichen"/>
-					<Item id="24421" name="Escapezeichen"/>
-					<Item id="24422" name="Abschlusszeichen"/>
-					<Item id="24423" name="Stil"/>
-					<Item id="24451" name="Trennzeichen 4"/>
-					<Item id="24470" name="Anfangszeichen"/>
-					<Item id="24471" name="Escapezeichen"/>
-					<Item id="24472" name="Abschlusszeichen"/>
-					<Item id="24473" name="Stil"/>
-					<Item id="24501" name="Trennzeichen 5"/>
-					<Item id="24520" name="Anfangszeichen"/>
-					<Item id="24521" name="Escapezeichen"/>
-					<Item id="24522" name="Abschlusszeichen"/>
-					<Item id="24523" name="Stil"/>
-					<Item id="24551" name="Trennzeichen 6"/>
-					<Item id="24570" name="Anfangszeichen"/>
-					<Item id="24571" name="Escapezeichen"/>
-					<Item id="24572" name="Abschlusszeichen"/>
-					<Item id="24573" name="Stil"/>
-					<Item id="24601" name="Trennzeichen 7"/>
-					<Item id="24620" name="Anfangszeichen"/>
-					<Item id="24621" name="Escapezeichen"/>
-					<Item id="24622" name="Abschlusszeichen"/>
-					<Item id="24623" name="Stil"/>
-					<Item id="24651" name="Trennzeichen 8"/>
-					<Item id="24670" name="Anfangszeichen"/>
-					<Item id="24671" name="Escapezeichen"/>
-					<Item id="24672" name="Abschlusszeichen"/>
-					<Item id="24673" name="Stil"/>
-				</Operator>
-			</UserDefine>
-			<Preference title="Optionen">
-				<Item id="6001" name="Schließen"/>
-				<Global title="Oberfläche 1">
-					<Item id="6101" name="Symbolleiste"/>
-					<Item id="6102" name="Ausblenden"/>
-					<Item id="6103" name="Kleine Icons"/>
-					<Item id="6104" name="Große Icons"/>
-					<Item id="6105" name="Kleine Standard-Icons"/>
+            <UserDefine title="Benutzerdefinierte Sprache">
+                <Item id="20001" name="Andocken"/>
+                <Item id="20002" name="Umbenennen"/>
+                <Item id="20003" name="Neue erstellen …"/>
+                <Item id="20004" name="Löschen"/>
+                <Item id="20005" name="Speichern als …"/>
+                <Item id="20007" name="Benutzer Sprache: "/>
+                <Item id="20009" name="Erw.:"/>
+                <Item id="20012" name="Groß/klein ignorieren"/>
+                <Item id="20011" name="Transparenz"/>
+                <Item id="20015" name="Importieren"/>
+                <Item id="20016" name="Exportieren"/>
+                <StylerDialog title="Stiloptionen für benutzerdefinierte Sprachen">
+                    <Item id="25030" name="Schriftoptionen"/>
+                    <Item id="25006" name="Vordergrundfarbe:"/>
+                    <Item id="25007" name="Hintergrundfarbe:"/>
+                    <Item id="25031" name="Schriftart:"/>
+                    <Item id="25032" name="Größe:"/>
+                    <Item id="25001" name="Fett"/>
+                    <Item id="25002" name="Kursiv"/>
+                    <Item id="25003" name="Unterstrichen"/>
+                    <Item id="25029" name="Eingebettete Stile"/>
+                    <Item id="25008" name="Trennzeichen 1"/>
+                    <Item id="25009" name="Trennzeichen 2"/>
+                    <Item id="25010" name="Trennzeichen 3"/>
+                    <Item id="25011" name="Trennzeichen 4"/>
+                    <Item id="25012" name="Trennzeichen 5"/>
+                    <Item id="25013" name="Trennzeichen 6"/>
+                    <Item id="25014" name="Trennzeichen 7"/>
+                    <Item id="25015" name="Trennzeichen 8"/>
+                    <Item id="25018" name="Schlüsselwörter 1"/>
+                    <Item id="25019" name="Schlüsselwörter 2"/>
+                    <Item id="25020" name="Schlüsselwörter 3"/>
+                    <Item id="25021" name="Schlüsselwörter 4"/>
+                    <Item id="25022" name="Schlüsselwörter 5"/>
+                    <Item id="25023" name="Schlüsselwörter 6"/>
+                    <Item id="25024" name="Schlüsselwörter 7"/>
+                    <Item id="25025" name="Schlüsselwörter 8"/>
+                    <Item id="25016" name="Kommentare"/>
+                    <Item id="25017" name="Zeilenkommentare"/>
+                    <Item id="25026" name="Operatoren 1"/>
+                    <Item id="25027" name="Operatoren 2"/>
+                    <Item id="25028" name="Zahlen"/>
+                    <Item id="1"     name="OK"/>
+                    <Item id="2"     name="Abbrechen"/>
+                </StylerDialog>
+                <Folder title="Textblöcke && Voreinstellung">
+                    <Item id="21101" name="Standardschrift"/>
+                    <Item id="21102" name="Stil"/>
+                    <Item id="21105" name="Dokumentation"/>
+                    <Item id="21104" name="Dokumentation online:"/>
+                    <Item id="21106" name="Leerzeilen mit einfalten (kompakte Faltung)"/>
+                    <Item id="21220" name="Textblöcke im Code 1"/>
+                    <Item id="21224" name="Anfang"/>
+                    <Item id="21225" name="Mitte"/>
+                    <Item id="21226" name="Ende"/>
+                    <Item id="21227" name="Stil"/>
+                    <Item id="21320" name="Textblöcke im Code 2 (mit Trennzeichen)"/>
+                    <Item id="21324" name="Anfang"/>
+                    <Item id="21325" name="Mitte"/>
+                    <Item id="21326" name="Ende"/>
+                    <Item id="21327" name="Stil"/>
+                    <Item id="21420" name="Textblöcke in Kommentaren"/>
+                    <Item id="21424" name="Anfang"/>
+                    <Item id="21425" name="Mitte"/>
+                    <Item id="21426" name="Ende"/>
+                    <Item id="21427" name="Stil"/>
+                </Folder>
+                <Keywords title="Schlüsselwörter">
+                    <Item id="22101" name="1. Gruppe"/>
+                    <Item id="22201" name="2. Gruppe"/>
+                    <Item id="22301" name="3. Gruppe"/>
+                    <Item id="22401" name="4. Gruppe"/>
+                    <Item id="22451" name="5. Gruppe"/>
+                    <Item id="22501" name="6. Gruppe"/>
+                    <Item id="22551" name="7. Gruppe"/>
+                    <Item id="22601" name="8. Gruppe"/>
+                    <Item id="22121" name="Präfixmodus"/>
+                    <Item id="22221" name="Präfixmodus"/>
+                    <Item id="22321" name="Präfixmodus"/>
+                    <Item id="22421" name="Präfixmodus"/>
+                    <Item id="22471" name="Präfixmodus"/>
+                    <Item id="22521" name="Präfixmodus"/>
+                    <Item id="22571" name="Präfixmodus"/>
+                    <Item id="22621" name="Präfixmodus"/>
+                    <Item id="22122" name="Stil"/>
+                    <Item id="22222" name="Stil"/>
+                    <Item id="22322" name="Stil"/>
+                    <Item id="22422" name="Stil"/>
+                    <Item id="22472" name="Stil"/>
+                    <Item id="22522" name="Stil"/>
+                    <Item id="22572" name="Stil"/>
+                    <Item id="22622" name="Stil"/>
+                </Keywords>
+                <Comment title="Kommentare && Zahlen">
+                    <Item id="23002" name="Am Zeilenanfang Zeilenkommentar erzwingen"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                    <Item id="23003" name="Position von Zeilenkommentaren"/>
+                    <Item id="23004" name="Überall erlauben"/>
+                    <Item id="23005" name="Nur am Zeilenanfang"/>
+                    <Item id="23006" name="Führende Leerzeichen erlauben"/>
+                    <Item id="23001" name="Einfalten von Kommentaren erlauben"/>
+                    <Item id="23326" name="Stil"/>
+                    <Item id="23323" name="Kommentaranfang"/>
+                    <Item id="23324" name="Fortsetzungszeichen"/>
+                    <Item id="23325" name="Kommentarende"/>
+                    <Item id="23301" name="Zeilenkommentare"/>
+                    <Item id="23124" name="Stil"/>
+                    <Item id="23122" name="Kommentaranfang"/>
+                    <Item id="23123" name="Kommentarende"/>
+                    <Item id="23101" name="Blockkommentare"/>
+                    <Item id="23201" name="Zahlen"/>
+                    <Item id="23220" name="Stil"/>
+                    <Item id="23230" name="Präfix 1"/>
+                    <Item id="23232" name="Präfix 2"/>
+                    <Item id="23234" name="Extras 1"/>
+                    <Item id="23236" name="Extras 2"/>
+                    <Item id="23238" name="Suffix 1"/>
+                    <Item id="23240" name="Suffix 2"/>
+                    <Item id="23242" name="Bereich"/>
+                    <Item id="23244" name="Dezimaltrenner"/>
+                    <Item id="23245" name="Punkt"/>
+                    <Item id="23246" name="Komma"/>
+                    <Item id="23247" name="Beides"/>
+                </Comment>
+                <Operator title="Operatoren && Trenner">
+                    <Item id="24101" name="Operatoren"/>
+                    <Item id="24113" name="Stil"/>
+                    <Item id="24116" name="Operatoren 1"/>
+                    <Item id="24117" name="Operatoren 2 (leerzeichengetrennt)"/>
+                    <Item id="24201" name="Trennzeichen 1"/>
+                    <Item id="24220" name="Anfangszeichen"/>
+                    <Item id="24221" name="Escapezeichen"/>
+                    <Item id="24222" name="Abschlusszeichen"/>
+                    <Item id="24223" name="Stil"/>
+                    <Item id="24301" name="Trennzeichen 2"/>
+                    <Item id="24320" name="Anfangszeichen"/>
+                    <Item id="24321" name="Escapezeichen"/>
+                    <Item id="24322" name="Abschlusszeichen"/>
+                    <Item id="24323" name="Stil"/>
+                    <Item id="24401" name="Trennzeichen 3"/>
+                    <Item id="24420" name="Anfangszeichen"/>
+                    <Item id="24421" name="Escapezeichen"/>
+                    <Item id="24422" name="Abschlusszeichen"/>
+                    <Item id="24423" name="Stil"/>
+                    <Item id="24451" name="Trennzeichen 4"/>
+                    <Item id="24470" name="Anfangszeichen"/>
+                    <Item id="24471" name="Escapezeichen"/>
+                    <Item id="24472" name="Abschlusszeichen"/>
+                    <Item id="24473" name="Stil"/>
+                    <Item id="24501" name="Trennzeichen 5"/>
+                    <Item id="24520" name="Anfangszeichen"/>
+                    <Item id="24521" name="Escapezeichen"/>
+                    <Item id="24522" name="Abschlusszeichen"/>
+                    <Item id="24523" name="Stil"/>
+                    <Item id="24551" name="Trennzeichen 6"/>
+                    <Item id="24570" name="Anfangszeichen"/>
+                    <Item id="24571" name="Escapezeichen"/>
+                    <Item id="24572" name="Abschlusszeichen"/>
+                    <Item id="24573" name="Stil"/>
+                    <Item id="24601" name="Trennzeichen 7"/>
+                    <Item id="24620" name="Anfangszeichen"/>
+                    <Item id="24621" name="Escapezeichen"/>
+                    <Item id="24622" name="Abschlusszeichen"/>
+                    <Item id="24623" name="Stil"/>
+                    <Item id="24651" name="Trennzeichen 8"/>
+                    <Item id="24670" name="Anfangszeichen"/>
+                    <Item id="24671" name="Escapezeichen"/>
+                    <Item id="24672" name="Abschlusszeichen"/>
+                    <Item id="24673" name="Stil"/>
+                </Operator>
+            </UserDefine>
+            <Preference title="Optionen">
+                <Item id="6001" name="Schließen"/>
+                <Global title="Oberfläche 1">
+                    <Item id="6101" name="Symbolleiste"/>
+                    <Item id="6102" name="Ausblenden"/>
+                    <Item id="6103" name="Kleine Icons"/>
+                    <Item id="6104" name="Große Icons"/>
+                    <Item id="6105" name="Kleine Standard-Icons"/>
 
-					<Item id="6106" name="Dateireiter (Tabs)"/>
-					<Item id="6107" name="Verkleinern"/>
-					<Item id="6108" name="Tabs nicht mit der Maus verschiebbar"/>
-					<Item id="6109" name="Inaktive Tabs dunkler darstellen"/>
-					<Item id="6110" name="Aktiven Tab farbig hervorheben"/>
+                    <Item id="6106" name="Dateireiter (Tabs)"/>
+                    <Item id="6107" name="Verkleinern"/>
+                    <Item id="6108" name="Tabs nicht mit der Maus verschiebbar"/>
+                    <Item id="6109" name="Inaktive Tabs dunkler darstellen"/>
+                    <Item id="6110" name="Aktiven Tab farbig hervorheben"/>
 
-					<Item id="6111" name="Statusleiste anzeigen"/>
-					<Item id="6112" name="Schließen-Kreuz auf jedem Tab"/>
-					<Item id="6113" name="Tabs per Doppelklick schließen"/>
-					<Item id="6118" name="Ausblenden"/>
-					<Item id="6119" name="Mehrzeilig"/>
-					<Item id="6120" name="Vertikal"/>
-					<Item id="6121" name="Programm beim Schließen des letzten Tabs beenden"/>
+                    <Item id="6111" name="Statusleiste anzeigen"/>
+                    <Item id="6112" name="Schließen-Kreuz auf jedem Tab"/>
+                    <Item id="6113" name="Tabs per Doppelklick schließen"/>
+                    <Item id="6118" name="Ausblenden"/>
+                    <Item id="6119" name="Mehrzeilig"/>
+                    <Item id="6120" name="Vertikal"/>
+                    <Item id="6121" name="Programm beim Schließen des letzten Tabs beenden"/>
 
-					<Item id="6122" name="Menüleiste ausblenden (wechseln: Alt oder F10)"/>
-					<Item id="6123" name="Sprache der Benutzeroberfläche"/>
+                    <Item id="6122" name="Menüleiste ausblenden (wechseln: Alt oder F10)"/>
+                    <Item id="6123" name="Sprache der Benutzeroberfläche"/>
 
-					<Item id="6125" name="Liste der geöffneten Dateien"/>
-					<Item id="6126" name="Anzeigen"/>
-					<Item id="6127" name="Erweiterungsspalte ausblenden"/>
-				</Global>
-				<Scintillas title="Oberfläche 2">
-					<Item id="6216" name="Cursoreinstellungen"/>
-					<Item id="6217" name="Breite"/>
-					<Item id="6219" name="Geschwindigkeit"/>
-					<Item id="6221" name="S"/>
-					<Item id="6222" name="L"/>
-					<Item id="6224" name="Mehrfaches Editieren"/>
-					<Item id="6225" name="Aktivieren (Strg+Mausklick)"/>
-					<Item id="6201" name="Textblock-Faltung"/>
-					<Item id="6202" name="Plus/minus"/>
-					<Item id="6203" name="Pfeile"/>
-					<Item id="6204" name="Kreise"/>
-					<Item id="6205" name="Quadrate"/>
-					<Item id="6226" name="Aus"/>
+                    <Item id="6125" name="Liste der geöffneten Dateien"/>
+                    <Item id="6126" name="Anzeigen"/>
+                    <Item id="6127" name="Erweiterungsspalte ausblenden"/>
+                </Global>
+                <Scintillas title="Oberfläche 2">
+                    <Item id="6216" name="Cursoreinstellungen"/>
+                    <Item id="6217" name="Breite"/>
+                    <Item id="6219" name="Geschwindigkeit"/>
+                    <Item id="6221" name="S"/>
+                    <Item id="6222" name="L"/>
+                    <Item id="6224" name="Mehrfaches Editieren"/>
+                    <Item id="6225" name="Aktivieren (Strg+Mausklick)"/>
+                    <Item id="6201" name="Textblock-Faltung"/>
+                    <Item id="6202" name="Plus/minus"/>
+                    <Item id="6203" name="Pfeile"/>
+                    <Item id="6204" name="Kreise"/>
+                    <Item id="6205" name="Quadrate"/>
+                    <Item id="6226" name="Aus"/>
 
-					<Item id="6227" name="Umgebrochene Zeilen"/>
-					<Item id="6228" name="Standard"/>
-					<Item id="6229" name="Linksbündig"/>
-					<Item id="6230" name="Hängend"/>
+                    <Item id="6227" name="Umgebrochene Zeilen"/>
+                    <Item id="6228" name="Standard"/>
+                    <Item id="6229" name="Linksbündig"/>
+                    <Item id="6230" name="Hängend"/>
 
-					<Item id="6206" name="Zeilennummernrand"/>
-					<Item id="6207" name="Lesezeichenrand"/>
-					<Item id="6208" name="Randbegrenzung anzeigen"/>
-					<Item id="6209" name="Anzahl der Spalten:"/>
-					<Item id="6234" name="Flüssiges Scrollen deaktivieren&#x0a;(bei Touchpad-Problemen)"/>
+                    <Item id="6206" name="Zeilennummernrand"/>
+                    <Item id="6207" name="Lesezeichenrand"/>
+                    <Item id="6208" name="Randbegrenzung anzeigen"/>
+                    <Item id="6209" name="Anzahl der Spalten:"/>
+                    <Item id="6234" name="Flüssiges Scrollen deaktivieren&#x0a;(bei Touchpad-Problemen)"/>
 
-					<Item id="6211" name="Rechter Rand"/>
-					<Item id="6212" name="Vertikale Linie"/>
-					<Item id="6213" name="Farbiger Hintergrund"/>
-					<Item id="6214" name="Aktuelle Zeile hervorheben"/>
-					<Item id="6215" name="Kantenglättung der Schriftarten"/>
-					<Item id="6231" name="Rahmenbreite"/>
-					<Item id="6235" name="Kein Rand"/>
-					<Item id="6236" name="Scrollen über letzte Zeile hinaus"/>
-				</Scintillas>
+                    <Item id="6211" name="Rechter Rand"/>
+                    <Item id="6212" name="Vertikale Linie"/>
+                    <Item id="6213" name="Farbiger Hintergrund"/>
+                    <Item id="6214" name="Aktuelle Zeile hervorheben"/>
+                    <Item id="6215" name="Kantenglättung der Schriftarten"/>
+                    <Item id="6231" name="Rahmenbreite"/>
+                    <Item id="6235" name="Kein Rand"/>
+                    <Item id="6236" name="Scrollen über letzte Zeile hinaus"/>
+                </Scintillas>
 
-				<NewDoc title="Neue Dateien">
-					<Item id="6401" name="Zeilenenden"/>
-					<Item id="6402" name="Windows"/>
-					<Item id="6403" name="UNIX"/>
-					<Item id="6404" name="Mac"/>
-					<Item id="6405" name="Kodierung"/>
-					<Item id="6406" name="ANSI"/>
-					<Item id="6407" name="UTF-8 ohne BOM"/>
-					<Item id="6408" name="UTF-8"/>
-					<Item id="6409" name="UCS-2 Big Endian"/>
-					<Item id="6410" name="UCS-2 Little Endian"/>
-					<Item id="6411" name="Standardsprache"/>
-					<Item id="6419" name="Format für neue Dateien"/>
-					<Item id="6420" name="Auch beim Öffnen von ANSI-Dateien"/>
-				</NewDoc>
+                <NewDoc title="Neue Dateien">
+                    <Item id="6401" name="Zeilenenden"/>
+                    <Item id="6402" name="Windows"/>
+                    <Item id="6403" name="UNIX"/>
+                    <Item id="6404" name="Mac"/>
+                    <Item id="6405" name="Kodierung"/>
+                    <Item id="6406" name="ANSI"/>
+                    <Item id="6407" name="UTF-8 ohne BOM"/>
+                    <Item id="6408" name="UTF-8"/>
+                    <Item id="6409" name="UCS-2 Big Endian"/>
+                    <Item id="6410" name="UCS-2 Little Endian"/>
+                    <Item id="6411" name="Standardsprache"/>
+                    <Item id="6419" name="Format für neue Dateien"/>
+                    <Item id="6420" name="Auch beim Öffnen von ANSI-Dateien"/>
+                </NewDoc>
 
-				<DefaultDir title="Standardverzeichnis">
-					<Item id="6413" name="Verzeichnis beim Öffnen/Speichern"/>
-					<Item id="6414" name="Wie aktuelle Datei"/>
-					<Item id="6415" name="Letztes Verzeichnis merken"/>
-					<Item id="6430" name="Neuen Stilspeicherungsdialog benutzen (ohne Dateierweiterungen)"/>	
-					<Item id="6431" name="Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses"/>
-					<Item id="6418" name="…"/>		<!-- kommt im englischen nicht oder nicht mehr vor -->
-				</DefaultDir>
+                <DefaultDir title="Standardverzeichnis">
+                    <Item id="6413" name="Verzeichnis beim Öffnen/Speichern"/>
+                    <Item id="6414" name="Wie aktuelle Datei"/>
+                    <Item id="6415" name="Letztes Verzeichnis merken"/>
+                    <Item id="6430" name="Neuen Stilspeicherungsdialog benutzen (ohne Dateierweiterungen)"/>    
+                    <Item id="6431" name="Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses"/>
+                    <Item id="6418" name="…"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
+                </DefaultDir>
 
-				<FileAssoc title="Dateiverknüpfungen">
-					<Item id="4009" name="Unterstützte Erw.:"/>
-					<Item id="4010" name="Registrierte Erw.:"/>
-				</FileAssoc>
+                <FileAssoc title="Dateiverknüpfungen">
+                    <Item id="4009" name="Unterstützte Erw.:"/>
+                    <Item id="4010" name="Registrierte Erw.:"/>
+                </FileAssoc>
 
-				<Language title="Sprache">
-					<Item id="6505" name="Verfügbar:"/>
-					<Item id="6506" name="Deaktiviert:"/>
-					<Item id="6507" name="Sprachmenü verschachtelt darstellen"/>
-					<Item id="6508" name="Sprachmenü"/>
-					<Item id="6301" name="Tabulatoren"/>
-					<Item id="6302" name="Durch Leerzeichen ersetzen"/>
-					<Item id="6303" name="Tabulatorbreite:"/>
-					<Item id="6510" name="Standard verwenden"/>
-				</Language>
+                <Language title="Sprache">
+                    <Item id="6505" name="Verfügbar:"/>
+                    <Item id="6506" name="Deaktiviert:"/>
+                    <Item id="6507" name="Sprachmenü verschachtelt darstellen"/>
+                    <Item id="6508" name="Sprachmenü"/>
+                    <Item id="6301" name="Tabulatoren"/>
+                    <Item id="6302" name="Durch Leerzeichen ersetzen"/>
+                    <Item id="6303" name="Tabulatorbreite:"/>
+                    <Item id="6510" name="Standard verwenden"/>
+                </Language>
 
-				<Highlighting title="Hervorhebung">
-					<Item id="6333" name="Automatische Hervorhebung bei Auswahl"/>
-					<Item id="6326" name="Hervorhebung aktivieren"/>
-					<Item id="6332" name="Groß-/Kleinschreibung beachten"/>
-					<Item id="6338" name="Übereinstimmung mit ganzem Wort"/>
-					<Item id="6339" name="Sucheinstellungen benutzen"/>
-					<Item id="6340" name="Andere Hervorhebung"/>
-					<Item id="6329" name="HTML-Hervorhebung"/>
-					<Item id="6327" name="Tags hervorheben"/>
-					<Item id="6328" name="Attribute hervorheben"/>
-					<Item id="6330" name="PHP-/ASP-Bereiche hervorheben"/>
-				</Highlighting>
+                <Highlighting title="Hervorhebung">
+                    <Item id="6333" name="Automatische Hervorhebung bei Auswahl"/>
+                    <Item id="6326" name="Hervorhebung aktivieren"/>
+                    <Item id="6332" name="Groß-/Kleinschreibung beachten"/>
+                    <Item id="6338" name="Übereinstimmung mit ganzem Wort"/>
+                    <Item id="6339" name="Sucheinstellungen benutzen"/>
+                    <Item id="6340" name="Andere Hervorhebung"/>
+                    <Item id="6329" name="HTML-Hervorhebung"/>
+                    <Item id="6327" name="Tags hervorheben"/>
+                    <Item id="6328" name="Attribute hervorheben"/>
+                    <Item id="6330" name="PHP-/ASP-Bereiche hervorheben"/>
+                </Highlighting>
 
-				<Print title="Drucken">
-					<Item id="6601" name="Zeilennummern drucken"/>
-					<Item id="6602" name="Farboptionen"/>
-					<Item id="6603" name="Wie angezeigt"/>
-					<Item id="6604" name="Invertieren"/>
-					<Item id="6605" name="Schwarz auf Weiß"/>
-					<Item id="6606" name="Keine Hintergrundfarbe"/>
-					<Item id="6607" name="Seitenränder (mm)"/>
-					<Item id="6612" name="Links"/>
-					<Item id="6613" name="Oben"/>
-					<Item id="6614" name="Rechts"/>
-					<Item id="6615" name="Unten"/>
-					<Item id="6706" name="Fett"/>
-					<Item id="6707" name="Kursiv"/>
-					<Item id="6708" name="Kopfzeile"/>
-					<Item id="6709" name="Linke Seite"/>
-					<Item id="6710" name="Mitte"/>
-					<Item id="6711" name="Rechte Seite"/>
-					<Item id="6717" name="Fett"/>
-					<Item id="6718" name="Kursiv"/>
-					<Item id="6719" name="Fußzeile"/>
-					<Item id="6720" name="Linke Seite"/>
-					<Item id="6721" name="Mitte"/>
-					<Item id="6722" name="Rechte Seite"/>
-					<Item id="6723" name="Hinzufügen"/>
-					<Item id="6725" name="Element"/>
-					<Item id="6727" name="Welcher Teil:"/>
-					<Item id="6728" name="Kopf- und Fußzeile"/>
-				</Print>
+                <Print title="Drucken">
+                    <Item id="6601" name="Zeilennummern drucken"/>
+                    <Item id="6602" name="Farboptionen"/>
+                    <Item id="6603" name="Wie angezeigt"/>
+                    <Item id="6604" name="Invertieren"/>
+                    <Item id="6605" name="Schwarz auf Weiß"/>
+                    <Item id="6606" name="Keine Hintergrundfarbe"/>
+                    <Item id="6607" name="Seitenränder (mm)"/>
+                    <Item id="6612" name="Links"/>
+                    <Item id="6613" name="Oben"/>
+                    <Item id="6614" name="Rechts"/>
+                    <Item id="6615" name="Unten"/>
+                    <Item id="6706" name="Fett"/>
+                    <Item id="6707" name="Kursiv"/>
+                    <Item id="6708" name="Kopfzeile"/>
+                    <Item id="6709" name="Linke Seite"/>
+                    <Item id="6710" name="Mitte"/>
+                    <Item id="6711" name="Rechte Seite"/>
+                    <Item id="6717" name="Fett"/>
+                    <Item id="6718" name="Kursiv"/>
+                    <Item id="6719" name="Fußzeile"/>
+                    <Item id="6720" name="Linke Seite"/>
+                    <Item id="6721" name="Mitte"/>
+                    <Item id="6722" name="Rechte Seite"/>
+                    <Item id="6723" name="Hinzufügen"/>
+                    <Item id="6725" name="Element"/>
+                    <Item id="6727" name="Welcher Teil:"/>
+                    <Item id="6728" name="Kopf- und Fußzeile"/>
+                </Print>
 
-				<RecentFilesHistory title="Zuletzt geöffn. Dateien">
-					<Item id="6304" name="Zuletzt geöffnete Dateien"/>
-					<Item id="6306" name="Max. Menüeinträge:"/>
-					<Item id="6305" name="Beim Programmstart nicht überprüfen"/>
-					<Item id="6429" name="Anzeige im Dateimenü"/>
-					<Item id="6424" name="Als Untermenü"/>
-					<Item id="6425" name="Nur Dateinamen"/>
-					<Item id="6426" name="Namen mit vollem Pfad"/>
-					<Item id="6427" name="Benutzerdefinierte Pfadlänge:"/>
-				</RecentFilesHistory>
+                <RecentFilesHistory title="Zuletzt geöffn. Dateien">
+                    <Item id="6304" name="Zuletzt geöffnete Dateien"/>
+                    <Item id="6306" name="Max. Menüeinträge:"/>
+                    <Item id="6305" name="Beim Programmstart nicht überprüfen"/>
+                    <Item id="6429" name="Anzeige im Dateimenü"/>
+                    <Item id="6424" name="Als Untermenü"/>
+                    <Item id="6425" name="Nur Dateinamen"/>
+                    <Item id="6426" name="Namen mit vollem Pfad"/>
+                    <Item id="6427" name="Benutzerdefinierte Pfadlänge:"/>
+                </RecentFilesHistory>
 
-				<Backup title="Sicherheitskopien">
-					<Item id="6817" name="Sitzungen automatisch speichern"/>
-					<Item id="6818" name="Sitzungen zeitgesteuert speichern"/>
-					<Item id="6819" name="Speichere Sitzung alle"/>
-					<Item id="6821" name="Sekunden"/>
-					<Item id="6822" name="Verzeichnis:"/>
-					<Item id="6309" name="Aktuelle Sitzung für den nächsten Start merken"/>
-					<Item id="6801" name="Sicherheitskopie beim Speichern von Dateien"/>
-					<Item id="6315" name="Keine"/>
-					<Item id="6316" name="Einfach"/>
-					<Item id="6317" name="Erweitert"/>
-					<Item id="6804" name="Verzeichnisangabe für die Sicherheitskopien"/>
-					<Item id="6803" name="Verzeichnis:"/>
-				</Backup>
+                <Backup title="Sicherheitskopien">
+                    <Item id="6817" name="Sitzungen automatisch speichern"/>
+                    <Item id="6818" name="Sitzungen zeitgesteuert speichern"/>
+                    <Item id="6819" name="Speichere Sitzung alle"/>
+                    <Item id="6821" name="Sekunden"/>
+                    <Item id="6822" name="Verzeichnis:"/>
+                    <Item id="6309" name="Aktuelle Sitzung für den nächsten Start merken"/>
+                    <Item id="6801" name="Sicherheitskopie beim Speichern von Dateien"/>
+                    <Item id="6315" name="Keine"/>
+                    <Item id="6316" name="Einfach"/>
+                    <Item id="6317" name="Erweitert"/>
+                    <Item id="6804" name="Verzeichnisangabe für die Sicherheitskopien"/>
+                    <Item id="6803" name="Verzeichnis:"/>
+                </Backup>
 
-				<AutoCompletion title="Autovervollständigung">
-					<Item id="6807" name="Autovervollständigung"/>
-					<Item id="6808" name="Autovervollständigung aktivieren"/>
-					<Item id="6809" name="Funktionsvervollständigung"/>
-					<Item id="6810" name="Wortvervollständigung"/>
-					<Item id="6816" name="Wort- und Funktionsvervollständigung"/>
-					<Item id="6824" name="Zahlen ignorieren"/>
-					<Item id="6811" name="ab"/>
-					<Item id="6813" name="Zeichen"/>
-					<Item id="6814" name="(mögliche Werte: 1–9)"/>
-					<Item id="6815" name="Funktionsparameter anzeigen"/>
-					<Item id="6851" name="Klammern automatisch schließen"/>
-					<Item id="6857" name="HTML/XML-Tags"/>
-					<Item id="6858" name="links"/>
-					<Item id="6859" name="rechts"/>
-					<Item id="6860" name="Zeichenpaar 1:"/>
-					<Item id="6863" name="Zeichenpaar 2:"/>
-					<Item id="6866" name="Zeichenpaar 3:"/>
-				</AutoCompletion>
+                <AutoCompletion title="Autovervollständigung">
+                    <Item id="6807" name="Autovervollständigung"/>
+                    <Item id="6808" name="Autovervollständigung aktivieren"/>
+                    <Item id="6809" name="Funktionsvervollständigung"/>
+                    <Item id="6810" name="Wortvervollständigung"/>
+                    <Item id="6816" name="Wort- und Funktionsvervollständigung"/>
+                    <Item id="6824" name="Zahlen ignorieren"/>
+                    <Item id="6811" name="ab"/>
+                    <Item id="6813" name="Zeichen"/>
+                    <Item id="6814" name="(mögliche Werte: 1–9)"/>
+                    <Item id="6815" name="Funktionsparameter anzeigen"/>
+                    <Item id="6851" name="Klammern automatisch schließen"/>
+                    <Item id="6857" name="HTML/XML-Tags"/>
+                    <Item id="6858" name="links"/>
+                    <Item id="6859" name="rechts"/>
+                    <Item id="6860" name="Zeichenpaar 1:"/>
+                    <Item id="6863" name="Zeichenpaar 2:"/>
+                    <Item id="6866" name="Zeichenpaar 3:"/>
+                </AutoCompletion>
 
-				<MultiInstance title="Mehrere Instanzen">
-					<Item id="6151" name="Mehrere Instanzen"/>
-					<Item id="6152" name="Sitzungsdateien in einer neuen Instanz öffnen"/>
-					<Item id="6153" name="Immer im Mehrinstanzmodus"/>
-					<Item id="6154" name="Standard (nur eine Instanz)"/>
-					<Item id="6155" name="Nach Änderung der Einstellung muss Notepad++ neu gestartet werden."/>
-				</MultiInstance>
+                <MultiInstance title="Mehrere Instanzen">
+                    <Item id="6151" name="Mehrere Instanzen"/>
+                    <Item id="6152" name="Sitzungsdateien in einer neuen Instanz öffnen"/>
+                    <Item id="6153" name="Immer im Mehrinstanzmodus"/>
+                    <Item id="6154" name="Standard (nur eine Instanz)"/>
+                    <Item id="6155" name="Nach Änderung der Einstellung muss Notepad++ neu gestartet werden."/>
+                </MultiInstance>
 
-				<Delimiter title="Trennzeichen">
-					<Item id="6251" name="Trennzeichen für erweiterte Auswahl (Strg+Doppelklick)"/>
-					<Item id="6252" name="Anfang"/>
-					<Item id="6255" name="Ende"/>
-					<Item id="6256" name="Über mehrere Zeilen"/>
-					<Item id="6161" name="Liste der Wortzeichen (Word character list)"/>
-					<Item id="6162" name="Verwende die ursprüngliche Liste der Wortzeichen"/>
-					<Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0a;(nicht verwenden wenn man nicht sicher ist)"/>
+                <Delimiter title="Trennzeichen">
+                    <Item id="6251" name="Trennzeichen für erweiterte Auswahl (Strg+Doppelklick)"/>
+                    <Item id="6252" name="Anfang"/>
+                    <Item id="6255" name="Ende"/>
+                    <Item id="6256" name="Über mehrere Zeilen"/>
+                    <Item id="6161" name="Liste der Wortzeichen (Word character list)"/>
+                    <Item id="6162" name="Verwende die ursprüngliche Liste der Wortzeichen"/>
+                    <Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0a;(nicht verwenden wenn man nicht sicher ist)"/>
                     </Delimiter>
 
-				<Cloud title="Cloud-Einstellungen">
-					<Item id="6262" name="Einstellungen in der Cloud speichern"/>
-					<Item id="6263" name="Aus"/>
-					<Item id="6267" name="Netzwerkpfad:"/>
-				</Cloud>
+                <Cloud title="Cloud-Einstellungen">
+                    <Item id="6262" name="Einstellungen in der Cloud speichern"/>
+                    <Item id="6263" name="Aus"/>
+                    <Item id="6267" name="Netzwerkpfad:"/>
+                </Cloud>
 
-				<SearchEngine title="Suchmaschine">
-					<Item id="6271" name="Suchmaschine (für das Kommando &quot;Suche im Internet&quot;)"/>
-					<Item id="6272" name="DuckDuckGo"/>
-					<Item id="6273" name="Google"/>
-					<Item id="6274" name="Bing"/>
-					<Item id="6275" name="Yahoo!"/>
-					<Item id="6276" name="Suchmaschine hier einstellen:"/>
-					<!-- Don't change anything after Example: -->
-					<Item id="6278" name="Beispiel: https://www.google.com/search?q=$(CURRENT_WORD)"/>
-				</SearchEngine>
+                <SearchEngine title="Suchmaschine">
+                    <Item id="6271" name="Suchmaschine (für das Kommando &quot;Suche im Internet&quot;)"/>
+                    <Item id="6272" name="DuckDuckGo"/>
+                    <Item id="6273" name="Google"/>
+                    <Item id="6274" name="Bing"/>
+                    <Item id="6275" name="Yahoo!"/>
+                    <Item id="6276" name="Suchmaschine hier einstellen:"/>
+                    <!-- Don't change anything after Example: -->
+                    <Item id="6278" name="Beispiel: https://www.google.com/search?q=$(CURRENT_WORD)"/>
+                </SearchEngine>
 
-				<MISC title="Diverses">
-					<Item id="6307" name="Aktivieren"/>
-					<Item id="6308" name="In Infobereich (Tray) minimieren"/>
-					<Item id="6312" name="Automatische Änderungserkennung"/>
-					<Item id="6313" name="Ohne Rückfrage aktualisieren"/>
-					<Item id="6318" name="Klickbare Links"/>
-					<Item id="6325" name="Nach Aktualisierung zum Ende scrollen"/>
-					<Item id="6319" name="Aktivieren"/>
-					<Item id="6320" name="Links nicht unterstreichen"/>
-					<Item id="6322" name="Sitzungsdatei-Erw.:"/>
-					<Item id="6323" name="Automatische Updates aktivieren"/>
-					<Item id="6324" name="Dokumentenumschalter (Strg+Tab)"/>
-					<Item id="6331" name="Nur Dateinamen in Titelleiste anzeigen"/>
-					<Item id="6334" name="Kodierung automatisch erkennen"/>
-					<Item id="6335" name="Backslash ist Escapezeichen für SQL"/>
-					<Item id="6337" name="Arbeitsbereich Dateierw.:"/>
-					<Item id="6114" name="Aktivieren"/>
-					<Item id="6115" name="Automatische Einrückung"/>
-					<Item id="6117" name="In Reihenfolge der Benutzung"/>
-					<Item id="6344" name="Momentaufnahme des Dokuments"/>
-					<Item id="6345" name="Momentaufnahme in Tab"/>
-					<Item id="6346" name="Momentaufnahme in Miniaturansicht"/></MISC>
-			</Preference>
-			<MultiMacro title="Makro mehrfach ausführen">
-				<Item id="1"    name="Ausführen"/>
-				<Item id="2"    name="Abbrechen"/>
-				<Item id="8006" name="Makro:"/>
-				<Item id="8001" name="Makro"/>
-				<Item id="8005" name="mal ausführen"/>
-				<Item id="8002" name="Bis zum Ende der Datei ausführen"/>
-			</MultiMacro>
-			<Window title="Fenster">
-				<Item id="1"    name="Aktivieren"/>
-				<Item id="2"    name="OK"/>
-				<Item id="7002" name="Speichern"/>
-				<Item id="7003" name="Tab schließen"/>
-				<Item id="7004" name="Sortiere Tabs"/>
-			</Window>
-			<ColumnEditor title="Block-Editor">
-				<Item id="2023" name="Text einfügen"/>
-				<Item id="2033" name="Zahlen einfügen"/>
-				<Item id="2030" name="Beginnen mit:"/>
-				<Item id="2031" name="Erhöhen um:"/>
-				<Item id="2035" name="Führende Nullen"/>
-				<Item id="2036" name="Wiederholen:"/>
-				<Item id="2032" name="Format"/>
-				<Item id="2024" name="Dezimal"/>
-				<Item id="2025" name="Oktal"/>
-				<Item id="2026" name="Hexadezimal"/>
-				<Item id="2027" name="Binär"/>
-				<Item id="1"    name="Ausführen"/>
-				<Item id="2"    name="Abbrechen"/>
-			</ColumnEditor>
-		</Dialog>
-		<MessageBox>
-			<ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&#x0A;das Kontextmenü von Notepad++ anpassen.&#x0A;Nach dem Bearbeiten müssen Sie Notepad++ neu&#x0A;starten, damit die Änderungen wirksam werden."/>
-			<NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&#x0A;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&#x0A;von der Notepad++-Website herunter."/>
-			<SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&#x0A;&#x0A;Fortfahren?"/>
-			<LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&#x0A;&#x0A;Fortfahren?"/>
-			<CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&#x0A;Bitte zuerst speichern und erneut versuchen."/>
-			<DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&#x0A;gespeicherten Version erneut laden und die&#x0A;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
-			<FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &#x0A;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
-			<FileAlreadyOpenedInNpp title="Datei bereits geöffnet" message="Die Datei ist bereits in Notepad++ geöffnet."/>
-			<DeleteFileFailed title="Löschen fehlgeschlagen!" message="Datei konnte nicht gelöscht werden."/>
+                <MISC title="Diverses">
+                    <Item id="6307" name="Aktivieren"/>
+                    <Item id="6308" name="In Infobereich (Tray) minimieren"/>
+                    <Item id="6312" name="Automatische Änderungserkennung"/>
+                    <Item id="6313" name="Ohne Rückfrage aktualisieren"/>
+                    <Item id="6318" name="Klickbare Links"/>
+                    <Item id="6325" name="Nach Aktualisierung zum Ende scrollen"/>
+                    <Item id="6319" name="Aktivieren"/>
+                    <Item id="6320" name="Links nicht unterstreichen"/>
+                    <Item id="6322" name="Sitzungsdatei-Erw.:"/>
+                    <Item id="6323" name="Automatische Updates aktivieren"/>
+                    <Item id="6324" name="Dokumentenumschalter (Strg+Tab)"/>
+                    <Item id="6331" name="Nur Dateinamen in Titelleiste anzeigen"/>
+                    <Item id="6334" name="Kodierung automatisch erkennen"/>
+                    <Item id="6335" name="Backslash ist Escapezeichen für SQL"/>
+                    <Item id="6337" name="Arbeitsbereich Dateierw.:"/>
+                    <Item id="6114" name="Aktivieren"/>
+                    <Item id="6115" name="Automatische Einrückung"/>
+                    <Item id="6117" name="In Reihenfolge der Benutzung"/>
+                    <Item id="6344" name="Momentaufnahme des Dokuments"/>
+                    <Item id="6345" name="Momentaufnahme in Tab"/>
+                    <Item id="6346" name="Momentaufnahme in Miniaturansicht"/></MISC>
+            </Preference>
+            <MultiMacro title="Makro mehrfach ausführen">
+                <Item id="1"    name="Ausführen"/>
+                <Item id="2"    name="Abbrechen"/>
+                <Item id="8006" name="Makro:"/>
+                <Item id="8001" name="Makro"/>
+                <Item id="8005" name="mal ausführen"/>
+                <Item id="8002" name="Bis zum Ende der Datei ausführen"/>
+            </MultiMacro>
+            <Window title="Fenster">
+                <Item id="1"    name="Aktivieren"/>
+                <Item id="2"    name="OK"/>
+                <Item id="7002" name="Speichern"/>
+                <Item id="7003" name="Tab schließen"/>
+                <Item id="7004" name="Sortiere Tabs"/>
+            </Window>
+            <ColumnEditor title="Block-Editor">
+                <Item id="2023" name="Text einfügen"/>
+                <Item id="2033" name="Zahlen einfügen"/>
+                <Item id="2030" name="Beginnen mit:"/>
+                <Item id="2031" name="Erhöhen um:"/>
+                <Item id="2035" name="Führende Nullen"/>
+                <Item id="2036" name="Wiederholen:"/>
+                <Item id="2032" name="Format"/>
+                <Item id="2024" name="Dezimal"/>
+                <Item id="2025" name="Oktal"/>
+                <Item id="2026" name="Hexadezimal"/>
+                <Item id="2027" name="Binär"/>
+                <Item id="1"    name="Ausführen"/>
+                <Item id="2"    name="Abbrechen"/>
+            </ColumnEditor>
+        </Dialog>
+        <MessageBox>
+            <ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&#x0A;das Kontextmenü von Notepad++ anpassen.&#x0A;Nach dem Bearbeiten müssen Sie Notepad++ neu&#x0A;starten, damit die Änderungen wirksam werden."/>
+            <NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&#x0A;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&#x0A;von der Notepad++-Website herunter."/>
+            <SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&#x0A;&#x0A;Fortfahren?"/>
+            <LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&#x0A;&#x0A;Fortfahren?"/>
+            <CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&#x0A;Bitte zuerst speichern und erneut versuchen."/>
+            <DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&#x0A;gespeicherten Version erneut laden und die&#x0A;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
+            <FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &#x0A;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
+            <FileAlreadyOpenedInNpp title="Datei bereits geöffnet" message="Die Datei ist bereits in Notepad++ geöffnet."/>
+            <DeleteFileFailed title="Löschen fehlgeschlagen!" message="Datei konnte nicht gelöscht werden."/>
 
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
-			<NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&#x0A;Sind Sie sicher?"/>
-			<SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&#x0A;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&#x0A;ohne die erforderlichen Schreibrechte zeigen.&#x0A;Die Einstellungen in der Cloud werden abgebrochen.&#x0A;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
-			<FilePathNotFoundWarning title="Datei öffnen" message="Die Datei zum Öffnen existiert nicht."/>
-			<SessionFileInvalidError title="Konnte Sitzung nicht laden" message="Sitzungsdatei ist entweder beschädigt oder ungültig."/>
-			<ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&#x0A;um in den Spalten-Modus zu wechseln."/>
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&#x0A;Sind Sie sicher?"/>
+            <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&#x0A;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&#x0A;ohne die erforderlichen Schreibrechte zeigen.&#x0A;Die Einstellungen in der Cloud werden abgebrochen.&#x0A;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
+            <FilePathNotFoundWarning title="Datei öffnen" message="Die Datei zum Öffnen existiert nicht."/>
+            <SessionFileInvalidError title="Konnte Sitzung nicht laden" message="Sitzungsdatei ist entweder beschädigt oder ungültig."/>
+            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&#x0A;um in den Spalten-Modus zu wechseln."/>
 
-			<!-- $STR_REPLACE$ is a place holder, don't translate it -->
-			<SortingError title="Sortierung fehlgeschlagen" message="Kann aufgrund der Zeile $STR_REPLACE$ keine numerische Sortierung durchführen."/>
-			<BufferInvalidWarning title="Speichern fehlgeschlagen" message="Kann nicht speichern: Puffer ist ungültig."/>
-			<OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0A;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
-			<OpenInAdminModeFailed title="Starten im Administrator-Modus fehlgeschlagen" message="Notepad++ kann nicht im Administrator-Modus gestartet werden."/>
-			<OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0A;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
-			<DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&#x0A;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
-		</MessageBox>
-		<ClipboardHistory>
-			<PanelTitle name="Zwischenablage"/>
-		</ClipboardHistory>
-		<DocSwitcher>
-			<PanelTitle name="Geöffnete Dateien"/>
-			<ColumnName name="Name"/>
-			<ColumnExt name="Erw."/>
-		</DocSwitcher>
-		<AsciiInsertion>
-			<PanelTitle name="Zeichentabelle"/>
-			<ColumnVal name="Dezimal"/>
+            <!-- $STR_REPLACE$ is a place holder, don't translate it -->
+            <SortingError title="Sortierung fehlgeschlagen" message="Kann aufgrund der Zeile $STR_REPLACE$ keine numerische Sortierung durchführen."/>
+            <BufferInvalidWarning title="Speichern fehlgeschlagen" message="Kann nicht speichern: Puffer ist ungültig."/>
+            <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0A;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <OpenInAdminModeFailed title="Starten im Administrator-Modus fehlgeschlagen" message="Notepad++ kann nicht im Administrator-Modus gestartet werden."/>
+            <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0A;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&#x0A;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
+        </MessageBox>
+        <ClipboardHistory>
+            <PanelTitle name="Zwischenablage"/>
+        </ClipboardHistory>
+        <DocSwitcher>
+            <PanelTitle name="Geöffnete Dateien"/>
+            <ColumnName name="Name"/>
+            <ColumnExt name="Erw."/>
+        </DocSwitcher>
+        <AsciiInsertion>
+            <PanelTitle name="Zeichentabelle"/>
+            <ColumnVal name="Dezimal"/>
             <ColumnHex name="Hexadezimal"/>
-			<ColumnChar name="Zeichen"/>
-		</AsciiInsertion>
-		<DocumentMap>
-			<PanelTitle name="Miniaturansicht"/>
-		</DocumentMap>
-		<FunctionList>
-			<PanelTitle name="Funktionsliste"/>
-			<SortTip name="Sortieren"/>
-			<ReloadTip name="Neu laden"/>
-		</FunctionList>
-		<ProjectManager>
-			<PanelTitle name="Projektverwaltung"/>
-			<WorkspaceRootName name="Arbeitsbereich"/>
-			<NewProjectName name="Projektname"/>
-			<NewFolderName name="Ordnername"/>
-			<Menus>
-				<Entries>
-					<Item id="0" name="Arbeitsbereich"/>
-					<Item id="1" name="Bearbeiten"/>
-				</Entries>
-				<WorkspaceMenu>
-					<Item id="3122" name="Neuer Arbeitsbereich"/>
-					<Item id="3123" name="Arbeitsbereich öffnen"/>
-					<Item id="3124" name="Arbeitsbereich neu laden"/>
-					<Item id="3125" name="Speichern"/>
-					<Item id="3126" name="Speichern unter …"/>
-					<Item id="3127" name="Kopie speichern unter …"/>
-					<Item id="3121" name="Neues Projekt hinzufügen"/>
-				</WorkspaceMenu>
-				<ProjectMenu>
-					<Item id="3111" name="Umbenennen"/>
-					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen …"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
-					<Item id="3114" name="Entfernen"/>
-					<Item id="3118" name="Nach oben schieben"/>
-					<Item id="3119" name="Nach unten schieben"/>
-				</ProjectMenu>
-				<FolderMenu>
-					<Item id="3111" name="Umbenennen"/>
-					<Item id="3112" name="Projektordner hinzufügen"/>
-					<Item id="3113" name="Dateien hinzufügen …"/>
-					<Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
-					<Item id="3114" name="Entfernen"/>
-					<Item id="3118" name="Nach oben schieben"/>
-					<Item id="3119" name="Nach unten schieben"/>
-				</FolderMenu>
-				<FileMenu>
-					<Item id="3111" name="Umbenennen"/>
-					<Item id="3115" name="Entfernen"/>
-					<Item id="3116" name="Dateipfad ändern"/>
-					<Item id="3118" name="Nach oben schieben"/>
-					<Item id="3119" name="Nach unten schieben"/>
-				</FileMenu>
-			</Menus>
-		</ProjectManager>
-		<MiscStrings>
-			<word-chars-list-tip value="Das erlaubt es ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick auf die Auswahl hinzuzufügen oder mit der aktivierten Option &quot;Übereinstimmung mit ganzem Wort&quot;."/>
-			<word-chars-list-warning-begin value="Achtung: "/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
-			<word-chars-list-space-warning value="$INT_REPLACE$ Leerzeichen"/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
-			<word-chars-list-tab-warning value="$INT_REPLACE$ Tab(s)"/>
-			<word-chars-list-warning-end value=" in der Liste der Wortzeichen."/>
-			<cloud-invalid-warning value="Ungültiger Pfad."/>
-			<cloud-restart-warning value="Zum Übernehmen Notepad++ bitte neu starten."/>
-			<shift-change-direction-tip value="Enter: Suche vorwärts&#x0a;Shift+Enter: Suche rückwärts"/>
-		</MiscStrings>
-	</Native-Langue>
+            <ColumnChar name="Zeichen"/>
+        </AsciiInsertion>
+        <DocumentMap>
+            <PanelTitle name="Miniaturansicht"/>
+        </DocumentMap>
+        <FunctionList>
+            <PanelTitle name="Funktionsliste"/>
+            <SortTip name="Sortieren"/>
+            <ReloadTip name="Neu laden"/>
+        </FunctionList>
+        <ProjectManager>
+            <PanelTitle name="Projektverwaltung"/>
+            <WorkspaceRootName name="Arbeitsbereich"/>
+            <NewProjectName name="Projektname"/>
+            <NewFolderName name="Ordnername"/>
+            <Menus>
+                <Entries>
+                    <Item id="0" name="Arbeitsbereich"/>
+                    <Item id="1" name="Bearbeiten"/>
+                </Entries>
+                <WorkspaceMenu>
+                    <Item id="3122" name="Neuer Arbeitsbereich"/>
+                    <Item id="3123" name="Arbeitsbereich öffnen"/>
+                    <Item id="3124" name="Arbeitsbereich neu laden"/>
+                    <Item id="3125" name="Speichern"/>
+                    <Item id="3126" name="Speichern unter …"/>
+                    <Item id="3127" name="Kopie speichern unter …"/>
+                    <Item id="3121" name="Neues Projekt hinzufügen"/>
+                </WorkspaceMenu>
+                <ProjectMenu>
+                    <Item id="3111" name="Umbenennen"/>
+                    <Item id="3112" name="Projektordner hinzufügen"/>
+                    <Item id="3113" name="Dateien hinzufügen …"/>
+                    <Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
+                    <Item id="3114" name="Entfernen"/>
+                    <Item id="3118" name="Nach oben schieben"/>
+                    <Item id="3119" name="Nach unten schieben"/>
+                </ProjectMenu>
+                <FolderMenu>
+                    <Item id="3111" name="Umbenennen"/>
+                    <Item id="3112" name="Projektordner hinzufügen"/>
+                    <Item id="3113" name="Dateien hinzufügen …"/>
+                    <Item id="3117" name="Dateien aus Verzeichnis hinzufügen …"/>
+                    <Item id="3114" name="Entfernen"/>
+                    <Item id="3118" name="Nach oben schieben"/>
+                    <Item id="3119" name="Nach unten schieben"/>
+                </FolderMenu>
+                <FileMenu>
+                    <Item id="3111" name="Umbenennen"/>
+                    <Item id="3115" name="Entfernen"/>
+                    <Item id="3116" name="Dateipfad ändern"/>
+                    <Item id="3118" name="Nach oben schieben"/>
+                    <Item id="3119" name="Nach unten schieben"/>
+                </FileMenu>
+            </Menus>
+        </ProjectManager>
+        <MiscStrings>
+            <word-chars-list-tip value="Das erlaubt es ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick auf die Auswahl hinzuzufügen oder mit der aktivierten Option &quot;Übereinstimmung mit ganzem Wort&quot;."/>
+            <word-chars-list-warning-begin value="Achtung: "/>
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <word-chars-list-space-warning value="$INT_REPLACE$ Leerzeichen"/>
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <word-chars-list-tab-warning value="$INT_REPLACE$ Tab(s)"/>
+            <word-chars-list-warning-end value=" in der Liste der Wortzeichen."/>
+            <cloud-invalid-warning value="Ungültiger Pfad."/>
+            <cloud-restart-warning value="Zum Übernehmen Notepad++ bitte neu starten."/>
+            <shift-change-direction-tip value="Enter: Suche vorwärts&#x0a;Shift+Enter: Suche rückwärts"/>
+        </MiscStrings>
+    </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -458,7 +458,7 @@
             <StyleConfig title="Stile">
                 <Item id="1"    name="Übernehmen"/>                <!-- kommt im englischen nicht oder nicht mehr vor -->
                 <Item id="2"    name="Abbrechen"/>
-                <Item id="2301" name="Speichern && Schließen"/>
+                <Item id="2301" name="Speichern & Schließen"/>
                 <Item id="2303" name="Transparenz"/>
                 <Item id="2306" name="Design:"/>
                 <SubDialog>
@@ -534,7 +534,7 @@
                     <Item id="1"     name="OK"/>
                     <Item id="2"     name="Abbrechen"/>
                 </StylerDialog>
-                <Folder title="Textblöcke && Voreinstellung">
+                <Folder title="Textblöcke & Voreinstellung">
                     <Item id="21101" name="Standardschrift"/>
                     <Item id="21102" name="Stil"/>
                     <Item id="21105" name="Dokumentation"/>
@@ -582,7 +582,7 @@
                     <Item id="22572" name="Stil"/>
                     <Item id="22622" name="Stil"/>
                 </Keywords>
-                <Comment title="Kommentare && Zahlen">
+                <Comment title="Kommentare & Zahlen">
                     <Item id="23002" name="Am Zeilenanfang Zeilenkommentar erzwingen"/>        <!-- kommt im englischen nicht oder nicht mehr vor -->
                     <Item id="23003" name="Position von Zeilenkommentaren"/>
                     <Item id="23004" name="Überall erlauben"/>
@@ -612,7 +612,7 @@
                     <Item id="23246" name="Komma"/>
                     <Item id="23247" name="Beides"/>
                 </Comment>
-                <Operator title="Operatoren && Trenner">
+                <Operator title="Operatoren & Trenner">
                     <Item id="24101" name="Operatoren"/>
                     <Item id="24113" name="Stil"/>
                     <Item id="24116" name="Operatoren 1"/>
@@ -713,7 +713,7 @@
                     <Item id="6207" name="Lesezeichenrand"/>
                     <Item id="6208" name="Randbegrenzung anzeigen"/>
                     <Item id="6209" name="Anzahl der Spalten:"/>
-                    <Item id="6234" name="Flüssiges Scrollen deaktivieren&#x0a;(bei Touchpad-Problemen)"/>
+                    <Item id="6234" name="Flüssiges Scrollen deaktivieren&#x0D;(bei Touchpad-Problemen)"/>
 
                     <Item id="6211" name="Rechter Rand"/>
                     <Item id="6212" name="Vertikale Linie"/>
@@ -870,7 +870,7 @@
                     <Item id="6256" name="Über mehrere Zeilen"/>
                     <Item id="6161" name="Liste der Wortzeichen (Word character list)"/>
                     <Item id="6162" name="Verwende die ursprüngliche Liste der Wortzeichen"/>
-                    <Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0a;(nicht verwenden wenn man nicht sicher ist)"/>
+                    <Item id="6163" name="Füge Zeichen als Teil der Wortzeichen hinzu&#x0D;(nicht verwenden, wenn man nicht sicher ist)"/>
                     </Delimiter>
 
                 <Cloud title="Cloud-Einstellungen">
@@ -945,30 +945,30 @@
             </ColumnEditor>
         </Dialog>
         <MessageBox>
-            <ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&#x0A;das Kontextmenü von Notepad++ anpassen.&#x0A;Nach dem Bearbeiten müssen Sie Notepad++ neu&#x0A;starten, damit die Änderungen wirksam werden."/>
-            <NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&#x0A;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&#x0A;von der Notepad++-Website herunter."/>
-            <SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&#x0A;&#x0A;Fortfahren?"/>
-            <LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&#x0A;&#x0A;Fortfahren?"/>
-            <CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&#x0A;Bitte zuerst speichern und erneut versuchen."/>
-            <DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&#x0A;gespeicherten Version erneut laden und die&#x0A;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
-            <FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &#x0A;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
+            <ContextMenuXmlEditWarning title="Kontextmenü anpassen" message="Durch Bearbeiten der Datei contextMenu.xml können Sie&#x0D;das Kontextmenü von Notepad++ anpassen.&#x0D;Nach dem Bearbeiten müssen Sie Notepad++ neu&#x0D;starten, damit die Änderungen wirksam werden."/>
+            <NppHelpAbsentWarning title="Fehlende Hilfedatei" message="&#x0D;wurde nicht gefunden. Bitte laden Sie die Hilfedateien&#x0D;von der Notepad++-Website herunter."/>
+            <SaveCurrentModifWarning title="Änderungen speichern" message="Bitte speichern Sie Ihre Änderungen.&#x0D;&#x0D;Fortfahren?"/>
+            <LoseUndoAbilityWarning title="Änderungen können nicht rückgängig gemacht werden" message="Diese Änderung kann nicht rückgängig gemacht werden.&#x0D;&#x0D;Fortfahren?"/>
+            <CannotMoveDoc title="In neue Instanz verschieben" message="Dokument wurde geändert.&#x0D;Bitte zuerst speichern und erneut versuchen."/>
+            <DocReloadWarning title="Datei wurde geändert!" message="Sind Sie sicher, dass Sie die Datei in der zuletzt&#x0D;gespeicherten Version erneut laden und die&#x0D;in Notepad++ gemachten Änderungen verwerfen wollen?"/>
+            <FileLockedWarning title="Speichern fehlgeschlagen!" message="Datei konnte von Notepad++ nicht gespeichert werden. &#x0D;Bitte überprüfen Sie, ob die Datei in einem anderen Programm geöffnet ist."/>
             <FileAlreadyOpenedInNpp title="Datei bereits geöffnet" message="Die Datei ist bereits in Notepad++ geöffnet."/>
             <DeleteFileFailed title="Löschen fehlgeschlagen!" message="Datei konnte nicht gelöscht werden."/>
 
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&#x0A;Sind Sie sicher?"/>
-            <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&#x0A;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&#x0A;ohne die erforderlichen Schreibrechte zeigen.&#x0A;Die Einstellungen in der Cloud werden abgebrochen.&#x0A;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
+            <NbFileToOpenImportantWarning title="Viele Dateien zu öffnen" message="$INT_REPLACE$ Dateien sollen in Notepad++ geöffnet werden.&#x0D;Sind Sie sicher?"/>
+            <SettingsOnCloudError title="Cloud-Einstellungen" message="Der Pfad zu den Einstellungen in der Cloud dürfte&#x0D;auf ein Laufwerk nur mit Leserechten oder auf ein Verzeichnis&#x0D;ohne die erforderlichen Schreibrechte zeigen.&#x0D;Die Einstellungen in der Cloud werden abgebrochen.&#x0D;Bitte stellen Sie auf einen schlüssigen Wert in den Einstellungen um."/>
             <FilePathNotFoundWarning title="Datei öffnen" message="Die Datei zum Öffnen existiert nicht."/>
             <SessionFileInvalidError title="Konnte Sitzung nicht laden" message="Sitzungsdatei ist entweder beschädigt oder ungültig."/>
-            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&#x0A;um in den Spalten-Modus zu wechseln."/>
+            <ColumnModeTip title="Tip für Spalten-Modus" message="Verwende &quot;ALT+Maus Auswahl&quot; oder &quot;Alt+Shift+Pfeiltaste&quot;&#x0D;um in den Spalten-Modus zu wechseln."/>
 
             <!-- $STR_REPLACE$ is a place holder, don't translate it -->
             <SortingError title="Sortierung fehlgeschlagen" message="Kann aufgrund der Zeile $STR_REPLACE$ keine numerische Sortierung durchführen."/>
             <BufferInvalidWarning title="Speichern fehlgeschlagen" message="Kann nicht speichern: Puffer ist ungültig."/>
-            <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0A;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <OpenInAdminMode title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
             <OpenInAdminModeFailed title="Starten im Administrator-Modus fehlgeschlagen" message="Notepad++ kann nicht im Administrator-Modus gestartet werden."/>
-            <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0A;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
-            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&#x0A;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
+            <OpenInAdminModeWithoutCloseCurrent title="Speichern fehlgeschlagen" message="Die Datei kann nicht gespeichert werden weil sie vielleicht geschützt ist.&#x0D;Soll Notepad++ im Administrator-Modus gestartet werden?"/>
+            <DroppingFolderAsProjetModeWarning title="Ungültige Aktion" message="Es können entweder Dateien oder Verzeichnisse verschoben werden, aber nicht beides zugleich.&#x0D;Dafür muss &quot;Alle Dateien im jeweiligen Verzeichnis öffnen anstelle des Start-Verzeichnisses&quot; im Bereich &quot;Standardverzeichnis&quot; der Einstellungen ausgewählt werden."/>
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Zwischenablage"/>
@@ -1039,7 +1039,7 @@
             </Menus>
         </ProjectManager>
         <MiscStrings>
-            <word-chars-list-tip value="Das erlaubt es ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick auf die Auswahl hinzuzufügen oder mit der aktivierten Option &quot;Übereinstimmung mit ganzem Wort&quot;."/>
+            <word-chars-list-tip value="Erlaubt ein zusätzliches Zeichen zur aktuellen Liste der Wortzeichen durch Doppelklick zur Auswahl hinzuzufügen, oder als Suche mit der aktivierten Option &quot;Übereinstimmung mit ganzem Wort&quot;."/>
             <word-chars-list-warning-begin value="Achtung: "/>
             <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ Leerzeichen"/>
@@ -1048,7 +1048,7 @@
             <word-chars-list-warning-end value=" in der Liste der Wortzeichen."/>
             <cloud-invalid-warning value="Ungültiger Pfad."/>
             <cloud-restart-warning value="Zum Übernehmen Notepad++ bitte neu starten."/>
-            <shift-change-direction-tip value="Enter: Suche vorwärts&#x0a;Shift+Enter: Suche rückwärts"/>
+            <shift-change-direction-tip value="Enter: Suche vorwärts&#x0D;Shift+Enter: Suche rückwärts"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>


### PR DESCRIPTION
…rch" for the latter

including Pull Request
 https://github.com/notepad-plus-plus/notepad-plus-plus/pull/3471
 https://github.com/notepad-plus-plus/notepad-plus-plus/pull/3471/commits/4e949c3bc04e19944ef7f19ad78d44130b1a6490

fixes #3471 and #3474 and #3415 and could be used as a "template" for other langs.