### PR TITLE
BaanC Function List xml changes

### DIFF
--- a/PowerEditor/src/functionList.xml
+++ b/PowerEditor/src/functionList.xml
@@ -89,6 +89,7 @@
 			<association id=   "innosetup_syntax"     langID="46"                          />
 			<association id=  "powershell_function"   langID="53"                          />
 			<association id=  "javascript_function"   langID="58"                          />
+			<association id=       "baanc_function"   langID="60"                          />
 			<!-- ======================================================================== -->
 			<association id=         "krl_function"   userDefinedLangName="KRL"            />
 			<association id=         "krl_function"   ext=".src"                           />
@@ -1293,6 +1294,22 @@
 							)
 						"
 				/>
+			</parser>
+			
+			<!-- ======================================================= [ BaanC ] -->
+			<parser
+				displayName="BaanC"
+				id         ="baanc_function"
+				commentExpr="(?m-s:/|.*?$)"
+			>
+				<function
+					mainExpr="^\h*(?i:function)\s+[\w\.\s]+\("
+				>
+					<functionName>
+						<nameExpr expr="[\w\.\s]+\(" />
+						<nameExpr expr="[\w\.\s]+" />
+					</functionName>
+				</function>
 			</parser>
 
 			<!-- ================================================================= -->


### PR DESCRIPTION
Includes BaanC to the function list
[BaanC_FunctionList.bc.txt](https://github.com/notepad-plus-plus/notepad-plus-plus/files/1262824/BaanC_FunctionList.bc.txt)

A sample source file with the possibilities is attached for preview.

@MAPJe71 , this PR is a continuation of the #3670 .
I had to close it because, I messed up with the commits.
But, all the review comments are included, except the one about comments.
The '|' is the comment symbol and not the forward slash.

As of now, not all the possible ways of writing a function is captured by this regex.
Multi-line regex looks complicated to me, I have tested only the basic ones.
If you have any pointers on how to achieve all combinations let me know.

Regards,