### PR TITLE
Fixed problems found by VS 2017

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -765,7 +765,7 @@ COLORREF getCtrlBgColor(HWND hWnd)
 
 generic_string stringToUpper(generic_string strToConvert)
 {
-    std::transform(strToConvert.begin(), strToConvert.end(), strToConvert.begin(), ::toupper);
+    std::transform(strToConvert.begin(), strToConvert.end(), strToConvert.begin(), ::_totupper);
     return strToConvert;
 }
 

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -110,7 +110,7 @@ bool findStrNoCase(const generic_string & strHaystack, const generic_string & st
 	auto it = std::search(
 		strHaystack.begin(), strHaystack.end(),
 		strNeedle.begin(), strNeedle.end(),
-		[](char ch1, char ch2){return std::toupper(ch1) == std::toupper(ch2); }
+		[](TCHAR ch1, TCHAR ch2){return ::_totupper(ch1) == ::_totupper(ch2); }
 	);
 	return (it != strHaystack.end());
 }

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -26,7 +26,6 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 
-#include <algorithm>
 #include "shortcut.h"
 #include "Parameters.h"
 #include "ScintillaEditView.h"
@@ -483,7 +482,7 @@ INT_PTR CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 // return true if one of CommandShortcuts is deleted. Otherwise false.
 void Accelerator::updateShortcuts() 
 {
-	vector<int> incrFindAccIds;
+	vector<UINT> incrFindAccIds;
 	incrFindAccIds.push_back(IDM_SEARCH_FINDNEXT);
 	incrFindAccIds.push_back(IDM_SEARCH_FINDPREV);
 	incrFindAccIds.push_back(IDM_SEARCH_FINDINCREMENT);


### PR DESCRIPTION
Common.cpp and pluginsAdmin.cpp: unicode string is treated as non-unicode
shortcut.cpp: signed and unsigned comparison

Aside from fixing potential problems it's also a precursor for making build under VS 2017 with built-in v141_xp  Platform Toolset. See attached log with compilation errors: 
[VS2017CompilationErros.txt](https://github.com/notepad-plus-plus/notepad-plus-plus/files/1123953/VS2017CompilationErros.txt)
