### PR TITLE
Code improvement

### DIFF
--- a/PowerEditor/installer/nsisInclude/autoCompletion.nsh
+++ b/PowerEditor/installer/nsisInclude/autoCompletion.nsh
@@ -209,10 +209,6 @@ SectionGroup un.autoCompletionComponent
 		Delete "$INSTDIR\plugins\APIs\nsis.xml"
 	SectionEnd
 	
-	Section un.AWK
-		Delete "$INSTDIR\plugins\APIs\awk.xml"
-	SectionEnd
-	
 	Section un.CMAKE
 		Delete "$INSTDIR\plugins\APIs\cmake.xml"
 	SectionEnd	

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -115,6 +115,11 @@ protected:
 	WcharMbcsConvertor() {}
 	~WcharMbcsConvertor() {}
 
+	// Since there's no public ctor, we need to void the default assignment operator and copy ctor.
+	// Since these are marked as deleted does not matter under which access specifier are kept
+	WcharMbcsConvertor(const WcharMbcsConvertor&) = delete;
+	WcharMbcsConvertor& operator= (const WcharMbcsConvertor&) = delete;
+
 	static WcharMbcsConvertor* _pSelf;
 
 	template <class T>
@@ -154,10 +159,6 @@ protected:
 
 	StringBuffer<char> _multiByteStr;
 	StringBuffer<wchar_t> _wideCharStr;
-
-private:
-	// Since there's no public ctor, we need to void the default assignment operator.
-	WcharMbcsConvertor& operator= (const WcharMbcsConvertor&);
 };
 
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -874,7 +874,7 @@ struct ScintillaViewParams
 	int _zoom = 0;
 	int _zoom2 = 0;
 	bool _whiteSpaceShow = false;
-	bool _eolShow;
+	bool _eolShow = false;
 	int _borderWidth = 2;
 	bool _scrollBeyondLastLine = false;
 	bool _disableAdvancedScrolling = false;

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.h
@@ -56,8 +56,6 @@ private:
 
 class AutoCompletion {
 public:
-	enum ActiveCompletion {CompletionNone = 0, CompletionAuto, CompletionWord, CompletionFunc, CompletionPath};
-
 	explicit AutoCompletion(ScintillaEditView * pEditView): _pEditView(pEditView), _funcCalltip(pEditView) {
 		//Do not load any language yet
 		_insertedMatchedChars.init(_pEditView);

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -212,7 +212,7 @@ tTbData* DockingCont::findToolbarByName(TCHAR* pszName)
 
 void DockingCont::setActiveTb(tTbData* pTbData)
 {
-	int iItem = SearchPosInTab(pTbData);
+	int iItem = searchPosInTab(pTbData);
 	setActiveTb(iItem);
 }
 
@@ -221,7 +221,7 @@ void DockingCont::setActiveTb(int iItem)
 	//if ((iItem != -1) && (iItem < ::SendMessage(_hContTab, TCM_GETITEMCOUNT, 0, 0)))
 	if (iItem < ::SendMessage(_hContTab, TCM_GETITEMCOUNT, 0, 0))
 	{
-		SelectTab(iItem);
+		selectTab(iItem);
 	}
 }
 
@@ -658,7 +658,7 @@ LRESULT DockingCont::runProcTab(HWND hwnd, UINT Message, WPARAM wParam, LPARAM l
 			info.pt.y = HIWORD(lParam);
 			iItem = static_cast<int32_t>(::SendMessage(hwnd, TCM_HITTEST, 0, reinterpret_cast<LPARAM>(&info)));
 
-			SelectTab(iItem);
+			selectTab(iItem);
 			_beginDrag = FALSE;
 			return TRUE;
 		}
@@ -678,7 +678,7 @@ LRESULT DockingCont::runProcTab(HWND hwnd, UINT Message, WPARAM wParam, LPARAM l
 			info.pt.y = HIWORD(lParam);
 			iItem = static_cast<int32_t>(::SendMessage(hwnd, TCM_HITTEST, 0, reinterpret_cast<LPARAM>(&info)));
 
-			SelectTab(iItem);
+			selectTab(iItem);
 
 			// get data and hide toolbar
 			tcItem.mask		= TCIF_PARAM;
@@ -707,7 +707,7 @@ LRESULT DockingCont::runProcTab(HWND hwnd, UINT Message, WPARAM wParam, LPARAM l
 
 			if ((_beginDrag == TRUE) && (wParam == MK_LBUTTON))
 			{
-				SelectTab(iItem);
+				selectTab(iItem);
 
 				// send moving message to parent window
 				_dragFromTab = TRUE;
@@ -811,7 +811,7 @@ LRESULT DockingCont::runProcTab(HWND hwnd, UINT Message, WPARAM wParam, LPARAM l
 				info.pt.y = HIWORD(lParam);
 				iItem = static_cast<int32_t>(::SendMessage(hwnd, TCM_HITTEST, 0, reinterpret_cast<LPARAM>(&info)));
 
-				SelectTab(iItem);
+				selectTab(iItem);
 			}
 			break;
 		}
@@ -1146,7 +1146,7 @@ void DockingCont::doClose()
 		TCITEM		tcItem		= {0};
 
 		// get item data
-		SelectTab(iItemOff);
+		selectTab(iItemOff);
 		tcItem.mask	= TCIF_PARAM;
 		::SendMessage(_hContTab, TCM_GETITEM, iItemOff, reinterpret_cast<LPARAM>(&tcItem));
 		if (!tcItem.lParam)
@@ -1186,7 +1186,7 @@ void DockingCont::showToolbar(tTbData* pTbData, BOOL state)
 
 int DockingCont::hideToolbar(tTbData *pTbData, BOOL hideClient)
 {
-	int iItem = SearchPosInTab(pTbData);
+	int iItem = searchPosInTab(pTbData);
 
 	// delete item
 	if (TRUE == ::SendMessage(_hContTab, TCM_DELETEITEM, iItem, 0))
@@ -1206,7 +1206,7 @@ int DockingCont::hideToolbar(tTbData *pTbData, BOOL hideClient)
 
 			// activate new selected item and view plugin dialog
 			_prevItem = iItem;
-			SelectTab(iItem);
+			selectTab(iItem);
 
 			// hide tabs if only one element
 			if (iItemCnt == 1)
@@ -1256,7 +1256,7 @@ void DockingCont::viewToolbar(tTbData *pTbData)
 	}
 
 	// create new tab if it not exists
-	int iTabPos = SearchPosInTab(pTbData);
+	int iTabPos = searchPosInTab(pTbData);
 	tcItem.mask			= TCIF_PARAM;
 	tcItem.lParam = reinterpret_cast<LPARAM>(pTbData);
 
@@ -1264,13 +1264,13 @@ void DockingCont::viewToolbar(tTbData *pTbData)
 	{
 		// set only params and text even if icon available
 		::SendMessage(_hContTab, TCM_INSERTITEM, iItemCnt, reinterpret_cast<LPARAM>(&tcItem));
-		SelectTab(iItemCnt);
+		selectTab(iItemCnt);
 	}
 	// if exists select it and update data
 	else
 	{
 		::SendMessage(_hContTab, TCM_SETITEM, iTabPos, reinterpret_cast<LPARAM>(&tcItem));
-		SelectTab(iTabPos);
+		selectTab(iTabPos);
 	}
 
 	// show dialog and notify parent to update dialog view
@@ -1284,7 +1284,7 @@ void DockingCont::viewToolbar(tTbData *pTbData)
 	onSize();
 }
 
-int DockingCont::SearchPosInTab(tTbData* pTbData)
+int DockingCont::searchPosInTab(tTbData* pTbData)
 {
 	TCITEM tcItem = {0};
 	int iItemCnt = static_cast<int32_t>(::SendMessage(_hContTab, TCM_GETITEMCOUNT, 0, 0));
@@ -1303,7 +1303,7 @@ int DockingCont::SearchPosInTab(tTbData* pTbData)
 	return -1;
 }
 
-void DockingCont::SelectTab(int iTab)
+void DockingCont::selectTab(int iTab)
 {
 	if (iTab != -1)
 	{

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
@@ -90,8 +90,8 @@ public:
 	};
 
 	void setActiveTb(tTbData* pTbData);
-	void setActiveTb(INT iItem);
-	INT getActiveTb();
+	void setActiveTb(int iItem);
+	int getActiveTb();
 	tTbData * getDataOfActiveTb();
 	std::vector<tTbData *> getDataOfAllTb() {
 		return _vTbData;
@@ -163,18 +163,18 @@ protected :
 	void onSize();
 
 	// functions for caption handling and drawing
-	eMousePos isInRect(HWND hwnd, INT x, INT y);
+	eMousePos isInRect(HWND hwnd, int x, int y);
 
 	// handling of toolbars
 	void doClose();
 
 	// return new item
-	INT  SearchPosInTab(tTbData* pTbData);
-	void SelectTab(INT iTab);
+	int  searchPosInTab(tTbData* pTbData);
+	void selectTab(int iTab);
 
-	INT  hideToolbar(tTbData* pTbData, BOOL hideClient = TRUE);
+	int  hideToolbar(tTbData* pTbData, BOOL hideClient = TRUE);
 	void viewToolbar(tTbData *pTbData);
-	INT  removeTab(tTbData* pTbData) {
+	int  removeTab(tTbData* pTbData) {
 		return hideToolbar(pTbData, FALSE);
 	};
 

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -186,7 +186,6 @@ protected:
 
 	BrowserNodeType getNodeType(HTREEITEM hItem);
 	void popupMenuCmd(int cmdID);
-	POINT getMenuDisplayPoint(int iButton);
 	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void notified(LPNMHDR notification);
 	void showContextMenu(int x, int y);


### PR DESCRIPTION
- autoCompletion.nsh 
     - Autocomplete for AWK (awk.xml) is not available. So deleting unused script.
- common.h
     - Since there was no public ctor and default assignment operator was also blocked, we should block copy ctor as well.
- Parameters.h
     - Initiliaze variable at creation.
     - ~~deleted two not-implemented functions (```getAllWordStyles``` and ```getIndexFromKeywordListName```)~~. Handled in seperate PR by @donho .
- AutoCompletion.h
     - ```enum ActiveCompletion``` declared but not used. So deleted.
- DockingCont.h
     - Functions signatures in declaration and definition were not matching
```C++
// Declared as
void setActiveTb(INT iItem);
eMousePos isInRect(HWND hwnd, INT x, INT y);
void SelectTab(INT iTab);

// while implemented as below (Notice INT->int)
void DockingCont::setActiveTb(int iItem){}
eMousePos DockingCont::isInRect(HWND hwnd, int x, int y){}
void DockingCont::SelectTab(int iTab){}
```
- fileBrowser.h
     - deleted not-implemented functions (```getMenuDisplayPoint```).
