### PR TITLE
fix feedScintKeys when more than two shortcuts are configured

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2458,7 +2458,7 @@ void NppParameters::feedScintKeys(TiXmlNode *node)
 				KeyCombo kc;
 				for (TiXmlNode *nextNode = childNode->FirstChildElement(TEXT("NextKey"));
 					nextNode ;
-					nextNode = childNode->NextSibling(TEXT("NextKey")) )
+					nextNode = nextNode->NextSibling(TEXT("NextKey")))
 				{
 					const TCHAR *str = (nextNode->ToElement())->Attribute(TEXT("Ctrl"));
 					if (!str)


### PR DESCRIPTION
fixes #3720 

The iterator of xml node was wrong. Iterator read only the first child, others children was ignored.
Now every children are read.