### PR TITLE
Fix Python the variable "def" not working correctly in Function List

### DIFF
--- a/PowerEditor/src/functionList.xml
+++ b/PowerEditor/src/functionList.xml
@@ -746,7 +746,7 @@
 						<nameExpr expr="\w+(?=[\(|:])" />
 					</className>
 					<function
-						mainExpr="(?&lt;=def\x20).+?(?=:)"
+						mainExpr="(?&lt;=\sdef\x20).+?(?=:)"
 					>
 						<functionName>
 							<funcNameExpr expr=".*" />
@@ -754,13 +754,14 @@
 					</function>
 				</classRange>
 				<function
-					mainExpr="(?&lt;=def\x20).+?(?=:)"
+					mainExpr="(?&lt;=\sdef\x20).+?(?=:)"
 				>
 					<functionName>
 						<nameExpr expr=".*" />
 					</functionName>
 				</function>
 			</parser>
+
 
 			<!-- ======================================================== [ Bash ] -->
 			<!-- BASH - Bourne-Again Shell                                         -->


### PR DESCRIPTION
Fixed issue #3645
Fix the "In Python the variable "def" not working correctly in Function List"


i've tested it with following files:
---------------------------------------------------------

USER_DEF = 1000

def test2():
	pass

def test():
	print("hello")

def a():
	pass
---------------------------------------------------------

#there is the same problem
USER_CLASS = 67

class Test:

	USER_DEF = 1000

	def test2():
		pass

	def test():
		print("hello")

	def a():
		pass
	
def b():
      pass

---------------------------------------------------------

USER_DEF = 1000

class Test:

	def test2():
		pass

	def test():
		print("hello")

	def a():
		pass
	
def b():

---------------------------------------------------------

USER_CLASS = 1000

class Test:

	def test2():
		pass

	def test():
		print("hello")

	def a():
		pass
	
def b():