### PR TITLE
Regexp backreference \0 not properly handled

### DIFF
--- a/scintilla/boostregex/BoostRegExSearch.cxx
+++ b/scintilla/boostregex/BoostRegExSearch.cxx
@@ -445,7 +445,7 @@ const char *BoostRegexSearch::SubstituteByPosition(Document* doc, const char *te
 
 template <class CharT, class CharacterIterator>
 char *BoostRegexSearch::EncodingDependent<CharT, CharacterIterator>::SubstituteByPosition(const char *text, int *length) {
-	char *substituted = stringToCharPtr(_match.format((const CharT*)CharTPtr(text), boost::format_all));
+	char *substituted = stringToCharPtr(_match.format((const CharT*)CharTPtr(text), boost::format_sed | boost::format_all));
 	*length = static_cast<int>(strlen(substituted));
 	return substituted;
 }


### PR DESCRIPTION
Steps to reproduce:
1. Document: ``aa``
2. Press Ctrl+H to popup Replace dialog. Setup next settings:
Find what: ``a``
Replace with: ``\0_``
Search Mode: Regular expression
3. Press "Replace All"

Actual result: ``<empty document>``
Expected result: ``a_a_``

[Scintilla's documentation](http://www.scintilla.org/ScintillaDoc.html#SCI_REPLACETARGETRE) stated:
> SCI_REPLACETARGETRE(int length, const char *text) → int
This replaces the target using regular expressions. If length is -1, text is a zero terminated string, otherwise length is the number of characters to use. The replacement string is formed from the text string with any sequences of \1 through \9 replaced by tagged matches from the most recent regular expression search. \0 is replaced with all the matched text from the most recent search. After replacement, the target range refers to the replacement text. The return value is the length of the replacement string.

[format_sed description](http://www.boost.org/doc/libs/1_55_0/libs/regex/doc/html/boost_regex/ref/match_flag_type.html):
> 
format_sed | Specifies that when a regular expression match is to be replaced by a new string, that the new string is constructed using the rules used by the Unix sed utility in IEEE Std 1003.1-2001, Portable Operating SystemInterface (POSIX ), Shells and Utilities.
-- | --




This fix came from [Notepad2e](https://github.com/ProgerXP/Notepad2e) project which uses adopted boost regex implementation for Scintilla which came from Notepad++. The flag required for processing \0 backreference was missing in the original regex implementation. The bug was described in this [issue](https://github.com/ProgerXP/Notepad2e/issues/145#issuecomment-370162056).