### PR TITLE
Split the character counting into two cases based on encoding allowin…

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -516,6 +516,7 @@ private:
 	void updateStatusBar();
 	size_t getSelectedCharNumber(UniMode);
 	size_t getCurrentDocCharCount(UniMode u);
+	size_t getCurrentDocCharCountNoSpace(UniMode u);
 	size_t getSelectedAreas();
 	size_t getSelectedBytes();
 	bool isFormatUnicode(UniMode);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1917,7 +1917,8 @@ void Notepad_plus::command(int id)
 				characterNumber += TEXT("\r");
 				characterNumber += TEXT("\r");
 			}
-			TCHAR *nbCharLabel = TEXT("Characters (without blanks): ");
+			TCHAR *nbCharLabel = TEXT("Characters: ");
+			TCHAR *nbCharLabelNoSpace = TEXT("Characters (without spaces): ");
 			TCHAR *nbWordLabel = TEXT("Words: ");
 			TCHAR *nbLineLabel = TEXT("Lines: ");
 			TCHAR *nbByteLabel = TEXT("Current document length: ");
@@ -1927,6 +1928,7 @@ void Notepad_plus::command(int id)
 
 			UniMode um = _pEditView->getCurrentBuffer()->getUnicodeMode();
 			auto nbChar = getCurrentDocCharCount(um);
+			auto nbCharNoSpace = getCurrentDocCharCountNoSpace(um);
 			int nbWord = wordCount();
 			auto nbLine = _pEditView->execute(SCI_GETLINECOUNT);
 			auto nbByte = _pEditView->execute(SCI_GETLENGTH);
@@ -1937,6 +1939,13 @@ void Notepad_plus::command(int id)
 			characterNumber += nbCharLabel;
 			characterNumber += commafyInt(nbChar).c_str();
 			characterNumber += TEXT("\r");
+
+			if (um == uniUTF8 || um == uniCookie)
+			{
+				characterNumber += nbCharLabelNoSpace;
+				characterNumber += commafyInt(nbCharNoSpace).c_str();
+				characterNumber += TEXT("\r");
+			}
 
 			characterNumber += nbWordLabel;
 			characterNumber += commafyInt(nbWord).c_str();


### PR DESCRIPTION
For the issue #3849 
Split char counting into 2 cases to have counting without whitespaces.
For UTF-8, add one more measure in summary to have count without white spaces.
For other encodings, it remains the same.

Using UTF-8 encoding
![first](https://user-images.githubusercontent.com/6385118/33107096-a244cee8-cf03-11e7-8f39-a74c2fa69bd8.jpg)

Using ANSI encoding
![second](https://user-images.githubusercontent.com/6385118/33107097-a25784d4-cf03-11e7-9770-7ad4c0c0271d.jpg)
