### PR TITLE
Fixed hang issue while opening JavaScript file

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -3306,7 +3306,7 @@ void ScintillaEditView::setTabSettings(Lang *lang)
 		if (lang->_langID == L_JAVASCRIPT)
 		{
 			Lang *ljs = _pParameter->getLangFromID(L_JS);
-			execute(SCI_SETTABWIDTH, ljs->_tabSize);
+			execute(SCI_SETTABWIDTH, ljs->_tabSize > 0 ? ljs->_tabSize : lang->_tabSize);
 			execute(SCI_SETUSETABS, !ljs->_isTabReplacedBySpace);
 			return;
 		}


### PR DESCRIPTION
Fixed issue  #3770 

**Root Cause:**
When setting for javascript.js is changed to use tabs instead of spaces, lang.xml is written as below - 

``` <Language name="javascript.js" ext="js jsm jsx ts tsx" commentLine="//" commentStart="/*" commentEnd="*/" tabSettings="-1"> ```

When next time npp is opened, below statment cause problem as tab width can't be set negative.
```execute(SCI_SETTABWIDTH, ljs->_tabSize);```
