### PR TITLE
Fixed issue and corrected code

### DIFF
--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1615,16 +1615,6 @@ INT_PTR CALLBACK LangMenuDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 				// Lang Menu
 				if (LOWORD(wParam) == IDC_LIST_DISABLEDLANG || LOWORD(wParam) == IDC_LIST_ENABLEDLANG)
 				{
-					HWND hEnableList = ::GetDlgItem(_hSelf, IDC_LIST_ENABLEDLANG);
-					HWND hDisableList = ::GetDlgItem(_hSelf, IDC_LIST_DISABLEDLANG);
-					if (HIWORD(wParam) == LBN_DBLCLK)
-					{
-						if (HWND(lParam) == hEnableList)
-							::SendMessage(_hSelf, WM_COMMAND, IDC_BUTTON_REMOVE, 0);
-						else if (HWND(lParam) == hDisableList)
-							::SendMessage(_hSelf, WM_COMMAND, IDC_BUTTON_RESTORE, 0);
-						return TRUE;
-					}
 					int idButton2Enable;
 					int idButton2Disable;
 
@@ -1699,6 +1689,27 @@ INT_PTR CALLBACK LangMenuDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 				}
 
             }
+
+			// Check if it is double click
+			else if (HIWORD(wParam) == LBN_DBLCLK)
+			{
+				// Lang Menu
+				if (LOWORD(wParam) == IDC_LIST_DISABLEDLANG || LOWORD(wParam) == IDC_LIST_ENABLEDLANG)
+				{
+					// On double click an item, the item should be moved
+					// from one list to other list
+
+					HWND(lParam) == ::GetDlgItem(_hSelf, IDC_LIST_ENABLEDLANG) ?
+						::SendMessage(_hSelf, WM_COMMAND, IDC_BUTTON_REMOVE, 0) :
+						::SendMessage(_hSelf, WM_COMMAND, IDC_BUTTON_RESTORE, 0);
+					return TRUE;
+				}
+
+				// Tab setting - Double click is not used at this moment
+				/*else if (LOWORD(wParam) == IDC_LIST_TABSETTNG)
+				{
+				}*/
+			}
 
 			switch (wParam)
             {


### PR DESCRIPTION
A partial fix to issue: #3589 (Now language can be moved between Listboxes using double click)

Corrected Code:
           -  There was issue in code. At line 1613, it checks for ```if (HIWORD(wParam) == LBN_SELCHANGE)``` while in same ```if``` block it checks for ```if (HIWORD(wParam) == LBN_DBLCLK)``` which can't happen.
