### PR TITLE
Add w/ BOM and remove w/o BOM in Russian locale

### DIFF
--- a/PowerEditor/installer/nativeLang/russian.xml
+++ b/PowerEditor/installer/nativeLang/russian.xml
@@ -693,8 +693,8 @@
 					<Item id="6406" name="ANSI"/>
 					<Item id="6407" name="UTF-8"/>
 					<Item id="6408" name="UTF-8 c BOM"/>
-					<Item id="6409" name="UCS2 Big Endian c BOM"/>
-					<Item id="6410" name="UCS2 Small Endian c BOM"/>
+					<Item id="6409" name="UCS-2 Big Endian c BOM"/>
+					<Item id="6410" name="UCS-2 Small Endian c BOM"/>
 					<Item id="6411" name="Синтаксис по умолч.:"/>
 					<Item id="6419" name="Новый Документ"/>
 					<Item id="6420" name="Применить к откр. ANSI файлам"/>

--- a/PowerEditor/installer/nativeLang/russian.xml
+++ b/PowerEditor/installer/nativeLang/russian.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <NotepadPlus>
-	<Native-Langue name="Русский" filename="russian.xml" version="7.5.6">
+	<Native-Langue name="Русский" filename="russian.xml" version="7.5.7">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->

--- a/PowerEditor/installer/nativeLang/russian.xml
+++ b/PowerEditor/installer/nativeLang/russian.xml
@@ -267,14 +267,14 @@
 					<Item id="45003" name="Преобразовать в MAC-формат (CR)"/>
 					<Item id="45004" name="Кодировка в ANSI"/>
 					<Item id="45005" name="Кодировка в UTF-8 с BOM"/>
-					<Item id="45006" name="Кодировка в UCS-2 Big Endian с BOM"/>
-					<Item id="45007" name="Кодировка в UCS-2 Little Endian с BOM"/>
+					<Item id="45006" name="Кодировка в UCS-2 BE с BOM"/>
+					<Item id="45007" name="Кодировка в UCS-2 LE с BOM"/>
 					<Item id="45008" name="Кодировка в UTF-8"/>
 					<Item id="45009" name="Преобразовать в ANSI"/>
 					<Item id="45010" name="Преобразовать в UTF-8"/>
 					<Item id="45011" name="Преобразовать в UTF-8 с BOM"/>
-					<Item id="45012" name="Преобразовать в UCS-2 Big Endian с BOM"/>
-					<Item id="45013" name="Преобразовать в UCS-2 Little Endian с BOM"/>
+					<Item id="45012" name="Преобразовать в UCS-2 BE с BOM"/>
+					<Item id="45013" name="Преобразовать в UCS-2 LE с BOM"/>
 					<Item id="46001" name="Определение стилей..."/>
 					<Item id="46019" name="INI файл"/>
 					<Item id="46015" name="MS-DOS стиль"/>

--- a/PowerEditor/installer/nativeLang/russian.xml
+++ b/PowerEditor/installer/nativeLang/russian.xml
@@ -266,15 +266,15 @@
 					<Item id="45002" name="Преобразовать в UNIX-формат (LF)"/>
 					<Item id="45003" name="Преобразовать в MAC-формат (CR)"/>
 					<Item id="45004" name="Кодировка в ANSI"/>
-					<Item id="45005" name="Кодировка в UTF-8"/>
-					<Item id="45006" name="Кодировка в UCS-2 Big Endian"/>
-					<Item id="45007" name="Кодировка в UCS-2 Little Endian"/>
-					<Item id="45008" name="Кодировка в UTF-8 без BOM"/>
+					<Item id="45005" name="Кодировка в UTF-8 с BOM"/>
+					<Item id="45006" name="Кодировка в UCS-2 Big Endian с BOM"/>
+					<Item id="45007" name="Кодировка в UCS-2 Little Endian с BOM"/>
+					<Item id="45008" name="Кодировка в UTF-8"/>
 					<Item id="45009" name="Преобразовать в ANSI"/>
-					<Item id="45010" name="Преобразовать в UTF-8 без BOM"/>
-					<Item id="45011" name="Преобразовать в UTF-8"/>
-					<Item id="45012" name="Преобразовать в UCS-2 Big Endian"/>
-					<Item id="45013" name="Преобразовать в UCS-2 Little Endian"/>
+					<Item id="45010" name="Преобразовать в UTF-8"/>
+					<Item id="45011" name="Преобразовать в UTF-8 с BOM"/>
+					<Item id="45012" name="Преобразовать в UCS-2 Big Endian с BOM"/>
+					<Item id="45013" name="Преобразовать в UCS-2 Little Endian с BOM"/>
 					<Item id="46001" name="Определение стилей..."/>
 					<Item id="46019" name="INI файл"/>
 					<Item id="46015" name="MS-DOS стиль"/>


### PR DESCRIPTION
There is a confusion of `UTF-8-BOM` and simple `UTF-8` in the Russian localisation.

This is because:
* `UTF-8` was named as `UTF-8 without BOM` (in Russian: `UTF-8 без BOM`).
* `UTF-8-BOM` was named as `UTF-8`.

So many users (that don't know what BOM is) think that they should select `UTF-8` to work with simple `UTF-8` but they actually work with `UTF-8-BOM`. It has been happening for many years! Actually, I also stepped on these rakes when I started to learn programming many years ago.

I propose to change the localisation file to the [English file](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/f4460075e6fe6400a7d595fa82bab54693d01929/PowerEditor/installer/nativeLang/english.xml#L263) style. Now:
* `UTF-8` is named as `UTF-8`.
* `UTF-8-BOM` is named as `UTF-8 with BOM` (in Russian: `UTF-8 с BOM`).

Also I added `with BOM` (in Russian: `с BOM`) to `UCS-2` encodings (again as in the English file).

I edited only the `<all menu item>` block because the `<NewDoc>` block had been already translated properly: it has the same style (check [this block](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/f4460075e6fe6400a7d595fa82bab54693d01929/PowerEditor/installer/nativeLang/russian.xml#L687)).