### PR TITLE
Cleanup in context menu and Run entries (resubmit)

### DIFF
--- a/PowerEditor/src/contextMenu.xml
+++ b/PowerEditor/src/contextMenu.xml
@@ -55,14 +55,12 @@ http://docs.notepad-plus-plus.org/index.php/Context_Menu
 		ItemNameAs can be used in any type of item. ItemNameAs value can be in any language.
 		-->
         <Item FolderName="Plugin commands" PluginEntryName="NppExport" PluginCommandItemName="Copy all formats to clipboard" ItemNameAs="Copy Text with Syntax Highlighting" />
-		<Item id="0"/>
-        <Item MenuEntryName="Run" MenuItemName="Google Search"/>
         <Item id="0"/>
         <Item MenuEntryName="Edit" MenuItemName="UPPERCASE"/>
         <Item MenuEntryName="Edit" MenuItemName="lowercase"/>
         <Item id="0"/>
         <Item MenuEntryName="Edit" MenuItemName="Open File"/>
-        <Item MenuEntryName="Edit" MenuItemName="Search On Internet"/>
+        <Item MenuEntryName="Edit" MenuItemName="Search on Internet"/>
         <Item id="0"/>
         <Item MenuEntryName="Edit" MenuItemName="Toggle Single Line Comment"/>
         <Item MenuEntryName="Edit" MenuItemName="Block Comment"/>

--- a/PowerEditor/src/shortcuts.xml
+++ b/PowerEditor/src/shortcuts.xml
@@ -11,7 +11,7 @@
         <Command name="Launch in IE" Ctrl="yes" Alt="yes" Shift="yes" Key="73">iexplore &quot;$(FULL_CURRENT_PATH)&quot;</Command>
         <Command name="Launch in Chrome" Ctrl="yes" Alt="yes" Shift="yes" Key="82">chrome &quot;$(FULL_CURRENT_PATH)&quot;</Command>
         <Command name="Launch in Safari" Ctrl="yes" Alt="yes" Shift="yes" Key="65">safari &quot;$(FULL_CURRENT_PATH)&quot;</Command>
-        <Command name="Get php help" Ctrl="no" Alt="yes" Shift="no" Key="112">http://www.php.net/$(CURRENT_WORD)</Command>
+        <Command name="Get PHP help" Ctrl="no" Alt="yes" Shift="no" Key="112">http://www.php.net/$(CURRENT_WORD)</Command>
         <Command name="Wikipedia Search" Ctrl="no" Alt="yes" Shift="no" Key="114">https://en.wikipedia.org/wiki/Special:Search?search=$(CURRENT_WORD)</Command>
         <Command name="Open file in another instance" Ctrl="no" Alt="yes" Shift="no" Key="117">$(NPP_FULL_FILE_PATH) $(CURRENT_WORD) -nosession -multiInst</Command>
         <Command name="Send via Outlook" Ctrl="yes" Alt="yes" Shift="yes" Key="79">outlook /a &quot;$(FULL_CURRENT_PATH)&quot;</Command>


### PR DESCRIPTION
Resubmit of #4513, without removing that Safari entry…

This leaves us with the following:

* Context menu: remove entry "Google Search"

  * redundant with the "Search On Internet" entry
  * … and just noneffective as the corresponding Run entry has been removed
  * introduced in https://github.com/notepad-plus-plus/notepad-plus-plus/commit/e451efbd290f36300fe08a3b5be5460c5dd94f84, see also my past comment on it: https://github.com/notepad-plus-plus/notepad-plus-plus/commit/e451efbd290f36300fe08a3b5be5460c5dd94f84#r22615404

* Fix case: "Get php help" → "Get PHP help"