### PR TITLE
Get rid of ATL dependency

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -82,9 +82,9 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 				else
 				{
 					DWORD dwAction;
-					CStringW wstrFilename;
+					std::wstring wstrFilename;
 					changes.Pop(dwAction, wstrFilename);
-					generic_string fn = wstrFilename.GetString();
+					generic_string fn = wstrFilename;
 
 					// Fix monitoring files which are under root problem
 					size_t pos = fn.find(TEXT("\\\\"));

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1336,7 +1336,7 @@ DWORD WINAPI FolderUpdater::watching(void *params)
 			// We've received a notification in the queue.
 			{
 				DWORD dwAction;
-				CStringW wstrFilename;
+				std::wstring wstrFilename;
 				if (changes.CheckOverflow())
 					printStr(L"Queue overflowed.");
 				else
@@ -1349,14 +1349,14 @@ DWORD WINAPI FolderUpdater::watching(void *params)
 					switch (dwAction)
 					{
 						case FILE_ACTION_ADDED:
-							file2Change.push_back(wstrFilename.GetString());
+							file2Change.push_back(wstrFilename);
 							//thisFolderUpdater->updateTree(dwAction, file2Change);
 							::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_ADDFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&file2Change));
 							oldName = TEXT("");
 							break;
 
 						case FILE_ACTION_REMOVED:
-							file2Change.push_back(wstrFilename.GetString());
+							file2Change.push_back(wstrFilename);
 							//thisFolderUpdater->updateTree(dwAction, file2Change);
 							::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_RMFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&file2Change));
 							oldName = TEXT("");
@@ -1367,14 +1367,14 @@ DWORD WINAPI FolderUpdater::watching(void *params)
 							break;
 
 						case FILE_ACTION_RENAMED_OLD_NAME:
-							oldName = wstrFilename.GetString();
+							oldName = wstrFilename;
 							break;
 
 						case FILE_ACTION_RENAMED_NEW_NAME:
 							if (not oldName.empty())
 							{
 								file2Change.push_back(oldName);
-								file2Change.push_back(wstrFilename.GetString());
+								file2Change.push_back(wstrFilename);
 								//thisFolderUpdater->updateTree(dwAction, file2Change);
 								::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_RNFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&file2Change));
 							}

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.cpp
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.cpp
@@ -29,6 +29,8 @@
 #include "ReadDirectoryChanges.h"
 #include "ReadDirectoryChangesPrivate.h"
 
+#include <process.h> // _beginthreadex
+
 using namespace ReadDirectoryChangesPrivate;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -85,13 +87,13 @@ void CReadDirectoryChanges::AddDirectory( LPCTSTR szDirectory, BOOL bWatchSubtre
 	QueueUserAPC(CReadChangesServer::AddDirectoryProc, m_hThread, (ULONG_PTR)pRequest);
 }
 
-void CReadDirectoryChanges::Push(DWORD dwAction, CStringW& wstrFilename)
+void CReadDirectoryChanges::Push(DWORD dwAction, std::wstring& wstrFilename)
 {
 	TDirectoryChangeNotification dirChangeNotif = TDirectoryChangeNotification(dwAction, wstrFilename);
 	m_Notifications.push(dirChangeNotif);
 }
 
-bool  CReadDirectoryChanges::Pop(DWORD& dwAction, CStringW& wstrFilename)
+bool  CReadDirectoryChanges::Pop(DWORD& dwAction, std::wstring& wstrFilename)
 {
 	TDirectoryChangeNotification pair;
 	if (!m_Notifications.pop(pair))

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
@@ -41,19 +41,15 @@
 
 #include <windows.h>
 
-#define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS      // some CString constructors will be explicit
-
-#include <atlbase.h>
-#include <atlstr.h>
-
 #include <vector>
 #include <list>
+#include <string>
 
 using namespace std;
 
 #include "ThreadSafeQueue.h"
 
-typedef pair<DWORD,CStringW> TDirectoryChangeNotification;
+typedef pair<DWORD, wstring> TDirectoryChangeNotification;
 
 namespace ReadDirectoryChangesPrivate
 {
@@ -98,7 +94,7 @@ namespace ReadDirectoryChangesPrivate
 ///				// We've received a notification in the queue.
 ///				{
 ///					DWORD dwAction;
-///					CStringW wstrFilename;
+///					std::wstring wstrFilename;
 ///					changes.Pop(dwAction, wstrFilename);
 ///					wprintf(L"%s %s\n", ExplainAction(dwAction), wstrFilename);
 ///				}
@@ -143,10 +139,10 @@ public:
 	/// </summary>
 	HANDLE GetWaitHandle() { return m_Notifications.GetWaitHandle(); }
 
-	bool Pop(DWORD& dwAction, CStringW& wstrFilename);
+	bool Pop(DWORD& dwAction, wstring& wstrFilename);
 
 	// "Push" is for usage by ReadChangesRequest.  Not intended for external usage.
-	void Push(DWORD dwAction, CStringW& wstrFilename);
+	void Push(DWORD dwAction, wstring& wstrFilename);
 
 	// Check if the queue overflowed. If so, clear it and return true.
 	bool CheckOverflow();

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
@@ -77,7 +77,7 @@ protected:
 	// Parameters from the caller for ReadDirectoryChangesW().
 	DWORD		m_dwFilterFlags;
 	BOOL		m_bIncludeChildren;
-	CStringW	m_wstrDirectory;
+	wstring		m_wstrDirectory;
 
 	// Result of calling CreateFile().
 	HANDLE		m_hDirectory;


### PR DESCRIPTION
The ATL dependency is quite annoying when working in Visual Studio Express (where there's no ATL included). Moreover, currently it's easy to get rid of the ATL dependency at all - actually it does not add anything to the code that really worth this dependency.