### PR TITLE
harmonization of the encoding name in status bar

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2321,9 +2321,9 @@ void Notepad_plus::setUniModeText()
 			case uni16LE:
 				uniModeTextString = TEXT("UCS-2 LE BOM"); break;
 			case uni16BE_NoBOM:
-				uniModeTextString = TEXT("UCS-2 Big Endian"); break;
+				uniModeTextString = TEXT("UCS-2 BE"); break;
 			case uni16LE_NoBOM:
-				uniModeTextString = TEXT("UCS-2 Little Endian"); break;
+				uniModeTextString = TEXT("UCS-2 LE"); break;
 			case uniCookie:
 				uniModeTextString = TEXT("UTF-8"); break;
 			default :


### PR DESCRIPTION
The encoding of the current file is displayed on status bar :
![encodestatusbar](https://user-images.githubusercontent.com/12849364/30247822-4f90e602-961c-11e7-8481-14c453da3cd7.jpg)


### Description of the Issue
The following values are possible
* ANSI
* UTF-8-BOM
* UTF-8
* UCS-2 BE BOM
* **UCS-2 Big Endian**
* UCS-2 LE BOM
* **UCS-2 Little Endian**
* ...

The expected values should be
* ANSI
* UTF-8-BOM
* UTF-8
* UCS-2 BE BOM
* **UCS-2 BE**
* UCS-2 LE BOM
* **UCS-2 LE**
* ...

Fix : #3727