### PR TITLE
Correctly use const qualifier for variables holding string literals

### DIFF
--- a/PowerEditor/src/EncodingMapper.h
+++ b/PowerEditor/src/EncodingMapper.h
@@ -31,7 +31,7 @@
 
 struct EncodingUnit {
    int _codePage;
-   char *_aliasList;
+   const char *_aliasList;
 };
 
 class EncodingMapper {

--- a/PowerEditor/src/MISC/Process/Processus.cpp
+++ b/PowerEditor/src/MISC/Process/Processus.cpp
@@ -32,7 +32,7 @@
 
 void Process::run()
 {
-	TCHAR *opVerb = TEXT("open");
+	const TCHAR *opVerb = TEXT("open");
 	::ShellExecute(NULL, opVerb, _command.c_str(), _args.c_str(), _curDir.c_str(), SW_SHOWNORMAL);
 }
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2592,7 +2592,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 			{
 				if (nextChar == '}')
 				{
-					char *eolChars;
+					const char *eolChars;
 					if (eolMode == SC_EOL_CRLF)
 						eolChars = "\r\n";
 					else if (eolMode == SC_EOL_LF)
@@ -6233,7 +6233,7 @@ static const QuoteParams quotes[] =
 
 
 const int nbWtf = 5;
-wchar_t* wtf[nbWtf] =
+const wchar_t* wtf[nbWtf] =
 {
 	TEXT("WTF?!"),
 	TEXT("lol"),

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -124,7 +124,7 @@ LRESULT Notepad_plus_Window::runProc(HWND hwnd, UINT message, WPARAM wParam, LPA
 }
 
 // Used by NPPM_GETFILENAMEATCURSOR
-int CharacterIs(TCHAR c, TCHAR *any)
+int CharacterIs(TCHAR c, const TCHAR *any)
 {
 	int i;
 	for (i = 0; any[i] != 0; i++)
@@ -755,7 +755,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				// it's not a full file name so try to find the beginning and ending of it
 				int start;
 				int end;
-				TCHAR *delimiters;
+				const TCHAR *delimiters;
 
 				lineNumber = _pEditView->getCurrentLineNumber();
 				col = _pEditView->getCurrentColumnNumber();

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1917,10 +1917,10 @@ void Notepad_plus::command(int id)
 
 			if (fileLen != -1)
 			{
-				TCHAR *filePathLabel = TEXT("Full file path: ");
-				TCHAR *fileCreateTimeLabel = TEXT("Created: ");
-				TCHAR *fileModifyTimeLabel = TEXT("Modified: ");
-				TCHAR *fileLenLabel = TEXT("File length (in byte): ");
+				const TCHAR *filePathLabel = TEXT("Full file path: ");
+				const TCHAR *fileCreateTimeLabel = TEXT("Created: ");
+				const TCHAR *fileModifyTimeLabel = TEXT("Modified: ");
+				const TCHAR *fileLenLabel = TEXT("File length (in byte): ");
 
 				characterNumber += filePathLabel;
 				characterNumber += curBuf->getFullPathName();
@@ -1939,13 +1939,13 @@ void Notepad_plus::command(int id)
 				characterNumber += TEXT("\r");
 				characterNumber += TEXT("\r");
 			}
-			TCHAR *nbCharLabel = TEXT("Characters (without blanks): ");
-			TCHAR *nbWordLabel = TEXT("Words: ");
-			TCHAR *nbLineLabel = TEXT("Lines: ");
-			TCHAR *nbByteLabel = TEXT("Current document length: ");
-			TCHAR *nbSelLabel1 = TEXT(" selected characters (");
-			TCHAR *nbSelLabel2 = TEXT(" bytes) in ");
-			TCHAR *nbRangeLabel = TEXT(" ranges");
+			const TCHAR *nbCharLabel = TEXT("Characters (without blanks): ");
+			const TCHAR *nbWordLabel = TEXT("Words: ");
+			const TCHAR *nbLineLabel = TEXT("Lines: ");
+			const TCHAR *nbByteLabel = TEXT("Current document length: ");
+			const TCHAR *nbSelLabel1 = TEXT(" selected characters (");
+			const TCHAR *nbSelLabel2 = TEXT(" bytes) in ");
+			const TCHAR *nbRangeLabel = TEXT(" ranges");
 
 			UniMode um = _pEditView->getCurrentBuffer()->getUnicodeMode();
 			auto nbChar = getCurrentDocCharCount(um);
@@ -2421,9 +2421,9 @@ void Notepad_plus::command(int id)
 		case IDM_SETTING_IMPORTPLUGIN :
         {
             // get plugin source path
-            TCHAR *extFilterName = TEXT("Notepad++ plugin");
-            TCHAR *extFilter = TEXT(".dll");
-            TCHAR *destDir = TEXT("plugins");
+            const TCHAR *extFilterName = TEXT("Notepad++ plugin");
+            const TCHAR *extFilter = TEXT(".dll");
+            const TCHAR *destDir = TEXT("plugins");
 
             vector<generic_string> copiedFiles = addNppComponents(destDir, extFilterName, extFilter);
 
@@ -2444,9 +2444,9 @@ void Notepad_plus::command(int id)
         case IDM_SETTING_IMPORTSTYLETHEMS :
         {
             // get plugin source path
-            TCHAR *extFilterName = TEXT("Notepad++ style theme");
-            TCHAR *extFilter = TEXT(".xml");
-            TCHAR *destDir = TEXT("themes");
+            const TCHAR *extFilterName = TEXT("Notepad++ style theme");
+            const TCHAR *extFilter = TEXT(".xml");
+            const TCHAR *destDir = TEXT("themes");
 
             // load styler
             NppParameters *pNppParams = NppParameters::getInstance();
@@ -2637,7 +2637,7 @@ void Notepad_plus::command(int id)
 				{
 					if (_nativeLangSpeaker.getLangEncoding() == NPP_CP_BIG5)
 					{
-						char *authorName = "«J¤µ§^";
+						const char *authorName = "«J¤µ§^";
 						HWND hItem = ::GetDlgItem(_aboutDlg.getHSelf(), IDC_AUTHOR_NAME);
 
 						WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -51,7 +51,7 @@ struct WinMenuKeyDefinition //more or less matches accelerator table definition,
 	bool isCtrl;
 	bool isAlt;
 	bool isShift;
-	TCHAR * specialName;		//Used when no real menu name exists (in case of toggle for example)
+	const TCHAR * specialName;		//Used when no real menu name exists (in case of toggle for example)
 };
 
 
@@ -697,7 +697,7 @@ bool LocalizationSwitcher::addLanguageFromXml(wstring xmlFullPath)
 }
 
 
-bool LocalizationSwitcher::switchToLang(wchar_t *lang2switch) const
+bool LocalizationSwitcher::switchToLang(const wchar_t *lang2switch) const
 {
 	wstring langPath = getXmlFilePathFromLangName(lang2switch);
 	if (langPath.empty())
@@ -3179,7 +3179,7 @@ void NppParameters::feedUserKeywordList(TiXmlNode *node)
 		TiXmlNode *valueNode = childNode->FirstChild();
 		if (valueNode)
 		{
-			TCHAR *kwl = nullptr;
+			const TCHAR *kwl = nullptr;
 			if (!lstrcmp(udlVersion, TEXT("")) && !lstrcmp(keywordsName, TEXT("Delimiters")))	// support for old style (pre 2.0)
 			{
 				basic_string<TCHAR> temp;
@@ -5259,7 +5259,7 @@ bool NppParameters::writeScintillaParams()
 	(scintNode->ToElement())->SetAttribute(TEXT("Wrap"), _svp._doWrap?TEXT("yes"):TEXT("no"));
 	(scintNode->ToElement())->SetAttribute(TEXT("borderEdge"), _svp._showBorderEdge ? TEXT("yes") : TEXT("no"));
 
-	TCHAR *edgeStr = NULL;
+	const TCHAR *edgeStr;
 	if (_svp._edgeMode == EDGE_NONE)
 		edgeStr = TEXT("no");
 	else if (_svp._edgeMode == EDGE_LINE)

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1130,15 +1130,15 @@ friend class NppParameters;
 public:
 	struct LocalizationDefinition
 	{
-		wchar_t *_langName;
-		wchar_t *_xmlFileName;
+		const wchar_t *_langName;
+		const wchar_t *_xmlFileName;
 	};
 
 	bool addLanguageFromXml(std::wstring xmlFullPath);
 	std::wstring getLangFromXmlFileName(const wchar_t *fn) const;
 
 	std::wstring getXmlFilePathFromLangName(const wchar_t *langName) const;
-	bool switchToLang(wchar_t *lang2switch) const;
+	bool switchToLang(const wchar_t *lang2switch) const;
 
 	size_t size() const
 	{

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -430,7 +430,7 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	if (isHTML) // for HTML: ignore void elements
 	{
 		// https://www.w3.org/TR/html5/syntax.html#void-elements
-		char *disallowedTags[] = {
+		const char *disallowedTags[] = {
 				"area", "base", "br", "col", "embed", "hr", "img", "input",
 				"keygen", "link", "meta", "param", "source", "track", "wbr",
 				"!doctype"
@@ -542,7 +542,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 {
 	const vector< pair<char, char> > & matchedPairs = matchedPairConf._matchedPairs;
 	int caretPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
-	char *matchedChars = NULL;
+	const char *matchedChars = NULL;
 
 	char charPrev = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, caretPos - 2));
 	char charNext = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, caretPos));

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2920,7 +2920,7 @@ void FindReplaceDlg::drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 {
 	//printStr(TEXT("OK"));
 	COLORREF fgColor = RGB(0, 0, 0); // black by default
-	PTSTR ptStr =(PTSTR)lpDrawItemStruct->itemData;
+	PCTSTR ptStr =(PCTSTR)lpDrawItemStruct->itemData;
 
 	if (_statusbarFindStatus == FSNotFound)
 	{
@@ -2992,7 +2992,7 @@ void Finder::addFileHitCount(int count)
 
 void Finder::addSearchHitCount(int count, bool isMatchLines)
 {
-	TCHAR *moreInfo = isMatchLines ? TEXT(" - Line Filter Mode: only display the filtered results") :TEXT("");
+	const TCHAR *moreInfo = isMatchLines ? TEXT(" - Line Filter Mode: only display the filtered results") :TEXT("");
 	TCHAR text[100];
 	if(count == 1 && _nbFoundFiles == 1)
 		wsprintf(text, TEXT(" (1 hit in 1 file%s)"), moreInfo);
@@ -3530,7 +3530,7 @@ void FindIncrementDlg::markSelectedTextInc(bool enable, FindOption *opt)
 void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted)
 {
 	static TCHAR findCount[128] = TEXT("");
-	static TCHAR *findStatus[] = { findCount, // FSFound
+	static const TCHAR * const findStatus[] = { findCount, // FSFound
 	                               TEXT("Phrase not found"), //FSNotFound
 	                               TEXT("Reached top of page, continued from bottom"), // FSTopReached
 	                               TEXT("Reached end of page, continued from top")}; // FSEndReached

--- a/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
+++ b/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
@@ -404,7 +404,7 @@ class StringDlg : public StaticDialog
 {
 public :
     StringDlg() : StaticDialog() {};
-    void init(HINSTANCE hInst, HWND parent, TCHAR *title, TCHAR *staticName, TCHAR *text2Set, int txtLen = 0) {
+    void init(HINSTANCE hInst, HWND parent, const TCHAR *title, const TCHAR *staticName, const TCHAR *text2Set, int txtLen = 0) {
         Window::init(hInst, parent);
         _title = title;
         _static = staticName;

--- a/PowerEditor/src/WinControls/AboutDlg/URLCtrl.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/URLCtrl.cpp
@@ -104,7 +104,7 @@ static BYTE ANDMask[128] =
 
 
 
-void URLCtrl::create(HWND itemHandle, TCHAR * link, COLORREF linkColor)
+void URLCtrl::create(HWND itemHandle, const TCHAR * link, COLORREF linkColor)
 {
 	// turn on notify style
     ::SetWindowLongPtr(itemHandle, GWL_STYLE, ::GetWindowLongPtr(itemHandle, GWL_STYLE) | SS_NOTIFY);

--- a/PowerEditor/src/WinControls/AboutDlg/URLCtrl.h
+++ b/PowerEditor/src/WinControls/AboutDlg/URLCtrl.h
@@ -37,7 +37,7 @@ public:
     URLCtrl():_hfUnderlined(0),_hCursor(0), _msgDest(NULL), _cmdID(0), _oldproc(NULL), \
 		_linkColor(), _visitedColor(), _clicking(false), _URL(TEXT("")){};
 
-    void create(HWND itemHandle, TCHAR * link, COLORREF linkColor = RGB(0,0,255));
+    void create(HWND itemHandle, const TCHAR * link, COLORREF linkColor = RGB(0,0,255));
 	void create(HWND itemHandle, int cmd, HWND msgDest = NULL);
     void destroy();
 private:

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -118,7 +118,7 @@ int         FindGrid(UINT);
 void		ShowVscroll(HWND,int);
 void		ShowHscroll(HWND,int);
 int         BinarySearchListBox(HWND,TCHAR*);
-void        DisplayEditString(HWND ,int ,TCHAR*);
+void        DisplayEditString(HWND ,int , const TCHAR*);
 int         CountGrids();
 
 
@@ -1157,7 +1157,7 @@ void CloseEdit(HWND hWnd,int SI)
      NotifyEditEnd(hWnd,SI);
     }
 
-void DisplayEditString(HWND hWnd,int SI,TCHAR* tstring)
+void DisplayEditString(HWND hWnd,int SI, const TCHAR* tstring)
     {
        int r,c;
        HFONT holdfont;

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -2833,7 +2833,7 @@ INT_PTR CALLBACK AutoCompletionDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 				case IDD_AUTOC_QUOTESCHECK :
 				{
 					bool isChecked = (BST_CHECKED == ::SendDlgItemMessage(_hSelf, static_cast<int32_t>(wParam), BM_GETCHECK, 0, 0));
-					TCHAR *label;
+					const TCHAR *label;
 					if (wParam == IDD_AUTOCPARENTHESES_CHECK)
 					{
 						nppGUI._matchedPairConf._doParentheses = isChecked;

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.h
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.h
@@ -142,7 +142,7 @@ private :
 struct strCouple {
 	generic_string _varDesc;
 	generic_string _var;
-	strCouple(TCHAR *varDesc, TCHAR *var): _varDesc(varDesc), _var(var){};
+	strCouple(const TCHAR *varDesc, const TCHAR *var): _varDesc(varDesc), _var(var){};
 };
 
 class PrintSettingsDlg : public StaticDialog

--- a/PowerEditor/src/WinControls/TabBar/ControlsTab.h
+++ b/PowerEditor/src/WinControls/TabBar/ControlsTab.h
@@ -38,7 +38,7 @@ struct DlgInfo
     generic_string _name;
 	generic_string _internalName;
 
-	DlgInfo(Window *dlg, TCHAR *name, TCHAR *internalName = NULL): _dlg(dlg), _name(name), _internalName(internalName?internalName:TEXT("")) {};
+	DlgInfo(Window *dlg, const TCHAR *name, const TCHAR *internalName = TEXT("")): _dlg(dlg), _name(name), _internalName(internalName) {};
 };
 
 typedef std::vector<DlgInfo> WindowVector;

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -132,7 +132,7 @@ void TabBar::getCurrentTitle(TCHAR *title, int titleLen)
 }
 
 
-void TabBar::setFont(TCHAR *fontName, int fontSize)
+void TabBar::setFont(const TCHAR *fontName, int fontSize)
 {
 	if (_hFont)
 		::DeleteObject(_hFont);

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -98,7 +98,7 @@ public:
         return _nbItem;
     }
 
-	void setFont(TCHAR *fontName, int fontSize);
+	void setFont(const TCHAR *fontName, int fontSize);
 
 	void setVertical(bool b) {
 		_isVertical = b;

--- a/PowerEditor/src/WinControls/TaskList/TaskList.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.cpp
@@ -139,7 +139,7 @@ RECT TaskList::adjustSize()
 	return _rc;
 }
 
-void TaskList::setFont(TCHAR *fontName, int fontSize)
+void TaskList::setFont(const TCHAR *fontName, int fontSize)
 {
 	if (_hFont)
 		::DeleteObject(_hFont);

--- a/PowerEditor/src/WinControls/TaskList/TaskList.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.h
@@ -49,7 +49,7 @@ public:
 	virtual ~TaskList() {};
 	void init(HINSTANCE hInst, HWND hwnd, HIMAGELIST hImaLst, int nbItem, int index2set);
 	virtual void destroy();
-	void setFont(TCHAR *fontName, int fontSize);
+	void setFont(const TCHAR *fontName, int fontSize);
 	RECT adjustSize();
 	int getCurrentIndex() const {return _currentIndex;}
 	int updateCurrentIndex();

--- a/PowerEditor/src/WinControls/TrayIcon/trayIconControler.cpp
+++ b/PowerEditor/src/WinControls/TrayIcon/trayIconControler.cpp
@@ -28,7 +28,7 @@
 
 #include "trayIconControler.h"
 
-trayIconControler::trayIconControler(HWND hwnd, UINT uID, UINT uCBMsg, HICON hicon, TCHAR *tip)
+trayIconControler::trayIconControler(HWND hwnd, UINT uID, UINT uCBMsg, HICON hicon, const TCHAR *tip)
 {
   _nid.cbSize = sizeof(_nid);
   _nid.hWnd = hwnd;

--- a/PowerEditor/src/WinControls/TrayIcon/trayIconControler.h
+++ b/PowerEditor/src/WinControls/TrayIcon/trayIconControler.h
@@ -41,7 +41,7 @@
 class trayIconControler
 {
 public:
-  trayIconControler(HWND hwnd, UINT uID, UINT uCBMsg, HICON hicon, TCHAR *tip);
+  trayIconControler(HWND hwnd, UINT uID, UINT uCBMsg, HICON hicon, const TCHAR *tip);
   int doTrayIcon(DWORD op);
   bool isInTray() const {return _isIconShowed;};
 

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -106,6 +106,7 @@
       <SmallerTypeCheck>false</SmallerTypeCheck>
       <DisableSpecificWarnings>4091;4456;4457;4459</DisableSpecificWarnings>
       <WarningVersion>18</WarningVersion>
+      <AdditionalOptions>/Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalOptions>/fixed:no %(AdditionalOptions)</AdditionalOptions>
@@ -143,6 +144,7 @@
       <SmallerTypeCheck>false</SmallerTypeCheck>
       <DisableSpecificWarnings>4091;4456;4457;4459</DisableSpecificWarnings>
       <WarningVersion>18</WarningVersion>
+      <AdditionalOptions>/Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalOptions>/fixed:no %(AdditionalOptions)</AdditionalOptions>
@@ -186,6 +188,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091;4456;4457;4459</DisableSpecificWarnings>
       <WarningVersion>18</WarningVersion>
+      <AdditionalOptions>/Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;Version.lib;Crypt32.lib;wintrust.lib;Sensapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -237,6 +240,7 @@ copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4091;4456;4457;4459</DisableSpecificWarnings>
       <WarningVersion>18</WarningVersion>
+      <AdditionalOptions>/Zc:strictStrings %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Oleacc.lib;Dbghelp.lib;Version.lib;Crypt32.lib;wintrust.lib;Sensapi.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Fixes #4146

This PR enables `/Zc:strictStrings` for a VS2015 project. Since this compilation flag disallows assigning string literals to non-const variables (like C++ standards states), code changes were made to ensure all variables storing pointers to string literals are const-qualified.

While is this purely a code clarity fix, it has potential for resolving one potential issue - previously, string literals were assigned to a non-const `pszText` field in `LVCOLUMN` structure. Documentation says nothing whether contents of this field are guaranteed not to be modified when `LVCOLUMN` is being read from (not populated to), so it was potentially unsafe.