### PR TITLE
Appveyor CI image update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-version: 1.0.{build}
-image: Visual Studio 2013
+version: 7.4.2.{build}
+image: Visual Studio 2015
 
 
 clone_depth: 1
@@ -26,7 +26,7 @@ build_script:
     - if "%configuration%"=="Unicode Release" set scintilla_debug=
     - nmake NOBOOST=1 %scintilla_debug% -f scintilla.mak
     - cd c:\projects\notepad-plus-plus\PowerEditor\visual.net\
-    - msbuild notepadPlus.vcxproj /p:configuration="%configuration%" /p:platform="%platform%"
+    - msbuild notepadPlus.vcxproj /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
     - cd c:\projects\notepad-plus-plus\


### PR DESCRIPTION
- updated appveyor build image to Visual Studio 2015, see PR #3492, as preparation to be able to build at least VS2015 projects (the CI image is almost the same as the one for VS2013 except that additionally VS2015 is available, see https://www.appveyor.com/docs/build-environment/#build-worker-images)
- added appveyor MSBuildLogger to see build errors/warning on the message tab, see https://www.appveyor.com/docs/build-phase/
- updated the version to the current n++ version
