### PR TITLE
Function List Tracks Editing Pane Cursor (Issue715)

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5960,13 +5960,6 @@ void Notepad_plus::launchFunctionList()
 	_pEditView->getFocus();
 }
 
-void Notepad_plus::updateFunctionList()
-{
-	if (_pFuncList)
-	{
-		_pFuncList->markEntry();
-	}
-}
 
 
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5960,6 +5960,13 @@ void Notepad_plus::launchFunctionList()
 	_pEditView->getFocus();
 }
 
+void Notepad_plus::updateFunctionList()
+{
+	if (_pFuncList)
+	{
+		_pFuncList->markEntry();
+	}
+}
 
 
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -514,6 +514,7 @@ private:
 	void activateDoc(size_t pos);
 
 	void updateStatusBar();
+	void updateFunctionList();
 	size_t getSelectedCharNumber(UniMode);
 	size_t getCurrentDocCharCount(UniMode u);
 	size_t getSelectedAreas();

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -514,7 +514,6 @@ private:
 	void activateDoc(size_t pos);
 
 	void updateStatusBar();
-	void updateFunctionList();
 	size_t getSelectedCharNumber(UniMode);
 	size_t getCurrentDocCharCount(UniMode u);
 	size_t getSelectedAreas();

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -28,6 +28,7 @@
 
 
 #include "Notepad_plus_Window.h"
+#include "functionListPanel.h"
 #include "xmlMatchedTagsHighlighter.h"
 #include "VerticalFileSwitcher.h"
 #include "ProjectPanel.h"
@@ -847,7 +848,8 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			}
 
 			updateStatusBar();
-			updateFunctionList();
+			if (_pFuncList && (!_pFuncList->isClosed()) && _pFuncList->isVisible())
+				_pFuncList->markEntry();
 			AutoCompletion * autoC = isFromPrimary?&_autoCompleteMain:&_autoCompleteSub;
 			autoC->update(0);
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -847,6 +847,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			}
 
 			updateStatusBar();
+			updateFunctionList();
 			AutoCompletion * autoC = isFromPrimary?&_autoCompleteMain:&_autoCompleteSub;
 			autoC->update(0);
 

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -304,6 +304,8 @@ bool FunctionListPanel::serialize(const generic_string & outputFilename)
 void FunctionListPanel::reload()
 {
 	// clean up
+	_findLine = -1;
+	_findEndLine = -1;
 	TreeStateNode currentTree;
 	bool isOK = _treeView.retrieveFoldingStateTo(currentTree, _treeView.getRoot());
 	if (isOK)
@@ -391,6 +393,73 @@ void FunctionListPanel::reload()
 	::InvalidateRect(_hSearchEdit, NULL, TRUE);
 }
 
+void FunctionListPanel::markEntry()
+{
+	LONG lineNr = static_cast<LONG>((*_ppEditView)->getCurrentLineNumber());
+	HTREEITEM root = _treeView.getRoot();
+	if (_findLine != -1)
+	{
+		if (lineNr >= _findLine && lineNr < _findEndLine)
+		{
+			return;
+		}
+	}
+	_findLine = -1;
+	_findEndLine = -1;
+	findMarkEntry(root, lineNr);
+	if (_findLine != -1)
+	{
+			_treeView.selectItem(_findItem);
+	}
+	else
+	{
+		_treeView.selectItem(root);
+	}
+
+}
+
+void FunctionListPanel::findMarkEntry(HTREEITEM htItem, LONG line)
+{
+	HTREEITEM cItem;
+	TVITEM tvItem;
+	for (; htItem != NULL; htItem = _treeView.getNextSibling(htItem))
+	{
+		cItem = _treeView.getChildFrom(htItem);
+		if (cItem != NULL)
+		{
+			findMarkEntry(cItem, line);
+		}
+		else
+		{
+			tvItem.hItem = htItem;
+			tvItem.mask = TVIF_IMAGE | TVIF_PARAM;
+			::SendMessage(_treeViewSearchResult.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
+
+			generic_string *posStr = reinterpret_cast<generic_string *>(tvItem.lParam);
+			if (posStr)
+			{
+				int pos = generic_atoi(posStr->c_str());
+				if (pos != -1)
+				{
+					LONG sci_line = static_cast<LONG>((*_ppEditView)->execute(SCI_LINEFROMPOSITION, pos));
+					if (line >= sci_line)
+					{
+						if (sci_line > _findLine || _findLine == -1)
+						{
+							_findLine = sci_line;
+							_findItem = htItem;
+						}
+					}
+					else
+					{
+						if (sci_line < _findEndLine)
+							_findEndLine = sci_line;
+					}
+				}
+			}
+		}
+	}
+}
 
 void FunctionListPanel::init(HINSTANCE hInst, HWND hPere, ScintillaEditView **ppEditView)
 {
@@ -708,6 +777,7 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 
 			_treeViewSearchResult.init(_hInst, _hSelf, IDC_LIST_FUNCLIST_AUX);
 			_treeView.init(_hInst, _hSelf, IDC_LIST_FUNCLIST);
+			_treeView.makeLabelEditable(false);
 			setTreeViewImageList(IDI_FUNCLIST_ROOT, IDI_FUNCLIST_NODE, IDI_FUNCLIST_LEAF);
 
 			_treeView.display();

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -397,19 +397,14 @@ void FunctionListPanel::markEntry()
 {
 	LONG lineNr = static_cast<LONG>((*_ppEditView)->getCurrentLineNumber());
 	HTREEITEM root = _treeView.getRoot();
-	if (_findLine != -1)
-	{
-		if (lineNr >= _findLine && lineNr < _findEndLine)
-		{
-			return;
-		}
-	}
+	if (_findLine != -1 && _findEndLine != -1 && lineNr >= _findLine && lineNr < _findEndLine)
+		return;
 	_findLine = -1;
 	_findEndLine = -1;
 	findMarkEntry(root, lineNr);
 	if (_findLine != -1)
 	{
-			_treeView.selectItem(_findItem);
+		_treeView.selectItem(_findItem);
 	}
 	else
 	{

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -108,6 +108,7 @@ public:
 	// functionalities
 	void sortOrUnsort();
 	void reload();
+	void markEntry();
 	bool serialize(const generic_string & outputFilename = TEXT(""));
 	void addEntry(const TCHAR *node, const TCHAR *displayText, size_t pos);
 	void removeAllEntries();
@@ -124,6 +125,10 @@ private:
 	TreeView _treeView;
 	TreeView _treeViewSearchResult;
 
+	LONG _findLine = -1;
+	LONG _findEndLine = -1;
+	HTREEITEM _findItem;
+	
 	generic_string _sortTipStr;
 	generic_string _reloadTipStr;
 
@@ -143,5 +148,6 @@ private:
 	bool openSelection(const TreeView &treeView);
 	bool shouldSort();
 	void setSort(bool isEnabled);
+	void findMarkEntry(HTREEITEM htItem, LONG line);
 };
 

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -125,10 +125,10 @@ private:
 	TreeView _treeView;
 	TreeView _treeViewSearchResult;
 
-	LONG _findLine = -1;
-	LONG _findEndLine = -1;
+	long _findLine = -1;
+	long _findEndLine = -1;
 	HTREEITEM _findItem;
-	
+
 	generic_string _sortTipStr;
 	generic_string _reloadTipStr;
 


### PR DESCRIPTION
This Pull Request addresses Issue #715 and allows the Function List pane's selected function to track the user's traversal within the editing pane.
I have tested and seen it working with both Python and C++ test cases.
The changes were coded up by KlausiD, and I integrated them into the latest version of the NPP sources.

Not sure why there are some white space changes below attributed to this PR, but these white space changes in Notepad_plus.h and functionListPanel.cpp must be attributable to the environment. 