### PR TITLE
Regression: Fixed Nsis warning

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -86,13 +86,7 @@ page Custom ExtraOptions
 
 
 !include "nsisInclude\langs4Installer.nsh"
-
-
-
-
 !include "nsisInclude\mainSectionFuncs.nsh"
-
-
 !include "nsisInclude\langs4Npp.nsh"
 !include "nsisInclude\autoCompletion.nsh"
 !include "nsisInclude\themes.nsh"
@@ -121,6 +115,27 @@ SectionEnd
 
 Var diffArchDir2Remove
 Var noUpdater
+
+Section -"Notepad++" mainSection
+
+	Call setPathAndOptions
+
+	${If} $diffArchDir2Remove != ""
+		!insertmacro uninstallRegKey
+		!insertmacro uninstallDir $diffArchDir2Remove
+	${endIf}
+
+	Call copyCommonFiles
+
+	Call removeUnstablePlugins
+
+	Call removeOldContextMenu
+
+	Call shortcutLinkManagement
+
+SectionEnd
+
+
 Function .onInit
 
 	${GetParameters} $R0 
@@ -194,26 +209,6 @@ noDelete64:
 	${MementoSectionRestore}
 
 FunctionEnd
-
-
-Section -"Notepad++" mainSection
-
-	Call setPathAndOptions
-	
-	${If} $diffArchDir2Remove != ""
-		!insertmacro uninstallRegKey
-		!insertmacro uninstallDir $diffArchDir2Remove 
-	${endIf}
-
-	Call copyCommonFiles
-
-	Call removeUnstablePlugins
-
-	Call removeOldContextMenu
-	
-	Call shortcutLinkManagement
-	
-SectionEnd
 
 
 Function .onInstSuccess


### PR DESCRIPTION
Moving mainSection from top to bottom created nsis warning.

![image](https://user-images.githubusercontent.com/14791461/30556690-5720aba6-9cc9-11e7-9cc3-dc56422d67de.png)


I know there was fixed done related to uninstaller (installing x64 over x86 and vice versa). Instead of moving whole function, declaring variable ```Var diffArchDir2Remove``` just before use (before both mainSection and .onInit) could have fixed the issue.