### PR TITLE
Fix incorrect document map highlight when scrolling past end of file.

### DIFF
--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -248,7 +248,7 @@ void DocumentMap::scrollMap()
 			if (lowerY == 0)
 			{
 				auto lineHeight = _pMapView->execute(SCI_TEXTHEIGHT, firstVisibleDocLine);
-				lowerY = nbLine * lineHeight + firstVisibleDocLine;
+				lowerY = nbLine * lineHeight + higherY;
 			}
 		}
 		else


### PR DESCRIPTION
Fix for [Issue #4579](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/4579).

![Screenshot](https://user-images.githubusercontent.com/21075688/41331497-47aa3448-6ea7-11e8-93ae-02879ed241dd.jpg)
