### PR TITLE
correct typo STRT_REPLACE -> STR_REPLACE to fix issue #4354

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -396,7 +396,7 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
         {
 			_nativeLangSpeaker.messageBox("OpenFileError",
 				_pPublicInterface->getHSelf(),
-				TEXT("Can not open file \"$STRT_REPLACE$\"."),
+				TEXT("Can not open file \"$STR_REPLACE$\"."),
 				TEXT("ERROR"),
 				MB_OK,
 				0,


### PR DESCRIPTION
introduced with https://github.com/notepad-plus-plus/notepad-plus-plus/commit/a1b4628b8b6e43bc8af59f58b9d5cde34b9afff6#diff-76c62ef652708b4b7b02f049a16b0629, see comment there