### PR TITLE
Translations: Chinese(Taiwan): Replace tab indentation to align with rest of the style

### DIFF
--- a/PowerEditor/installer/nativeLang/chinese.xml
+++ b/PowerEditor/installer/nativeLang/chinese.xml
@@ -12,7 +12,7 @@
                     <Item menuId="encoding" name="編碼(&amp;N)"/>
                     <Item menuId="language" name="語言(&amp;L)"/>
                     <Item menuId="settings" name="設定(&amp;T)"/>
-					<Item menuId="tools" name="工具(&amp;O)"/>
+                    <Item menuId="tools" name="工具(&amp;O)"/>
                     <Item menuId="macro" name="巨集(&amp;M)"/>
                     <Item menuId="run" name="執行(&amp;R)"/>
                     <Item idName="Plugins" name="外掛(&amp;P)"/>
@@ -32,7 +32,7 @@
                     <Item subMenuId="edit-eolConversion" name="換行格式"/>
                     <Item subMenuId="edit-blankOperations" name="空格處理"/>
                     <Item subMenuId="edit-pasteSpecial" name="特殊貼上"/>
-					<Item subMenuId="edit-onSelection" name="選取字元"/>
+                    <Item subMenuId="edit-onSelection" name="選取字元"/>
                     <Item subMenuId="search-markAll" name="全部標記"/>
                     <Item subMenuId="search-unmarkAll" name="去除標記"/>
                     <Item subMenuId="search-jumpUp" name="上個標記"/>
@@ -109,16 +109,16 @@
                     <Item id="42015" name="向下移動現行行列"/>
                     <Item id="42016" name="轉成大寫"/>
                     <Item id="42017" name="轉成小寫"/>
-					<Item id="42067" name="每字第一字母大寫，其他皆小寫"/>
+                    <Item id="42067" name="每字第一字母大寫，其他皆小寫"/>
                     <Item id="42068" name="每字第一字母大寫"/>
                     <Item id="42069" name="句子第一字母大寫，其他皆小寫"/>
                     <Item id="42070" name="句子第一字母大寫"/>
                     <Item id="42071" name="大小寫互換"/>
                     <Item id="42072" name="隨機大小寫"/>
-					<Item id="42073" name="開啟檔案"/>
-					<Item id="42074" name="開啟此資料夾於檔案總管"/>
-					<Item id="42075" name="上網搜尋"/>
-					<Item id="42076" name="更改搜索引擎..."/>
+                    <Item id="42073" name="開啟檔案"/>
+                    <Item id="42074" name="開啟此資料夾於檔案總管"/>
+                    <Item id="42075" name="上網搜尋"/>
+                    <Item id="42076" name="更改搜索引擎..."/>
                     <Item id="42018" name="開始錄製巨集"/>
                     <Item id="42019" name="停止錄製巨集"/>
                     <Item id="42021" name="播放巨集(&amp;P)"/>
@@ -164,7 +164,7 @@
                     <Item id="42063" name="升冪排序小數 (,)"/>
                     <Item id="42064" name="降冪排序小數 (,)"/>
                     <Item id="42065" name="升冪排序小數 (.)"/>
-					<Item id="42066" name="降冪排序小數 (.)"/>
+                    <Item id="42066" name="降冪排序小數 (.)"/>
                     <Item id="43001" name="尋找(&amp;F)..."/>
                     <Item id="43002" name="向下尋找(&amp;N)"/>
                     <Item id="43003" name="取代..."/>
@@ -214,7 +214,7 @@
                     <Item id="43047" name="上一個搜尋結果"/>
                     <Item id="43048" name="選取並搜尋下一個"/>
                     <Item id="43049" name="選取並搜尋上一個"/>
-					<Item id="43054" name="標記..."/>
+                    <Item id="43054" name="標記..."/>
                     <Item id="43050" name="反向標記書籤"/>
                     <Item id="44009" name="便條紙"/>
                     <Item id="44010" name="折疊所有層次"/>
@@ -244,8 +244,8 @@
                     <Item id="44094" name="欄標九"/>
                     <Item id="44095" name="下一個欄標"/>
                     <Item id="44096" name="上一個欄標"/>
-					<Item id="44097" name="監視日誌 (tail -f)"/>
-					<Item id="44098" name="前移欄標"/>
+                    <Item id="44097" name="監視日誌 (tail -f)"/>
+                    <Item id="44098" name="前移欄標"/>
                     <Item id="44099" name="後移欄標"/>
                     <Item id="44032" name="全螢幕"/>
                     <Item id="44033" name="復原字體大小"/>
@@ -288,9 +288,9 @@
                     <Item id="47006" name="升級 Notepad++"/>
                     <Item id="47008" name="全攻略秘籍"/>
                     <Item id="47009" name="設定更新程式代理伺服器..."/>
-					<Item id="47010" name="指令列參數..."/>
-					<Item id="47011" name="技術支援熱線"/>
-					<Item id="47012" name="除錯資訊..."/>
+                    <Item id="47010" name="指令列參數..."/>
+                    <Item id="47011" name="技術支援熱線"/>
+                    <Item id="47012" name="除錯資訊..."/>
                     <Item id="48005" name="匯入外掛模組..."/>
                     <Item id="48006" name="匯入主題面板..."/>
                     <Item id="48018" name="編輯彈跳選單"/>
@@ -376,14 +376,14 @@
                 <Item id="1703" name="「.」包含換行"/>
             </Find>
             <FindCharsInRange title="在範圍內搜尋字元">
-				<Item id="2" name="關閉"/>
-				<Item id="2901" name="非 ASCII 字元 (128-255)"/>
-				<Item id="2902" name="ASCII 字元 (0-127)"/>
+                <Item id="2" name="關閉"/>
+                <Item id="2901" name="非 ASCII 字元 (128-255)"/>
+                <Item id="2902" name="ASCII 字元 (0-127)"/>
                 <Item id="2903" name="自定範圍:"/>
-				<Item id="2906" name="上(&amp;U)"/>
-				<Item id="2907" name="下(&amp;D)"/>
+                <Item id="2906" name="上(&amp;U)"/>
+                <Item id="2907" name="下(&amp;D)"/>
                 <Item id="2908" name="方向"/>
-				<Item id="2909" name="循環(&amp;D)"/>
+                <Item id="2909" name="循環(&amp;D)"/>
                 <Item id="2910" name="尋找"/>
             </FindCharsInRange>
             <GoToLine title="到那兒去溜搭溜搭">
@@ -497,7 +497,7 @@
                     <Item id="25026" name="運算元1"/>
                     <Item id="25027" name="運算元2"/>
                     <Item id="25028" name="數字"/>
-					<Item id="1" name="儲存"/>
+                    <Item id="1" name="儲存"/>
                     <Item id="2" name="取消"/>
                 </StylerDialog>
                 <Folder title="層次設定與內定格式">
@@ -643,7 +643,7 @@
                     <Item id="6118" name="隱藏"/>
                     <Item id="6119" name="多行"/>
                     <Item id="6120" name="直式"/>
-					<Item id="6121" name="關閉最後一個文件時關閉程式"/>
+                    <Item id="6121" name="關閉最後一個文件時關閉程式"/>
                     <Item id="6122" name="隱藏 (用 Alt 或 F10 切換)"/>
                     <Item id="6123" name="界面語言​​"/>
                     <Item id="6125" name="文件清單面板"/>
@@ -681,10 +681,10 @@
                     <Item id="6212" name="垂直線模式"/>
                     <Item id="6213" name="背景色模式"/>
                     <Item id="6214" name="啟動現行行列背景顏色"/>
-					<Item id="6215" name="啟用 smooth font"/>
+                    <Item id="6215" name="啟用 smooth font"/>
                     <Item id="6231" name="邊框寬度"/>
-					<Item id="6235" name="無邊框"/>
-					<Item id="6236" name="啟用超出了最後一行捲動功能"/>
+                    <Item id="6235" name="無邊框"/>
+                    <Item id="6236" name="啟用超出了最後一行捲動功能"/>
                 </Scintillas>
                 <NewDoc title="開新文件">
                     <Item id="6401" name="格式"/>
@@ -706,8 +706,8 @@
                     <Item id="6413" name="預設資料夾 (開啟/儲存)"/>
                     <Item id="6414" name="依照目前文件"/>
                     <Item id="6415" name="記住上次使用的資料夾"/>
-					<Item id="6430" name="使用新式儲存對話框（不含副檔名功能支援）"/>
-					<Item id="6431" name="拖放文件夾開啟文件夾中所有文件，而不啟動文件夾工作區"/>
+                    <Item id="6430" name="使用新式儲存對話框（不含副檔名功能支援）"/>
+                    <Item id="6431" name="拖放文件夾開啟文件夾中所有文件，而不啟動文件夾工作區"/>
                 </DefaultDir>
 
                 <FileAssoc title="副檔名連結設定">
@@ -729,8 +729,8 @@
                     <Item id="6333" name="字慧高亮度顯示"/>
                     <Item id="6326" name="啟動【字慧】高亮度顯示"/>
                     <Item id="6332" name="區別大小寫"/>
-					<Item id="6338" name="僅符合整個單字"/>
-					<Item id="6339" name="使用搜尋對話框的設定"/>
+                    <Item id="6338" name="僅符合整個單字"/>
+                    <Item id="6339" name="使用搜尋對話框的設定"/>
                     <Item id="6340" name="高亮度延伸至另一視窗"/>
                     <Item id="6329" name="高亮度顯示相契合的 xml/html 標示 (tag)"/>
                     <Item id="6327" name="啟動"/>
@@ -779,10 +779,10 @@
                 </RecentFilesHistory>
 
                 <Backup title="備份">
-					<Item id="6817" name="檔案組群快照和定期備份"/>
+                    <Item id="6817" name="檔案組群快照和定期備份"/>
                     <Item id="6818" name="啟用開檔狀態及定期備份"/>
-					<Item id="6819" name="每"/>
-					<Item id="6821" name="秒"/>
+                    <Item id="6819" name="每"/>
+                    <Item id="6821" name="秒"/>
                     <Item id="6822" name="備份路徑:"/>
                     <Item id="6309" name="為下次開啟程式記住開檔狀態"/>
                     <Item id="6801" name="備份"/>
@@ -799,7 +799,7 @@
                     <Item id="6809" name="函式"/>
                     <Item id="6810" name="字詞"/>
                     <Item id="6816" name="函式與字詞"/>
-					<Item id="6824" name="忽略數字"/>
+                    <Item id="6824" name="忽略數字"/>
                     <Item id="6811" name="從第"/>
                     <Item id="6813" name="個字元開始"/>
                     <Item id="6814" name="有效值：1 - 9"/>
@@ -825,12 +825,12 @@
                     <Item id="6252" name="起"/>
                     <Item id="6255" name="迄"/>
                     <Item id="6256" name="容許多行選取"/>
-					<Item id="6161" name="定義單字的字符 (Word character list)"/>
+                    <Item id="6161" name="定義單字的字符 (Word character list)"/>
                     <Item id="6162" name="使用原始的單字字符集（建議使用）"/>
                     <Item id="6163" name="添加你的字符集（不建議選取如果你不了解這選項）"/>
                 </Delimiter>
 
-				<Cloud title="雲端">
+                <Cloud title="雲端">
                     <Item id="6262" name="雲端上儲存讀取設定"/>
                     <Item id="6263" name="晴朗無雲"/>
                     <Item id="6267" name="在此設定雲端路徑:"/>
@@ -860,10 +860,10 @@
                     <Item id="6322" name="開檔狀態檔副檔名:"/>
                     <Item id="6323" name="啟用 Notepad++ 自動更新"/>
                     <Item id="6324" name="文件切換器 (Ctrl+TAB)"/>
-					<Item id="6331" name="在標題列僅顯示檔案名稱〈無路徑〉"/>
-					<Item id="6334" name="自動檢測字符編碼"/>
-					<Item id="6335" name="視反斜標號為 SQL 轉義字符"/>
-					<Item id="6337" name="文件夾工作區檔案副檔名:"/>
+                    <Item id="6331" name="在標題列僅顯示檔案名稱〈無路徑〉"/>
+                    <Item id="6334" name="自動檢測字符編碼"/>
+                    <Item id="6335" name="視反斜標號為 SQL 轉義字符"/>
+                    <Item id="6337" name="文件夾工作區檔案副檔名:"/>
                     <Item id="6114" name="啟動"/>
                     <Item id="6115" name="自動縮排"/>
                     <Item id="6117" name="開啟 MRU (Most Recently Used) 功能"/>
@@ -925,24 +925,24 @@
             <SettingsOnCloudError title="雲端設定" message="雲端路徑似乎設成唯讀磁碟，或是資料夾需要寫入權限。
 您的雲端設定將被取消。
 請在「喜好設定」對話框重設相關設定值。"/>
-			<FilePathNotFoundWarning title="開啟檔案" message="你試圖開啟的文件不存在。"/>
+            <FilePathNotFoundWarning title="開啟檔案" message="你試圖開啟的文件不存在。"/>
         </MessageBox>
-		<ClipboardHistory>
+        <ClipboardHistory>
             <PanelTitle name="剪貼簿記錄"/>
         </ClipboardHistory>
         <DocSwitcher>
             <PanelTitle name="文件切換器"/>
             <ColumnName name="名稱"/>
-			<ColumnExt name="副檔名"/>
+            <ColumnExt name="副檔名"/>
         </DocSwitcher>
         <AsciiInsertion>
-			<PanelTitle name="ASCII 插入面板"/>
-			<ColumnVal name="數值"/>
-			<ColumnHex name="十六進位碼"/>
-			<ColumnChar name="字元"/>
+            <PanelTitle name="ASCII 插入面板"/>
+            <ColumnVal name="數值"/>
+            <ColumnHex name="十六進位碼"/>
+            <ColumnChar name="字元"/>
         </AsciiInsertion>
-		<DocumentMap>
-			<PanelTitle name="文件縮圖"/>
+        <DocumentMap>
+            <PanelTitle name="文件縮圖"/>
         </DocumentMap>
         <FunctionList>
             <PanelTitle name="函式清單"/>
@@ -993,17 +993,17 @@
                 </FileMenu>
             </Menus>
         </ProjectManager>
-		<MiscStrings>
-			<word-chars-list-tip value="這允許你附加字符在當前單字字符集中，當滑鼠雙擊以進行選擇或以『僅符合整個單字』選項進行搜索。"/>
-			<word-chars-list-warning-begin value="警告："/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
+        <MiscStrings>
+            <word-chars-list-tip value="這允許你附加字符在當前單字字符集中，當滑鼠雙擊以進行選擇或以『僅符合整個單字』選項進行搜索。"/>
+            <word-chars-list-warning-begin value="警告："/>
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ 空白字元(space)"/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-tab-warning value="$INT_REPLACE$ 空白字元(TAB)"/>
-			<word-chars-list-warning-end value="  在你的單字字符集中。"/>
-			<cloud-invalid-warning value="無效路徑"/>
-			<cloud-restart-warning value="請重新啟動 Notepad++ 以讓改變生效"/>
-			<shift-change-direction-tip value="使用 Shift + Enter 以相反方向進行搜索"/>
+            <word-chars-list-warning-end value="  在你的單字字符集中。"/>
+            <cloud-invalid-warning value="無效路徑"/>
+            <cloud-restart-warning value="請重新啟動 Notepad++ 以讓改變生效"/>
+            <shift-change-direction-tip value="使用 Shift + Enter 以相反方向進行搜索"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>


### PR DESCRIPTION
A few of the markup uses tab indentation instead of spaces and will display misaligned on viewers doesn't consider tab characters as certain space characters width, replace them with space indentation of the rest of the markup to fix this issue.

This patch is NOT tested as it is done on a Linux laptop ;), please review before merging.

Signed-off-by: 林博仁 &lt;<Buo.Ren.Lin@gmail.com>&gt;