### PR TITLE
Fix for "Toggle Single Line Comment" malfunctioning with HTML/XML

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3951,7 +3951,7 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 	//The NORMAL MODE is used for all Lexers which have a commentLineSymbol defined.
 	//The ADVANCED MODE is only available for Lexers which do not have a commentLineSymbol but commentStreamSymbols (start/end) defined.
 	//The ADVANCED MODE behaves the same way as the NORMAL MODE (comment/uncomment every single line in the selection range separately)
-	//but uses two smbols to accomplish this.
+	//but uses two symbols to accomplish this.
 	bool isSingleLineAdvancedMode = false;
 
 	if (buf->getLangType() == L_USER)
@@ -4073,7 +4073,7 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 		if (avoidIndent)
 			lineIndent = lineStart;
 
-		size_t linebufferSize = lineEnd - lineIndent + comment_length;
+		size_t linebufferSize = lineEnd - lineIndent + 1;
 		TCHAR* linebuf = new TCHAR[linebufferSize];
 
 		_pEditView->getGenericText(linebuf, linebufferSize, lineIndent, lineEnd);


### PR DESCRIPTION
This fixes #3869

As seen, a one off issue caused the last line character to be replaced by null terminator in the call to `getGenericText` (said function uses `_tcsncpy_s` with `_TRUNCATE` parameter which forces null terminator to be added if buffer is not large enough). Since provided buffer can store as many characters as the line has, null terminator replaces the last character in the line - and that prevents further parts of the code from detecting closing comment tags properly.