### PR TITLE
Do not reload function list when switching to the same file in cloned view

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3510,6 +3510,8 @@ int Notepad_plus::switchEditViewTo(int gid)
 		// Make sure the colors of the tab controls match
 		::InvalidateRect(_mainDocTab.getHSelf(), NULL, FALSE);
 		::InvalidateRect(_subDocTab.getHSelf(), NULL, FALSE);
+		// Make sure that plugins still get notified
+		doNotifyBufferActivated(_pEditView->getCurrentBufferID());
 	}
 	return oldView;
 }
@@ -5232,11 +5234,7 @@ void Notepad_plus::notifyBufferActivated(BufferID bufid, int view)
 	::InvalidateRect(_mainDocTab.getHSelf(), NULL, FALSE);
 	::InvalidateRect(_subDocTab.getHSelf(), NULL, FALSE);
 
-	SCNotification scnN;
-	scnN.nmhdr.code = NPPN_BUFFERACTIVATED;
-	scnN.nmhdr.hwndFrom = _pPublicInterface->getHSelf();
-	scnN.nmhdr.idFrom = (uptr_t)bufid;
-	_pluginsManager.notify(&scnN);
+	doNotifyBufferActivated(bufid);
 
 	if (_pFileSwitcherPanel)
 	{
@@ -5255,6 +5253,14 @@ void Notepad_plus::notifyBufferActivated(BufferID bufid, int view)
 	}
 
 	_linkTriggered = true;
+}
+
+void Notepad_plus::doNotifyBufferActivated(BufferID bufid) {
+	SCNotification scnN;
+	scnN.nmhdr.code = NPPN_BUFFERACTIVATED;
+	scnN.nmhdr.hwndFrom = _pPublicInterface->getHSelf();
+	scnN.nmhdr.idFrom = (uptr_t)bufid;
+	_pluginsManager.notify(&scnN);
 }
 
 void Notepad_plus::loadCommandlineParams(const TCHAR * commandLine, CmdLineParams * pCmdParams)

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3497,11 +3497,20 @@ int Notepad_plus::switchEditViewTo(int gid)
 	{
 		_pDocMap->initWrapMap();
 	}
-
-	// Before switching off, synchronize backup file
-	MainFileManager->backupCurrentBuffer();
-
-	notifyBufferActivated(_pEditView->getCurrentBufferID(), currentView());
+	if (_pNonEditView->getCurrentBufferID() != _pEditView->getCurrentBufferID())
+	{
+		// We are switching to a different file in another view
+		// Before switching off, synchronize backup file
+		MainFileManager->backupCurrentBuffer();
+		notifyBufferActivated(_pEditView->getCurrentBufferID(), currentView());
+	}
+	else
+	{
+		// We are switching to the same file in another view
+		// Make sure the colors of the tab controls match
+		::InvalidateRect(_mainDocTab.getHSelf(), NULL, FALSE);
+		::InvalidateRect(_subDocTab.getHSelf(), NULL, FALSE);
+	}
 	return oldView;
 }
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -410,6 +410,7 @@ private:
 
 	bool activateBuffer(BufferID id, int whichOne);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);
+	void doNotifyBufferActivated(BufferID bufid);
 	void performPostReload(int whichOne);
 //END: Document management
 


### PR DESCRIPTION
fixes #3592 

Notepad_plus::switchEditViewTo() method now does not call notifyBufferActivated() always - only if it detects that the buffer we are switching to in other view is actually different than current one. Assumption is that we don't really need to activate the buffer if it is already active, so in that case we can skip some potentially lengthy operations - like Function list recompiling. In that case, we can just invalidate rects for active and inactive view to update the colors of the tab controls.