### PR TITLE
Update romanian.xml for version 7.5.5

### DIFF
--- a/PowerEditor/installer/nativeLang/romanian.xml
+++ b/PowerEditor/installer/nativeLang/romanian.xml
@@ -166,7 +166,7 @@
                     <Item id="42035" name="Comentare linie"/>
                     <Item id="42036" name="Eliminare comentariu linie"/>
                     <Item id="42055" name="Eliminare linii goale"/>
-                    <Item id="42056" name="Eliminare linii goale (ce conțin caractere goale)"/>
+                    <Item id="42056" name="Eliminare linii goale (ce conțin spații goale)"/>
                     <Item id="42057" name="Inserare linie goală deasupra"/>
                     <Item id="42058" name="Inserare linie goală dedesubt"/>
                     <Item id="43001" name="Cău&amp;tare..."/>

--- a/PowerEditor/installer/nativeLang/romanian.xml
+++ b/PowerEditor/installer/nativeLang/romanian.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
+ <!--
+-    Traducerea în română pentru Notepad++ 7.5.5
+-    Ultima modificare 20 Februarie 2018 de către Barna Cosmin Marian
+     Pentru actualizări vizitați: https://github.com/notepad-plus-plus/notepad-plus-plus/tree/master/PowerEditor/installer/nativeLang
+ -->
 <NotepadPlus>
-    <Native-Langue name="Romanian" filename="romanian.xml" version="7.5">
+    <Native-Langue name="Romanian" filename="romanian.xml" version="7.5.5">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
                 <Entries>
-                    <Item menuId="file" name="&amp;Fişier"/>
+                    <Item menuId="file" name="&amp;Fișier"/>
                     <Item menuId="edit" name="&amp;Editare"/>
                     <Item menuId="search" name="&amp;Căutare"/>
-                    <Item menuId="view" name="&amp;Afişare"/>
+                    <Item menuId="view" name="&amp;Afișare"/>
                     <Item menuId="encoding" name="C&amp;odificare"/>
                     <Item menuId="language" name="&amp;Limbaj"/>
                     <Item menuId="settings" name="Se&amp;tări"/>
@@ -20,17 +25,17 @@
                 </Entries>
                 <!-- Sub Menu Entries -->
                 <SubEntries>
-                    <Item subMenuId="file-openFolder" name="Deschide folderul gazdă"/>
+                    <Item subMenuId="file-openFolder" name="Deschidere folder gazdă"/>
                     <Item subMenuId="file-closeMore" name="Închidere multiplă"/>
-                    <Item subMenuId="file-recentFiles" name="Fişiere recente"/>
+                    <Item subMenuId="file-recentFiles" name="Fișiere recente"/>
                     <Item subMenuId="edit-copyToClipboard"  name="Copiere în Clipboard"/>
                     <Item subMenuId="edit-indent" name="Indentare"/>
                     <Item subMenuId="edit-convertCaseTo" name="Convertire litere în"/>
-                    <Item subMenuId="edit-lineOperations" name="Operaţii linie"/>
-                    <Item subMenuId="edit-comment" name="Comentariu/Anulare"/>
+                    <Item subMenuId="edit-lineOperations" name="Operații linii"/>
+                    <Item subMenuId="edit-comment" name="Creare/Anulare comentariu"/>
                     <Item subMenuId="edit-autoCompletion" name="Autocompletare"/>
-                    <Item subMenuId="edit-eolConversion" name="Conversie EOL"/>
-                    <Item subMenuId="edit-blankOperations" name="Operaţii spaţii libere"/>
+                    <Item subMenuId="edit-eolConversion" name="Convertire sfârșit de linie"/>
+                    <Item subMenuId="edit-blankOperations" name="Operații spații libere"/>
                     <Item subMenuId="edit-pasteSpecial" name="Lipire specială"/>
                     <Item subMenuId="edit-onSelection" name="Pe selecție"/>
                     <Item subMenuId="search-markAll" name="Marcare tot"/>
@@ -42,16 +47,16 @@
                     <Item subMenuId="view-zoom"  name="Dimensiune"/>
                     <Item subMenuId="view-moveCloneDocument"  name="Mutare/Clonare document curent"/>
                     <Item subMenuId="view-tab"  name="Fila"/>
-                    <Item subMenuId="view-collapseLevel" name="Restrânge nivel"/>
-                    <Item subMenuId="view-uncollapseLevel" name="Extinde nivel"/>
+                    <Item subMenuId="view-collapseLevel" name="Restrângere nivel"/>
+                    <Item subMenuId="view-uncollapseLevel" name="Extindere nivel"/>
                     <Item subMenuId="view-project" name="Proiect"/>
-                    <Item subMenuId="encoding-characterSets"  name="Set caractere"/>
+                    <Item subMenuId="encoding-characterSets"  name="Set de caractere"/>
                     <Item subMenuId="encoding-arabic"  name="Arabic"/>
                     <Item subMenuId="encoding-baltic"  name="Baltic"/>
                     <Item subMenuId="encoding-celtic"  name="Celtic"/>
                     <Item subMenuId="encoding-cyrillic"  name="Chirilic"/>
                     <Item subMenuId="encoding-centralEuropean"  name="Central European"/>
-                    <Item subMenuId="encoding-chinese"  name="Chinese"/>
+                    <Item subMenuId="encoding-chinese"  name="Chinezesc"/>
                     <Item subMenuId="encoding-easternEuropean"  name="Est European"/>
                     <Item subMenuId="encoding-greek"  name="Grec"/>
                     <Item subMenuId="encoding-hebrew"  name="Ebraic"/>
@@ -63,42 +68,42 @@
                     <Item subMenuId="encoding-westernEuropean" name="Vest European"/>
                     <Item subMenuId="encoding-vietnamese" name="Vietnamez"/>
                     <Item subMenuId="settings-import"  name="Importare"/>
-		    <Item subMenuId="tools-md5"  name="MD5"/>
+                    <Item subMenuId="tools-md5"  name="MD5"/>
                 </SubEntries>
                 <!-- all menu item -->
                 <Commands>
                     <Item id="41001" name="&amp;Nou"/>
-                    <Item id="41002" name="&amp;Deschide"/>
+                    <Item id="41002" name="&amp;Deschidere"/>
                     <Item id="41019" name="Explorator"/>
                     <Item id="41020" name="cmd"/>
-                    <Item id="41003" name="Închide"/>
-                    <Item id="41004" name="În&amp;chide toate"/>
-                    <Item id="41005" name="Închide toate fără documentul curent"/>
-                    <Item id="41009" name="Închide toate spre stânga"/>
-                    <Item id="41018" name="Închide toate spre dreapta"/>
+                    <Item id="41003" name="Închidere"/>
+                    <Item id="41004" name="În&amp;chidere toate"/>
+                    <Item id="41005" name="Închidere toate fără documentul curent"/>
+                    <Item id="41009" name="Închidere toate spre stânga"/>
+                    <Item id="41018" name="Închidere toate spre dreapta"/>
                     <Item id="41006" name="&amp;Salvare"/>
                     <Item id="41007" name="Salvar&amp;e toate"/>
                     <Item id="41008" name="S&amp;alvare ca..."/>
                     <Item id="41010" name="Tipărire..."/>
-                    <Item id="1001"  name="Tipăreşte acum"/>
-                    <Item id="41011" name="I&amp;eşire"/>
+                    <Item id="1001"  name="Tipărire acum"/>
+                    <Item id="41011" name="I&amp;eșire"/>
                     <Item id="41012" name="Încărcare sesiune..."/>
                     <Item id="41013" name="Salvare sesiune..."/>
                     <Item id="41014" name="Reîncărcare de pe disc"/>
                     <Item id="41015" name="Salvare copie ca..."/>
-                    <Item id="41016" name="Ştergere de pe disc"/>
+                    <Item id="41016" name="Ștergere de pe disc"/>
                     <Item id="41017" name="Redenumire..."/>
-                    <Item id="41021" name="Restaurare fişiere închise recent"/>
-                    <Item id="41022" name="Deschide folderul ca spaţiu de lucru"/>
-                    <Item id="41023" name="Deschide în vizualizatorul implicit"/>
+                    <Item id="41021" name="Restaurare fișiere închise recent"/>
+                    <Item id="41022" name="Deschidere fo&amp;lder ca spațiu de lucru"/>
+                    <Item id="41023" name="Deschidere în vizualizatorul implicit"/>
                     <Item id="42001" name="Dec&amp;upare"/>
                     <Item id="42002" name="&amp;Copiere"/>
                     <Item id="42003" name="A&amp;nulare"/>
                     <Item id="42004" name="&amp;Revenire"/>
                     <Item id="42005" name="&amp;Lipire"/>
-                    <Item id="42006" name="Şter&amp;gere"/>
+                    <Item id="42006" name="Șter&amp;gere"/>
                     <Item id="42007" name="Selectare t&amp;ot"/>
-                    <Item id="42020" name="Selectare Început/Sfârşit"/>
+                    <Item id="42020" name="Selectare început/sfârșit"/>
                     <Item id="42008" name="Mărire indentare linie"/>
                     <Item id="42009" name="Reducere indentare linie"/>
                     <Item id="42010" name="Duplicare linie curentă"/>
@@ -122,46 +127,46 @@
                     <Item id="42070" name="Prima literă din propoziție mare (îmbinare)"/>
                     <Item id="42071" name="iNVERsARE LiTEre"/>
                     <Item id="42072" name="LiTerE AleaTOarE"/>
-		    <Item id="42073" name="Deschide fișier"/>
-		    <Item id="42074" name="Deschide dosar gazdă în Explorer"/>
-		    <Item id="42075" name="Caută pe Internet"/>
-		    <Item id="42076" name="Schimbare motor de căutare..."/>
+                    <Item id="42073" name="Deschidere fișier"/>
+                    <Item id="42074" name="Deschidere folder gazdă în Explorer"/>
+                    <Item id="42075" name="Căutare pe Internet"/>
+                    <Item id="42076" name="Schimbare motor de căutare..."/>
                     <Item id="42018" name="S&amp;tart înregistrare"/>
                     <Item id="42019" name="St&amp;op înregistrare"/>
                     <Item id="42021" name="&amp;Redare"/>
                     <Item id="42022" name="Comutare comentariu linie"/>
-                    <Item id="42023" name="Bloc comentariu"/>
-                    <Item id="42047" name="Anulare bloc comentariu"/>
-                    <Item id="42024" name="Eliminare spaţii sfârşit"/>
-                    <Item id="42042" name="Eliminare spaţii început de linie" />
-                    <Item id="42043" name="Eliminare spaţii capete linie"/>
-                    <Item id="42044" name="EOL în spaţiu"/>
-                    <Item id="42045" name="Eliminare spaţii inutile şi EOL"/>
-                    <Item id="42046" name="TAB în spaţiu"/>
-                    <Item id="42054" name="Spaţii în TAB (toate)"/>
-                    <Item id="42053" name="Spaţii în TAB (început)"/>
-                    <Item id="42038" name="Lipire conţinut HTML"/>
-                    <Item id="42039" name="Lipire conţint RTF"/>
-                    <Item id="42048" name="Copire conţinut binar"/>
-                    <Item id="42049" name="Decupare conţinut binar"/>
-                    <Item id="42050" name="Lipire conţinut binar"/>
+                    <Item id="42023" name="Comentariu multilinie"/>
+                    <Item id="42047" name="Anulare comentariu multilinie"/>
+                    <Item id="42024" name="Eliminare spații la sfârșit de linii"/>
+                    <Item id="42042" name="Eliminare spații la început de linii" />
+                    <Item id="42043" name="Eliminare spații capete linii"/>
+                    <Item id="42044" name="Convertire sfârșit de linie în spațiu"/>
+                    <Item id="42045" name="Eliminare spații inutile și sfârșit de linii"/>
+                    <Item id="42046" name="Tab în spațiu"/>
+                    <Item id="42054" name="Spații în Tab (toate)"/>
+                    <Item id="42053" name="Spații în Tab (la început de linie)"/>
+                    <Item id="42038" name="Lipire conținut HTML"/>
+                    <Item id="42039" name="Lipire conțint RTF"/>
+                    <Item id="42048" name="Copiere conținut binar"/>
+                    <Item id="42049" name="Decupare conținut binar"/>
+                    <Item id="42050" name="Lipire conținut binar"/>
                     <Item id="42037" name="Mod coloană..."/>
                     <Item id="42034" name="Editor coloane..."/>
                     <Item id="42051" name="Panou caractere"/>
                     <Item id="42052" name="Istoric Clipboard"/>
                     <Item id="42025" name="Salvare macro înregistrat"/>
-                    <Item id="42026" name="Direcţie text DLS"/>
-                    <Item id="42027" name="Direcţie text SLD"/>
-                    <Item id="42028" name="Setare stare doar-citire"/>
-                    <Item id="42029" name="Copiere cale fişier în Clipboard"/>
-                    <Item id="42030" name="Copiere nume fişier în Clipboard"/>
+                    <Item id="42026" name="Direcție text DLS"/>
+                    <Item id="42027" name="Direcție text SLD"/>
+                    <Item id="42028" name="Setare stare doar citire"/>
+                    <Item id="42029" name="Copiere cale fișier în Clipboard"/>
+                    <Item id="42030" name="Copiere nume fișier în Clipboard"/>
                     <Item id="42031" name="Copiere cale folder în Clipboard"/>
                     <Item id="42032" name="Executare macro în mod repetat..."/>
-                    <Item id="42033" name="Eliminare stare doar-citire"/>
+                    <Item id="42033" name="Eliminare stare doar citire"/>
                     <Item id="42035" name="Comentare linie"/>
                     <Item id="42036" name="Eliminare comentariu linie"/>
                     <Item id="42055" name="Eliminare linii goale"/>
-                    <Item id="42056" name="Eliminare linii goale (ce conţin caractere goale)"/>
+                    <Item id="42056" name="Eliminare linii goale (ce conțin caractere goale)"/>
                     <Item id="42057" name="Inserare linie goală deasupra"/>
                     <Item id="42058" name="Inserare linie goală dedesubt"/>
                     <Item id="43001" name="Cău&amp;tare..."/>
@@ -176,14 +181,14 @@
                     <Item id="43019" name="Copiere linii cu semne de carte"/>
                     <Item id="43020" name="Lipire la (înlocuire) linii cu semne de carte"/>
                     <Item id="43021" name="Eliminare linii cu semne de carte"/> 
-		    <Item id="43051" name="Eliminare linii fără semne de carte"/>
+                    <Item id="43051" name="Eliminare linii fără semne de carte"/>
                     <Item id="43050" name="Inversare semne de carte"/>
-		    <Item id="43052" name="Căutare caractere în interval..."/>
+                    <Item id="43052" name="Căutare caractere în interval..."/>
                     <Item id="43053" name="Selectare tot între acolade"/>
                     <Item id="43009" name="Salt la acolada pereche"/>
                     <Item id="43010" name="Căutare anterior"/>
                     <Item id="43011" name="Căutare &amp;incrementală"/>
-                    <Item id="43013" name="Căutare în fişiere"/>
+                    <Item id="43013" name="Căutare în fișiere"/>
                     <Item id="43014" name="Căutare (volatilă) următor"/>
                     <Item id="43015" name="Căutare (volatilă) anterior"/>
                     <Item id="43022" name="Utilizare stil 1"/>
@@ -212,42 +217,42 @@
                     <Item id="43045" name="Fereastră rezultate căutare"/>
                     <Item id="43046" name="Următorul rezultat găsit"/>
                     <Item id="43047" name="Rezultat anterior găsit"/>
-                    <Item id="43048" name="Selectare şi căutare următor"/>
-                    <Item id="43049" name="Selectare şi căutare anterior"/>
+                    <Item id="43048" name="Selectare și căutare următor"/>
+                    <Item id="43049" name="Selectare și căutare anterior"/>
                     <Item id="43054" name="Marcare..."/>
-                    <Item id="44009" name="&amp;Comutare bară unelte şi titlu file"/>
+                    <Item id="44009" name="&amp;Comutare bară unelte și titlu file"/>
                     <Item id="44010" name="Pliere toate"/>
-                    <Item id="44019" name="Afişare toate caracterele"/>
-                    <Item id="44020" name="Afişare ghidaj indentare"/>
+                    <Item id="44019" name="Afișare toate caracterele"/>
+                    <Item id="44020" name="Afișare ghidaj indentare"/>
                     <Item id="44022" name="Limitare margine linii"/>
-                    <Item id="44023" name="&amp;Mărire Ctrl+Rotiţă maus sus"/>
-                    <Item id="44024" name="Micşo&amp;rare Ctrl+Rotiţă maus jos"/>
-                    <Item id="44025" name="Afişare spaţii libere şi TAB"/>
-                    <Item id="44026" name="Afişare sfârşit linie (EOL)"/>
+                    <Item id="44023" name="&amp;Mărire Ctrl+rotiță maus sus"/>
+                    <Item id="44024" name="Micșo&amp;rare Ctrl+rotiță maus jos"/>
+                    <Item id="44025" name="Afișare spații libere și Tab-uri"/>
+                    <Item id="44026" name="Afișare sfârșit de linie"/>
                     <Item id="44029" name="Depliere toate"/>
                     <Item id="44030" name="Restrângere nivel curent"/>
                     <Item id="44031" name="Extindere nivel curent"/>
                     <Item id="44049" name="Sumar..."/>
                     <Item id="44080" name="Hartă document"/>
-                    <Item id="44084" name="Listă funcţii"/>
-		    <Item id="44085" name="Folder ca spaţiu de lucru"/>
-                    <Item id="44086" name="Tab &amp;1"/>
-                    <Item id="44087" name="Tab &amp;2"/>
-                    <Item id="44088" name="Tab &amp;3"/>
-                    <Item id="44089" name="Tab &amp;4"/>
-                    <Item id="44090" name="Tab &amp;5"/>
-                    <Item id="44091" name="Tab &amp;6"/>
-                    <Item id="44092" name="Tab &amp;7"/>
-                    <Item id="44093" name="Tab &amp;8"/>
-                    <Item id="44094" name="Tab &amp;9"/>
+                    <Item id="44084" name="Listă funcții"/>
+                    <Item id="44085" name="Folder ca spațiu de lucru"/>
+                    <Item id="44086" name="Fila &amp;1"/>
+                    <Item id="44087" name="Fila &amp;2"/>
+                    <Item id="44088" name="Fila &amp;3"/>
+                    <Item id="44089" name="Fila &amp;4"/>
+                    <Item id="44090" name="Fila &amp;5"/>
+                    <Item id="44091" name="Fila &amp;6"/>
+                    <Item id="44092" name="Fila &amp;7"/>
+                    <Item id="44093" name="Fila &amp;8"/>
+                    <Item id="44094" name="Fila &amp;9"/>
                     <Item id="44095" name="Fila următoare"/>
                     <Item id="44096" name="Fila anterioară"/>
                     <Item id="44097" name="Monitorizare (tail -f)"/>
-                    <Item id="44098" name="Mutare Tab înainte"/>
-                    <Item id="44099" name="Mutare Tab înapoi"/>
+                    <Item id="44098" name="Mutare filă înainte"/>
+                    <Item id="44099" name="Mutare filă înapoi"/>
                     <Item id="44032" name="Comutare ecran complet"/>
                     <Item id="44033" name="Restaurare dimensiune afișare"/>
-                    <Item id="44034" name="Întotdeuna deasupra"/>
+                    <Item id="44034" name="Întotdeauna deasupra"/>
                     <Item id="44035" name="Sincronizare derulare verticală"/>
                     <Item id="44036" name="Sincronizare derulare orizontală"/>
                     <Item id="44041" name="Afișare simbol limitare"/>
@@ -255,134 +260,134 @@
                     <Item id="44081" name="Panou proiect 1" />
                     <Item id="44082" name="Panou proiect 2" />
                     <Item id="44083" name="Panou proiect 3" />
-                    <Item id="45001" name="Convertire la format Windows (CR+LF)"/>
-                    <Item id="45002" name="Convertire la format UNIX (LF)"/>
-                    <Item id="45003" name="Convertire la format MAC (CR)"/>
+                    <Item id="45001" name="Convertire în format Windows (CR+LF)"/>
+                    <Item id="45002" name="Convertire în format UNIX (LF)"/>
+                    <Item id="45003" name="Convertire în format MAC (CR)"/>
                     <Item id="45004" name="Codificare în ANSI"/>
-                    <Item id="45005" name="Codificare în UTF-8"/>
+                    <Item id="45005" name="Codificare în UTF-8-BOM"/>
                     <Item id="45006" name="Codificare în UCS-2 Big Endian"/>
                     <Item id="45007" name="Codificare în UCS-2 Little Endian"/>
-                    <Item id="45008" name="Codificare în UTF-8 fără BOM"/>
-                    <Item id="45009" name="Convertire la ANSI"/>
-                    <Item id="45010" name="Convertire la UTF-8 fără BOM"/>
-                    <Item id="45011" name="Convertire la UTF-8"/>
-                    <Item id="45012" name="Convertire la UCS-2 Big Endian"/>
-                    <Item id="45013" name="Convertire la UCS-2 Little Endian"/>
+                    <Item id="45008" name="Codificare în UTF-8"/>
+                    <Item id="45009" name="Convertire în ANSI"/>
+                    <Item id="45010" name="Convertire în UTF-8"/>
+                    <Item id="45011" name="Convertire în UTF-8-BOM"/>
+                    <Item id="45012" name="Convertire în UCS-2 Big Endian"/>
+                    <Item id="45013" name="Convertire în UCS-2 Little Endian"/>
 
                     <Item id="10001" name="Mutare în alt panou"/>
                     <Item id="10002" name="Clonare în alt panou"/>
-                    <Item id="10003" name="Mutare în instanţă nouă"/>
-                    <Item id="10004" name="Deschide în instanţă nouă"/>
+                    <Item id="10003" name="Mutare în instanță nouă"/>
+                    <Item id="10004" name="Deschidere în instanță nouă"/>
 
                     <Item id="46001" name="Configurator stil..."/>
-                    <Item id="46150" name="Definiţi limbajul dvs..."/>
+                    <Item id="46150" name="Definire limbaj..."/>
                     <Item id="46080" name="Definit de utilizator"/>
                     <Item id="47000" name="Despre Notepad++..."/>
                     <Item id="47010" name="Argumente linie de comandă..."/>
-                    <Item id="47001" name="Pagina web Notepad++"/>
+                    <Item id="47001" name="Pagină web Notepad++"/>
                     <Item id="47002" name="Pagină proiect Notepad++"/>
-                    <Item id="47003" name="Documentaţie online"/>
+                    <Item id="47003" name="Documentație online"/>
                     <Item id="47004" name="Comunitatea Notepad++ (Forum)"/>
                     <Item id="47011" name="Suport Live"/>
                     <Item id="47012" name="Informații depanare"/>
-                    <Item id="47005" name="Luaţi mai multe extensii"/>
+                    <Item id="47005" name="Luați mai multe extensii"/>
                     <Item id="47006" name="Actualizare Notepad++"/>
                     <Item id="47009" name="Setare proxy actualizare..."/>
                     <Item id="48005" name="Importare extensie(i) ..."/>
                     <Item id="48006" name="Importare temă(e) ..."/>
                     <Item id="48018" name="Editare meniu contextual"/>
-                    <Item id="48009" name="Hartă scurtături..."/>
-                    <Item id="48011" name="Preferinţe..."/>
+                    <Item id="48009" name="Listă combinații taste..."/>
+                    <Item id="48011" name="Preferințe..."/>
                     <Item id="48501" name="Generare..."/>
                     <Item id="48502" name="Generare din fișiere..."/>
                     <Item id="48503" name="Generare în memorie"/>
                     <Item id="49000" name="&amp;Executare..."/>
 
-                    <Item id="50000" name="Completare funcţii"/>
+                    <Item id="50000" name="Completare funcții"/>
                     <Item id="50001" name="Completare cuvinte"/>
-                    <Item id="50002" name="Sugestii parametri funcţii"/>
+                    <Item id="50002" name="Sugestii parametri funcții"/>
                     <Item id="50006" name="Completare căi"/>
-                    <Item id="44042" name="Ascunde liniile"/>
-                    <Item id="42040" name="Deschide toate fişierele recente"/>
-                    <Item id="42041" name="Golire listă fişiere recente"/>
-                    <Item id="48016" name="Modificare scurtătură/Ştergere macro..."/>
-                    <Item id="48017" name="Modificare scurtătură/Ştergere comandă..."/>
+                    <Item id="44042" name="Ascundere linii"/>
+                    <Item id="42040" name="Deschidere toate fișierele recente"/>
+                    <Item id="42041" name="Golire listă fișiere recente"/>
+                    <Item id="48016" name="Modificare scurtătură/Ștergere macro..."/>
+                    <Item id="48017" name="Modificare scurtătură/Ștergere comandă..."/>
                 </Commands>
             </Main>
             <Splitter>
             </Splitter>
             <TabBar>
-                    <Item CMID="0" name="Închide"/>
-                    <Item CMID="1" name="Închide toate fără acesta"/>
+                    <Item CMID="0" name="Închidere"/>
+                    <Item CMID="1" name="Închidere toate fără acesta"/>
                     <Item CMID="2" name="Salvare"/>
                     <Item CMID="3" name="Salvare ca..."/>
                     <Item CMID="4" name="Tipărire"/>
                     <Item CMID="5" name="Mutare în altă vedere"/>
                     <Item CMID="6" name="Clonare în altă vedere"/>
-                    <Item CMID="7" name="Copiere cale fişier în Clipboard"/>
-                    <Item CMID="8" name="Copiere nume fişier în Clipboard"/>
+                    <Item CMID="7" name="Copiere cale fișier în Clipboard"/>
+                    <Item CMID="8" name="Copiere nume fișier în Clipboard"/>
                     <Item CMID="9" name="Copiere cale folder în Clipboard"/>
                     <Item CMID="10" name="Redenumire"/>
-                    <Item CMID="11" name="Mutare în Coş de reciclare"/>
-                    <Item CMID="12" name="Doar-citire"/>
-                    <Item CMID="13" name="Anulare stare doar-citire"/>
-                    <Item CMID="14" name="Mutare în instanţă nouă"/>
-                    <Item CMID="15" name="Deschide în instanţă nouă"/>
+                    <Item CMID="11" name="Mutare în coșul de reciclare"/>
+                    <Item CMID="12" name="Blocare salvare modificări"/>
+                    <Item CMID="13" name="Anulare blocare salvare modificări"/>
+                    <Item CMID="14" name="Mutare în instanță nouă"/>
+                    <Item CMID="15" name="Deschidere în instanță nouă"/>
                     <Item CMID="16" name="Reîncărcare"/>
-		    <Item CMID="17" name="Închide toate spre stânga"/>
-                    <Item CMID="18" name="Închide toate spre dreapta"/>
-                    <Item CMID="19" name="Deschide folderul gazdă în Explorer"/>
-                    <Item CMID="20" name="Deschide folderul gazdă în cmd"/>
+                    <Item CMID="17" name="Închidere toate spre stânga"/>
+                    <Item CMID="18" name="Închidere toate spre dreapta"/>
+                    <Item CMID="19" name="Deschidere folder gazdă în Explorer"/>
+                    <Item CMID="20" name="Deschidere folder gazdă în cmd"/>
+                    <Item CMID="21" name="Deschidere în vizualizator implicit"/>
             </TabBar>
         </Menu>
         <Dialog>
-            <Find title="" titleFind="Căutare" titleReplace="Înlocuire" titleFindInFiles="Căutare în fişiere" titleMark="Marcare">
+            <Find title="" titleFind="Căutare" titleReplace="Înlocuire" titleFindInFiles="Căutare în fișiere" titleMark="Marcare">
                 <Item id="1"    name="Următorul"/>
-                <Item id="2"    name="Închide"/>
+                <Item id="1722" name="Inversare direcție de căutare"/>
+                <Item id="2"    name="Închidere"/>
+                <Item id="1620" name="Căutare:"/>
                 <Item id="1603" name="Potrivire &amp;numai cuvinte întregi"/>
                 <Item id="1604" name="Potrivire &amp;litere"/>
                 <Item id="1605" name="&amp;Expresie regulată"/>
                 <Item id="1606" name="În tot &amp;documentul"/>
+                <Item id="1614" name="Numărare"/>
+                <Item id="1615" name="Căutare toate"/>
+                <Item id="1616" name="Marcare linie"/>
+                <Item id="1618" name="Curățare marcaje înainte de fiecare căutare"/>
+                <Item id="1611" name="În&amp;locuire cu:"/>
                 <Item id="1608" name="Înl&amp;ocuire"/>
                 <Item id="1609" name="Înlocuire &amp;tot"/>
-                <Item id="1611" name="În&amp;locuire cu:"/>
-                <Item id="1612" name="În &amp;sus"/>
-                <Item id="1613" name="În &amp;jos"/>
-                <Item id="1614" name="Numărare"/>
-                <Item id="1615" name="Caută toate"/>
-                <Item id="1616" name="Marcare linie"/>
-                <Item id="1618" name="Curăţare marcaje înainte de fiecare căutare"/>
-                <Item id="1620" name="Căutare:"/>
-                <Item id="1621" name="Direcţie"/>
-                <Item id="1624" name="Mod căutare"/>
-                <Item id="1632" name="În selecţie"/>
-                <Item id="1633" name="Golire"/>
-                <Item id="1635" name="Înlocuire în toate documentele deschise"/>
-                <Item id="1636" name="Caută toate în toate documentele deschise"/>
-                <Item id="1654" name="Filtre:"/>
-                <Item id="1655" name="Folder:"/>
-                <Item id="1656" name="Caută toate"/>
-                <Item id="1658" name="În toate subfolderele"/>
-                <Item id="1659" name="În folderele ascunse"/>
                 <Item id="1687" name="La pierderea focalizării"/>
                 <Item id="1688" name="Întotdeauna"/>
-
+                <Item id="1632" name="În selecție"/>
+                <Item id="1633" name="Anulare marcare"/>
+                <Item id="1635" name="Înlocuire în toate documentele deschise"/>
+                <Item id="1636" name="Căutare toate în toate documentele deschise"/>
+                <Item id="1654" name="Filtre:"/>
+                <Item id="1655" name="Folder:"/>
+                <Item id="1656" name="Căutare toate"/>
+                <Item id="1658" name="În toate subfolderele"/>
+                <Item id="1659" name="În folderele ascunse"/>
+                <Item id="1624" name="Mod căutare"/>
                 <Item id="1625" name="Normal"/>
                 <Item id="1626" name="Extins (\n, \r, \t, \0, \x...)"/>
-                <Item id="1660" name="Înlocuire în fişiere"/>
+                <Item id="1660" name="Înlocuire în fișiere"/>
                 <Item id="1661" name="Folder document curent"/>
-                <Item id="1641" name="Caută toate în     documentul curent"/>
-                <Item id="1686" name="Transparenţă"/>
-		<Item id="1703" name="&amp;. este \r şi \n"/>
+                <Item id="1641" name="Căutare toate în   documentul curent"/>
+                <Item id="1686" name="Transparență"/>
+                <Item id="1703" name="&amp;. este \r sau \n"/>
+
             </Find>
-            <FindCharsInRange title="Find Characters in Range...">
-                <Item id="2" name="Închide"/>
+
+            <FindCharsInRange title="Căutare caractere în interval...">
+                <Item id="2" name="Închidere"/>
                 <Item id="2901" name="Caractere Non-ASCII (128-255)"/>
                 <Item id="2902" name="Caractere ASCII (0-127)"/>
                 <Item id="2903" name="În intervalul:"/>
                 <Item id="2906" name="&amp;Sus"/>
                 <Item id="2907" name="&amp;Jos"/>
-                <Item id="2908" name="Direcţia"/>
+                <Item id="2908" name="Direcția"/>
                 <Item id="2909" name="Înca&amp;drare"/>
                 <Item id="2910" name="Căutare"/>
             </FindCharsInRange>
@@ -399,7 +404,7 @@
             </GoToLine>
 
             <Run title="Executare...">
-                <Item id="1903" name="Programul de executat"/>
+                <Item id="1903" name="Program de executat"/>
                 <Item id="1"    name="Executare"/>
                 <Item id="2"    name="Anulare"/>
                 <Item id="1904" name="Salvare..."/>
@@ -408,28 +413,28 @@
             <MD5FromFilesDlg title="Generare sumă de control MD5 din fișiere">
                 <Item id="1922" name="Alegere fișiere pentru generare MD5..."/>
                 <Item id="1924" name="Copiere în memorie"/>
-                <Item id="2"    name="Închide"/>
+                <Item id="2"    name="Închidere"/>
             </MD5FromFilesDlg>
 
             <MD5FromTextDlg title="Generate sumă de control MD5">
                 <Item id="1932" name="Consideră fiecare linie ca un șir separat"/>
                 <Item id="1934" name="Copiere în memorie"/>
-                <Item id="2"    name="Închide"/>
+                <Item id="2"    name="Închidere"/>
             </MD5FromTextDlg>
           
             <StyleConfig title="Configurator stil">
                 <Item id="2"    name="Anulare"/>
                 <Item id="2301" name="Salvare &amp;&amp; închidere"/>
-                <Item id="2303" name="Transparenţă"/>       
+                <Item id="2303" name="Transparență"/>       
                 <Item id="2306" name="Selectare temă: "/>
                 <SubDialog>
-                    <Item id="2204" name="Îngroşat"/>
+                    <Item id="2204" name="Îngroșat"/>
                     <Item id="2205" name="Înclinat"/>
                     <Item id="2206" name="Culoare prim-plan"/>
                     <Item id="2207" name="Culoare fundal"/>
                     <Item id="2208" name="Nume font:"/>
                     <Item id="2209" name="Mărime font:"/>
-					<Item id="2211" name="Stil:"/>
+                    <Item id="2211" name="Stil:"/>
                     <Item id="2212" name="Stil culoare"/>
                     <Item id="2213" name="Stil font"/>
                     <Item id="2214" name="Extensie implicită:"/>
@@ -442,14 +447,41 @@
                     <Item id="2227" name="Activare globală culoare fundal"/>
                     <Item id="2228" name="Activare globală font"/>
                     <Item id="2229" name="Activare globală mărime font"/>
-                    <Item id="2230" name="Activare globală stil font îngroşat"/>
+                    <Item id="2230" name="Activare globală stil font îngroșat"/>
                     <Item id="2231" name="Activare globală stil font înclinat"/>
                     <Item id="2232" name="Activare globală stil font subliniere"/>
                 </SubDialog>                
             </StyleConfig>
-        
+            <ShortcutMapper title="Listă combinații taste">
+                <Item id="2602" name="Modificare"/>
+                <Item id="2603" name="Ștergere"/>
+                <Item id="2606" name="Golire"/>
+                <Item id="2607" name="Filtrare: "/>
+                <Item id="1" name="Închidere"/>
+                <ColumnName name="Nume"/>
+                <ColumnShortcut name="Combinație"/>
+                <ColumnCategory name="Categorie"/>
+                <ColumnPlugin name="Extensie"/>
+                <MainMenuTab name="Meniu"/>
+                <MacrosTab name="Macro"/>
+                <RunCommandsTab name="Comenzi lansare"/>
+                <PluginCommandsTab name="Comenzi extensii"/>
+                <ScintillaCommandsTab name="Comenzi Scintilla"/>
+                <ConflictInfoOk name="Nu sunt conflicte pentru acest element."/>
+                <ConflictInfoEditing name="Nu sunt conflicte ..."/>
+            </ShortcutMapper>
+            <ShortcutMapperSubDialg title="Combinație">
+                <Item id="1" name="OK"/>
+                <Item id="2" name="Anulare"/>
+                <Item id="5006" name="Nume"/>
+                <Item id="5008" name="Adăugare"/>
+                <Item id="5009" name="Eliminare"/>
+                <Item id="5010" name="Aplicare"/>
+                <Item id="5007" name="Se va elimina combinația de la această comandă"/>
+                <Item id="5012" name="CONFLICT APĂRUT!"/>
+            </ShortcutMapperSubDialg>        
             <UserDefine title="Definit de utilizator">
-		<Item id="20001" name="Alipire"/>
+                <Item id="20001" name="Alipire"/>
                 <Item id="20002" name="Redenumire"/>
                 <Item id="20003" name="Creare nou..."/>
                 <Item id="20004" name="Eliminare"/>
@@ -457,56 +489,56 @@
                 <Item id="20007" name="Limbaj utilizator: "/>
                 <Item id="20009" name="Ext.:"/>
                 <Item id="20012" name="Ignoră tip litere"/>
-                <Item id="20011" name="Transparenţă"/>
+                <Item id="20011" name="Transparență"/>
                 <Item id="20015" name="Importare..."/>
                 <Item id="20016" name="Export..."/>
-		<StylerDialog title="Dialog stilizare">
-			<Item id="25030" name="Opţiuni font:"/>
-			<Item id="25006" name="Culoare prim-plan"/>
-			<Item id="25007" name="Culoare fundal"/>
-			<Item id="25031" name="Nume:"/>
-			<Item id="25032" name="Mărime:"/>
-			<Item id="25001" name="Îngroşat"/>
-			<Item id="25002" name="Înclinat"/>
-			<Item id="25003" name="Subliniere"/>
-			<Item id="25029" name="Stiluri integrate:"/>
-			<Item id="25008" name="Delimitator 1"/>
-			<Item id="25009" name="Delimitator 2"/>
-			<Item id="25010" name="Delimitator 3"/>
-			<Item id="25011" name="Delimitator 4"/>
-			<Item id="25012" name="Delimitator 5"/>
-			<Item id="25013" name="Delimitator 6"/>
-			<Item id="25014" name="Delimitator 7"/>
-			<Item id="25015" name="Delimitator 8"/>
-			<Item id="25018" name="Cuvânt-cheie 1"/>
-			<Item id="25019" name="Cuvânt-cheie 2"/>
-			<Item id="25020" name="Cuvânt-cheie 3"/>
-			<Item id="25021" name="Cuvânt-cheie 4"/>
-			<Item id="25022" name="Cuvânt-cheie 5"/>
-			<Item id="25023" name="Cuvânt-cheie 6"/>
-			<Item id="25024" name="Cuvânt-cheie 7"/>
-			<Item id="25025" name="Cuvânt-cheie 8"/>
-			<Item id="25016" name="Comentariu"/>
-			<Item id="25017" name="Comentariu linie"/>
-			<Item id="25026" name="Operator 1"/>
-			<Item id="25027" name="Operator 2"/>
-			<Item id="25028" name="Numere"/>
-			<Item id="1" name="OK"/>
-			<Item id="2" name="Anulare"/>
+        <StylerDialog title="Dialog stilizare">
+            <Item id="25030" name="Opțiuni font:"/>
+            <Item id="25006" name="Culoare prim-plan"/>
+            <Item id="25007" name="Culoare fundal"/>
+            <Item id="25031" name="Nume:"/>
+            <Item id="25032" name="Mărime:"/>
+            <Item id="25001" name="Îngroșat"/>
+            <Item id="25002" name="Înclinat"/>
+            <Item id="25003" name="Subliniere"/>
+            <Item id="25029" name="Stiluri integrate:"/>
+            <Item id="25008" name="Delimitator 1"/>
+            <Item id="25009" name="Delimitator 2"/>
+            <Item id="25010" name="Delimitator 3"/>
+            <Item id="25011" name="Delimitator 4"/>
+            <Item id="25012" name="Delimitator 5"/>
+            <Item id="25013" name="Delimitator 6"/>
+            <Item id="25014" name="Delimitator 7"/>
+            <Item id="25015" name="Delimitator 8"/>
+            <Item id="25018" name="Cuvânt-cheie 1"/>
+            <Item id="25019" name="Cuvânt-cheie 2"/>
+            <Item id="25020" name="Cuvânt-cheie 3"/>
+            <Item id="25021" name="Cuvânt-cheie 4"/>
+            <Item id="25022" name="Cuvânt-cheie 5"/>
+            <Item id="25023" name="Cuvânt-cheie 6"/>
+            <Item id="25024" name="Cuvânt-cheie 7"/>
+            <Item id="25025" name="Cuvânt-cheie 8"/>
+            <Item id="25016" name="Comentariu"/>
+            <Item id="25017" name="Comentariu linie"/>
+            <Item id="25026" name="Operator 1"/>
+            <Item id="25027" name="Operator 2"/>
+            <Item id="25028" name="Numere"/>
+            <Item id="1" name="OK"/>
+            <Item id="2" name="Anulare"/>
                 </StylerDialog>
                 <Folder title="Foldere &amp;&amp; Implicite">
                     <Item id="21101" name="Stil implicit"/>
                     <Item id="21102" name="Stilizare"/>
-                    <Item id="21105" name="Documentaţie:"/>
-                    <Item id="21104" name="Documentaţie online:"/>
-                    <Item id="21106" name="Pliere compactă (pliere şi linii goale)"/>
-		    <Item id="21220" name="Stil 1 pliere în cod:"/>
-		    <Item id="21224" name="Deschidere:"/>
+                    <Item id="21105" name="Documentație:"/>
+                    <Item id="21104" name="Documentație online:"/>
+                    <Item id="21106" name="Pliere compactă (pliere și linii goale)"/>
+                    <Item id="21220" name="Stil 1 pliere în cod:"/>
+                    <Item id="21224" name="Deschidere:"/>
                     <Item id="21225" name="Mijloc:"/>
                     <Item id="21226" name="Închidere:"/>
                     <Item id="21227" name="Stilizare"/>
-		    <Item id="21320" name="Stil 2 pliere în cod (separatori necesari):"/>
-		    <Item id="21324" name="Deschidere:"/>
+                    <Item id="21320" name="Stil 2 pliere în cod (separatori necesari):"/>
+                    <Item id="21324" name="Deschidere:"/>
                     <Item id="21325" name="Mijloc:"/>
                     <Item id="21326" name="Închidere:"/>
                     <Item id="21327" name="Stilizare"/>
@@ -533,7 +565,7 @@
                     <Item id="22521" name="Mod prefix"/>
                     <Item id="22571" name="Mod prefix"/>
                     <Item id="22621" name="Mod prefix"/>
-		    <Item id="22122" name="Stilizare"/>
+            <Item id="22122" name="Stilizare"/>
                     <Item id="22222" name="Stilizare"/>
                     <Item id="22322" name="Stilizare"/>
                     <Item id="22422" name="Stilizare"/>
@@ -543,10 +575,10 @@
                     <Item id="22622" name="Stilizare"/>
                 </Keywords>
                 <Comment title="Comentarii &amp;&amp; Numere">
-                    <Item id="23003" name="Poziţie comentariu pe linie"/>
+                    <Item id="23003" name="Poziție comentariu pe linie"/>
                     <Item id="23004" name="Permite oriunde"/>
-                    <Item id="23005" name="Forţare la început de linie"/>
-                    <Item id="23006" name="Permite precedare cu spaţii"/>
+                    <Item id="23005" name="Forțare la început de linie"/>
+                    <Item id="23006" name="Permite precedare cu spații"/>
                     <Item id="23001" name="Permite pliere comentarii"/>
                     <Item id="23326" name="Stilizare"/>
                     <Item id="23323" name="Început"/>
@@ -556,7 +588,7 @@
                     <Item id="23124" name="Stilizare"/>
                     <Item id="23122" name="Început"/>
                     <Item id="23123" name="Sfârșit"/>
-                    <Item id="23101" name="Stil bloc comentariu"/>
+                    <Item id="23101" name="Stil comentariu bloc"/>
                     <Item id="23201" name="Stil numere"/>
                     <Item id="23220" name="Stilizare"/>
                     <Item id="23230" name="Prefix 1"/>
@@ -573,90 +605,90 @@
                 </Comment>
                 <Operator title="Operatori &amp;&amp; Separatori">
                     <Item id="24101" name="Stil operatori"/>
-		    <Item id="24113" name="Stilizare"/>
-		    <Item id="24116" name="Operatori 1"/>
-		    <Item id="24117" name="Operatori 2 (separatori necesari)"/>
-		    <Item id="24201" name="Stil separator 1"/>
-		    <Item id="24220" name="Deschidere:"/>
-		    <Item id="24221" name="Escape:"/>
-		    <Item id="24222" name="Închidere:"/>
-		    <Item id="24223" name="Stilizare"/>
-		    <Item id="24301" name="Stil separator 2"/>
-		    <Item id="24320" name="Deschidere:"/>
-		    <Item id="24321" name="Escape:"/>
-		    <Item id="24322" name="Închidere:"/>
-		    <Item id="24323" name="Stilizare"/>
-		    <Item id="24401" name="Stil separator 3"/>
-		    <Item id="24420" name="Deschidere:"/>
-		    <Item id="24421" name="Escape:"/>
-		    <Item id="24422" name="Închidere:"/>
-		    <Item id="24423" name="Stilizare"/>
-		    <Item id="24451" name="Stil separator 4"/>
-		    <Item id="24470" name="Deschidere:"/>
-		    <Item id="24471" name="Escape:"/>
-		    <Item id="24472" name="Închidere:"/>
-		    <Item id="24473" name="Stilizare"/>
-		    <Item id="24501" name="Stil separator 5"/>
-		    <Item id="24520" name="Deschidere:"/>
-		    <Item id="24521" name="Escape:"/>
-		    <Item id="24522" name="Închidere:"/>
-		    <Item id="24523" name="Stilizare"/>
-		    <Item id="24551" name="Stil separator 6"/>
-		    <Item id="24570" name="Deschidere:"/>
-		    <Item id="24571" name="Escape:"/>
-	            <Item id="24572" name="Închidere:"/>
-		    <Item id="24573" name="Stilizare"/>
-		    <Item id="24601" name="Stil separator 7"/>
-		    <Item id="24620" name="Deschidere:"/>
-		    <Item id="24621" name="Escape:"/>
-		    <Item id="24622" name="Închidere:"/>
-		    <Item id="24623" name="Stilizare"/>
-		    <Item id="24651" name="Stil separator 8"/>
-		    <Item id="24670" name="Deschidere:"/>
-		    <Item id="24671" name="Escape:"/>
-		    <Item id="24672" name="Închidere:"/>
-		    <Item id="24673" name="Stilizare"/>
+            <Item id="24113" name="Stilizare"/>
+            <Item id="24116" name="Operatori 1"/>
+            <Item id="24117" name="Operatori 2 (separatori necesari)"/>
+            <Item id="24201" name="Stil separator 1"/>
+            <Item id="24220" name="Deschidere:"/>
+            <Item id="24221" name="Escape:"/>
+            <Item id="24222" name="Închidere:"/>
+            <Item id="24223" name="Stilizare"/>
+            <Item id="24301" name="Stil separator 2"/>
+            <Item id="24320" name="Deschidere:"/>
+            <Item id="24321" name="Escape:"/>
+            <Item id="24322" name="Închidere:"/>
+            <Item id="24323" name="Stilizare"/>
+            <Item id="24401" name="Stil separator 3"/>
+            <Item id="24420" name="Deschidere:"/>
+            <Item id="24421" name="Escape:"/>
+            <Item id="24422" name="Închidere:"/>
+            <Item id="24423" name="Stilizare"/>
+            <Item id="24451" name="Stil separator 4"/>
+            <Item id="24470" name="Deschidere:"/>
+            <Item id="24471" name="Escape:"/>
+            <Item id="24472" name="Închidere:"/>
+            <Item id="24473" name="Stilizare"/>
+            <Item id="24501" name="Stil separator 5"/>
+            <Item id="24520" name="Deschidere:"/>
+            <Item id="24521" name="Escape:"/>
+            <Item id="24522" name="Închidere:"/>
+            <Item id="24523" name="Stilizare"/>
+            <Item id="24551" name="Stil separator 6"/>
+            <Item id="24570" name="Deschidere:"/>
+            <Item id="24571" name="Escape:"/>
+            <Item id="24572" name="Închidere:"/>
+            <Item id="24573" name="Stilizare"/>
+            <Item id="24601" name="Stil separator 7"/>
+            <Item id="24620" name="Deschidere:"/>
+            <Item id="24621" name="Escape:"/>
+            <Item id="24622" name="Închidere:"/>
+            <Item id="24623" name="Stilizare"/>
+            <Item id="24651" name="Stil separator 8"/>
+            <Item id="24670" name="Deschidere:"/>
+            <Item id="24671" name="Escape:"/>
+            <Item id="24672" name="Închidere:"/>
+            <Item id="24673" name="Stilizare"/>
                 </Operator>
 
             </UserDefine>
-            <Preference title="Preferinţe">
-                <Item id="6001" name="Închide"/>
+            <Preference title="Preferințe">
+                <Item id="6001" name="Închidere"/>
                 <Global title="Generale">
-                    <Item id="6101" name="Bară unelte"/>
-                    <Item id="6102" name="Ascunde"/>
+                    <Item id="6101" name="Bara de unelte"/>
+                    <Item id="6102" name="Ascundere"/>
                     <Item id="6103" name="Pictograme mici"/>
                     <Item id="6104" name="Pictograme mari"/>
                     <Item id="6105" name="Pictograme standard"/>
                    
-                    <Item id="6106" name="Bară file"/>
-                    <Item id="6107" name="Micşorată"/>
-                    <Item id="6108" name="Blocare (fără tragere şi plasare)"/>
+                    <Item id="6106" name="Bara de file"/>
+                    <Item id="6107" name="Micșorată"/>
+                    <Item id="6108" name="Blocare (filele nu se pot muta)"/>
                     <Item id="6109" name="Întunecare file inactive"/>
                     <Item id="6110" name="Desenare linie colorată pe fila activă"/>
                    
-                    <Item id="6111" name="Afişare bară de stare"/>
-                    <Item id="6112" name="Afişare buton închidere pe fiecare filă"/>
+                    <Item id="6111" name="Afișare bară de stare"/>
+                    <Item id="6112" name="Afișare buton închidere pe fiecare filă"/>
                     <Item id="6113" name="Închidere document cu dublu clic"/>
-                    <Item id="6118" name="Ascunde"/>
-                    <Item id="6119" name="Multi-linie"/>
+                    <Item id="6118" name="Ascundere"/>
+                    <Item id="6119" name="Multilinie"/>
                     <Item id="6120" name="Verticală"/>
                     <Item id="6121" name="Ieșire la închiderea ultimei file"/>
                  
-                    <Item id="6122" name="Ascunde bară meniu (comutare cu Alt sau F10)"/>
-                    <Item id="6123" name="Localizare"/>
+                    <Item id="6122" name="Ascundere bară de meniu (comutare cu Alt sau F10)"/>
+                    <Item id="6123" name="Limba"/>
 
-		    <Item id="6125" name="Panou listă documente"/>
-                    <Item id="6126" name="Afişare"/>
+            <Item id="6125" name="Panou listă documente"/>
+                    <Item id="6126" name="Afișare"/>
                     <Item id="6127" name="Dezactivare coloană extensii"/>
                 </Global>
                 <Scintillas title="Editare">
                     <Item id="6216" name="Setări cursor"/>
-                    <Item id="6217" name="Lăţime:"/>
-                    <Item id="6219" name="Rată afişare:"/>
-                    <Item id="6221" name="R"/>
-                    <Item id="6222" name="Î"/>
-                    <Item id="6224" name="Setări multi-editare"/>
-                    <Item id="6225" name="Activare (Ctrl+clic maus/selecţie)"/>
+                    <Item id="6217" name="Lățime:"/>
+                    <Item id="6219" name="Viteză clipire:"/>
+                    <Item id="6221" name="100"/>
+                    <Item id="6222" name="0"/>
+                    <Item id="6224" name="Setări editare multiplă"/>
+                    <Item id="6225" name="Activare (Ctrl+clic maus pe selecție)"/>
                     <Item id="6201" name="Stil margine pliere"/>
                     <Item id="6202" name="Simplă"/>
                     <Item id="6203" name="Săgeată"/>
@@ -669,23 +701,23 @@
                     <Item id="6229" name="Aliniere"/>
                     <Item id="6230" name="Indentare"/>
 
-                    <Item id="6206" name="Afişare numere linii"/>
-                    <Item id="6207" name="Afişare semne de carte"/>
-                    <Item id="6208" name="Afişare margine verticală"/>
+                    <Item id="6206" name="Afișare numere linii"/>
+                    <Item id="6207" name="Afișare semne de carte"/>
+                    <Item id="6208" name="Afișare margine verticală"/>
                     <Item id="6209" name="Număr de coloane: "/>
-                    <Item id="6234" name="Dezactivare funcţie derulare avansată
-(dacă aveţi probleme cu touchpad)"/>
+                    <Item id="6234" name="Dezactivare funcție derulare avansată
+(dacă aveți probleme cu touchpad)"/>
 
                     <Item id="6211" name="Setări margine verticală"/>
                     <Item id="6212" name="Mod linie"/>
                     <Item id="6213" name="Mod în fundal"/>
-                    <Item id="6214" name="Activare evidenţiere linie curentă"/>
+                    <Item id="6214" name="Activare evidențiere linie curentă"/>
                     <Item id="6215" name="Activare font finisat"/>
-		    <Item id="6231" name="Lăţime bordură"/>
+                    <Item id="6231" name="Lățime bordură"/>
                     <Item id="6235" name="Fără bordură" />
                     <Item id="6236" name="Activare derulare dincolo de ultima linie"/>
                 </Scintillas>
-				
+                
                 <NewDoc title="Document nou">
                     <Item id="6401" name="Formatare"/>
                     <Item id="6402" name="Windows"/>
@@ -693,13 +725,13 @@
                     <Item id="6404" name="Mac"/>
                     <Item id="6405" name="Codificare"/>
                     <Item id="6406" name="ANSI"/>
-                    <Item id="6407" name="UTF-8 fără BOM"/>
-                    <Item id="6408" name="UTF-8"/>
+                    <Item id="6407" name="UTF-8"/>
+                    <Item id="6408" name="UTF-8 cu BOM"/>
                     <Item id="6409" name="UCS-2 Big Endian"/>
                     <Item id="6410" name="UCS-2 Little Endian"/>
                     <Item id="6411" name="Limbaj implicit:"/>
                     <Item id="6419" name="Document"/>
-                    <Item id="6420" name="Aplicare la fişiere ANSI deschise"/>
+                    <Item id="6420" name="Aplicare la fișiere ANSI deschise"/>
                 </NewDoc>
 
                 <DefaultDir title="Folder implicit">
@@ -707,10 +739,10 @@
                     <Item id="6414" name="Folder document curent"/>
                     <Item id="6415" name="Memorare ultimul folder folosit"/>
                     <Item id="6430" name="Utilizare stil nou dialog salvare (fără extensii predefinite)" />
-                    <Item id="6431" name="Open all files of folder instead of launching Folder as Workspace on folder dropping"/>
+                    <Item id="6431" name="La plasarea unui folder, se deschid fișierele din el, fără a-l stabili ca spațiu de lucru"/>
                 </DefaultDir>
 
-                <FileAssoc title="Asociere fişiere">
+                <FileAssoc title="Asociere fișiere">
                     <Item id="4009" name="Extensii asociate:"/>
                     <Item id="4010" name="Extensii înregistrate:"/>
                 </FileAssoc>
@@ -719,8 +751,8 @@
                     <Item id="6506" name="Articole dezactivate"/>
                     <Item id="6507" name="Compactare meniu limbaje"/>
                     <Item id="6508" name="Meniu limbaje"/>
-                    <Item id="6301" name="Setări TAB"/>
-                    <Item id="6302" name="Înlocuire cu spaţiu"/>
+                    <Item id="6301" name="Setări Tab"/>
+                    <Item id="6302" name="Înlocuire cu spațiu"/>
                     <Item id="6303" name="Mărime Tab: "/>
                     <Item id="6510" name="Aplicare valoare implicită" />
                 </Language>
@@ -728,85 +760,85 @@
                 <Highlighting title="Evidențiere">
                     <Item id="6333" name="Evidențiere inteligentă"/>
                     <Item id="6326" name="Activare evidențiere inteligentă"/>
-		    <Item id="6332" name="Potrivire litere MARI/mici"/>
-		    <Item id="6338" name="Potrivie cuvânt întreg"/>
-		    <Item id="6339" name="Folosire setări din dialogul Căutare"/>
+                    <Item id="6332" name="Potrivire litere MARI/mici"/>
+                    <Item id="6338" name="Potrivie cuvânt întreg"/>
+                    <Item id="6339" name="Folosire setări din dialogul Căutare"/>
                     <Item id="6340" name="Evidențiere cealaltă afișare"/>
-                    <Item id="6329" name="Evidenţiere marcaje pereche"/>
+                    <Item id="6329" name="Evidențiere etichete pereche"/>
                     <Item id="6327" name="Activare"/>
-                    <Item id="6328" name="Evidențiere atribute marcaje"/>
+                    <Item id="6328" name="Evidențiere atribute etichete"/>
                     <Item id="6330" name="Evidențiere zone comentarii/php/asp"/>
                 </Highlighting>
 
                 <Print title="Tipărire">
                     <Item id="6601" name="Tipărire număr linie"/>
-                    <Item id="6602" name="Opţiuni culoare"/>
+                    <Item id="6602" name="Opțiuni culoare"/>
                     <Item id="6603" name="WYSIWYG"/>
                     <Item id="6604" name="Inversare"/>
-                    <Item id="6605" name="Alb şi negru"/>
+                    <Item id="6605" name="Alb și negru"/>
                     <Item id="6606" name="Fără culoare fundal"/>
                     <Item id="6607" name="Setări margine (Unitate:mm)"/>
                     <Item id="6612" name="Stânga"/>
                     <Item id="6613" name="Sus"/>
                     <Item id="6614" name="Dreapta"/>
                     <Item id="6615" name="Jos"/>
-                    <Item id="6706" name="Îngroşat"/>
+                    <Item id="6706" name="Îngroșat"/>
                     <Item id="6707" name="Înclinat"/>
                     <Item id="6708" name="Antet"/>
                     <Item id="6709" name="Partea stângă"/>
                     <Item id="6710" name="Partea de mijloc"/>
                     <Item id="6711" name="Partea dreaptă"/>
-                    <Item id="6717" name="Îngroşat"/>
-                    <Item id="6718" name="Înclinare"/>
+                    <Item id="6717" name="Îngroșat"/>
+                    <Item id="6718" name="Înclinat"/>
                     <Item id="6719" name="Subsol"/>
                     <Item id="6720" name="Partea stângă"/>
                     <Item id="6721" name="Partea de mijloc"/>
                     <Item id="6722" name="Partea dreaptă"/>
                     <Item id="6723" name="Adăugare"/>
                     <Item id="6725" name="Variabilă:"/>
-		    <Item id="6727" name="Aici se afișează setările variabilelor"/>
-                    <Item id="6728" name="Antet şi subsol"/>
+            <Item id="6727" name="Aici se afișează setările variabilelor"/>
+                    <Item id="6728" name="Antet și subsol"/>
                 </Print>
 
-                <RecentFilesHistory title="Istoric fişiere recente">
-                    <Item id="6304" name="Istoric fişiere recente"/>
+                <RecentFilesHistory title="Istoric fișiere recente">
+                    <Item id="6304" name="Istoric fișiere recente"/>
                     <Item id="6306" name="Număr maxim intrări:"/>
-                    <Item id="6305" name="NU verifica la pornire"/>
-                    <Item id="6429" name="Afişare"/>
+                    <Item id="6305" name="Nu verifica la pornire"/>
+                    <Item id="6429" name="Afișare"/>
                     <Item id="6424" name="În submeniu"/>
-                    <Item id="6425" name="Numai nume fişiere"/>
-                    <Item id="6426" name="Cale completă fişiere"/>
+                    <Item id="6425" name="Numai nume fișiere"/>
+                    <Item id="6426" name="Cale completă fișiere"/>
                     <Item id="6427" name="Lungime maximă personalizată:"/>
                 </RecentFilesHistory>
 
-                <Backup title="Copie de rezervă">
-		    <Item id="6817" name="Captură sesiune şi rezervă periodică"/>
-		    <Item id="6818" name="Activare captură sesiune şi rezervă periodică"/>
-		    <Item id="6819" name="Rezervă la fiecare"/>
-		    <Item id="6821" name="secunde"/>
-		    <Item id="6822" name="Cale rezerve:"/>
-		    <Item id="6309" name="Memorare sesiune curentă pentru următoarea pornire"/>
-                    <Item id="6801" name="Copie de rezervă"/>
-                    <Item id="6315" name="Fără copie"/>
-                    <Item id="6316" name="Copie de rezervă simplă"/>
-                    <Item id="6317" name="Copie de rezervă cu detalii"/>
-                    <Item id="6804" name="Folder personal copii de rezervă"/>
+                <Backup title="Conservări">
+                    <Item id="6817" name="Capturare sesiuni și conservare periodică"/>
+                    <Item id="6818" name="Activare capturare sesiune și conservare periodică"/>
+                    <Item id="6819" name="Conservare la fiecare"/>
+                    <Item id="6821" name="secunde"/>
+                    <Item id="6822" name="Cale conservări:"/>
+                    <Item id="6309" name="Memorare sesiune curentă pentru următoarea pornire"/>
+                    <Item id="6801" name="Conservări"/>
+                    <Item id="6315" name="Fără conservări"/>
+                    <Item id="6316" name="Conservare simplă"/>
+                    <Item id="6317" name="Conservare cu detalii"/>
+                    <Item id="6804" name="Folder personal conservări"/>
                     <Item id="6803" name="Folder:"/>
                 </Backup>
 
                 <AutoCompletion title="Autocompletare">
                     <Item id="6807" name="Autocompletare"/>
-                    <Item id="6808" name="Activare autocompletare introducere"/>
-                    <Item id="6809" name="Completare funcţii"/>
+                    <Item id="6808" name="Activare autocompletare la tastare"/>
+                    <Item id="6809" name="Completare funcții"/>
                     <Item id="6810" name="Completare cuvinte"/>
-		    <Item id="6816" name="Completare funcţii şi cuvinte"/>
+                    <Item id="6816" name="Completare funcții și cuvinte"/>
                     <Item id="6824" name="Ignorare cifre"/>
                     <Item id="6811" name="De la"/>
                     <Item id="6813" name="caracter"/>
                     <Item id="6814" name="Valoare validă: 1 - 9"/>
-                    <Item id="6815" name="Sugestii parametri funcţii la introducere"/>
+                    <Item id="6815" name="Sugestii parametri funcții la tastare"/>
                     <Item id="6851" name="Autoinserare"/>
-                    <Item id="6857" name="marcaje html/xml"/>
+                    <Item id="6857" name="etichete html/xml"/>
                     <Item id="6858" name="Deschis"/>
                     <Item id="6859" name="Închis"/>
                     <Item id="6860" name="Pereche caractere 1:"/>
@@ -814,62 +846,62 @@
                     <Item id="6866" name="Pereche caractere 3:"/>
                 </AutoCompletion>
 
-                <MultiInstance title="Instanţe multiple">
-                    <Item id="6151" name="Setări instanţe multiple"/>
-                    <Item id="6152" name="Deschide sesiune în instanţă nouă Notepad++"/>
-                    <Item id="6153" name="Totdeauna în mod instanţă multiplă"/>
-                    <Item id="6154" name="Implicit (instanţă unică)"/>
-                    <Item id="6155" name="* Modificarea acestor setări solicită restartarea Notepad++"/>
+                <MultiInstance title="Instanțe multiple">
+                    <Item id="6151" name="Setări instanțe multiple"/>
+                    <Item id="6152" name="Deschidere sesiune în instanță nouă Notepad++"/>
+                    <Item id="6153" name="Totdeauna în mod instanță multiplă"/>
+                    <Item id="6154" name="Implicit (instanță unică)"/>
+                    <Item id="6155" name="* Modificarea acestor setări necesită repornirea Notepad++"/>
                 </MultiInstance>
 
                 <Delimiter title="Separatori">
-                    <Item id="6251" name="Setări separatori selecţie (Ctrl + dublu clic maus)"/>
+                    <Item id="6251" name="Setări separatori selecție (Ctrl + dublu clic maus)"/>
                     <Item id="6252" name="Început"/>
-                    <Item id="6255" name="Sfârşit"/>
-                    <Item id="6256" name="Permite pe linii multiple"/>
-		    <Item id="6161" name="Listă caractere"/>
-                    <Item id="6162" name="Folosire listă carcatere implicită așa cum e"/>
+                    <Item id="6255" name="Sfârșit"/>
+                    <Item id="6256" name="Permitere pe linii multiple"/>
+                    <Item id="6161" name="Listă caractere"/>
+                    <Item id="6162" name="Folosire listă caractere implicită așa cum e"/>
                     <Item id="6163" name="Adăugare caractere personale la listă
 (nu alegeți decât dacă știți bine ce înseamnă)"/>
                 </Delimiter>
                  <Cloud title="Cloud">
                     <Item id="6262" name="Setări pentru cloud"/>
                     <Item id="6263" name="Fără Cloud"/>
-                    <Item id="6267" name="Stabiliţi aici calea locaţiei pentru cloud:"/>
+                    <Item id="6267" name="Stabilire cale localizare cloud:"/>
                 </Cloud>
 
-                <SearchEngine title="Motor căutare">
-                    <Item id="6271" name="Motor căutare (pentru comanda &quot;Căutare pe Internet&quot;)"/>
+                <SearchEngine title="Motor de căutare">
+                    <Item id="6271" name="Motor de căutare (pentru comanda &quot;Căutare pe Internet&quot;)"/>
                     <Item id="6272" name="DuckDuckGo"/>
                     <Item id="6273" name="Google"/>
                     <Item id="6274" name="Bing"/>
                     <Item id="6275" name="Yahoo!"/>
-                    <Item id="6276" name="Stabilire motor de căutare aici:"/>
+                    <Item id="6276" name="Stabilire motor de căutare:"/>
                     <!-- Don't change anything after Example: -->
                     <Item id="6278" name="Exemplu: https://www.google.com/search?q=$(CURRENT_WORD)"/>
                 </SearchEngine>
 
                 <MISC title="DIVERSE">
                     <Item id="6307" name="Activare"/>
-                    <Item id="6308" name="Micşorare în zona sistem"/>
-                    <Item id="6312" name="Autodetectare stare fişier"/>
-                    <Item id="6313" name="Actualizare silenţioasă"/>
+                    <Item id="6308" name="Micșorare în zona de sistem"/>
+                    <Item id="6312" name="Autodetectare stare fișier"/>
+                    <Item id="6313" name="Actualizare silențioasă"/>
                     <Item id="6318" name="Setări legături web active"/>
                     <Item id="6325" name="Derulare la ultima linie după actualizare"/>
                     <Item id="6319" name="Activare"/>
                     <Item id="6320" name="Fără subliniere"/>
-                    <Item id="6322" name="Extensie fişier sesiune:"/>
+                    <Item id="6322" name="Extensie fișier sesiune:"/>
                     <Item id="6323" name="Activare autoactualizare Notepad++"/>
-                    <Item id="6324" name="Comutare documente (Ctrl+TAB)"/>
-                    <Item id="6331" name="Afişare numai nume fişier în bara de titlu"/>
-		    <Item id="6334" name="Autodetectare codificare caractere"/>
-		    <Item id="6335" name="Consideră '\' ca şi caracter escape pentru SQL"/>
+                    <Item id="6324" name="Comutare documente (Ctrl+Tab)"/>
+                    <Item id="6331" name="Afișare doar nume fișier în bara de titlu"/>
+                    <Item id="6334" name="Autodetectare codificare caractere"/>
+                    <Item id="6335" name="Consideră '\' ca și caracter escape pentru SQL"/>
                     <Item id="6337" name="Extensie fișier spațiu de lucru:" />
                     <Item id="6114" name="Activare"/>
                     <Item id="6115" name="Autoindentare"/>
                     <Item id="6117" name="În ordinea utilizării"/>             
                     <Item id="6344" name="Previzualizare document"/>
-                    <Item id="6345" name="Previzualizare pe tab"/>
+                    <Item id="6345" name="Previzualizare pe filă"/>
                     <Item id="6346" name="Previzualizare pe hartă document"/>
                 </MISC>
             </Preference>
@@ -879,19 +911,19 @@
                 <Item id="8006" name="Macro:"/>
                 <Item id="8001" name="Executare"/>
                 <Item id="8005" name="ori"/>
-                <Item id="8002" name="Executare până la sfârşitul fişierului"/>
+                <Item id="8002" name="Executare până la sfârșitul fișierului"/>
             </MultiMacro>
             <Window title="Ferestre">
                 <Item id="1" name="Activare"/>
                 <Item id="2" name="OK"/>
                 <Item id="7002" name="Salvare"/>
-                <Item id="7003" name="Închide selectate"/>
+                <Item id="7003" name="Închidere selectate"/>
                 <Item id="7004" name="Sortare ferestre"/>
             </Window>
             <ColumnEditor title="Editor coloane">
                 <Item id="2023" name="Text de inserat"/>
                 <Item id="2033" name="Număr de inserat"/>
-                <Item id="2030" name="Număr iniţial:"/>
+                <Item id="2030" name="Număr inițial:"/>
                 <Item id="2031" name="Incrementare cu:"/>
                 <Item id="2035" name="Precede zerouri"/>
                 <Item id="2036" name="Repetare :"/>
@@ -904,69 +936,147 @@
                 <Item id="2" name="Anulare"/>
             </ColumnEditor>
         </Dialog>
-        <MessageBox>
-            <ContextMenuXmlEditWarning title="Editare meniu contextual" message="Editarea fişierului contextMenu.xml vă permite să modificaţi meniul contextual al Notepad++.
-Trebuie să reporniţi Notepad++ pentru a se aplica modificările efectuate în contextMenu.xml."/>
-            <NppHelpAbsentWarning title="Fişierul nu există" message=" nu există. Vă rugăm să-l descărcaţi de pe site-ul Notepad++."/>
-            <SaveCurrentModifWarning title="Salvare modificare curentă" message="Ar trebui să salvaţi modificările curente. Toate modificările salvate nu vor putea fi refăcute. Continuaţi?"/>
-            <LoseUndoAbilityWarning title="Atenţionare pierdere abilitate revenire" message="Ar trebui să salvaţi modificările curente. Toate modificările salvate nu vor putea fi refăcute. Continuaţi?"/>
-            <CannotMoveDoc title="Mutare în instanţă nouă Notepad++" message="Documentul este modificat, salvaţi-l şi încercaţi din nou."/>
-            <DocReloadWarning title="Reîncărcare" message="Sunteţi sigur că doriţi să reîncărcaţi fişierul curent şi să pierdeţi modificările efectuate în Notepad++?"/>
-            <FileLockedWarning title="Salvare eşuată" message="Verificaţi dacă acest fişier nu este accesat şi de un alt program"/>
-            <FileAlreadyOpenedInNpp title="" message="Fişierul este deja deschis în Notepad++."/>
-            <DeleteFileFailed title="Ştergere fişier" message="Ştergere fişier eşuată"/>
-            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <NbFileToOpenImportantWarning title="Numărul fişierelor de deschis este prea mare" message="$INT_REPLACE$ fişiere sunt pe cale să fie deschise. Sunteţi sigur că doriţi să le deschideţi?"/>
-	    <SettingsOnCloudError title="Setări pentru Cloud" message="Calea setărilor pentru Cloud este stabilită pe o unitate doar cu drepturi de citire sau un folder are nevoie de drepturi de acces pentru scriere. Setările pentru cloud vor fi anulate. Reintroduceţi o cale validă în panoul Preferinţe."/>
-	    <FilePathNotFoundWarning title="Deschide fișier" message="Fișierul pe care doriți să-l deschideți nu există."/>
-	    <SessionFileInvalidError title="Nu s-a putut încărca sesiunea" message="Sesiunea fișierului este fie coruptă fie invalidă."/>
+        <MessageBox> <!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <ContextMenuXmlEditWarning title="Editare meniu contextual" message="Editarea fișierului contextMenu.xml vă permite să modificați meniul contextual al Notepad++.
+Trebuie să reporniți Notepad++ pentru a se aplica modificările efectuate în contextMenu.xml."/>
+            <NppHelpAbsentWarning title="Fișierul nu există" message="
+nu există. Vă rugăm să-l descărcați de pe site-ul Notepad++."/>
+            <SaveCurrentModifWarning title="Salvare modificare curentă" message="Ar trebui să salvați modificările curente.
+Toate modificările salvate nu vor putea fi refăcute.
+Continuați?"/>
+            <LoseUndoAbilityWarning title="Atenționare pierdere posibilitate revenire" message="Ar trebui să salvați modificările curente.
+Toate modificările salvate nu vor putea fi refăcute.
+Continuați?"/>
+            <CannotMoveDoc title="Mutare în instanță nouă Notepad++" message="Documentul este modificat, salvați-l și încercați din nou."/>
+            <DocReloadWarning title="Reîncărcare" message="Sigur doriți să reîncărcați fișierul curent și să pierdeți modificările efectuate în Notepad++?"/>
+            <FileLockedWarning title="Salvare eșuată" message="Verificați dacă acest fișier nu este accesat și de un alt program."/>
+            <FileAlreadyOpenedInNpp title="" message="Fișierul este deja deschis în Notepad++."/>
+            <DeleteFileFailed title="Ștergere fișier" message="Ștergere fișier eșuată."/>
+
+            <NbFileToOpenImportantWarning title="Numărul fișierelor de deschis este prea mare" message="$INT_REPLACE$ fișiere sunt pe cale să fie deschise.
+Sigur doriți să le deschideți?"/>
+            <SettingsOnCloudError title="Setări pentru Cloud" message="Calea setărilor pentru Cloud se află pe o unitate doar cu drepturi de citire
+sau într-un folder ce are nevoie de drepturi de acces pentru scriere.
+Setările pentru cloud vor fi anulate. Reintroduceți o cale validă în panoul [Preferințe]."/>
+             <FilePathNotFoundWarning title="Deschidere fișier" message="Fișierul pe care doriți să-l deschideți nu există."/>
+             <SessionFileInvalidError title="Nu s-a putut încărca sesiunea" message="Sesiunea fișierului este fie coruptă, fie nevalidă."/>
+            <DroppingFolderAsProjetModeWarning title="Invalid action" message="Puteți plasa doar fișiere sau doar foldere, dar nu ambele deodată, deoarece sunteți în modul folder ca proiect.
+Pentru a putea efectua această operație, trebuie să activați opțiunea &quot;La plasarea unui folder, se deschid fișierele din el, fără a-l stabili ca spațiu de lucru&quot; din secțiunea &quot;Folder implicit&quot; din panoul [Preferințe]."/>
+            <SortingError title="Eroare sortare" message="Nu se poate executa sortarea numerică datorită liniei $INT_REPLACE$."/>
+            <ColumnModeTip title="Pont mod coloană" message="Folosiți &quot;ALT+selectare cu maus&quot; sau &quot;Alt+Shift+săgeată&quot; pentru comutare în mod coloană."/>
+            <BufferInvalidWarning title="Salvare eșuată" message="Nu se poate salva: Bufferul nu este valid."/>
+            <DoSaveOrNot title="Salvare" message="Salvați fișierul &quot;$STR_REPLACE$&quot; ?"/>
+            <DoCloseOrNot title="Păstrare fișiere inexistente" message="Fișierul &quot;$STR_REPLACE$&quot; nu mai există.
+Îl păstrați în editor?"/>
+            <DoDeleteOrNot title="Ștergere fișier" message="Fișierul &quot;$STR_REPLACE$&quot;
+va fi mutat în coșul de reciclare și acest document va fi închis.
+Continuați?"/>
+            <NoBackupDoSaveFile title="Salvare" message="Fișierul de rezervă nu poate fi găsit (a fost șters cu alt program).
+Salvați-l sau veți pierde datele.
+Doriți să salvați fișierul &quot;$STR_REPLACE$&quot;?"/>
+            <DoReloadOrNot title="Reîncărcare" message="&quot;$STR_REPLACE$&quot;
+Acest fișier a fost modificat de un alt program.
+Doriți să-l reîncărcați?"/>
+            <DoReloadOrNotAndLooseChange title="Reîncărcare" message="&quot;$STR_REPLACE$&quot;
+Acest fișier a fost modificat de un alt program.
+Doriți să-l reîncărcați și să anulați modificările efectuate în Notepad++?"/>
+            <PrehistoricSystemDetected title="S-a detectat un sistem preistoric" message="Se pare că încă folosiți un sistem foarte vechi. Această funcție se poate executa doar pe un sistem modern."/>
+            <XpUpdaterProblem title="Actualizator Notepad++" message="Actualizatorul Notepad++ nu este compatibil cu Windows XP datorită nivelelor de securitate depășite ale acestuia.
+Doriți să vizitați pagina de descărcare a Notepad++ pentru a descărca ultima versiune?"/>
+            <DocTooDirtyToMonitor title="Problemă monitorizare" message="Documentul este necorespunzător. Salvați modificările înainte de a-l monitoriza."/>
+            <DocNoExistToMonitor title="Problemă monitorizare" message="Pentru a putea fi monitorizat fișierul trebuie să existe."/>
+            <FileTooBigToOpene title="Problemă dimensiune fișier" message="Fișierul este prea mare pentru a fi deschis cu Notepad++"/>
+            <CreateNewFileOrNot title="Creare fișier nou" message="Fișierul &quot;$INT_REPLACE$&quot; nu există. Îl creați?."/>
+            <CreateNewFileError title="Creare fișier nou" message="Nu se poate crea fișierul &quot;$INT_REPLACE$&quot;."/>
+            <OpenFileError title="EROARE" message="Nu se poate deschide fișierul &quot;$INT_REPLACE$&quot;."/>
+            <FileBackupFailed title="Eșuare conservare fișier" message="Versiunea anterioară a fișierului nu a putut fi salvată în folderul de conservări aflat în &quot;$INT_REPLACE$&quot;.
+Doriți totuși să salvați fișierul curent?"/>
+            <LoadStylersFailed title="Eșuare încărcare stylers.xml" message="Încărcare eșuată &quot;$INT_REPLACE$&quot;!"/>
+            <LoadLangsFailed title="Configurator" message="Eșuare încărcare langs.xml!
+Doriți să recuperați fișierul langs.xml?"/>
+            <LoadLangsFailedFinal title="Configurator" message="Eșuare încărcare langs.xml!"/>
+            <FolderAsWorspaceSubfolderExists title="Problemă adăugare folder ca spațiu de lucru" message="Există un subfolder al folderului pe care doriți să-l adăugați.
+Eliminați rădăcina acestuia din panou înainte de a adăuga folderul &quot;$STR_REPLACE$&quot;."/>
+
+            <ProjectPanelChanged title="$STR_REPLACE$" message="Spațiul de lucru a fost modificat. Doriți să-l salvați?"/>
+            <ProjectPanelChangedSaveError title="$STR_REPLACE$" message="Spațiul de lucru nu a fost salvat."/>
+            <ProjectPanelOpenDoSaveDirtyWsOrNot title="Deschidere spațiu de lucru" message="Spațiul de lucru curent a fost modificat. Doriți să salvați proiectul curent?"/>
+            <ProjectPanelNewDoSaveDirtyWsOrNot title="Spațiu de lucru nou" message="Spațiul de lucru curent a fost modificat. Doriți să salvați proiectul curent?"/>
+            <ProjectPanelOpenFailed title="Deschidere spațiu de lucru" message="Spațiul de lucru nu a putut fi deschis.
+Se pare că fișierul ce trebuie dschis nu este un fișier de proiect valid."/>
+            <ProjectPanelRemoveFolderFromProject title="Eliminare folder din proiect" message="Toate subelementele acestuia vor fi eliminate.
+Sigur doriți să eliminați acest folder din proiect?"/>
+            <ProjectPanelRemoveFileFromProject title="Eliminare fișier din proiect" message="Sigur doriți să eliminați acest fișier din proiect?"/>
+            <ProjectPanelReloadError title="Reîncărcare spațiu de lucru" message="Nu se poate găsi fișierul ce trebuie reîncărcat."/>
+            <ProjectPanelReloadDirty title="Reîncărcare spațiu de lucru" message="Spațiul de lucru a fost modificat. Reîncărcarea va ignora toate modificările efectuate.
+Doriți să continuați?"/>
+            <UDLNewNameError title="Eroare UDL" message="Acest nume este utilizat de alt limbaj,
+alegeți altul."/>
+            <UDLRemoveCurrentLang title="Eliminare limbaj curent" message="Sunteți sigur?"/>
+            <SCMapperDoDeleteOrNot title="Sunteți sigur?" message="Sigur doriți să eliminați această combinație de taste?"/>
+            <FindCharRangeValueError title="Problemă valoare interval" message="Ar trebui să introduceți o valoare între 0 și 255."/>
         </MessageBox>
         <ClipboardHistory>
-			<PanelTitle name="Istoric Clipboard"/>
+            <PanelTitle name="Istoric Clipboard"/>
         </ClipboardHistory>
         <DocSwitcher>
-			<PanelTitle name="Comutare doc"/>
-			<ColumnName name="Nume"/>
-			<ColumnExt name="Ext."/>
+            <PanelTitle name="Comutare document"/>
+            <ColumnName name="Nume"/>
+            <ColumnExt name="Ext."/>
         </DocSwitcher>
         <AsciiInsertion>
-			<PanelTitle name="Panou inserare ASCII"/>
-			<ColumnVal name="Valoare"/>
-			<ColumnHex name="Hex"/>
-			<ColumnChar name="Caracter"/>
+            <PanelTitle name="Panou inserare ASCII"/>
+            <ColumnVal name="Valoare"/>
+            <ColumnHex name="Hex"/>
+            <ColumnChar name="Caracter"/>
         </AsciiInsertion>
         <DocumentMap>
-			<PanelTitle name="Hartă document"/>
+            <PanelTitle name="Hartă document"/>
         </DocumentMap>
         <FunctionList>
-			<PanelTitle name="Listă funcţii"/>
-			<SortTip name="Sortare" />
-			<ReloadTip name="Reactualizare" />
+            <PanelTitle name="Listă funcții"/>
+            <SortTip name="Sortare" />
+            <ReloadTip name="Reactualizare" />
         </FunctionList>
+        <FolderAsWorkspace>
+            <PanelTitle name="Folder ca spațiu de lucru"/>
+            <SelectFolderFromBrowserString name="Selectare folder adăugat în panoul [Folder ca spațiu de lucru]"/>
+            <Menus>
+                <Item id="3511" name="Eliminare"/>
+                <Item id="3512" name="Eliminare toate"/>
+                <Item id="3513" name="Adăugare"/>
+                <Item id="3514" name="Executat de sistem"/>
+                <Item id="3515" name="Deschidere"/>
+                <Item id="3516" name="Copiere cale"/>
+                <Item id="3517" name="Căutare în fișiere..."/>
+                <Item id="3518" name="Explorer aici"/>
+                <Item id="3519" name="CMD aici"/>
+            </Menus>
+        </FolderAsWorkspace>
         <ProjectManager>
             <PanelTitle name="Proiect"/>
-            <WorkspaceRootName name="Spaţiu de lucru"/>
+            <WorkspaceRootName name="Spațiu de lucru"/>
             <NewProjectName name="Nume proiect"/>
             <NewFolderName name="Nume folder"/>
             <Menus>
                 <Entries>
-                    <Item id="0" name="Spaţiu de lucru"/>
+                    <Item id="0" name="Spațiu de lucru"/>
                     <Item id="1" name="Editare"/>
                 </Entries>
                 <WorkspaceMenu>
-                    <Item id="3122" name="Spaţiu de lucru nou"/>
-                    <Item id="3123" name="Deschide spaţiu de lucru"/>
-                    <Item id="3124" name="Reîncărcate spaţiu de lucru"/>
+                    <Item id="3122" name="Spațiu de lucru nou"/>
+                    <Item id="3123" name="Deschidere spațiu de lucru"/>
+                    <Item id="3124" name="Reîncărcate spațiu de lucru"/>
                     <Item id="3125" name="Salvare"/>
                     <Item id="3126" name="Salvare ca..."/>
-                    <Item id="3127" name="Salvare o copie ca..."/>
+                    <Item id="3127" name="Salvare copie ca..."/>
                     <Item id="3121" name="Adăugare proiect nou"/>
                 </WorkspaceMenu>
                 <ProjectMenu>
                     <Item id="3111" name="Redenumire"/>
                     <Item id="3112" name="Adăugare folder"/>
-                    <Item id="3113" name="Adăugare fişiere..."/>
-                    <Item id="3117" name="Adăugare fişiere din folder..."/>
+                    <Item id="3113" name="Adăugare fișiere..."/>
+                    <Item id="3117" name="Adăugare fișiere din folder..."/>
                     <Item id="3114" name="Eliminare"/>
                     <Item id="3118" name="Urcare"/>
                     <Item id="3119" name="Coborâre"/>
@@ -974,8 +1084,8 @@ Trebuie să reporniţi Notepad++ pentru a se aplica modificările efectuate în 
                 <FolderMenu>
                     <Item id="3111" name="Redenumire"/>
                     <Item id="3112" name="Adăugare folder"/>
-                    <Item id="3113" name="Adăugare fişiere..."/>
-                    <Item id="3117" name="Adăugare fişiere din folder..."/>
+                    <Item id="3113" name="Adăugare fișiere..."/>
+                    <Item id="3117" name="Adăugare fișiere din folder..."/>
                     <Item id="3114" name="Eliminare"/>
                     <Item id="3118" name="Urcare"/>
                     <Item id="3119" name="Coborâre"/>
@@ -983,23 +1093,51 @@ Trebuie să reporniţi Notepad++ pentru a se aplica modificările efectuate în 
                 <FileMenu>
                     <Item id="3111" name="Redenumire"/>
                     <Item id="3115" name="Eliminare"/>
-                    <Item id="3116" name="Modificare cale fişier"/>
+                    <Item id="3116" name="Modificare cale fișier"/>
                     <Item id="3118" name="Urcare"/>
                     <Item id="3119" name="Coborâre"/>
                 </FileMenu>
             </Menus>
         </ProjectManager>
         <MiscStrings>
-	    <word-chars-list-tip value="Se permite includerea de caractere adiționale în lista curentă de caractere când se dă dublu-clic pe o selectare la căutarea cu opțiunea &quot;Potrivire doar cuvinte&quot; activată."/>
+        <word-chars-list-tip value="Se permite includerea de caractere adiționale în lista curentă de caractere când se dă dublu clic pe o selectare la căutarea cu opțiunea &quot;Potrivire doar cuvinte&quot; activată."/>
             <word-chars-list-warning-begin value="Atenție: "/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
             <word-chars-list-space-warning value="$INT_REPLACE$ spațiu(i)"/>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <word-chars-list-tab-warning value="$INT_REPLACE$ TAB(-uri)"/>
-	    <word-chars-list-warning-end value="  în lista de caractere."/>
-	    <cloud-invalid-warning value="Cale nevalidă."/>
-	    <cloud-restart-warning value="Reporniți Notepad++ pentru aplicare modificări."/>
-	    <shift-change-direction-tip value="Folosiți Shift + Enter pentru a căuta în direcția opusă"/>
+            <!-- $INT_REPLACE$ is a place holder, don't translate it -->
+            <word-chars-list-tab-warning value="$INT_REPLACE$ Tab(-uri)"/>
+        <word-chars-list-warning-end value="  în lista de caractere."/>
+        <cloud-invalid-warning value="Cale nevalidă."/>
+        <cloud-restart-warning value="Reporniți Notepad++ pentru aplicare modificări."/>
+        <cloud-select-folder value="Selectare folder din/în care Notepad++ citește/scrie setările sale"/>
+        <shift-change-direction-tip value="Folosiți Shift+Enter pentru a căuta în direcția opusă"/>
+        <two-find-buttons-tip value="Mod căutare cu 2 butoane"/>
+        <find-status-top-reached value="Căutare: S-a găsit prima potrivire de jos.S-a ajuns la începutul documentului."/>
+            <find-status-end-reached value="Căutare: S-a găsit prima potrivire de sus. S-a ajuns la sfârșitul documentului."/>
+            <find-status-replaceinfiles-1-replaced value="Înlocuire în fișiere: a fost înlocuită o potrivire"/>
+            <find-status-replaceinfiles-nb-replaced value="Înlocuire în fișiere: s-au înlocuit $INT_REPLACE$ potriviri."/>
+            <find-status-replaceinfiles-re-malformed value="Înlocuire în fișierele deschise: expresia regulată este eronată."/>
+            <find-status-replaceinopenedfiles-1-replaced value="Înlocuire în fișierele deschise: a fost înlocuită o potrivire"/>
+            <find-status-replaceinopenedfiles-nb-replaced value="Înlocuire în fișierele deschise: s-au înlocuit $INT_REPLACE$ potriviri."/>
+            <find-status-mark-re-malformed value="Marcare: expresia regulată de căutare este eronată."/>
+            <find-status-invalid-re value="Căutare: expresie regulată nevalidă."/>
+            <find-status-mark-1-match value="O potrivire"/>
+            <find-status-mark-nb-matches value="$INT_REPLACE$ potriviri"/>
+            <find-status-count-re-malformed value="Contorizare: expresia regulată de căutare este eronată."/>
+            <find-status-count-1-match value="Contorizare: o potrivire."/>
+            <find-status-count-nb-matches value="Contorizare: $INT_REPLACE$ potriviri."/>
+            <find-status-replaceall-re-malformed value="Înlocuire toate: expresia regulată este eronată."/>
+            <find-status-replaceall-1-replaced value="Înlocuire toate: a fost înlocuită o potrivire."/>
+            <find-status-replaceall-nb-replaced value="Înlocuire toate: s-au înlocuit $INT_REPLACE$ potriviri."/>
+            <find-status-replaceall-readonly value="Înlocuire toate: textul nu poate fi înlocuit. Documentul curent are blocată salvarea modificărilor."/>
+            <find-status-replace-end-reached value="Înlocuire: s-a înlocuit prima potrivire de sus. S-a atins sfârșitul documentului."/>
+            <find-status-replace-top-reached value="Înlocuire: s-a înlocuit prima potrivire de jos. S-a atins începutul documentului."/>
+            <find-status-relaced-next-found value="Înlocuire: s-a înlocuit o potrivire. S-a mai găsit o potrivire."/>
+            <find-status-relaced-next-not-found value="Înlocuire: s-a înlocuit o potrivire. Nu s-au mai găsit potriviri."/>
+            <find-status-replace-not-found value="Înlocuire: nu s-au găsit potriviri"/>
+            <find-status-replace-readonly value="Înlocuire: textul nu poate fi înlocuit. Documentul curent are blocată salvarea modificărilor."/>
+            <find-status-cannot-find value="Căutare: nu se poate găsi textul &quot;$STR_REPLACE$&quot;."/>
+            <find-status-mark-nb-matches value="$INT_REPLACE$ potriviri"/>
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>


### PR DESCRIPTION
I found some typos and bugs.
1. Typos that should be corrected in english.xml ver. 7.5.5
On line: 962 you => You
            966 remove space before '?'
            983 system, => system. (replace comma with dot after the system)

2. If in Preferences - Recent Files History - Display is activated the option [In submenu], there is no string to stranslate [Recent files] from [File] menu that will appear after that.

3. In Preferences - Print - [Header and Footer] the variable names from the combobox for Variable can't be translated.
Bug in 7.5.4
If you are activating the option [Synchronise Vertical Scrolling] and/or [Synchronise Horizontal Scrolling] from View menu and change the localization language from Preference - General, the options are still active but not marked anymore in View menu.
Greetings