### PR TITLE
Fixed pointer truncations

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -114,7 +114,7 @@ void Notepad_plus::command(int id)
 			// As per MSDN (https://msdn.microsoft.com/en-us/library/windows/desktop/bb762153(v=vs.85).aspx)
 			// If the function succeeds, it returns a value greater than 32.
 			// If the function fails, it returns an error value that indicates the cause of the failure.
-			int retResult = reinterpret_cast<int>(res);
+			int retResult = static_cast<int>(reinterpret_cast<INT_PTR>(res));
 			if (retResult <= 32)
 			{
 				generic_string errorMsg;

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <shlwapi.h>
+#include <cinttypes>
 #include "ScintillaEditView.h"
 #include "Parameters.h"
 #include "Sorters.h"
@@ -844,20 +845,19 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 		}
 	}
 
- 	char intBuffer[15];
-	char nestingBuffer[] = "userDefine.nesting.00";
+ 	char intBuffer[32];
 
-    itoa(userLangContainer->_forcePureLC, intBuffer, 10);
+	sprintf(intBuffer, "%d", userLangContainer->_forcePureLC);
 	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.forcePureLC"), reinterpret_cast<LPARAM>(intBuffer));
 
-    itoa(userLangContainer->_decimalSeparator, intBuffer, 10);
+	sprintf(intBuffer, "%d", userLangContainer->_decimalSeparator);
 	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.decimalSeparator"), reinterpret_cast<LPARAM>(intBuffer));
 
 	// at the end (position SCE_USER_KWLIST_TOTAL) send id values
-	itoa(reinterpret_cast<int>(userLangContainer->getName()), intBuffer, 10); // use numeric value of TCHAR pointer
+	sprintf(intBuffer, "%" PRIuPTR, reinterpret_cast<uintptr_t>(userLangContainer->getName())); // use numeric value of TCHAR pointer
 	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.udlName"), reinterpret_cast<LPARAM>(intBuffer));
 
-    itoa(reinterpret_cast<int>(_currentBufferID), intBuffer, 10); // use numeric value of BufferID pointer
+	sprintf(intBuffer, "%" PRIuPTR, reinterpret_cast<uintptr_t>(_currentBufferID)); // use numeric value of BufferID pointer
     execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.currentBufferID"), reinterpret_cast<LPARAM>(intBuffer));
 
 	for (int i = 0 ; i < SCE_USER_STYLE_TOTAL_STYLES ; ++i)
@@ -867,9 +867,10 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 		if (style._styleID == STYLE_NOT_USED)
 			continue;
 
-		if (i < 10)	itoa(i, (nestingBuffer+20), 10);
-		else		itoa(i, (nestingBuffer+19), 10);
-		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>(nestingBuffer), reinterpret_cast<LPARAM>(itoa(style._nesting, intBuffer, 10)));
+		char nestingBuffer[32];
+		sprintf(nestingBuffer, "userDefine.nesting.%02d", i );
+		sprintf(intBuffer, "%d", style._nesting);
+		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>(nestingBuffer), reinterpret_cast<LPARAM>(intBuffer));
 
 		setStyle(style);
 	}

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -29,7 +29,7 @@ HFONT holdfont;
 
 struct _gridhandlestruct
 	{
-        UINT gridmenu;
+        HMENU gridmenu;
 		HWND hlist1;
 		TCHAR protect[2];
         TCHAR title[305];
@@ -113,8 +113,8 @@ TCHAR data[1000];
 CREATESTRUCT cs,*lpcs;
 
 
-int         AddGrid(UINT);
-int         FindGrid(UINT);
+int         AddGrid(HMENU);
+int         FindGrid(HMENU);
 void		ShowVscroll(HWND,int);
 void		ShowHscroll(HWND,int);
 int         BinarySearchListBox(HWND,TCHAR*);
@@ -149,7 +149,7 @@ void RefreshGrid(HWND hWnd)
      int SI;
 	 GetClientRect(hWnd,&rect);
 	 InvalidateRect(hWnd,&rect,FALSE);
-	 SI=FindGrid((UINT)GetMenu(hWnd));
+	 SI=FindGrid(GetMenu(hWnd));
      if(BGHS[SI].EDITING)
          {
           DisplayEditString(hWnd, SI, TEXT(""));
@@ -609,7 +609,7 @@ void DisplayColumn(HWND hWnd,int SI,int c,int offset,HFONT hfont,HFONT hcolumnhe
 			   WPARAM wParam;
                buffer[0]=0x20;
                BGHS[SI].ownerdrawitem = generic_atoi(buffer);
-			   wParam=MAKEWPARAM((UINT)::GetMenu(hWnd),BGN_OWNERDRAW);
+			   wParam=MAKEWPARAM(::GetMenu(hWnd),BGN_OWNERDRAW);
 			   SendMessage(GetParent(hWnd), WM_COMMAND, wParam, reinterpret_cast<LPARAM>(&rect));
 			 }
 
@@ -892,9 +892,9 @@ void NotifyRowChanged(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_ROWCHANGED);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_ROWCHANGED);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
-	   wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_SELCHANGE);
+	   wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_SELCHANGE);
 	   SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 	}
 
@@ -904,9 +904,9 @@ void NotifyColChanged(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_COLCHANGED);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_COLCHANGED);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_SELCHANGE);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_SELCHANGE);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 
 	}
@@ -917,7 +917,7 @@ void NotifyEndEdit(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_EDITEND);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_EDITEND);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 
 	}
@@ -928,7 +928,7 @@ void NotifyDelete(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_DELETECELL);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_DELETECELL);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 
 	}
@@ -939,7 +939,7 @@ void NotifyEditBegin(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_EDITBEGIN);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_EDITBEGIN);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 
 	}
@@ -949,7 +949,7 @@ void NotifyEditEnd(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_EDITEND);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_EDITEND);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 
 	}
@@ -1080,7 +1080,7 @@ void NotifyCellClicked(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_CELLCLICKED);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_CELLCLICKED);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 
 	}
@@ -1090,7 +1090,7 @@ void NotifyCellDbClicked(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_CELLDBCLICKED);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_CELLDBCLICKED);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 	}
 
@@ -1099,7 +1099,7 @@ void NotifyCellRClicked(HWND hWnd,int SI)
 	 WPARAM wParam;
 	 LPARAM lParam;
 	   lParam = MAKELPARAM(BGHS[SI].cursorrow,BGHS[SI].cursorcol);
-       wParam=MAKEWPARAM((UINT)BGHS[SI].gridmenu,BGN_CELLRCLICKED);
+       wParam=MAKEWPARAM(BGHS[SI].gridmenu,BGN_CELLRCLICKED);
        SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 	}
 void GetVisibleColumns(HWND hWnd,int SI)
@@ -1326,13 +1326,13 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	TCHAR buffer[1000];
 	int SelfIndex;
 	int ReturnValue;
-    UINT SelfMenu;
+    HMENU SelfMenu;
 	HINSTANCE hInst;
     int iDataType;
     static int ASCII;
 
 
-	SelfIndex=FindGrid((UINT)GetMenu(hWnd));
+	SelfIndex=FindGrid(GetMenu(hWnd));
     SelfMenu=BGHS[SelfIndex].gridmenu;
 
 	//update the grid width and height variable
@@ -1544,7 +1544,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
               LPBGcell=(_BGCELL*)wParam;
               if(OutOfRange(LPBGcell))
                   {
-                   wParam=MAKEWPARAM((UINT)GetMenu(hWnd),BGN_OUTOFRANGE);
+                   wParam=MAKEWPARAM(GetMenu(hWnd),BGN_OUTOFRANGE);
                    lParam = 0;
                    SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 				   ReturnValue = -1;
@@ -1628,7 +1628,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
               LPBGcell=(_BGCELL*)wParam;
               if(OutOfRange(LPBGcell))
                   {
-                   wParam=MAKEWPARAM((UINT)GetMenu(hWnd),BGN_OUTOFRANGE);
+                   wParam=MAKEWPARAM(GetMenu(hWnd),BGN_OUTOFRANGE);
                    lParam = 0;
                    SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 				   ReturnValue = -1;
@@ -1767,7 +1767,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
               LPBGcell=(_BGCELL*)wParam;
               if(OutOfRange(LPBGcell))
                   {
-					  wParam = MAKEWPARAM(reinterpret_cast<UINT>(GetMenu(hWnd)), BGN_OUTOFRANGE);
+					  wParam = MAKEWPARAM(GetMenu(hWnd), BGN_OUTOFRANGE);
                    lParam = 0;
                    SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 				   ReturnValue = -1;
@@ -1831,7 +1831,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
               LPBGcell=(_BGCELL*)wParam;
               if(OutOfRange(LPBGcell))
                   {
-                   wParam=MAKEWPARAM((UINT)GetMenu(hWnd),BGN_OUTOFRANGE);
+                   wParam=MAKEWPARAM(GetMenu(hWnd),BGN_OUTOFRANGE);
                    lParam = 0;
                    SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 				   ReturnValue = -1;
@@ -1923,7 +1923,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
               LPBGcell=(_BGCELL*)wParam;
               if(OutOfRange(LPBGcell))
                   {
-                   wParam=MAKEWPARAM((UINT)GetMenu(hWnd),BGN_OUTOFRANGE);
+                   wParam=MAKEWPARAM(GetMenu(hWnd),BGN_OUTOFRANGE);
                    lParam = 0;
                    SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 				   ReturnValue = -1;
@@ -1951,7 +1951,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
               LPBGcell=(_BGCELL*)wParam;
               if(OutOfRange(LPBGcell))
                   {
-                   wParam=MAKEWPARAM((UINT)GetMenu(hWnd),BGN_OUTOFRANGE);
+                   wParam=MAKEWPARAM(GetMenu(hWnd),BGN_OUTOFRANGE);
                    lParam = 0;
                    SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
 				   ReturnValue = -1;
@@ -2926,7 +2926,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                SetHomeRow(hWnd,SelfIndex,BGHS[SelfIndex].cursorrow,BGHS[SelfIndex].cursorcol);
                SetHomeCol(hWnd,SelfIndex,BGHS[SelfIndex].cursorrow,BGHS[SelfIndex].cursorcol);
 
-               wParam=MAKEWPARAM((UINT)GetMenu(hWnd),BGN_GOTFOCUS);
+               wParam=MAKEWPARAM(GetMenu(hWnd),BGN_GOTFOCUS);
                lParam = 0;
                SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
                    {TEXTMETRIC tm;
@@ -2944,7 +2944,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			   DrawCursor(hWnd,SelfIndex);
 			   BGHS[SelfIndex].GRIDHASFOCUS	= FALSE;
 
-               wParam=MAKEWPARAM((UINT)GetMenu(hWnd),BGN_LOSTFOCUS);
+               wParam=MAKEWPARAM(GetMenu(hWnd),BGN_LOSTFOCUS);
                lParam = 0;
                SendMessage(GetParent(hWnd),WM_COMMAND,wParam,lParam);
                RefreshGrid(hWnd);
@@ -3026,7 +3026,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			  hInst = lpcs->hInstance;
 
 
-              BG_GridIndex = AddGrid((UINT)GetMenu(hWnd));
+              BG_GridIndex = AddGrid(GetMenu(hWnd));
 
               if(CountGrids()==1)
                   {
@@ -3047,7 +3047,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
               if((BG_GridIndex >= 0)&&(BG_GridIndex < MAX_GRIDS))//if you aren't over the MAX_GRIDS limit, add a grid
                   {
 
-			          BGHS[BG_GridIndex].gridmenu = (UINT)GetMenu(hWnd);
+			          BGHS[BG_GridIndex].gridmenu = GetMenu(hWnd);
 
 			          BGHS[BG_GridIndex].hlist1=CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("LISTBOX"), TEXT(""),
 				          WS_CHILD|LBS_STANDARD,50,150,200,100,hWnd,NULL,hInst,NULL);
@@ -3084,7 +3084,7 @@ int CountGrids()
 	}
 
 
-int AddGrid( UINT menuid)
+int AddGrid( HMENU menuid)
     {
      //if grid doesn't exist, add it.  otherwise return existing index + MAX_GRIDS
      //if trying to add more than MAX_GRIDS, return -1;
@@ -3123,7 +3123,7 @@ int AddGrid( UINT menuid)
 
     }
 
-int FindGrid( UINT menuid)
+int FindGrid( HMENU menuid)
     {
      //if grid doesn't exist, return -1, else return gridindex
      int returnvalue;

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
@@ -199,7 +199,7 @@ HINSTANCE Command::run(HWND hWnd)
 	// As per MSDN (https://msdn.microsoft.com/en-us/library/windows/desktop/bb762153(v=vs.85).aspx)
 	// If the function succeeds, it returns a value greater than 32.
 	// If the function fails, it returns an error value that indicates the cause of the failure.
-	int retResult = reinterpret_cast<int>(res);
+	int retResult = static_cast<int>(reinterpret_cast<INT_PTR>(res));
 	if (retResult <= 32)
 	{
 		generic_string errorMsg;
@@ -244,7 +244,7 @@ INT_PTR CALLBACK RunDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					_cmdLine = cmd;
 
 					HINSTANCE hInst = run(_hParent);
-					if (int(hInst) > 32)
+					if (reinterpret_cast<INT_PTR>(hInst) > 32)
 					{
 						addTextToCombo(_cmdLine.c_str());
 						display(false);

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -580,7 +580,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 	{
 		TCHAR message[1024];	//TODO: sane number
 		wsprintf(message, TEXT("An exception occured. Notepad++ cannot recover and must be shut down.\r\nThe exception details are as follows:\r\n")
-			TEXT("Code:\t0x%08X\r\nType:\t%S\r\nException address: 0x%08X"), ex.code(), ex.what(), reinterpret_cast<long>(ex.where()));
+			TEXT("Code:\t0x%08X\r\nType:\t%S\r\nException address: 0x%p"), ex.code(), ex.what(), ex.where());
 		::MessageBox(Notepad_plus_Window::gNppHWND, message, TEXT("Win32Exception"), MB_OK | MB_ICONERROR);
 		mdump.writeDump(ex.info());
 		doException(notepad_plus_plus);


### PR DESCRIPTION
N++ ships with `/Wv:18` option, which suppresses several warnings. It seems like it was added only to suppress "wrong sprintf format specified" types of warnings, however it also hid a noticeable amount of pointer truncation warnings.

This PR fixes all reported truncation warnings. `/Wv:18` is still left in place, since I did not touch format specifiers in any places, except one place where the function had to be replaced anyway (since there's no way to reliably call `itoa` on a pointer).