### PR TITLE
Auto compelte for Batch

### DIFF
--- a/PowerEditor/installer/nsisInclude/autoCompletion.nsh
+++ b/PowerEditor/installer/nsisInclude/autoCompletion.nsh
@@ -128,6 +128,11 @@ SectionGroup "Auto-completion Files" autoCompletionComponent
 		SetOutPath "$INSTDIR\plugins\APIs"
 		File ".\APIs\cmake.xml"
 	${MementoSectionEnd}
+
+	${MementoSection} "BATCH" BATCH
+		SetOutPath "$INSTDIR\plugins\APIs"
+		File ".\APIs\batch.xml"
+	${MementoSectionEnd}
 SectionGroupEnd
 
 
@@ -211,5 +216,9 @@ SectionGroup un.autoCompletionComponent
 	
 	Section un.CMAKE
 		Delete "$INSTDIR\plugins\APIs\cmake.xml"
-	SectionEnd	
+	SectionEnd
+
+	Section un.BATCH
+		Delete "$INSTDIR\plugins\APIs\batch.xml"
+	SectionEnd
 SectionGroupEnd


### PR DESCRIPTION
V7.5.1 change.log says [Auto complete support for batch file](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/d7f64d2027703b43e05206f15c5dc90bd1e93e39/PowerEditor/bin/change.log).
But auto complete file has not been included in installer.

## Before:
![image](https://user-images.githubusercontent.com/14791461/29865230-a52646e4-8d92-11e7-85e8-e6cc7e9163b7.png)

## After:
![image](https://user-images.githubusercontent.com/14791461/29865195-894fa9c4-8d92-11e7-8ffe-8a9a2c751a29.png)

