### PR TITLE
Update FileDialog.cpp

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -42,9 +42,7 @@ FileDialog::FileDialog(HWND hwnd, HINSTANCE hInst)
 	staticThis = this;
     //for (int i = 0 ; i < nbExtMax ; i++)
     //    _extArray[i][0] = '\0';
-
-	_fileName[0] = '\0';
- 
+        memset(_fileName, 0, sizeof(_fileName));
 	_winVersion = (NppParameters::getInstance())->getWinVersion();
 
 	_ofn.lStructSize = sizeof(_ofn);


### PR DESCRIPTION
Solve the problem that can't to open a long path.For example,  press ctrl + o , and enter a long path directly, "E:\notepad-plus-plus-7.5.6\test\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\ddddddd.txt", the non-zero buffer will occur error.