### PR TITLE
Improve installer

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -100,18 +100,12 @@ page Custom ExtraOptions
 
 !include "nsisInclude\mainSectionFuncs.nsh"
 
-!include "nsisInclude\langs4Npp.nsh"
 !include "nsisInclude\autoCompletion.nsh"
 
 !include "nsisInclude\binariesComponents.nsh"
 
 
 InstType "Minimalist"
-
-
-Section -FinishSection
-  Call writeInstallInfoInRegistry
-SectionEnd
 
 
 Var diffArchDir2Remove
@@ -142,7 +136,7 @@ ${If} $noUpdater == "true"
     SectionSetText ${AutoUpdater} ""
 ${EndIf}
 
-	SectionSetSize ${mainSection} 4500		; This is rough estimation of files present in function copyCommonFiles
+	Call SetRoughEstimation		; This is rough estimation of files present in function copyCommonFiles
 	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
 	Call preventInstallInWin9x
 		
@@ -210,6 +204,18 @@ Section -"Notepad++" mainSection
 	
 SectionEnd
 
+; Please **DONOT** move this function (SetRoughEstimation) anywhere else
+; Just keep it right after the "mainSection" section
+; Otherwise rough estimation for copyCommonFiles will not be set
+; which will become reason for showing 0.0KB size on components section page
+
+Function SetRoughEstimation
+	SectionSetSize ${mainSection} 4500		; This is rough estimation of files present in function copyCommonFiles
+FunctionEnd
+
+
+!include "nsisInclude\langs4Npp.nsh"
+
 !include "nsisInclude\themes.nsh"
 
 ${MementoSection} "Context Menu Entry" explorerContextMenu
@@ -250,6 +256,15 @@ Function .onInstSuccess
 	${MementoSectionSave}
 FunctionEnd
 
+
+; Keep "FinishSection" section in the last so that
+; writing installation info happens in the last
+; Specially for writing registry "EstimatedSize"
+; which is visible in control panel in column named "size"
+
+Section -FinishSection
+  Call writeInstallInfoInRegistry
+SectionEnd
 
 BrandingText "Je code donc je suis"
 

--- a/PowerEditor/installer/nsisInclude/binariesComponents.nsh
+++ b/PowerEditor/installer/nsisInclude/binariesComponents.nsh
@@ -118,7 +118,7 @@ SectionGroup un.Plugins
 		Delete "$UPDATE_PATH\plugins\Config\DSpellCheck.ini"
 		Delete "$INSTDIR\plugins\Config\Hunspell\en_US.aff"
 		Delete "$INSTDIR\plugins\Config\Hunspell\en_US.dic"
-		RMDir "$INSTDIRplugins\Config\Hunspell\"
+		RMDir /r "$INSTDIR\plugins\Config"			; Remove Config folder recursively only if empty
 	SectionEnd
 
 SectionGroupEnd


### PR DESCRIPTION
This PR fixes below issues
1. **Localization files installation is broken in V7.5.2**
     Fix: Moved "langs4Npp.nsh" just before "themes.nsh"

2. **After uninstallation, it does not remove below folders.**
    C:\Program Files (x86)\Notepad++\plugins\APIs\Config
    C:\Program Files (x86)\Notepad++\plugins\Config\Hunspell
    Updated file "binariesComponents.nsh" to fix this issue

3. Nsis warning
     Fix: Moved ```SectionSetSize ${mainSection} 4500``` right after section definition. So no more warning and it will provide rough estimated install size on component select page.
![image](https://user-images.githubusercontent.com/14791461/34417337-f9340296-ec1d-11e7-9ec6-1226cc7ca44c.png)


4. Even after selecting all the components installation size in control panel is less.
     Fix: Write installation info in the end after completing all the operation and then calculate the size of InstalDir and write registry info.
![image](https://user-images.githubusercontent.com/14791461/34417392-41b4753c-ec1e-11e7-9fe4-7ac5af17f987.png)
