### PR TITLE
Shortcut improvements

### DIFF
--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -108,11 +108,13 @@ void ShortcutMapper::initBabyGrid() {
 	
 	_babygrid.reSizeToWH(rect);
 	_babygrid.hideCursor();
-	_babygrid.makeColAutoWidth();
+	_babygrid.makeColAutoWidth(false);
 	_babygrid.setAutoRow(false);
 	_babygrid.setColsNumbered(false);
 	_babygrid.setColWidth(0, NppParameters::getInstance()->_dpiManager.scaleX(30));
-	_babygrid.setColWidth(1, NppParameters::getInstance()->_dpiManager.scaleX(250));
+	_babygrid.setColWidth(1, NppParameters::getInstance()->_dpiManager.scaleX(290));
+	_babygrid.setColWidth(2, NppParameters::getInstance()->_dpiManager.scaleX(140));
+	_babygrid.setColWidth(3, NppParameters::getInstance()->_dpiManager.scaleX(40));
 	_babygrid.setHeaderHeight(NppParameters::getInstance()->_dpiManager.scaleY(21));
 	_babygrid.setRowHeight(NppParameters::getInstance()->_dpiManager.scaleY(21));
 
@@ -130,10 +132,14 @@ void ShortcutMapper::fillOutBabyGrid()
 
 	size_t nbItems = 0;
 
+	_babygrid.setText(0, 1, TEXT("Name"));
+	_babygrid.setText(0, 2, TEXT("Shortcut"));
+	
 	switch(_currentState) {
 		case STATE_MENU: {
 			nbItems = nppParam->getUserShortcuts().size();
-			_babygrid.setLineColNumber(nbItems, 2);
+			_babygrid.setLineColNumber(nbItems, 3);
+			_babygrid.setText(0, 3, TEXT("Category"));
 			break; }
 		case STATE_MACRO: {
 			nbItems = nppParam->getMacroList().size();
@@ -145,16 +151,14 @@ void ShortcutMapper::fillOutBabyGrid()
 			break; }
 		case STATE_PLUGIN: {
 			nbItems = nppParam->getPluginCommandList().size();
-			_babygrid.setLineColNumber(nbItems, 2);
+			_babygrid.setLineColNumber(nbItems, 3);
+			_babygrid.setText(0, 3, TEXT("Plugin"));
 			break; }
 		case STATE_SCINTILLA: {
 			nbItems = nppParam->getScintillaKeyList().size();
 			_babygrid.setLineColNumber(nbItems, 2);
 			break; }
 	}
-
-	_babygrid.setText(0, 1, TEXT("Name"));
-	_babygrid.setText(0, 2, TEXT("Shortcut"));
 
 	bool isMarker = false;
 
@@ -169,7 +173,7 @@ void ShortcutMapper::fillOutBabyGrid()
 				_babygrid.setText(i+1, 1, cshortcuts[i].getName());
 				if (cshortcuts[i].isEnabled()) //avoid empty strings for better performance
 					_babygrid.setText(i+1, 2, cshortcuts[i].toString().c_str());
-
+				_babygrid.setText(i+1, 3, cshortcuts[i].getCategory());
 				if (isMarker)
 					isMarker = _babygrid.setMarker(false);
 			}
@@ -225,6 +229,7 @@ void ShortcutMapper::fillOutBabyGrid()
 				_babygrid.setText(i+1, 1, cshortcuts[i].getName());
 				if (cshortcuts[i].isEnabled()) //avoid empty strings for better performance
 					_babygrid.setText(i+1, 2, cshortcuts[i].toString().c_str());
+				_babygrid.setText(i+1, 3, cshortcuts[i].getModuleName());
 
 				if (isMarker)
 					isMarker = _babygrid.setMarker(false);

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -187,7 +187,14 @@ void Shortcut::setName(const TCHAR * name) {
 }
 
 generic_string ScintillaKeyMap::toString() const {
-	return toString(0);
+	generic_string sc = TEXT("");
+	size_t nbCombos = getSize();
+	for (size_t combo = 0; combo < nbCombos; ++combo){
+		sc += toString(combo);
+		if (combo < nbCombos - 1)
+			sc += TEXT(" or ");
+	}
+	return sc;
 }
 
 generic_string ScintillaKeyMap::toString(size_t index) const {

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -979,8 +979,6 @@ CommandShortcut::CommandShortcut(Shortcut sc, long id) :	Shortcut(sc), _id(id) {
 		_category = TEXT("Setting");
 	else if ( _id < IDM_EXECUTE)
 		_category = TEXT("Tool");
-	else if ( _id < IDM_EXECUTE)
-		_category = TEXT("Tool");
 	else
 		_category = TEXT("Execute");
 }

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -955,3 +955,32 @@ INT_PTR CALLBACK ScintillaKeyMap::run_dlgProc(UINT Message, WPARAM wParam, LPARA
 
 	//return FALSE;
 }
+
+CommandShortcut::CommandShortcut(Shortcut sc, long id) :	Shortcut(sc), _id(id) {
+	if ( _id < IDM_EDIT)
+		_category = TEXT("File");
+	else if ( _id < IDM_SEARCH)
+		_category = TEXT("Edit");
+	else if (_id >= IDM_EDIT_AUTOCOMPLETE and _id <= IDM_EDIT_AUTOCOMPLETE_PATH)
+		_category = TEXT("Edit");
+	else if ( _id < IDM_VIEW)
+		_category = TEXT("Search");
+	else if ( _id < IDM_FORMAT)
+		_category = TEXT("View");
+	else if ( _id >= IDM_VIEW_GOTO_ANOTHER_VIEW and _id <= IDM_VIEW_LOAD_IN_NEW_INSTANCE)
+		_category = TEXT("View");
+	else if ( _id < IDM_LANG)
+		_category = TEXT("Format");
+	else if ( _id < IDM_ABOUT)
+		_category = TEXT("Lang");
+	else if ( _id < IDM_SETTING)
+		_category = TEXT("About");
+	else if ( _id < IDM_TOOL)
+		_category = TEXT("Setting");
+	else if ( _id < IDM_EXECUTE)
+		_category = TEXT("Tool");
+	else if ( _id < IDM_EXECUTE)
+		_category = TEXT("Tool");
+	else
+		_category = TEXT("Execute");
+}

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -194,35 +194,7 @@ protected :
 		 
 class CommandShortcut : public Shortcut {
 public:
-	CommandShortcut(Shortcut sc, long id) :	Shortcut(sc), _id(id) {
-		long category_id = _id - _id % 500;
-		switch (category_id){
-			case IDM_FILE : 
-				_category = TEXT("File"); break;
-			case IDM_EDIT : 
-				_category = TEXT("Edit"); break;
-			case IDM_EDIT_AUTOCOMPLETE :
-				_category = TEXT("Edit"); break;
-			case IDM_SEARCH:
-				_category = TEXT("Search"); break;
-			case IDM_VIEW : 
-				_category = TEXT("View"); break;
-			case IDM_FORMAT : 
-				_category = TEXT("Format"); break;
-			case IDM_LANG : 
-				_category = TEXT("Lang"); break;
-			case IDM_ABOUT : 
-				_category = TEXT("About"); break;
-			case IDM_SETTING : 
-				_category = TEXT("Setting"); break;
-			case IDM_TOOL : 
-				_category = TEXT("Tool"); break; 
-			case IDM_EXECUTE : 
-				_category = TEXT("Execute"); break; 
-			default :
-				_category = TEXT(""); break;
-		}
-	};
+	CommandShortcut(Shortcut sc, long id);
 	unsigned long getID() const {return _id;};
 	void setID(unsigned long id) { _id = id;};
 	const TCHAR * getCategory() const { return _category.c_str(); };

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -32,6 +32,7 @@
 #include "Scintilla.h"
 #include "StaticDialog.h"
 #include "Common.h"
+#include "menuCmdID.h"
 
 const size_t nameLenMax = 64;
 
@@ -193,12 +194,42 @@ protected :
 		 
 class CommandShortcut : public Shortcut {
 public:
-	CommandShortcut(Shortcut sc, long id) :	Shortcut(sc), _id(id) {};
+	CommandShortcut(Shortcut sc, long id) :	Shortcut(sc), _id(id) {
+		long category_id = _id - _id % 500;
+		switch (category_id){
+			case IDM_FILE : 
+				_category = TEXT("File"); break;
+			case IDM_EDIT : 
+				_category = TEXT("Edit"); break;
+			case IDM_EDIT_AUTOCOMPLETE :
+				_category = TEXT("Edit"); break;
+			case IDM_SEARCH:
+				_category = TEXT("Search"); break;
+			case IDM_VIEW : 
+				_category = TEXT("View"); break;
+			case IDM_FORMAT : 
+				_category = TEXT("Format"); break;
+			case IDM_LANG : 
+				_category = TEXT("Lang"); break;
+			case IDM_ABOUT : 
+				_category = TEXT("About"); break;
+			case IDM_SETTING : 
+				_category = TEXT("Setting"); break;
+			case IDM_TOOL : 
+				_category = TEXT("Tool"); break; 
+			case IDM_EXECUTE : 
+				_category = TEXT("Execute"); break; 
+			default :
+				_category = TEXT(""); break;
+		}
+	};
 	unsigned long getID() const {return _id;};
 	void setID(unsigned long id) { _id = id;};
+	const TCHAR * getCategory() const { return _category.c_str(); };
 
 private :
 	unsigned long _id;
+	generic_string _category;
 };
 
 


### PR DESCRIPTION
Fixes #3583

Shorcut mapper - main panel : new colums that show the category of the shortcut
Shorcut mapper - plugin panel : new colums that show the plugin name that the shortcut belongs to
Shorcut mapper - scintilla panel : it shows every shortcuts configured for one command