### PR TITLE
Keep Doc Switcher's Tab ordering in sync

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -458,6 +458,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_INTERNAL_DOCORDERCHANGED :
 		{
+			if (_pFileSwitcherPanel)
+			{
+				_pFileSwitcherPanel->updateTabOrder();
+			}
+			
 			BufferID id = _pEditView->getCurrentBufferID();
 
 			// Notify plugins that current file is about to be closed

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
@@ -35,6 +35,12 @@
 
 #define FS_PROJECTPANELTITLE		TEXT("Doc Switcher")
 
+struct sortCompareData {
+  HWND hListView;
+  int columnIndex;
+  int sortDirection;
+};
+
 class VerticalFileSwitcher : public DockingDlgInterface {
 public:
 	VerticalFileSwitcher(): DockingDlgInterface(IDD_FILESWITCHER_PANEL) {};
@@ -75,7 +81,8 @@ public:
 		return _fileListView.getFullFilePath(i);
 	};
 
-	int setHeaderOrder(LPNMLISTVIEW pnm_list_view);
+	int setHeaderOrder(int columnIndex);
+	void updateHeaderArrow();
 
 	int nbSelectedFiles() const {
 		return _fileListView.nbSelectedFiles();
@@ -84,11 +91,18 @@ public:
 	std::vector<SwitcherFileInfo> getSelectedFiles(bool reverse = false) const {
 		return _fileListView.getSelectedFiles(reverse);
 	};
-
+	
+	void startColumnSort();
+	
 	void reload(){
-		_fileListView.deleteColumn(1);
-		_fileListView.deleteColumn(0);
 		_fileListView.reload();
+		startColumnSort();
+	};
+	
+	void updateTabOrder(){
+		if (_lastSortingDirection == SORT_DIRECTION_NONE) {
+			_fileListView.reload();
+		}
 	};
 
 	virtual void setBackgroundColor(COLORREF bgColour) {
@@ -98,11 +112,11 @@ public:
 	virtual void setForegroundColor(COLORREF fgColour) {
 		_fileListView.setForegroundColor(fgColour);
     };
-
 protected:
 	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
-
 private:
+	int _lastSortingColumn = 0;
+	int _lastSortingDirection = SORT_DIRECTION_NONE;
 	VerticalFileSwitcherListView _fileListView;
 	HIMAGELIST _hImaLst = nullptr;
 };

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
@@ -35,6 +35,7 @@
 class Buffer;
 typedef Buffer * BufferID;	//each buffer has unique ID by which it can be retrieved
 
+#define SORT_DIRECTION_NONE     -1
 #define SORT_DIRECTION_UP     0
 #define SORT_DIRECTION_DOWN   1
 


### PR DESCRIPTION
Closes #946 #1684 #2342 #4015

The patch introduces an "unsorted" direction (up, down, unsorted, up, down, unsorted, etc) which keeps in sync with the Tab Bar's ordering, but only while it's set to unsorted. This allows people to rearrange the Doc Switcher's files using the Tab Bar.

Changes Overview:

- Added "unsorted" sorting option on columns
- Tab order sync'd with Tab Bar while set to "unsorted"
- Sorting by "name" is preserved while toggling "exts" column
- Column widths no longer reset to default while toggling "exts" column (will resize if "exts" wont fit)