### PR TITLE
Extracted parts of FileManager::reloadBuffer and FileManager::loadFile to a separate func

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -97,6 +97,7 @@ public:
 	BufferID getBufferFromName(const TCHAR * name);
 	BufferID getBufferFromDocument(Document doc);
 
+	void setLoadedBufferEncodingAndEol(Buffer* buf, const Utf8_16_Read& UnicodeConvertor, int encoding, EolType bkformat);
 	bool reloadBuffer(BufferID id);
 	bool reloadBufferDeferred(BufferID id);
 	bool saveBuffer(BufferID id, const TCHAR* filename, bool isCopy = false, generic_string * error_msg = NULL);


### PR DESCRIPTION
Fixes #2637 and #2843

This is a de facto re-issue of #4077. I remade the PR after #4034 was merged. This time, however, I went ahead and extracted the common part of reloadBuffer and loadFile into a separate function.

My main reasoning behind that is code duplication - notice that if that logic was separate, this issue would not have existed in the first place! loadFile must have had its functionality expanded at some point, but reloadBuffer was left as is. I think extracting it to a separate function will ease maintenance.