### PR TITLE
Implemented Wish: "ignore first item" command line argument (for replacing Notepad)

### DIFF
--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -90,6 +90,27 @@ ParamVector parseCommandLine(const TCHAR* commandLine)
 	return result;
 }
 
+// Looks for -z arguments and strips command line arguments following those, if any
+void stripIgnoredParams(ParamVector & params)
+{
+	for ( auto it = params.begin(); it != params.end(); )
+	{
+		if (lstrcmp(it->c_str(), TEXT("-z")) == 0)
+		{
+			auto nextIt = std::next(it);
+			if ( nextIt != params.end() )
+			{
+				params.erase(nextIt);
+			}
+			it = params.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+}
+
 bool isInList(const TCHAR *token2Find, ParamVector& params, bool eraseArg = true)
 {
 	for (auto it = params.begin(); it != params.end(); ++it)
@@ -258,6 +279,7 @@ void doException(Notepad_plus_Window & notepad_plus_plus)
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 {
 	ParamVector params = parseCommandLine(::GetCommandLine());
+	stripIgnoredParams(params);
 
 	MiniDumper mdump;	//for debugging purposes.
 


### PR DESCRIPTION
This PR is split into two commits to ease review:

1. First commit **hugely** simplifies command line parsing (105 LoC -> 12 LoC) by replacing code manually tokenizing arguments with a call to `CommandLineToArgvW` - which does exactly what the original function does, no more, no less. And improving readability (and reliability) by removing code is good, right?
2. Second commit implemented #852 - a new `-z` command line argument has been added, which will cause the argument following it to be ignored (in our case, removed from `ParamVector` entirely).

With changes from this PR, it is now possible to override notepad.exe with notepad++.exe as described in #852, by invoking a command like so:

```
reg add "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\notepad.exe" /v "Debugger" /t REG_SZ /d "\"%ProgramFiles(x86)%\Notepad++\notepad++.exe\" -z" /f
```