### PR TITLE
Regression: Fixed multiple issues

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -86,12 +86,29 @@ page Custom ExtraOptions
 
 
 !include "nsisInclude\langs4Installer.nsh"
-
-
-
-
 !include "nsisInclude\mainSectionFuncs.nsh"
 
+Var diffArchDir2Remove
+Var noUpdater
+
+Section -"Notepad++" mainSection
+
+	Call setPathAndOptions
+
+	${If} $diffArchDir2Remove != ""
+		!insertmacro uninstallRegKey
+		!insertmacro uninstallDir $diffArchDir2Remove
+	${endIf}
+
+	Call copyCommonFiles
+
+	Call removeUnstablePlugins
+
+	Call removeOldContextMenu
+
+	Call shortcutLinkManagement
+
+SectionEnd
 
 !include "nsisInclude\langs4Npp.nsh"
 !include "nsisInclude\autoCompletion.nsh"
@@ -119,8 +136,7 @@ Section -FinishSection
 SectionEnd
 
 
-Var diffArchDir2Remove
-Var noUpdater
+
 Function .onInit
 
 	${GetParameters} $R0 
@@ -194,26 +210,6 @@ noDelete64:
 	${MementoSectionRestore}
 
 FunctionEnd
-
-
-Section -"Notepad++" mainSection
-
-	Call setPathAndOptions
-	
-	${If} $diffArchDir2Remove != ""
-		!insertmacro uninstallRegKey
-		!insertmacro uninstallDir $diffArchDir2Remove 
-	${endIf}
-
-	Call copyCommonFiles
-
-	Call removeUnstablePlugins
-
-	Call removeOldContextMenu
-	
-	Call shortcutLinkManagement
-	
-SectionEnd
 
 
 Function .onInstSuccess


### PR DESCRIPTION
This PR fixes below issue
  **1. Nsis wanring**
&nbsp;&nbsp;&nbsp;&nbsp; Fix: It will provide estimated install size on component select page.

**2. Themes files installation is broken in V7.5.2**
&nbsp;&nbsp;&nbsp;&nbsp; Root cause: Variable $UPDATE_PATH was not before calling themes.nsh.

**3. Localization files installation is broken in V7.5.2**
&nbsp;&nbsp;&nbsp;&nbsp; Root cause: In "%temp%/nst143F.tmp" (nst143F.tmp is not fixed, it is created randomly by nsis), nppLocalization folder is not created. I could not figure out why. But yes, once installation is done (on finish dialog, before clicking finish), this folder appears again in "%temp%/nst143F.tmp".

P.S.  Could not reopen PR #3750, so opening new PR.