### PR TITLE
Fix #3863 - Ctrl+A Keyboard shortcut doesn't work in the MD5 Generator

### DIFF
--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -192,6 +192,13 @@ INT_PTR CALLBACK MD5FromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				DEFAULT_PITCH | FF_DONTCARE, "Courier New");
 			::SendMessage(::GetDlgItem(_hSelf, IDC_MD5_TEXT_EDIT), WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
 			::SendMessage(::GetDlgItem(_hSelf, IDC_MD5_RESULT_FOMTEXT_EDIT), WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
+
+			_hMD5TextEdit = ::GetDlgItem(_hSelf, IDC_MD5_TEXT_EDIT);
+			if (NULL != _hMD5TextEdit)
+			{
+				::SetWindowLongPtr(_hMD5TextEdit, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
+				_MD5TextEditProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(_hMD5TextEdit, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(MD5TextEditStaticProc)));
+			}
 		}
 		return TRUE;
 
@@ -253,6 +260,27 @@ INT_PTR CALLBACK MD5FromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 		}
 	}
 	return FALSE;	
+}
+
+LRESULT MD5FromTextDlg::MD5TextEditRunProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	switch (message)
+	{
+		case WM_CHAR:
+		{
+			// Select All if Ctrl + A
+			if (wParam == 1)
+			{
+				::SendDlgItemMessage(_hSelf, IDC_MD5_TEXT_EDIT, EM_SETSEL, 0, -1);
+				return TRUE;
+			}
+			break;
+		}
+
+		default:
+			break;
+	}
+	return _MD5TextEditProc(hwnd, message, wParam, lParam);
 }
 
 void MD5FromTextDlg::doDialog(bool isRTL)

--- a/PowerEditor/src/MISC/md5/md5Dlgs.h
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.h
@@ -44,5 +44,15 @@ public :
 
 protected :
 	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+
+	LRESULT MD5TextEditRunProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK MD5TextEditStaticProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
+	{
+		return (((MD5FromTextDlg *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->MD5TextEditRunProc(hwnd, message, wParam, lParam));
+	};
+
+private :
+	HWND _hMD5TextEdit = nullptr;
+	WNDPROC _MD5TextEditProc = nullptr;
 };
 


### PR DESCRIPTION
When ES_MULTILINE is set for an Edit Control, Ctrl+A stop working. To fix that, I added a new window procedure for the MD5 Text edit control, where Ctrl+A is processed.

Although WM_KEYDOWN could be used, it would still present a beep sound. Therefore, WM_CHAR was used.