### PR TITLE
Make a copy of the command line so as to stop modifying the original

### DIFF
--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -315,7 +315,10 @@ void doException(Notepad_plus_Window & notepad_plus_plus)
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 {
-	LPTSTR cmdLine = ::GetCommandLine();
+	// Use a copy of the command line in order to preserve the original to be read by other processes.
+	LPTSTR cmdLine = _tcsdup(::GetCommandLine());
+	if(!cmdLine)
+		return -1;
 	ParamVector params;
 	parseCommandLine(cmdLine, params);
 


### PR DESCRIPTION
.. because other processes may want to read the command line that
started Notepad++. Prior to this change the original command line could
be seen by other processes as truncated due to parsing behavior.

Closes #xxxx

---

For example this command line:
"c:\program files (x86)\notepad++\notepad++.exe" foo bar\0

After Notepad++ parses it will change it to:
"c:\program files (x86)\notepad++\notepad++.exe" foo\0bar\0

Process Hacker reads the 64-bit PEB and will show:
"c:\program files (x86)\notepad++\notepad++.exe" foo bar

... but Process Explorer reads the 32-bit PEB and will show:
"c:\program files (x86)\notepad++\notepad++.exe" foo

