### PR TITLE
RFC: Normalize forward slashes in open file dialog

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -31,6 +31,7 @@
 #include "FileDialog.h"
 #include "Parameters.h"
 
+#include <algorithm>
 
 FileDialog *FileDialog::staticThis = NULL;
 //int FileDialog::_dialogFileBoxId = (NppParameters::getInstance())->getWinVersion() < WV_W2K?edt1:cmb13;
@@ -171,6 +172,12 @@ TCHAR* FileDialog::doOpenSingleFileDlg()
 
 	_ofn.Flags |= OFN_FILEMUSTEXIST;
 
+	if (!params->useNewStyleSaveDlg())
+	{
+		_ofn.Flags |= OFN_ENABLEHOOK | OFN_NOVALIDATE;
+		_ofn.lpfnHook = OFNHookProc;
+	}
+
 	TCHAR *fn = NULL;
 	try {
 		fn = ::GetOpenFileName(&_ofn)?_fileName:NULL;
@@ -200,7 +207,13 @@ stringVector * FileDialog::doOpenMultiFilesDlg()
 	NppParameters * params = NppParameters::getInstance();
 	_ofn.lpstrInitialDir = params->getWorkingDir();
 
-	_ofn.Flags |= OFN_FILEMUSTEXIST | OFN_ALLOWMULTISELECT;
+	_ofn.Flags |= OFN_FILEMUSTEXIST | OFN_ALLOWMULTISELECT | OFN_ENABLESIZING;
+
+	if (!params->useNewStyleSaveDlg())
+	{
+		_ofn.Flags |= OFN_ENABLEHOOK | OFN_NOVALIDATE;
+		_ofn.lpfnHook = OFNHookProc;
+	}
 
 	BOOL res = ::GetOpenFileName(&_ofn);
 	if (params->getNppGUI()._openSaveDir == dir_last)
@@ -256,7 +269,7 @@ TCHAR * FileDialog::doSaveDlg()
 
 	if (!params->useNewStyleSaveDlg())
 	{
-		_ofn.Flags |= OFN_ENABLEHOOK;
+		_ofn.Flags |= OFN_ENABLEHOOK | OFN_NOVALIDATE;
 		_ofn.lpfnHook = OFNHookProc;
 	}
 
@@ -355,7 +368,6 @@ static generic_string addExt(HWND textCtrl, HWND typeCtrl) {
 	return returnExt;
 };
 
-
 UINT_PTR CALLBACK FileDialog::OFNHookProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch(uMsg)
@@ -374,7 +386,6 @@ UINT_PTR CALLBACK FileDialog::OFNHookProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
 				HWND typeControl = ::GetDlgItem(hFileDlg, cmb1);
 				::SendMessage(typeControl, CB_SETCURSEL, index, 0);
 			}
-
 			// Don't touch the following 3 lines, they are cursed !!!
 			oldProc = reinterpret_cast<WNDPROC>(::GetWindowLongPtr(hFileDlg, GWLP_WNDPROC));
 			if (oldProc)
@@ -431,6 +442,34 @@ BOOL APIENTRY FileDialog::run(HWND hWnd, UINT uMsg, WPARAM, LPARAM lParam)
 					int index = static_cast<int32_t>(::SendMessage(typeControl, CB_GETCURSEL, 0, 0));
 					NppParameters *pNppParam = NppParameters::getInstance();
 					pNppParam->setFileSaveDlgFilterIndex(index);
+
+					// change forward-slash to back-slash directory paths so dialog can interpret
+					OPENFILENAME* ofn = reinterpret_cast<LPOFNOTIFY>(lParam)->lpOFN;
+					TCHAR* fileName = ofn->lpstrFile;
+
+					// note: this check is essential, because otherwise we could return True
+					//       with a OFN_NOVALIDATE dialog, which leads to opening every file
+					//       in the specified directory. Multi-select terminator is \0\0.
+					if ((ofn->Flags & OFN_ALLOWMULTISELECT) &&
+						(*(fileName + lstrlen(fileName) + 1) != '\0'))
+						return FALSE;
+
+					if (::PathIsDirectory(fileName))
+					{
+						// change to backslash, and insert trailing '\' to indicate directory
+						hFileDlg = ::GetParent(hWnd);
+						std::wstring _fnStr(fileName);
+						std::replace(_fnStr.begin(), _fnStr.end(), '/', '\\');
+
+						if (_fnStr.back() != '\\')
+							_fnStr.insert(_fnStr.end(), '\\');
+
+						// change the dialog directory selection
+						::SendMessage(hFileDlg, CDM_SETCONTROLTEXT, edt1,
+									reinterpret_cast<LPARAM>(_fnStr.c_str()));
+						::PostMessage(hFileDlg, WM_COMMAND, IDOK, 0);
+						::SetWindowLongPtr(hWnd, 0 /*DWL_MSGRESULT*/, 1);
+					}
 					return TRUE;
 				}
 


### PR DESCRIPTION
This PR adds a hook to the GetOpenFilename dialog box in order to normalize forward-slashes into back-slashes. This is useful, for example, when pasting paths from cross platform-oriented software which often defaults to displaying forward-slash paths (most often for me, CMake).

The downside is that setting `lpfnHook` causes the "Open File" dialog to [revert from Vista-style to XP-style](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/176#issuecomment-112815729). The only way around this is to use the Common Item Dialog boxes.

(would fix 2438 and 3840)