### PR TITLE
Warning/error fixes as per VS2017 code analysis

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -766,7 +766,9 @@ COLORREF getCtrlBgColor(HWND hWnd)
 
 generic_string stringToUpper(generic_string strToConvert)
 {
-    std::transform(strToConvert.begin(), strToConvert.end(), strToConvert.begin(), ::toupper);
+    std::transform(strToConvert.begin(), strToConvert.end(), strToConvert.begin(), 
+        [](TCHAR ch){ return static_cast<TCHAR>(_totupper(ch)); }
+    );
     return strToConvert;
 }
 

--- a/PowerEditor/src/TinyXml/tinyxml.h
+++ b/PowerEditor/src/TinyXml/tinyxml.h
@@ -58,6 +58,7 @@ distribution.
 
 #include <assert.h>
 
+#include <tchar.h>
 #include <string>
 
 #include "Common.h"
@@ -176,7 +177,7 @@ protected:
 	};
 
 	static const TCHAR*	SkipWhiteSpace( const TCHAR* );
-	inline static bool	IsWhiteSpace( int c )		{ return ( isspace( c ) || c == '\n' || c == '\r' ); }
+	inline static bool	IsWhiteSpace( int c )		{ return ( _istspace( static_cast<TCHAR>(c) ) || c == '\n' || c == '\r' ); }
 
 	virtual void StreamOut (TIXML_OSTREAM *) const = 0;
 

--- a/PowerEditor/src/TinyXml/tinyxmlparser.cpp
+++ b/PowerEditor/src/TinyXml/tinyxmlparser.cpp
@@ -24,6 +24,7 @@ distribution.
 
 
 #include <sstream>
+#include <tchar.h>
 #include "tinyxml.h"
 
 //#define DEBUG_PARSER
@@ -156,7 +157,7 @@ const TCHAR* TiXmlBase::SkipWhiteSpace( const TCHAR* p )
 	}
 	while ( p && *p )
 	{
-		if ( isspace( *p ) || *p == '\n' || *p =='\r' )		// Still using old rules for white space.
+		if ( _istspace( *p ) || *p == '\n' || *p =='\r' )		// Still using old rules for white space.
 			++p;
 		else
 			break;
@@ -204,10 +205,10 @@ const TCHAR* TiXmlBase::ReadName( const TCHAR* p, TIXML_STRING * name )
 	// hyphens, or colons. (Colons are valid ony for namespaces,
 	// but tinyxml can't tell namespaces from names.)
 	if (    p && *p 
-		 && ( isalpha( (UCHAR) *p ) || *p == '_' ) )
+		 && ( _istalpha( *p ) || *p == '_' ) )
 	{
 		while(		p && *p
-				&&	(		isalnum( (UCHAR ) *p ) 
+				&&	(		_istalnum( *p ) 
 						 || *p == '_'
 						 || *p == '-'
 						 || *p == '.'
@@ -270,7 +271,7 @@ bool TiXmlBase::StringEqual( const TCHAR* p,
 		return false;
 	}
 
-    if ( tolower( *p ) == tolower( *tag ) )
+    if ( _totlower( *p ) == _totlower( *tag ) )
 	{
 		const TCHAR* q = p;
 
@@ -289,7 +290,7 @@ bool TiXmlBase::StringEqual( const TCHAR* p,
 		}
 		else
 		{
-			while ( *q && *tag && tolower( *q ) == tolower( *tag ) )
+			while ( *q && *tag && _totlower( *q ) == _totlower( *tag ) )
 			{
 				++q;
 				++tag;
@@ -338,7 +339,7 @@ const TCHAR* TiXmlBase::ReadText(	const TCHAR* p,
 				whitespace = true;
 				++p;
 			}
-			else if ( isspace( *p ) )
+			else if ( _istspace( *p ) )
 			{
 				whitespace = true;
 				++p;
@@ -533,7 +534,7 @@ TiXmlNode* TiXmlNode::Identify( const TCHAR* p )
 		#endif
 		returnNode = new TiXmlDeclaration();
 	}
-	else if (    isalpha( *(p+1) )
+	else if (    _istalpha( *(p+1) )
 			  || *(p+1) == '_' )
 	{
 		#ifdef DEBUG_PARSER
@@ -1013,7 +1014,7 @@ const TCHAR* TiXmlAttribute::Parse( const TCHAR* p, TiXmlParsingData* data )
 		// its best, even without them.
 		value = TEXT("");
 		while (    p && *p										// existence
-				&& !isspace( *p ) && *p != '\n' && *p != '\r'	// whitespace
+				&& !_istspace( *p ) && *p != '\n' && *p != '\r'	// whitespace
 				&& *p != '/' && *p != '>' )						// tag end
 		{
 			value += *p;
@@ -1126,7 +1127,7 @@ const TCHAR* TiXmlDeclaration::Parse( const TCHAR* p, TiXmlParsingData* data )
 		else
 		{
 			// Read over whatever it is.
-			while( p && *p && *p != '>' && !isspace( *p ) )
+			while( p && *p && *p != '>' && !_istspace( *p ) )
 				++p;
 		}
 	}
@@ -1136,7 +1137,7 @@ const TCHAR* TiXmlDeclaration::Parse( const TCHAR* p, TiXmlParsingData* data )
 bool TiXmlText::Blank() const
 {
 	for (size_t i = 0, len = value.length(); i < len; i++)
-		if ( !isspace( value[i] ) )
+		if ( !_istspace( value[i] ) )
 			return false;
 	return true;
 }

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -129,7 +129,7 @@ void AnsiCharPanel::insertChar(unsigned char char2insert) const
 		bool isUnicode = ((*_ppEditView)->execute(SCI_GETCODEPAGE) == SC_CP_UTF8);
 		if (isUnicode)
 		{
-			MultiByteToWideChar(0, 0, charStr, -1, wCharStr, sizeof(wCharStr));
+			MultiByteToWideChar(0, 0, charStr, -1, wCharStr, _countof(wCharStr));
 			WideCharToMultiByte(CP_UTF8, 0, wCharStr, -1, multiByteStr, sizeof(multiByteStr), NULL, NULL);
 		}
 		else // ANSI
@@ -140,7 +140,7 @@ void AnsiCharPanel::insertChar(unsigned char char2insert) const
 	}
 	else
 	{
-		MultiByteToWideChar(codepage, 0, charStr, -1, wCharStr, sizeof(wCharStr));
+		MultiByteToWideChar(codepage, 0, charStr, -1, wCharStr, _countof(wCharStr));
 		WideCharToMultiByte(CP_UTF8, 0, wCharStr, -1, multiByteStr, sizeof(multiByteStr), NULL, NULL);
 	}
 	(*_ppEditView)->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));

--- a/PowerEditor/src/WinControls/AnsiCharPanel/asciiListView.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/asciiListView.cpp
@@ -119,7 +119,7 @@ generic_string AsciiListView::getAscii(unsigned char value)
 			char ascii[2];
 			ascii[0] = value;
 			ascii[1] = '\0';
-			MultiByteToWideChar(_codepage, 0, ascii, -1, charStr, sizeof(charStr));
+			MultiByteToWideChar(_codepage, 0, ascii, -1, charStr, _countof(charStr));
 			return charStr;
 		}
 

--- a/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
@@ -177,7 +177,7 @@ LRESULT DockingSplitter::runProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM 
 			if (hookMouse)
 			{
 				::UnhookWindowsHookEx(hookMouse);
-				::SetCapture(NULL);
+				::ReleaseCapture();
 				hookMouse = NULL;
 			}
 			_isLeftButtonDown = FALSE;

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -142,7 +142,7 @@ bool findStrNoCase(const generic_string & strHaystack, const generic_string & st
 	auto it = std::search(
 		strHaystack.begin(), strHaystack.end(),
 		strNeedle.begin(), strNeedle.end(),
-		[](char ch1, char ch2){return std::toupper(ch1) == std::toupper(ch2); }
+		[](TCHAR ch1, TCHAR ch2){return _totupper(ch1) == _totupper(ch2); }
 	);
 	return (it != strHaystack.end());
 }

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1359,7 +1359,7 @@ INT_PTR CALLBACK DefaultDirectoryDlg::run_dlgProc(UINT message, WPARAM wParam, L
 						TCHAR inputDir[MAX_PATH];
 						::SendDlgItemMessage(_hSelf, IDC_OPENSAVEDIR_ALWAYSON_EDIT, WM_GETTEXT, MAX_PATH, reinterpret_cast<LPARAM>(inputDir));
 						lstrcpy(nppGUI._defaultDir, inputDir);
-						::ExpandEnvironmentStrings(nppGUI._defaultDir, nppGUI._defaultDirExp, 500);
+						::ExpandEnvironmentStrings(nppGUI._defaultDir, nppGUI._defaultDirExp, _countof(nppGUI._defaultDirExp));
 						pNppParam->setWorkingDir(nppGUI._defaultDirExp);
 						return TRUE;
 					}

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -27,6 +27,7 @@
 
 
 #include <algorithm>
+#include <array>
 #include "shortcut.h"
 #include "Parameters.h"
 #include "ScintillaEditView.h"
@@ -467,10 +468,7 @@ INT_PTR CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 // return true if one of CommandShortcuts is deleted. Otherwise false.
 void Accelerator::updateShortcuts() 
 {
-	vector<int> incrFindAccIds;
-	incrFindAccIds.push_back(IDM_SEARCH_FINDNEXT);
-	incrFindAccIds.push_back(IDM_SEARCH_FINDPREV);
-	incrFindAccIds.push_back(IDM_SEARCH_FINDINCREMENT);
+	const array<unsigned long, 3> incrFindAccIds = { IDM_SEARCH_FINDNEXT, IDM_SEARCH_FINDPREV, IDM_SEARCH_FINDINCREMENT };
 
 	NppParameters *pNppParam = NppParameters::getInstance();
 


### PR DESCRIPTION
Since Visual Studio 2017 improved its warnings and static code analysis, I decided to give it a go and sanity check the code against those. Several fairly sensible warnings have been issues, so I decided to batch correct them. Those include two variable truncations, a few buffer overruns, one unsigned/signed mismatch and one instance of WinAPI misuse.

Please refer to reviewed comments for specific warnings/error which have been fixed - I think it's cleanest to pinpoint them this way.