### PR TITLE
Fix crash when too many directory changes happens

### DIFF
--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.cpp
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.cpp
@@ -34,8 +34,8 @@ using namespace ReadDirectoryChangesPrivate;
 ///////////////////////////////////////////////////////////////////////////
 // CReadDirectoryChanges
 
-CReadDirectoryChanges::CReadDirectoryChanges(int nMaxCount)
-	: m_Notifications(nMaxCount)
+CReadDirectoryChanges::CReadDirectoryChanges()
+	: m_Notifications()
 {
 	m_hThread	= NULL;
 	m_dwThreadId= 0;
@@ -101,12 +101,4 @@ bool  CReadDirectoryChanges::Pop(DWORD& dwAction, CStringW& wstrFilename)
 	wstrFilename = pair.second;
 
 	return true;
-}
-
-bool CReadDirectoryChanges::CheckOverflow()
-{
-	bool b = m_Notifications.overflow();
-	if (b)
-		m_Notifications.clear();
-	return b;
 }

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
@@ -99,8 +99,8 @@ namespace ReadDirectoryChangesPrivate
 ///				{
 ///					DWORD dwAction;
 ///					CStringW wstrFilename;
-///					changes.Pop(dwAction, wstrFilename);
-///					wprintf(L"%s %s\n", ExplainAction(dwAction), wstrFilename);
+///					while (changes.Pop(dwAction, wstrFilename))
+///						wprintf(L"%s %s\n", ExplainAction(dwAction), wstrFilename);
 ///				}
 ///				break;
 ///			case WAIT_OBJECT_0 + _countof(handles):
@@ -116,7 +116,7 @@ namespace ReadDirectoryChangesPrivate
 class CReadDirectoryChanges
 {
 public:
-	CReadDirectoryChanges(int nMaxChanges=1000);
+	CReadDirectoryChanges();
 	~CReadDirectoryChanges();
 
 	void Init();
@@ -147,9 +147,6 @@ public:
 
 	// "Push" is for usage by ReadChangesRequest.  Not intended for external usage.
 	void Push(DWORD dwAction, CStringW& wstrFilename);
-
-	// Check if the queue overflowed. If so, clear it and return true.
-	bool CheckOverflow();
 
 	unsigned int GetThreadId() { return m_dwThreadId; }
 

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.cpp
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.cpp
@@ -123,11 +123,8 @@ VOID CALLBACK CReadChangesRequest::NotificationCompletion(
 
 	// Can't use sizeof(FILE_NOTIFY_INFORMATION) because
 	// the structure is padded to 16 bytes.
-	_ASSERTE(dwNumberOfBytesTransfered >= offsetof(FILE_NOTIFY_INFORMATION, FileName) + sizeof(WCHAR));
-
-	// This might mean overflow? Not sure.
-	if(!dwNumberOfBytesTransfered)
-		return;
+	_ASSERTE((dwNumberOfBytesTransfered == 0) ||
+		(dwNumberOfBytesTransfered >= offsetof(FILE_NOTIFY_INFORMATION, FileName) + sizeof(WCHAR)));
 
 	pBlock->BackupBuffer(dwNumberOfBytesTransfered);
 

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ThreadSafeQueue.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ThreadSafeQueue.h
@@ -32,52 +32,35 @@ template <typename C>
 class CThreadSafeQueue : protected std::list<C>
 {
 public:
-	CThreadSafeQueue(int nMaxCount)
+	CThreadSafeQueue()
 	{
-		m_bOverflow = false;
-
-		m_hSemaphore = ::CreateSemaphore(
+		m_hEvent = ::CreateEvent(
 			NULL,		// no security attributes
-			0,			// initial count
-			nMaxCount,	// max count
+			FALSE,		// auto reset
+			FALSE,		// non-signalled
 			NULL);		// anonymous
 	}
 
 	~CThreadSafeQueue()
 	{
-		::CloseHandle(m_hSemaphore);
-		m_hSemaphore = NULL;
+		::CloseHandle(m_hEvent);
+		m_hEvent = NULL;
 	}
 
 	void push(C& c)
 	{
-		CComCritSecLock<CComAutoCriticalSection> lock( m_Crit, true );
-		push_back( c );
-		lock.Unlock();
-
-		if (!::ReleaseSemaphore(m_hSemaphore, 1, NULL))
 		{
-			// If the semaphore is full, then take back the entry.
-			lock.Lock();
-			pop_back();
-			if (GetLastError() == ERROR_TOO_MANY_POSTS)
-			{
-				m_bOverflow = true;
-			}
+			CComCritSecLock<CComAutoCriticalSection> lock(m_Crit, true);
+			push_back(c);
 		}
+		::SetEvent(m_hEvent);
 	}
 
 	bool pop(C& c)
 	{
 		CComCritSecLock<CComAutoCriticalSection> lock( m_Crit, true );
-
-		// If the user calls pop() more than once after the
-		// semaphore is signaled, then the semaphore count will
-		// get out of sync.  We fix that when the queue empties.
 		if (empty())
 		{
-			while (::WaitForSingleObject(m_hSemaphore, 0) != WAIT_TIMEOUT)
-				1;
 			return false;
 		}
 
@@ -87,30 +70,10 @@ public:
 		return true;
 	}
 
-	// If overflow, use this to clear the queue.
-	void clear()
-	{
-		CComCritSecLock<CComAutoCriticalSection> lock( m_Crit, true );
-
-		for (DWORD i=0; i<size(); i++)
-			WaitForSingleObject(m_hSemaphore, 0);
-
-		__super::clear();
-
-		m_bOverflow = false;
-	}
-
-	bool overflow()
-	{
-		return m_bOverflow;
-	}
-
-	HANDLE GetWaitHandle() { return m_hSemaphore; }
+	HANDLE GetWaitHandle() { return m_hEvent; }
 
 protected:
-	HANDLE m_hSemaphore;
+	HANDLE m_hEvent;
 
 	CComAutoCriticalSection m_Crit;
-
-	bool m_bOverflow;
 };


### PR DESCRIPTION
Hi,

I'm new to making contribution to open source projects, so please correct me If I'm doing something wrong.

I started looking into [this issue (#3780)](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/3780).

Main change is replacing Semaphore with Event as a way to do notifications for `CReadDirectoryChanges`.

Please take a look into changes. I did not learn the codebase, only the code around the crash, so maybe there is some deeper problem I did not noticed.

Thank you


