### PR TITLE
Restore window drawing after aborted shutdown

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1766,6 +1766,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					//User cancelled the shutdown
 					scnN.nmhdr.code = NPPN_CANCELSHUTDOWN;
 					_pluginsManager.notify(&scnN);
+					
+					if (isSnapshotMode)
+						::LockWindowUpdate(NULL);
 					return FALSE;
 				}
 


### PR DESCRIPTION
This bug is obnoxious. I've run into it a couple times and finally decided to fix it.

**How to replicate bug:**
Open scratch tab and input random text, then delete it from _AppData\Roaming\Notepad++\backup_ and try closing Notepad++ which will trigger a "Your backup file cannot be found (deleted from outside)" prompt, but click cancel on it. Enjoy using Npp after triggering this bug. 😋