### PR TITLE
Fixed monitoring related issuse and corrected code

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1937,13 +1937,10 @@ void Notepad_plus::command(int id)
 
 		case IDM_VIEW_MONITORING:
 		{
-			static HANDLE hThread = nullptr;
 			Buffer * curBuf = _pEditView->getCurrentBuffer();
 			if (curBuf->isMonitoringOn())
 			{
 				curBuf->stopMonitoring();
-				::CloseHandle(hThread);
-				hThread = nullptr;
 				checkMenuItem(IDM_VIEW_MONITORING, false);
 				_toolBar.setCheck(IDM_VIEW_MONITORING, false);
 				curBuf->setUserReadOnly(false);
@@ -1963,7 +1960,8 @@ void Notepad_plus::command(int id)
 						curBuf->setUserReadOnly(true);
 						
 						MonitorInfo *monitorInfo = new MonitorInfo(curBuf, _pPublicInterface->getHSelf());
-						hThread = ::CreateThread(NULL, 0, monitorFileOnChange, (void *)monitorInfo, 0, NULL); // will be deallocated while quitting thread
+						HANDLE hThread = ::CreateThread(NULL, 0, monitorFileOnChange, (void *)monitorInfo, 0, NULL); // will be deallocated while quitting thread
+						::CloseHandle(hThread);
 						checkMenuItem(IDM_VIEW_MONITORING, true);
 						_toolBar.setCheck(IDM_VIEW_MONITORING, true);
 					}

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -648,7 +648,11 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
 	if (buf->isMonitoringOn())
 	{
 		// turn off monitoring
-		command(IDM_VIEW_MONITORING);
+		//command(IDM_VIEW_MONITORING);
+		buf->stopMonitoring();
+		checkMenuItem(IDM_VIEW_MONITORING, false);
+		_toolBar.setCheck(IDM_VIEW_MONITORING, false);
+		buf->setUserReadOnly(false);
 	}
 
 	//Do all the works


### PR DESCRIPTION
### Updated file "NppIO.cpp" to deal with issue #3553 
However both existing and updated code looks same, but it is not.
```command(IDM_VIEW_MONITORING);```
looks equal to 
```
buf->stopMonitoring();
checkMenuItem(IDM_VIEW_MONITORING, false);
_toolBar.setCheck(IDM_VIEW_MONITORING, false);
buf->setUserReadOnly(false);
```
Updated code works on the current file being processed while existing code ```command(IDM_VIEW_MONITORING);``` works with current active buffer. Debugging for reported case can help to understand the above statement.

### Justification for updating file "NppCommands.cpp":
See ```static HANDLE hThread``` gets a handle when monitoring is activated on a tab.
This handle is overwritten if monitoring is activated on another tab. _**Resource leak happens here as previous handle can't be closed at all**_.
However, this handle is not used anywhere in the code, then just why not to close the handle as soon thread is created.