### PR TITLE
Write version info to installer

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -49,6 +49,17 @@ OutFile ".\build\npp.${APPVERSION}.Installer.x64.exe"
 !else
 OutFile ".\build\npp.${APPVERSION}.Installer.exe"
 !endif
+
+; ------------------------------------------------------------------------
+; Version Information
+   VIProductVersion	"${Version}"
+   VIAddVersionKey	"ProductName"		"${APPNAME}"
+   VIAddVersionKey	"CompanyName"		"${CompanyName}"
+   VIAddVersionKey	"LegalCopyright"	"${LegalCopyright}"
+   VIAddVersionKey	"FileDescription"	"${Description}"
+   VIAddVersionKey	"FileVersion"		"${Version}"
+   VIAddVersionKey	"ProductVersion"	"${ProdVer}"
+; ------------------------------------------------------------------------
  
 ; Insert CheckIfRunning function as an installer and uninstaller function.
 !insertmacro CheckIfRunning ""

--- a/PowerEditor/installer/nsisInclude/globalDef.nsh
+++ b/PowerEditor/installer/nsisInclude/globalDef.nsh
@@ -29,10 +29,43 @@
 ; Define the application name
 !define APPNAME "Notepad++"
 
-!define APPVERSION "7.5.1"
-!define APPNAMEANDVERSION "${APPNAME} v${APPVERSION}"
-!define VERSION_MAJOR 7
-!define VERSION_MINOR 51
+; ------------------------------------------------------------------------
+; Get Notepad++ version from the notepad++ binary
+
+!ifdef ARCH64
+	!getdllversion "..\bin64\notepad++.exe" nppVer_
+!else
+	!getdllversion "..\bin\notepad++.exe" nppVer_
+!endif
+
+!define APPVERSION		${nppVer_1}.${nppVer_2}		; 7.5
+!define VERSION_MAJOR		${nppVer_1}			; 7
+!define VERSION_MINOR		${nppVer_2}			; 5
+
+!if ${nppVer_3} != 0
+	!undef APPVERSION
+	!define APPVERSION	${nppVer_1}.${nppVer_2}.${nppVer_3}	; 7.5.1
+
+	!undef VERSION_MINOR
+	!define VERSION_MINOR	${nppVer_2}${nppVer_3}			; 51
+!endif
+
+!if ${nppVer_4} != 0
+	!undef APPVERSION
+	!define APPVERSION	${nppVer_1}.${nppVer_2}.${nppVer_3}.${nppVer_4}	; 7.5.1.3
+
+	!undef VERSION_MINOR
+	!define VERSION_MINOR	${nppVer_2}${nppVer_3}${nppVer_4}		; 513
+!endif
+
+; ------------------------------------------------------------------------
+
+!define APPNAMEANDVERSION	"${APPNAME} v${APPVERSION}"
+!define CompanyName		"Don HO don.h@free.fr"
+!define Description		"Notepad++ : a free (GNU) source code editor"
+!define Version		"${nppVer_1}.${nppVer_2}.${nppVer_3}.${nppVer_4}"
+!define ProdVer		"${VERSION_MAJOR}.${VERSION_MINOR}"
+!define LegalCopyright		"Copyleft 1998-2017 by Don HO"
 
 !define APPWEBSITE "http://notepad-plus-plus.org/"
 


### PR DESCRIPTION
1. Write version info to the installer
2. Avoid manual work of updating version info every time. Use notepad++.exe to get version.

![image](https://user-images.githubusercontent.com/14791461/30559166-54f914b4-9cd1-11e7-8e0b-272effc5ea9e.png)

**Note: As per [nsis doc](http://nsis.sourceforge.net/Reference/!getdllversion) ```!getdllversion``` was introduced in nsis version v3.0a0. I'm assuming npp installer is generated using above this version.** 