### PR TITLE
enhance ShortcutMapper behavior while resizing:

### DIFF
--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -425,7 +425,23 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 			_clientWidth = rect.right - rect.left;
 			_clientHeight = rect.bottom - rect.top;
 
+			int cy_border = GetSystemMetrics(SM_CYFRAME);
+			int cy_caption = GetSystemMetrics(SM_CYCAPTION);
+			_initClientWidth = _clientWidth;
+			_initClientHeight = _clientHeight + cy_caption + cy_border;
+			_dialogInitDone = true;
+
 			return TRUE;
+		}
+		case WM_GETMINMAXINFO :
+		{
+			MINMAXINFO* mmi = (MINMAXINFO*)lParam;
+			if (_dialogInitDone)
+			{
+				mmi->ptMinTrackSize.x = _initClientWidth;
+				mmi->ptMinTrackSize.y = _initClientHeight;
+			}
+			return 0;
 		}
 
 		case WM_DESTROY:
@@ -464,7 +480,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				HWND moveHwnd = ::GetDlgItem(_hSelf, moveWndID);
 				::GetWindowRect(moveHwnd, &rect);
 				::MapWindowPoints(NULL, _hSelf, (LPPOINT)&rect, 2);
-				::SetWindowPos(moveHwnd, NULL, rect.left + addWidth, rect.top + addHeight, 0, 0, SWP_NOSIZE | flags);
+				::SetWindowPos(moveHwnd, NULL, rect.left + addWidth / 2, rect.top + addHeight, 0, 0, SWP_NOSIZE | flags);
 			}
 			HWND moveHwnd = ::GetDlgItem(_hSelf, IDC_BABYGRID_STATIC);
 			::GetWindowRect(moveHwnd, &rect);

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
@@ -39,6 +39,7 @@ class ShortcutMapper : public StaticDialog {
 public:
 	ShortcutMapper() : _currentState(STATE_MENU), StaticDialog() {
 		_shortcutFilter = TEXT("");
+		_dialogInitDone = false;
 	};
 	~ShortcutMapper() {};
 
@@ -100,6 +101,9 @@ private:
 	};
 	LONG _clientWidth;
 	LONG _clientHeight;
+	LONG _initClientWidth;
+	LONG _initClientHeight;
+	bool _dialogInitDone;
 
 	void initTabs();
 	void initBabyGrid();


### PR DESCRIPTION
- keep centered buttons while resizing
- set minimum width and height

![capture_shortcut_mapper](https://user-images.githubusercontent.com/12024941/36172415-147c7404-1106-11e8-93c2-8e0a80ea936c.gif)
