### PR TITLE
english.xml: add short key in find dialog

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -371,7 +371,7 @@
                 <Item id="1626" name="E&amp;xtended (\n, \r, \t, \0, \x...)"/>
                 <Item id="1660" name="&amp;Replace in Files"/>
                 <Item id="1661" name="Follow current doc."/>
-                <Item id="1641" name="Find All in Current Document"/>
+                <Item id="1641" name="Find All in Current &amp;Document"/>
                 <Item id="1686" name="Transparenc&amp;y"/>
                 <Item id="1703" name="&amp;. matches newline"/>
             </Find>


### PR DESCRIPTION
added short key for button `Find All in Current Document`  in `find` dialog (which should not infer with another configuration of short cut).

Cf. Issue #4531.