### PR TITLE
correct appveyor CI config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build_script:
     - if "%configuration%"=="Unicode Release" set scintilla_debug=
     - nmake NOBOOST=1 %scintilla_debug% -f scintilla.mak
     - cd c:\projects\notepad-plus-plus\PowerEditor\visual.net\
-    - msbuild notepadPlus.vs2015.vcxproj /p:configuration="%configuration%" /p:platform="%platform%"
+    - msbuild notepadPlus.vcxproj /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 after_build:
     - cd c:\projects\notepad-plus-plus\


### PR DESCRIPTION
- correct appveyor.yml VS vcxproj after rename, broken with https://github.com/notepad-plus-plus/notepad-plus-plus/commit/40163e0338878c649804b3aa3d6a5dc4a4c1f70f
- add logger (https://www.appveyor.com/docs/build-phase/) to see warnings/errors in the message tab for the VS build
