### PR TITLE
Simplify and fix memory leak in getSpecialFolderLocation

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -949,15 +949,15 @@ bool NppParameters::reloadLang()
 
 generic_string NppParameters::getSpecialFolderLocation(int folderKind)
 {
-	ITEMIDLIST *pidl;
-	const HRESULT specialLocationResult = SHGetSpecialFolderLocation(NULL, folderKind, &pidl);
-	if (!SUCCEEDED( specialLocationResult))
-		return generic_string();
-	
 	TCHAR path[MAX_PATH];
-	SHGetPathFromIDList(pidl, path);
+	const HRESULT specialLocationResult = SHGetFolderPath(nullptr, folderKind, nullptr, SHGFP_TYPE_CURRENT, path);
 
-	return path;
+	generic_string result;
+	if (SUCCEEDED(specialLocationResult))
+	{
+		result = path;
+	}
+	return result;
 }
 
 


### PR DESCRIPTION
Fixes #399, which was assigned since July 2015 and no fix seems to exist, even though it's literally a few lines.

This PR rewrites `NppParameters::getSpecialFolderLocation`, improving upon a few things in this function:

1. Logic simplified overall - `SHGetSpecialFolderLocation` is deprecated, and the only use for the obtained `PIDL ` was to get a path to this folder - so by replacing it with `SHGetFolderPath` we achieve the same result with less code.
2. Fixed a memory leak - as noted in the documentation (and the issue linked), `SHGetSpecialFolderLocation` requires its output param to be freed with `CoTaskMemFree`. Now we don't need to worry about this.
3. Made the function have a single return point - this makes it eligible for NRVO optimization. I realize it's not going to gain anything since it's a simple and rarely used function, but if it was being rewritten anyway... then why not?

Sorry @milipili for kind of hijacking the issue, but I figured it's abandoned after 2.5 years.