### PR TITLE
Fix for #3895 Workaround Windows bug

### DIFF
--- a/scintilla/src/Editor.cxx
+++ b/scintilla/src/Editor.cxx
@@ -4135,7 +4135,7 @@ void Editor::ButtonDownWithModifiers(Point pt, unsigned int curTime, int modifie
 	if (shift && !inSelMargin) {
 		SetSelection(newPos);
 	}
-	if (((curTime - lastClickTime) < Platform::DoubleClickTime()) && Close(pt, lastClick, doubleClickCloseThreshold)) {
+	if (((int)(curTime - lastClickTime) < (int)Platform::DoubleClickTime()) && Close(pt, lastClick, doubleClickCloseThreshold)) {
 		//Platform::DebugPrintf("Double click %d %d = %d\n", curTime, lastClickTime, curTime - lastClickTime);
 		SetMouseCapture(true);
 		if (FineTickerAvailable()) {


### PR DESCRIPTION
Scintilla code changed, making fix in Notepad++ seems harder, still probably possible too

http://prntscr.com/ia5egq

Looks like the issue is related to some crazy timing information returned by GetMessageTime
so time between last message and current message gets negative and wraps around as the comparison to doubleclick time is an unsigned one. Happens with touchpads, probably some stupid gesture recognition doesn't write right timestamps..

These casts for signed comparison seems to fix it

src/Editor.cxx line 4458

if ((((int)(curTime - lastClickTime)) < (int)Platform::DoubleClickTime()) && Close(pt, lastClick, doubleClickCloseThreshold)) {