### PR TITLE
Added in the Character Panel two new columns showing HTML Codes

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1049,10 +1049,12 @@ Do you want to launch Notepad++ in Administrator mode?"/>
             <ColumnType name="Type"/>
         </WindowsDlg>
         <AsciiInsertion>
-            <PanelTitle name="ASCII Insertion Panel"/>
+            <PanelTitle name="ASCII/HTML Codes (ANSI or Windows-1252 character sets) Insertion Panel"/>
             <ColumnVal name="Value"/>
             <ColumnHex name="Hex"/>
             <ColumnChar name="Character"/>
+            <ColumnHtmlNumber name="HTML Number"/>
+            <ColumnHtmlName name="HTML Code"/>
         </AsciiInsertion>
         <DocumentMap>
             <PanelTitle name="Document Map"/>

--- a/PowerEditor/installer/nativeLang/french.xml
+++ b/PowerEditor/installer/nativeLang/french.xml
@@ -1022,10 +1022,12 @@ Veux-tu lancer Notepad++ en mode Administrateur?"/>
             <ColumnType name="Type"/>
         </WindowsDlg>
         <AsciiInsertion>
-            <PanelTitle name="Panneau des caractères ASCII"/>
+            <PanelTitle name="Panneau des caractères ASCII/Codes HTML (codage de caractères ANSI ou Windows-1252)"/>
             <ColumnVal name="Valeur"/>
             <ColumnHex name="Hexa"/>
             <ColumnChar name="Caractère"/>
+            <ColumnHtmlNumber name="Numéro HTML"/>
+            <ColumnHtmlName name="Code HTML"/>
         </AsciiInsertion>
         <DocumentMap>
             <PanelTitle name="Plan du Document"/>

--- a/PowerEditor/installer/nativeLang/spanish.xml
+++ b/PowerEditor/installer/nativeLang/spanish.xml
@@ -903,10 +903,12 @@
 			<ColumnExt name="Ext."/>
 		</DocSwitcher>
 		<AsciiInsertion>
-			<PanelTitle name="Panel de entrada ASCII"/>
+			<PanelTitle name="Panel de entrada ASCII/Códigos HTML (juego de caracteres ANSI o Windows-1252)"/>
 			<ColumnVal name="Valor"/>
 			<ColumnHex name="Hex"/>
 			<ColumnChar name="Carácter"/>
+			<ColumnHtmlNumber name="Número HTML"/>
+			<ColumnHtmlName name="Código HTML"/>
 		</AsciiInsertion>
 		<DocumentMap>
 			<PanelTitle name="Mapa de documento"/>

--- a/PowerEditor/installer/nativeLang/spanish_ar.xml
+++ b/PowerEditor/installer/nativeLang/spanish_ar.xml
@@ -826,9 +826,11 @@
 			<ColumnExt name="Ext."/>
         </DocSwitcher>
         <AsciiInsertion>
-			<PanelTitle name="Panel de inserción ASCII"/>
+			<PanelTitle name="Panel de inserción ASCII/Códigos HTML (páginas de código ANSI o Windows-1252)"/>
 			<ColumnVal name="Valor"/>
-			<ColumnChar name="Caracter"/>
+			<ColumnChar name="Carácter"/>
+			<ColumnHtmlNumber name="Número HTML"/>
+			<ColumnHtmlName name="Código HTML"/>
         </AsciiInsertion>
         <DocumentMap>
 			<PanelTitle name="Mapa del documento"/>

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5784,8 +5784,8 @@ void Notepad_plus::launchAnsiCharPanel()
 
 		NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance())->getNativeLangSpeaker();
 		generic_string title_temp = pNativeSpeaker->getAttrNameStr(AI_PROJECTPANELTITLE, "AsciiInsertion", "PanelTitle");
-		static TCHAR title[32];
-		if (title_temp.length() < 32)
+		static TCHAR title[85];
+		if (title_temp.length() < 85)
 		{
 			lstrcpy(title, title_temp.c_str());
 			data.pszName = title;

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -47,10 +47,14 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			generic_string valStr = pNativeSpeaker->getAttrNameStr(TEXT("Value"), "AsciiInsertion", "ColumnVal");
 			generic_string hexStr = pNativeSpeaker->getAttrNameStr(TEXT("Hex"), "AsciiInsertion", "ColumnHex");
 			generic_string charStr = pNativeSpeaker->getAttrNameStr(TEXT("Character"), "AsciiInsertion", "ColumnChar");
+			generic_string htmlNumberStr = pNativeSpeaker->getAttrNameStr(TEXT("HTML Number"), "AsciiInsertion", "ColumnHtmlNumber");
+			generic_string htmlNameStr = pNativeSpeaker->getAttrNameStr(TEXT("HTML Name"), "AsciiInsertion", "ColumnHtmlName");
 
 			_listView.addColumn(columnInfo(valStr, nppParam->_dpiManager.scaleX(45)));
 			_listView.addColumn(columnInfo(hexStr, nppParam->_dpiManager.scaleX(45)));
 			_listView.addColumn(columnInfo(charStr, nppParam->_dpiManager.scaleX(70)));
+			_listView.addColumn(columnInfo(htmlNumberStr, nppParam->_dpiManager.scaleX(100)));
+			_listView.addColumn(columnInfo(htmlNameStr, nppParam->_dpiManager.scaleX(90)));
 
 			_listView.init(_hInst, _hSelf);
 			int codepage = (*_ppEditView)->getCurrentBuffer()->getEncoding();
@@ -67,12 +71,29 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 				case NM_DBLCLK:
 				{
 					LPNMITEMACTIVATE lpnmitem = (LPNMITEMACTIVATE) lParam;
-					int i = lpnmitem->iItem;
+					LVHITTESTINFO pInfo;
+					pInfo.pt = lpnmitem->ptAction;
+					int lResult = ListView_SubItemHitTest(_listView.getHSelf(), &pInfo);
+
+					int i = pInfo.iItem;
+					int j = pInfo.iSubItem;
+					wchar_t buffer[10];
+					LVITEM item;
+					item.mask = LVIF_TEXT | LVIF_PARAM;
+					item.iItem = i;
+					item.iSubItem = j;
+					item.cchTextMax = 10;
+					item.pszText = buffer;
+					ListView_GetItem(_listView.getHSelf(), &item);
 
 					if (i == -1)
 						return TRUE;
 
-					insertChar(static_cast<unsigned char>(i));
+					if (j != 2)
+						insertString(item.pszText);
+					else
+						insertChar(static_cast<unsigned char>(i));
+					
 					return TRUE;
 				}
 
@@ -145,6 +166,34 @@ void AnsiCharPanel::insertChar(unsigned char char2insert) const
 	}
 	(*_ppEditView)->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
 	size_t len = (char2insert < 128) ? 1 : strlen(multiByteStr);
+	(*_ppEditView)->execute(SCI_ADDTEXT, len, reinterpret_cast<LPARAM>(multiByteStr));
+	(*_ppEditView)->getFocus();
+}
+
+void AnsiCharPanel::insertString(LPWSTR string2insert) const
+{
+	wchar_t wCharStr[10];
+	char multiByteStr[10];
+	int codepage = (*_ppEditView)->getCurrentBuffer()->getEncoding();
+	if (codepage == -1)
+	{
+		bool isUnicode = ((*_ppEditView)->execute(SCI_GETCODEPAGE) == SC_CP_UTF8);
+		if (isUnicode)
+		{
+			WideCharToMultiByte(CP_UTF8, 0, string2insert, -1, multiByteStr, sizeof(multiByteStr), NULL, NULL);
+		}
+		else // ANSI
+		{
+			wcstombs(multiByteStr, string2insert, 10);
+		}
+	}
+	else
+	{
+		WideCharToMultiByte(CP_UTF8, 0, string2insert, -1, multiByteStr, sizeof(multiByteStr), NULL, NULL);
+	}
+
+	(*_ppEditView)->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
+	size_t len = strlen(multiByteStr);
 	(*_ppEditView)->execute(SCI_ADDTEXT, len, reinterpret_cast<LPARAM>(multiByteStr));
 	(*_ppEditView)->getFocus();
 }

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.h
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.h
@@ -55,6 +55,7 @@ public:
 
 	void switchEncoding();
 	void insertChar(unsigned char char2insert) const;
+	void insertString(LPWSTR string2insert) const;
 
 	virtual void setBackgroundColor(int bgColour) const {
 		ListView_SetBkColor(_listView.getHSelf(), bgColour);

--- a/PowerEditor/src/WinControls/AnsiCharPanel/asciiListView.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/asciiListView.cpp
@@ -126,6 +126,274 @@ generic_string AsciiListView::getAscii(unsigned char value)
 	}
 }
 
+generic_string AsciiListView::getHtmlName(unsigned char value)
+{
+	switch (value)
+	{
+		case 34:
+			return TEXT("&quot;");
+		case 38:
+			return TEXT("&amp;");
+		case 60:
+			return TEXT("&lt;");
+		case 62:
+			return TEXT("&gt;");
+		case 128:
+			return TEXT("&euro;");
+		case 160:
+			return TEXT("&nbsp;");
+		case 161:
+			return TEXT("&iexcl;");
+		case 162:
+			return TEXT("&cent;");
+		case 163:
+			return TEXT("&pound;");
+		case 164:
+			return TEXT("&curren;");
+		case 165:
+			return TEXT("&yen;");
+		case 166:
+			return TEXT("&brvbar;");
+		case 167:
+			return TEXT("&sect;");
+		case 168:
+			return TEXT("&uml;");
+		case 169:
+			return TEXT("&copy;");
+		case 170:
+			return TEXT("&ordf;");
+		case 171:
+			return TEXT("&laquo;");
+		case 172:
+			return TEXT("&not;");
+		case 173:
+			return TEXT("&shy;");
+		case 174:
+			return TEXT("&reg;");
+		case 175:
+			return TEXT("&macr;");
+		case 176:
+			return TEXT("&deg;");
+		case 177:
+			return TEXT("&plusmn;");
+		case 178:
+			return TEXT("&sup2;");
+		case 179:
+			return TEXT("&sup3;");
+		case 180:
+			return TEXT("&acute;");
+		case 181:
+			return TEXT("&micro;");
+		case 182:
+			return TEXT("&para;");
+		case 183:
+			return TEXT("&middot;");
+		case 184:
+			return TEXT("&cedil;");
+		case 185:
+			return TEXT("&sup1;");
+		case 186:
+			return TEXT("&ordm;");
+		case 187:
+			return TEXT("&raquo;");
+		case 188:
+			return TEXT("&frac14;");
+		case 189:
+			return TEXT("&frac12;");
+		case 190:
+			return TEXT("&frac34;");
+		case 191:
+			return TEXT("&iquest;");
+		case 192:
+			return TEXT("&Agrave;");
+		case 193:
+			return TEXT("&Aacute;");
+		case 194:
+			return TEXT("&Acirc;");
+		case 195:
+			return TEXT("&Atilde;");
+		case 196:
+			return TEXT("&Auml;");
+		case 197:
+			return TEXT("&Aring;");
+		case 198:
+			return TEXT("&AElig;");
+		case 199:
+			return TEXT("&Ccedil;");
+		case 200:
+			return TEXT("&Egrave;");
+		case 201:
+			return TEXT("&Eacute;");
+		case 202:
+			return TEXT("&Ecirc;");
+		case 203:
+			return TEXT("&Euml;");
+		case 204:
+			return TEXT("&Igrave;");
+		case 205:
+			return TEXT("&Iacute;");
+		case 206:
+			return TEXT("&Icirc;");
+		case 207:
+			return TEXT("&Iuml;");
+		case 208:
+			return TEXT("&ETH;");
+		case 209:
+			return TEXT("&Ntilde;");
+		case 210:
+			return TEXT("&Ograve;");
+		case 211:
+			return TEXT("&Oacute;");
+		case 212:
+			return TEXT("&Ocirc;");
+		case 213:
+			return TEXT("&Otilde;");
+		case 214:
+			return TEXT("&Ouml;");
+		case 215:
+			return TEXT("&times;");
+		case 216:
+			return TEXT("&Oslash;");
+		case 217:
+			return TEXT("&Ugrave;");
+		case 218:
+			return TEXT("&Uacute;");
+		case 219:
+			return TEXT("&Ucirc;");
+		case 220:
+			return TEXT("&Uuml;");
+		case 221:
+			return TEXT("&Yacute;");
+		case 222:
+			return TEXT("&THORN;");
+		case 223:
+			return TEXT("&szlig;");
+		case 224:
+			return TEXT("&agrave;");
+		case 225:
+			return TEXT("&aacute;");
+		case 226:
+			return TEXT("&acirc;");
+		case 227:
+			return TEXT("&atilde;");
+		case 228:
+			return TEXT("&auml;");
+		case 229:
+			return TEXT("&aring;");
+		case 230:
+			return TEXT("&aelig;");
+		case 231:
+			return TEXT("&ccedil;");
+		case 232:
+			return TEXT("&egrave;");
+		case 233:
+			return TEXT("&eacute;");
+		case 234:
+			return TEXT("&ecirc;");
+		case 235:
+			return TEXT("&euml;");
+		case 236:
+			return TEXT("&igrave;");
+		case 237:
+			return TEXT("&iacute;");
+		case 238:
+			return TEXT("&icirc;");
+		case 239:
+			return TEXT("&iuml;");
+		case 240:
+			return TEXT("&eth;");
+		case 241:
+			return TEXT("&ntilde;");
+		case 242:
+			return TEXT("&ograve;");
+		case 243:
+			return TEXT("&oacute;");
+		case 244:
+			return TEXT("&ocirc;");
+		case 245:
+			return TEXT("&otilde;");
+		case 246:
+			return TEXT("&ouml;");
+		case 247:
+			return TEXT("&divide;");
+		case 248:
+			return TEXT("&oslash;");
+		case 249:
+			return TEXT("&ugrave;");
+		case 250:
+			return TEXT("&uacute;");
+		case 251:
+			return TEXT("&ucirc;");
+		case 252:
+			return TEXT("&uuml;");
+		case 253:
+			return TEXT("&yacute;");
+		case 254:
+			return TEXT("&thorn;");
+		case 255:
+			return TEXT("&yuml;");
+		default:
+		{
+			return TEXT("");
+		}
+		
+	}
+}
+
+int AsciiListView::getHtmlNumber(unsigned char value)
+{
+	switch (value)
+	{
+		case 128:
+			return 8364;
+		case 130:
+			return 8218;
+		case 131:
+			return 402;
+		case 132:
+			return 8222;
+		case 133:
+			return 8230;
+		case 134:
+			return 8224;
+		case 135:
+			return 8225;
+		case 137:
+			return 8240;
+		case 138:
+			return 352;
+		case 140:
+			return 338;
+		case 145:
+			return 8216;
+		case 146:
+			return 8217;
+		case 147:
+			return 8220;
+		case 148:
+			return 8221;
+		case 149:
+			return 8226;
+		case 150:
+			return 8211;
+		case 151:
+			return 8212;
+		case 153:
+			return 8482;
+		case 154:
+			return 353;
+		case 156:
+			return 339;
+		case 159:
+			return 376;
+		default:
+		{
+			return -1;
+		}
+		
+	}
+}
+
 void AsciiListView::setValues(int codepage)
 {
 	_codepage = codepage;
@@ -134,15 +402,46 @@ void AsciiListView::setValues(int codepage)
 	{
 		TCHAR dec[8];
 		TCHAR hex[8];
+		TCHAR htmlNumber[8];
+		generic_string htmlName;
 		generic_sprintf(dec, TEXT("%d"), i);
 		generic_sprintf(hex, TEXT("%02X"), i);
 		generic_string s = getAscii(static_cast<unsigned char>(i));
+
+		if (codepage == 0 || codepage == 1252)
+		{
+			if ((i >= 32 && i <= 126) || (i >= 160 && i <= 255))
+			{
+				generic_sprintf(htmlNumber, TEXT("&#%d"), i);
+			}
+			else
+			{
+				int n = getHtmlNumber(static_cast<unsigned char>(i));
+				if (n > -1)
+				{
+					generic_sprintf(htmlNumber, TEXT("&#%d"), n);
+				}
+				else
+				{
+					generic_sprintf(htmlNumber, TEXT(""));
+				}
+			}
+
+			htmlName = getHtmlName(static_cast<unsigned char>(i));
+		}
+		else
+		{
+			generic_sprintf(htmlNumber, TEXT(""));
+			htmlName = TEXT("");
+		}
 
 		std::vector<generic_string> values2Add;
 
 		values2Add.push_back(dec);
 		values2Add.push_back(hex);
 		values2Add.push_back(s);
+		values2Add.push_back(htmlNumber);
+		values2Add.push_back(htmlName);
 
 		addLine(values2Add);
 	}

--- a/PowerEditor/src/WinControls/AnsiCharPanel/asciiListView.h
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/asciiListView.h
@@ -36,6 +36,8 @@ public:
 	void resetValues(int codepage);
 
 	generic_string getAscii(unsigned char value);
+	generic_string getHtmlName(unsigned char value);
+	int getHtmlNumber(unsigned char value);
 private:
 	int _codepage = -1;
 };


### PR DESCRIPTION
Added in the Character Panel two new columns showing HTML Code and HTML Name for ANSI and Windows-1252 character sets.

Modified NM_DBLCLK event to insert in document the current cell value when double clicked in the Character Panel.

Modified translation files for French, English, Spanish and Spanish Argentina to include the new added columns in the Character Panel.

Modified maximum length of the Character Panel titlebar in Notepad_plus::launchAnsiCharPanel().