### PR TITLE
Fixed issue and disabled lexer signature checking in debug mode

### DIFF
--- a/PowerEditor/src/MISC/Common/verifySignedfile.cpp
+++ b/PowerEditor/src/MISC/Common/verifySignedfile.cpp
@@ -228,7 +228,7 @@ bool VerifySignedLibrary(const wstring& filepath,
 		display_name = display_name_buffer.get();
 
 	} catch (wstring s) {
-		::MessageBox(NULL, TEXT("DLL signature verification failed"), s.c_str(), MB_ICONERROR);
+		::MessageBox(NULL, s.c_str(), TEXT("DLL signature verification failed"), MB_ICONERROR);
 		OutputDebugString(TEXT("VerifyLibrary: error while getting certificate informations\n"));
 		status = false;
 	} catch (...) {
@@ -236,7 +236,7 @@ bool VerifySignedLibrary(const wstring& filepath,
 		OutputDebugString(TEXT("VerifyLibrary: error while getting certificate informations\n"));
 		wstring errMsg(TEXT("Unknown exception occured. "));
 		errMsg += GetLastErrorAsString(GetLastError());
-		::MessageBox(NULL, TEXT("DLL signature verification failed"), errMsg.c_str(), MB_ICONERROR);
+		::MessageBox(NULL, errMsg.c_str(), TEXT("DLL signature verification failed"), MB_ICONERROR);
 		status = false;
 	}
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -206,6 +206,10 @@ HMODULE loadSciLexerDll()
 {
 	generic_string sciLexerPath = getSciLexerFullPathName(moduleFileName, 1024);
 
+	// Do not check dll signature if npp is running in debug mode
+	// This is helpful for developers to skip signature checking
+	// while analyzing issue or modifying the lexer dll
+#ifndef _DEBUG
 	bool isOK = VerifySignedLibrary(sciLexerPath, SCINTILLA_SIGNER_KEY_ID, SCINTILLA_SIGNER_SUBJECT, SCINTILLA_SIGNER_DISPLAY_NAME, false, false);
 
 	if (!isOK)
@@ -216,6 +220,7 @@ HMODULE loadSciLexerDll()
 			MB_OK | MB_ICONERROR);
 		return nullptr;
 	}
+#endif // !_DEBUG
 
 	return ::LoadLibrary(sciLexerPath.c_str());
 }


### PR DESCRIPTION
1. Fixed issue #3688  (caption and message are interchanged)
![image](https://user-images.githubusercontent.com/14791461/29995750-5868da28-900e-11e7-9203-61d6ddea8e3d.png)

2. Disabled lexerdll signature checking in debug mode (just to help developers)