### PR TITLE
Fixed a piece of code

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -77,12 +77,12 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 			case WAIT_OBJECT_0 + 1:
 				// We've received a notification in the queue.
 			{
-				DWORD dwAction;
-				CStringW wstrFilename;
 				if (changes.CheckOverflow())
 					printStr(L"Queue overflowed.");
 				else
 				{
+					DWORD dwAction;
+					CStringW wstrFilename;
 					changes.Pop(dwAction, wstrFilename);
 					generic_string fn = wstrFilename.GetString();
 

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.cpp
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.cpp
@@ -149,7 +149,7 @@ void CReadChangesRequest::ProcessNotification()
 
 		CStringW wstrFilename(fni.FileName, fni.FileNameLength/sizeof(wchar_t));
 		// Handle a trailing backslash, such as for a root directory.
-		if (wstrFilename.Right(1) != L"\\")
+		if (m_wstrDirectory.Right(1) != L"\\")
 			wstrFilename = m_wstrDirectory + L"\\" + wstrFilename;
 		else
 			wstrFilename = m_wstrDirectory + wstrFilename;


### PR DESCRIPTION
**NppIO.cpp:**
Reduce the scope of local variable.


**ReadDirectoryChangesPrivate.cpp:** 
This seems to be a typo. Just think what if ```wstrFilename``` contains trailing backslash then what this statement ```wstrFilename = m_wstrDirectory + wstrFilename``` will do. 
But actual issue comes when ```m_wstrDirectory``` does not contains trailing backslash while ```wstrFilename``` contains.  
P.S. The probability of containing trailing backslash in ```wstrFilename``` is almost 0, that is the reason the piece of code is working fine so far.