### PR TITLE
File status detection under Windows XP, 32-bit only

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -62,7 +62,11 @@ const bool dirDown = false;
 #define generic_sscanf swscanf
 #define generic_fopen _wfopen
 #define generic_fgets fgetws
-#define generic_stat _wstat
+#ifdef _WIN64
+  #define generic_stat _wstat
+#else
+  #define generic_stat winapi_wstat
+#endif
 #define COPYDATA_FILENAMES COPYDATA_FILENAMESW
 
 typedef std::basic_string<TCHAR> generic_string;
@@ -192,3 +196,7 @@ HWND CreateToolTip(int toolID, HWND hDlg, HINSTANCE hInst, const PTSTR pszText);
 
 bool isCertificateValidated(const generic_string & fullFilePath, const generic_string & subjectName2check);
 bool isAssoCommandExisting(LPCTSTR FullPathName);
+
+#ifndef _WIN64
+int winapi_wstat(wchar_t const* _FileName, struct _stat* _Stat);
+#endif


### PR DESCRIPTION
File status detection under Windows XP, 32-bit only: the 