### PR TITLE
Fix PVS-Studio high severity messages

### DIFF
--- a/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
+++ b/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
@@ -329,8 +329,8 @@ public :
     void setScintilla(ScintillaEditView *pScinView) {
         _pScintilla = pScinView;
     };
-     virtual void create(int dialogID, bool isRTL = false) {
-        StaticDialog::create(dialogID, isRTL);
+     virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true) {
+        StaticDialog::create(dialogID, isRTL, msgDestParent);
     }
     void destroy() {
         // A Ajouter les fils...

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -43,12 +43,6 @@ static HHOOK	hookMouse		= NULL;
 
 static LRESULT CALLBACK hookProcMouse(UINT nCode, WPARAM wParam, LPARAM lParam)
 {
-    if(nCode < 0)
-    {
-		::CallNextHookEx(hookMouse, nCode, wParam, lParam);
-        return 0;
-    }
-
     switch (wParam)
     {
 		case WM_MOUSEMOVE:
@@ -1079,13 +1073,10 @@ void DockingCont::onSize()
 		else
 		{
 			// update floating size
-			if (_isFloating == true)
+			for (size_t iTb = 0, len = _vTbData.size(); iTb < len; ++iTb)
 			{
-				for (size_t iTb = 0, len = _vTbData.size(); iTb < len; ++iTb)
-				{
-					getWindowRect(_vTbData[iTb]->rcFloat);
-				}
-			}			
+				getWindowRect(_vTbData[iTb]->rcFloat);
+			}
 
 			// draw caption
 			if (iItemCnt >= 2)

--- a/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
@@ -44,21 +44,18 @@ static HHOOK	hookMouse		= NULL;
 
 static LRESULT CALLBACK hookProcMouse(UINT nCode, WPARAM wParam, LPARAM lParam)
 {
-    if(nCode >= 0)
-    {
-		switch (wParam)
-		{
-			case WM_MOUSEMOVE:
-			case WM_NCMOUSEMOVE:
-				::PostMessage(hWndMouse, static_cast<UINT>(wParam), 0, 0);
-				break;
-			case WM_LBUTTONUP:
-			case WM_NCLBUTTONUP:
-				::PostMessage(hWndMouse, static_cast<UINT>(wParam), 0, 0);
-				return TRUE;
-			default:
-				break;
-		}
+	switch (wParam)
+	{
+		case WM_MOUSEMOVE:
+		case WM_NCMOUSEMOVE:
+			::PostMessage(hWndMouse, static_cast<UINT>(wParam), 0, 0);
+			break;
+		case WM_LBUTTONUP:
+		case WM_NCLBUTTONUP:
+			::PostMessage(hWndMouse, static_cast<UINT>(wParam), 0, 0);
+			return TRUE;
+		default:
+			break;
 	}
 
 	return ::CallNextHookEx(hookMouse, nCode, wParam, lParam);

--- a/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
@@ -501,7 +501,7 @@ bool TreeView::swapTreeViewItem(HTREEITEM itemGoDown, HTREEITEM itemGoUp)
 		{
 			selectItem(hTreeParent2ndInserted);
 		}
-		else if (itemSelected == 2)
+		else
 		{
 			selectItem(hTreeParent1stInserted);
 		}

--- a/PowerEditor/src/WinControls/Window.h
+++ b/PowerEditor/src/WinControls/Window.h
@@ -97,7 +97,7 @@ public:
 	{
 		RECT rc;
 		::GetClientRect(_hSelf, &rc);
-		if (::IsWindowVisible(_hSelf) == TRUE)
+		if (::IsWindowVisible(_hSelf) != FALSE)
 			return (rc.bottom - rc.top);
 		return 0;
 	}


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. All issues were found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):

- V676 It is incorrect to compare the variable of BOOL type with TRUE. Correct expression is: '::IsWindowVisible(_hSelf) != FALSE'. window.h 100
- V547 Expression '_isFloating == true' is always true. dockingcont.cpp 1082
- V547 Expression 'nCode >= 0' is always true. Unsigned type value is always >= 0. dockingsplitter.cpp 47
- V547 Expression 'itemSelected == 2' is always true. treeview.cpp 504
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'UserDefineDialog' and base class 'StaticDialog'. userdefinedialog.h 332