### PR TITLE
avoid crash of #2727

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -652,7 +652,7 @@ typedef void (WINAPI *PGNSI)(LPSYSTEM_INFO);
 void cutString(const TCHAR* str2cut, vector<generic_string>& patternVect)
 {
 	TCHAR str2scan[MAX_PATH];
-	lstrcpy(str2scan, str2cut);
+	lstrcpyn(str2scan, str2cut, MAX_PATH);
 	size_t len = lstrlen(str2scan);
 	bool isProcessing = false;
 	TCHAR *pBegin = nullptr;


### PR DESCRIPTION
- fix of buffer overrun of issue #2727 with long UDL ext field
- PR just fixes the crash, but restricts the possible amount of extensions, also it is not immediately visible in the GUI, just after saving the udl on N++ shutdown and restart
- Unclear why MAX_PATH is needed as limitation for the complete ext field.
  