### PR TITLE
Fix highlighting of <script> tags in XML files

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -644,6 +644,8 @@ void ScintillaEditView::setXmlLexer(LangType type)
 			execute(SCI_SETKEYWORDS, i, reinterpret_cast<LPARAM>(TEXT("")));
 
         makeStyle(type);
+
+		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("lexer.xml.allow.scripts"), reinterpret_cast<LPARAM>("0"));
 	}
 	else if ((type == L_HTML) || (type == L_PHP) || (type == L_ASP) || (type == L_JSP))
 	{


### PR DESCRIPTION
Issue reported on [the forum](https://notepad-plus-plus.org/community/topic/14913/colorization-bug-in-xml).

Using `<script>` tags in XML has incorrect highlighting:

![before](https://user-images.githubusercontent.com/3694843/33954080-3d577e0a-e005-11e7-8888-407be6d8aa5a.png)

Since the HTML and XML lexer are the same, it treats `<script>` tags specially since HTML can embed code. The HTML lexer has a `"lexer.xml.allow.scripts"` property that should be used for XML to keep it from trying to parse embedded code. See this section within the HTML Lexer:

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/b2c3e82ce7a7eaa11b777c4c8dea6453adde8b7a/scintilla/lexers/LexHTML.cxx#L670-L672

After setting this property it now highlights it correctly:

![after](https://user-images.githubusercontent.com/3694843/33954111-58d3ed3a-e005-11e7-80bd-f70274f59a5a.png)
