### PR TITLE
Fix static analyzer issues

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -256,7 +256,7 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath, vector<generic_strin
 		_pluginInfos.push_back(pi);
 		return static_cast<int32_t>(_pluginInfos.size() - 1);
 	}
-	catch (std::exception e)
+	catch (std::exception& e)
 	{
 		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 		return -1;
@@ -519,7 +519,7 @@ void PluginsManager::runPluginCommand(size_t i)
 			{
 				_pluginsCommands[i]._pFunc();
 			}
-			catch (std::exception e)
+			catch (std::exception& e)
 			{
 				::MessageBoxA(NULL, e.what(), "PluginsManager::runPluginCommand Exception", MB_OK);
 			}
@@ -546,7 +546,7 @@ void PluginsManager::runPluginCommand(const TCHAR *pluginName, int commandID)
 				{
 					_pluginsCommands[i]._pFunc();
 				}
-				catch (std::exception e)
+				catch (std::exception& e)
 				{
 					::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 				}
@@ -575,7 +575,7 @@ void PluginsManager::notify(const SCNotification *notification)
 			{
 				_pluginInfos[i]->_pBeNotified(&scNotif);
 			}
-			catch (std::exception e)
+			catch (std::exception& e)
 			{
 				::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 			}
@@ -601,7 +601,7 @@ void PluginsManager::relayNppMessages(UINT Message, WPARAM wParam, LPARAM lParam
 			{
 				_pluginInfos[i]->_pMessageProc(Message, wParam, lParam);
 			}
-			catch (std::exception e)
+			catch (std::exception& e)
 			{
 				::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 			}
@@ -632,7 +632,7 @@ bool PluginsManager::relayPluginMessages(UINT Message, WPARAM wParam, LPARAM lPa
 				{
 					_pluginInfos[i]->_pMessageProc(Message, wParam, lParam);
 				}
-				catch (std::exception e)
+				catch (std::exception& e)
 				{
 					::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 				}

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -107,7 +107,7 @@ LRESULT Notepad_plus_Window::runProc(HWND hwnd, UINT message, WPARAM wParam, LPA
 				_notepad_plus_plus_core._pPublicInterface = this;
 				return _notepad_plus_plus_core.init(hwnd);
 			}
-			catch (std::exception ex)
+			catch (std::exception& ex)
 			{
 				::MessageBoxA(hwnd, ex.what(), "Exception On WM_CREATE", MB_OK);
 				exit(-1);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1693,7 +1693,7 @@ void Notepad_plus::command(int id)
 			TabBarPlus::setDrawTabCloseButton(!TabBarPlus::drawTabCloseButton());
 
 			// This part is just for updating (redraw) the tabs
-			int tabDpiDynamicalHeight = NppParameters::getInstance()->_dpiManager.scaleY(TabBarPlus::drawTabCloseButton() ? 22 : 22);
+			int tabDpiDynamicalHeight = NppParameters::getInstance()->_dpiManager.scaleY(22);
 			int tabDpiDynamicalWidth = NppParameters::getInstance()->_dpiManager.scaleX(TabBarPlus::drawTabCloseButton() ? 60 : 45);
 			TabCtrl_SetItemSize(_mainDocTab.getHSelf(), tabDpiDynamicalWidth, tabDpiDynamicalHeight);
 			TabCtrl_SetItemSize(_subDocTab.getHSelf(), tabDpiDynamicalWidth, tabDpiDynamicalHeight);

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -242,9 +242,9 @@ FindReplaceDlg::~FindReplaceDlg()
 	delete[] _uniFileName;
 }
 
-void FindReplaceDlg::create(int dialogID, bool isRTL) 
+void FindReplaceDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 {
-	StaticDialog::create(dialogID, isRTL);
+	StaticDialog::create(dialogID, isRTL, msgDestParent);
 	fillFindHistory();
 	_currentStatus = REPLACE_DLG;
 	initOptionsFromDlg();

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -242,7 +242,7 @@ public :
 		_ppEditView = ppEditView;
 	};
 
-	virtual void create(int dialogID, bool isRTL = false);
+	virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true);
 	
 	void initOptionsFromDlg();
 

--- a/PowerEditor/src/ScitillaComponent/GoToLineDlg.h
+++ b/PowerEditor/src/ScitillaComponent/GoToLineDlg.h
@@ -42,8 +42,8 @@ public :
 		_ppEditView = ppEditView;
 	};
 
-	virtual void create(int dialogID, bool isRTL = false) {
-		StaticDialog::create(dialogID, isRTL);
+	virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true) {
+		StaticDialog::create(dialogID, isRTL, msgDestParent);
 	};
 
 	void doDialog(bool isRTL = false) {

--- a/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
+++ b/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
@@ -329,8 +329,8 @@ public :
     void setScintilla(ScintillaEditView *pScinView) {
         _pScintilla = pScinView;
     };
-     virtual void create(int dialogID, bool isRTL = false) {
-        StaticDialog::create(dialogID, isRTL);
+     virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true) {
+        StaticDialog::create(dialogID, isRTL, msgDestParent);
     }
     void destroy() {
         // A Ajouter les fils...

--- a/PowerEditor/src/ScitillaComponent/columnEditor.h
+++ b/PowerEditor/src/ScitillaComponent/columnEditor.h
@@ -42,8 +42,8 @@ public :
 
 	void init(HINSTANCE hInst, HWND hPere, ScintillaEditView **ppEditView);
 
-	virtual void create(int dialogID, bool isRTL = false) {
-		StaticDialog::create(dialogID, isRTL);
+	virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true) {
+		StaticDialog::create(dialogID, isRTL, msgDestParent);
 	};
 
 	void doDialog(bool isRTL = false) {

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -836,9 +836,9 @@ void WordStyleDlg::setVisualFromStyleList()
 }
 
 
-void WordStyleDlg::create(int dialogID, bool isRTL)
+void WordStyleDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 {
-	StaticDialog::create(dialogID, isRTL);
+	StaticDialog::create(dialogID, isRTL, msgDestParent);
 
 	if ((NppParameters::getInstance())->isTransparentAvailable())
 	{

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -435,7 +435,7 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 									int tabColourIndex;
 									if ((tabColourIndex = whichTabColourIndex()) != -1)
 									{
-										tabColourIndex = tabColourIndex == (TabBarPlus::inactiveText ? TabBarPlus::inactiveBg : tabColourIndex);
+										tabColourIndex = (tabColourIndex == TabBarPlus::inactiveText ? TabBarPlus::inactiveBg : tabColourIndex);
 										TabBarPlus::setColour(_pBgColour->getColour(), (TabBarPlus::tabColourIndex)tabColourIndex);
 									}
 									apply();

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
@@ -74,7 +74,7 @@ public :
         Window::init(hInst, parent);
 	};
 
-	virtual void create(int dialogID, bool isRTL = false);
+	virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true);
 
     void doDialog(bool isRTL = false) {
     	if (!isCreated())
@@ -96,7 +96,7 @@ public :
 		_gOverride2restored = (NppParameters::getInstance())->getGlobalOverrideStyle();
 	};
 
-    virtual void redraw() const {
+    virtual void redraw(bool forceUpdate = false) const {
         _pFgColour->redraw();
 		_pBgColour->redraw();
 		::InvalidateRect(_hStyleInfoStaticText, NULL, TRUE);

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -1077,13 +1077,10 @@ void DockingCont::onSize()
 		else
 		{
 			// update floating size
-			if (_isFloating == true)
+			for (size_t iTb = 0, len = _vTbData.size(); iTb < len; ++iTb)
 			{
-				for (size_t iTb = 0, len = _vTbData.size(); iTb < len; ++iTb)
-				{
-					getWindowRect(_vTbData[iTb]->rcFloat);
-				}
-			}			
+				getWindowRect(_vTbData[iTb]->rcFloat);
+			}
 
 			// draw caption
 			if (iItemCnt >= 2)

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
@@ -49,8 +49,8 @@ public :
 		_ppEditView = ppEditView;
 	};
 
-	virtual void create(int dialogID, bool isRTL = false) {
-		StaticDialog::create(dialogID, isRTL);
+	virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true) {
+		StaticDialog::create(dialogID, isRTL, msgDestParent);
 	};
 
 	void doDialog(bool isRTL = false) {

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -708,7 +708,7 @@ TCHAR GetASCII(WPARAM wParam, LPARAM lParam)
      BYTE keys[256];
      WORD dwReturnedValue;
      GetKeyboardState(keys);
-	 result = ToAscii(static_cast<UINT>(wParam), (lParam >> 16) && 0xff, keys, &dwReturnedValue, 0);
+	 result = ToAscii(static_cast<UINT>(wParam), (lParam >> 16) & 0xff, keys, &dwReturnedValue, 0);
      returnvalue = (TCHAR) dwReturnedValue;
      if(returnvalue < 0){returnvalue = 0;}
      wsprintf(mbuffer, TEXT("return value = %d"), returnvalue);

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -180,7 +180,7 @@ TCHAR* FileDialog::doOpenSingleFileDlg()
 			::GetCurrentDirectory(MAX_PATH, dir);
 			params->setWorkingDir(dir);
 		}
-	} catch(std::exception e) {
+	} catch(std::exception& e) {
 		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 	} catch(...) {
 		::MessageBox(NULL, TEXT("doOpenSingleFileDlg crashes!!!"), TEXT(""), MB_OK);
@@ -268,7 +268,7 @@ TCHAR * FileDialog::doSaveDlg()
 			::GetCurrentDirectory(MAX_PATH, dir);
 			params->setWorkingDir(dir);
 		}
-	} catch(std::exception e) {
+	} catch(std::exception& e) {
 		::MessageBoxA(NULL, e.what(), "Exception", MB_OK);
 	} catch(...) {
 		::MessageBox(NULL, TEXT("GetSaveFileName crashes!!!"), TEXT(""), MB_OK);

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -203,12 +203,12 @@ long PluginsAdminDlg::searchFromCurrentSel(generic_string str2search, bool inWhi
 	return -1;
 }
 
-void PluginsAdminDlg::create(int dialogID, bool isRTL)
+void PluginsAdminDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 {
 	// get plugin installation path and launch mode (Admin or normal)
 	collectNppCurrentStatusInfos();
 
-	StaticDialog::create(dialogID, isRTL);
+	StaticDialog::create(dialogID, isRTL, msgDestParent);
 
 	RECT rect;
 	getClientRect(rect);

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -97,7 +97,7 @@ public :
         Window::init(hInst, parent);
 	};
 
-	virtual void create(int dialogID, bool isRTL = false);
+	virtual void create(int dialogID, bool isRTL = false, bool msgDestParent = true);
 
     void doDialog(bool isRTL = false) {
     	if (!isCreated())

--- a/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
@@ -495,16 +495,16 @@ bool TreeView::swapTreeViewItem(HTREEITEM itemGoDown, HTREEITEM itemGoUp)
 	removeItem(itemGoDown);
 
 	// Restore the selection if needed
-	if (itemSelected != 0)
+	switch (itemSelected)
 	{
-		if (itemSelected == 1)
-		{
+		case 1:
 			selectItem(hTreeParent2ndInserted);
-		}
-		else if (itemSelected == 2)
-		{
+			break;
+		case 2:
 			selectItem(hTreeParent1stInserted);
-		}
+			break;
+		default:
+			break;
 	}
 	return true;
 }

--- a/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.cpp
+++ b/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.cpp
@@ -118,7 +118,7 @@ void SplitterContainer::display(bool toShow) const
 }
 
 
-void SplitterContainer::redraw() const
+void SplitterContainer::redraw(bool forceUpdate) const
 {
 	assert(_pWin0 != nullptr);
 	assert(_pWin1 != nullptr);

--- a/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.h
+++ b/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.h
@@ -58,7 +58,7 @@ public :
 
 	virtual void display(bool toShow = true) const;
 
-	virtual void redraw() const;
+	virtual void redraw(bool forceUpdate = false) const;
 
 	void setWin0(Window* pWin)
 	{


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. The issue was found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):

- V547 Expression '_isFloating == true' is always true. dockingcont.cpp 1080
- V547 Expression 'itemSelected == 2' is always true. treeview.cpp 504
- V560 A part of conditional expression is always true: 0xff. babygrid.cpp 711
- V746 Object slicing. An exception should be caught by reference rather than by value. filedialog.cpp 183
- V746 Object slicing. An exception should be caught by reference rather than by value. nppbigswitch.cpp 110
- V746 Object slicing. An exception should be caught by reference rather than by value. pluginsmanager.cpp 259
- V768 The enumeration constant 'inactiveText' is used as a variable of a Boolean-type. wordstyledlg.cpp 438
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'UserDefineDialog' and base class 'StaticDialog'. userdefinedialog.h 332
- V762 It is possible a virtual function was overridden incorrectly. See first argument of function 'redraw' in derived class 'SplitterContainer' and base class 'Window'. splittercontainer.h 61
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'FindReplaceDlg' and base class 'StaticDialog'. findreplacedlg.h 245
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'GoToLineDlg' and base class 'StaticDialog'. gotolinedlg.h 45
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'FindCharsInRangeDlg' and base class 'StaticDialog'. findcharsinrange.h 52
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'ColumnEditorDlg' and base class 'StaticDialog'. columneditor.h 45
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'WordStyleDlg' and base class 'StaticDialog'. wordstyledlg.h 77
- V762 It is possible a virtual function was overridden incorrectly. See first argument of function 'redraw' in derived class 'WordStyleDlg' and base class 'Window'. wordstyledlg.h 99
- V762 It is possible a virtual function was overridden incorrectly. See third argument of function 'create' in derived class 'PluginsAdminDlg' and base class 'StaticDialog'. pluginsadmin.h 100
- V583 The '?:' operator, regardless of its conditional expression, always returns one and the same value: 22. nppcommands.cpp 1696