### PR TITLE
Fix #1017 - GDI objects leak

### DIFF
--- a/PowerEditor/src/tools/NppShell/src/NppShell.cpp
+++ b/PowerEditor/src/tools/NppShell/src/NppShell.cpp
@@ -467,7 +467,8 @@ CShellExt::CShellExt() :
 	m_nameLength(0),
 	m_nameMaxLength(maxText),
 	m_isDynamic(false),
-	m_winVer(0)
+	m_winVer(0),
+	m_hBitmap(NULL)
 {
 	TCHAR szKeyTemp [MAX_PATH + GUID_STRING_SIZE];
 	ZeroMemory(&m_stgMedium, sizeof(m_stgMedium));
@@ -532,6 +533,9 @@ CShellExt::~CShellExt() {
 	if (m_winVer >= WINVER_VISTA) {
 		DeinitTheming();
 	}
+
+	if (m_hBitmap != NULL && m_hBitmap != HBMMENU_CALLBACK)
+		DeleteBitmap(m_hBitmap);
 
 	if (m_pDataObj)
 		m_pDataObj->Release();
@@ -648,6 +652,7 @@ STDMETHODIMP CShellExt::QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT idCmd
 			}
 
 		}
+		m_hBitmap = icon;
 	}
 
 	m_hMenu = hMenu;

--- a/PowerEditor/src/tools/NppShell/src/NppShell.h
+++ b/PowerEditor/src/tools/NppShell/src/NppShell.h
@@ -91,6 +91,7 @@ private:
 	int m_nameLength;
 	int m_nameMaxLength;
 	bool m_isDynamic;
+	HBITMAP m_hBitmap;
 
 	DWORD m_winVer;	//current windows version
 


### PR DESCRIPTION
Fixed a leak of one GDI object, which occurs after each opening of the Shell context menu in which there is "Edit with Notepad ++".
Changes have been made in the NppShell.dll project. A variable is added to the class, which is freed in the destructor.