### PR TITLE
BaanC FunctionList

### DIFF
--- a/PowerEditor/src/functionList.xml
+++ b/PowerEditor/src/functionList.xml
@@ -89,6 +89,7 @@
 			<association id=   "innosetup_syntax"     langID="46"                          />
 			<association id=  "powershell_function"   langID="53"                          />
 			<association id=  "javascript_function"   langID="58"                          />
+			<association id=       "baanc_function"   langID="60"                          />
 			<!-- ======================================================================== -->
 			<association id=         "krl_function"   userDefinedLangName="KRL"            />
 			<association id=         "krl_function"   ext=".src"                           />
@@ -1293,6 +1294,22 @@
 							)
 						"
 				/>
+			</parser>
+			
+			<!-- ======================================================= [ BaanC ] -->
+			<parser
+				displayName="BaanC"
+				id         ="baanc_function"
+				commentExpr="(?m-s:/|.*?$)"
+			>
+				<function
+						mainExpr="^\h*(?i:function)\s+[\w\.\s]+\("
+				>
+					<functionName>
+						<nameExpr expr="[\w\.\s]+\(" />
+						<nameExpr expr="[\w\.\s]+" />
+					</functionName>
+				</function>
 			</parser>
 
 			<!-- ================================================================= -->


### PR DESCRIPTION
Enable FunctionList for BaanC language

[BaanC_FunctionList.bc.txt](https://github.com/notepad-plus-plus/notepad-plus-plus/files/1262603/BaanC_FunctionList.bc.txt)

@MAPJe71 attached a source file with a list of possible combinations.
At this point, not all the combinations are displayed... But, not sure where the issue is.

Thx for your review.