### PR TITLE
**1. Fix apparent hang when switching to a tab that contains a large …

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -782,6 +782,7 @@ void Notepad_plus::command(int id)
 		case IDM_VIEW_TAB8:
 		case IDM_VIEW_TAB9:
 		{
+			_isFolding = true; // Ignore SCN_FOLDINGSTATECHANGED events when switching tabs
 			const int index = id - IDM_VIEW_TAB1;
 			BufferID buf = _pDocTab->getBufferByIndex(index);
 			if(buf == BUFFER_INVALID)
@@ -792,31 +793,22 @@ void Notepad_plus::command(int id)
 					switchToFile(_pDocTab->getBufferByIndex(last_index));
 			}
 			else
+			{
 				switchToFile(buf);
+			}
+			_isFolding = false;
 		}
 		break;
 
 		case IDM_VIEW_TAB_NEXT:
-		{
-			const int current_index = _pDocTab->getCurrentTabIndex();
-			const int last_index = _pDocTab->getItemCount() - 1;
-			if(current_index < last_index)
-				switchToFile(_pDocTab->getBufferByIndex(current_index + 1));
-			else
-				switchToFile(_pDocTab->getBufferByIndex(0)); // Loop around.
-		}
-		break;
-
 		case IDM_VIEW_TAB_PREV:
 		{
-			const int current_index = _pDocTab->getCurrentTabIndex();
-			if(current_index > 0)
-				switchToFile(_pDocTab->getBufferByIndex(current_index - 1));
-			else
-			{
-				const int last_index = _pDocTab->getItemCount() - 1;
-				switchToFile(_pDocTab->getBufferByIndex(last_index)); // Loop around.
-			}
+			_isFolding = true; // Ignore SCN_FOLDINGSTATECHANGED events when switching tabs
+			const int current = _pDocTab->getCurrentTabIndex();
+			const int direction = (id == IDM_VIEW_TAB_NEXT) ? +1 : -1;
+			const int count = _pDocTab->getItemCount();
+			switchToFile(_pDocTab->getBufferByIndex((current + direction + count) % count));
+			_isFolding = false;
 		}
 		break;
 
@@ -2886,6 +2878,7 @@ void Notepad_plus::command(int id)
         case IDC_PREV_DOC :
         case IDC_NEXT_DOC :
         {
+			_isFolding = true; // Ignore SCN_FOLDINGSTATECHANGED events when switching tabs
 			size_t nbDoc = viewVisible(MAIN_VIEW) ? _mainDocTab.nbItem() : 0;
 			nbDoc += viewVisible(SUB_VIEW)?_subDocTab.nbItem():0;
 
@@ -2909,6 +2902,7 @@ void Notepad_plus::command(int id)
 				}
 			}
 			_linkTriggered = true;
+			_isFolding = false;
 		}
         break;
 


### PR DESCRIPTION
…number of closed folds by ignoring SCN_FOLDINGSTATECHANGED events when switching buffers. This fix copies an earlier fix made at NppNotification.cpp:370 to fix switching tabs using the mouse pointer and applies it to keyboard commands.**

  * To reproduce the bug in Notepad++ before applying this fix:

    1. Open notepad-plus-plus-master/PowerEditor/src/Parameters.cpp in one tab and create a second empty tab.
    2. Note good performance when switching back and forth between the tabs using the mouse pointer, ctrl-tab, ctrl-shift-tab, ctrl-pageup, ctrl-pagedown, and ctrl-numpad1..9.
    3. Switch to the tab containing Parameters.cpp and press alt-0 to fold everything in the file.
    4. Note continued good performance when switching back and forth between the tabs using the mouse pointer. (Switching with the mouse has good performance because of an earlier bug fix at NppNotification.cpp:370)
    5. Note extremely poor performance when switching to the folded tab using ctrl-tab, ctrl-shift-tab, ctrl-pageup, ctrl-pagedown, and ctrl-numpad1..9. (On my machine, it takes almost 20 seconds to switch tabs)

  * After applying the fix, repeat the tests listed above and note good performance when switching to a deeply-folded tab using any method.

**2. Combine and simplify the code that handles commands IDM_VIEW_TAB_NEXT and IDM_VIEW_TAB_PREV in NppCommands.cpp.**

  * To test change #2, ensure that ctrl-pageup and ctrl-pagedown properly cycle through multiple tabs and wrap around in both directions.