### PR TITLE
Add version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Build Status
 ------------
 
 [![Appveyor build status](https://ci.appveyor.com/api/projects/status/github/notepad-plus-plus/notepad-plus-plus?branch=master&svg=true)](https://ci.appveyor.com/project/donho/notepad-plus-plus)
+[![GitHub release](https://img.shields.io/github/release/notepad-plus-plus/notepad-plus-plus.svg)]()
 
 To build Notepad++ from source:
 -------------------------------


### PR DESCRIPTION
### Description
This adds the badge [![GitHub release](https://img.shields.io/github/release/notepad-plus-plus/notepad-plus-plus.svg)]() to README in order to show the latest version of Notepad++

It is provided by http://shields.io/ and uses the [latest release of Notepadd++ from GitHub](https://github.com/notepad-plus-plus/notepad-plus-plus/releases/latest)

### Preview

![image](https://user-images.githubusercontent.com/22953777/30243652-0a782458-95af-11e7-8af7-585a2d18473b.png)
