### PR TITLE
Fix for "Notepad++ can crash by launching it with specific commandline"

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5288,7 +5288,7 @@ void Notepad_plus::notifyBufferActivated(BufferID bufid, int view)
 	_linkTriggered = true;
 }
 
-void Notepad_plus::loadCommandlineParams(const TCHAR * commandLine, CmdLineParams * pCmdParams)
+void Notepad_plus::loadCommandlineParams(const TCHAR * commandLine, const CmdLineParamsDTO * pCmdParams)
 {
 	if (!commandLine || ! pCmdParams)
 		return;

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -572,7 +572,12 @@ private:
 	bool dumpFiles(const TCHAR * outdir, const TCHAR * fileprefix = TEXT(""));	//helper func
 	void drawTabbarColoursFromStylerArray();
 
-	void loadCommandlineParams(const TCHAR * commandLine, CmdLineParams * pCmdParams);
+	void loadCommandlineParams(const TCHAR * commandLine, const CmdLineParams * pCmdParams)
+	{
+		const CmdLineParamsDTO dto = CmdLineParamsDTO::FromCmdLineParams(*pCmdParams);
+		loadCommandlineParams(commandLine, &dto);
+	}
+	void loadCommandlineParams(const TCHAR * commandLine, const CmdLineParamsDTO * pCmdParams);
 	bool noOpenedDoc() const;
 	bool goToPreviousIndicator(int indicID2Search, bool isWrap = true) const;
 	bool goToNextIndicator(int indicID2Search, bool isWrap = true) const;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -558,9 +558,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			{
 				case COPYDATA_PARAMS:
 				{
-					CmdLineParams *cmdLineParam = static_cast<CmdLineParams *>(pCopyData->lpData); // CmdLineParams object from another instance
-					auto cmdLineParamsSize = static_cast<size_t>(pCopyData->cbData);  // CmdLineParams size from another instance
-					if (sizeof(CmdLineParams) == cmdLineParamsSize) // make sure the structure is the same
+					const CmdLineParamsDTO *cmdLineParam = static_cast<const CmdLineParamsDTO *>(pCopyData->lpData); // CmdLineParams object from another instance
+					const DWORD cmdLineParamsSize = pCopyData->cbData;  // CmdLineParams size from another instance
+					if (sizeof(CmdLineParamsDTO) == cmdLineParamsSize) // make sure the structure is the same
 					{
 						pNppParam->setCmdlineParam(*cmdLineParam);
 					}
@@ -579,7 +579,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				case COPYDATA_FILENAMESA:
 				{
 					char *fileNamesA = static_cast<char *>(pCopyData->lpData);
-					CmdLineParams & cmdLineParams = pNppParam->getCmdLineParams();
+					const CmdLineParamsDTO & cmdLineParams = pNppParam->getCmdLineParams();
 					WcharMbcsConvertor *wmc = WcharMbcsConvertor::getInstance();
 					const wchar_t *fileNamesW = wmc->char2wchar(fileNamesA, CP_ACP);
 					loadCommandlineParams(fileNamesW, &cmdLineParams);
@@ -589,7 +589,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				case COPYDATA_FILENAMESW:
 				{
 					wchar_t *fileNamesW = static_cast<wchar_t *>(pCopyData->lpData);
-					CmdLineParams & cmdLineParams = pNppParam->getCmdLineParams();
+					const CmdLineParamsDTO & cmdLineParams = pNppParam->getCmdLineParams();
 					loadCommandlineParams(fileNamesW, &cmdLineParams);
 					break;
 				}

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -235,6 +235,38 @@ struct CmdLineParams
 	}
 };
 
+// A POD class to send CmdLineParams through WM_COPYDATA and to Notepad_plus::loadCommandlineParams
+struct CmdLineParamsDTO
+{
+	bool _isReadOnly;
+	bool _isNoSession;
+	bool _isSessionFile;
+	bool _isRecursive;
+
+	int _line2go;
+	int _column2go;
+	int _pos2go;
+
+	LangType _langType;
+
+	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
+	{
+		CmdLineParamsDTO dto;
+		dto._isReadOnly = params._isReadOnly;
+		dto._isNoSession = params._isNoSession;
+		dto._isSessionFile = params._isSessionFile;
+		dto._isRecursive = params._isRecursive;
+
+		dto._line2go = params._line2go;
+		dto._column2go = params._column2go;
+		dto._pos2go = params._pos2go;
+		
+		dto._langType = params._langType;
+
+		return dto;
+	}
+};
+
 struct FloatingWindowInfo
 {
 	int _cont;
@@ -1423,11 +1455,11 @@ public:
 
 	void removeTransparent(HWND hwnd);
 
-	void setCmdlineParam(const CmdLineParams & cmdLineParams)
+	void setCmdlineParam(const CmdLineParamsDTO & cmdLineParams)
 	{
 		_cmdLineParams = cmdLineParams;
 	}
-	CmdLineParams & getCmdLineParams() {return _cmdLineParams;};
+	const CmdLineParamsDTO & getCmdLineParams() const {return _cmdLineParams;};
 
 	void setFileSaveDlgFilterIndex(int ln) {_fileSaveDlgFilterIndex = ln;};
 	int getFileSaveDlgFilterIndex() const {return _fileSaveDlgFilterIndex;};
@@ -1639,7 +1671,7 @@ private:
 	ExternalLangContainer *_externalLangArray[NB_MAX_EXTERNAL_LANG];
 	int _nbExternalLang = 0;
 
-	CmdLineParams _cmdLineParams;
+	CmdLineParamsDTO _cmdLineParams;
 
 	int _fileSaveDlgFilterIndex = -1;
 

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -483,10 +483,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 
 			if (params.size() > 0)	//if there are files to open, use the WM_COPYDATA system
 			{
+				CmdLineParamsDTO dto = CmdLineParamsDTO::FromCmdLineParams(cmdLineParams);
+
 				COPYDATASTRUCT paramData;
 				paramData.dwData = COPYDATA_PARAMS;
-				paramData.lpData = &cmdLineParams;
-				paramData.cbData = sizeof(cmdLineParams);
+				paramData.lpData = &dto;
+				paramData.cbData = sizeof(dto);
 
 				COPYDATASTRUCT fileNamesData;
 				fileNamesData.dwData = COPYDATA_FILENAMES;


### PR DESCRIPTION
A fix for #4621. Please refer to this issue for detailed description and a repro path.

I created a new POD type which gets transferred between instances, instead of existing `CmdLineParams` which is **not** a POD type (because of `std::string`, whose contents don't need to be transferred between instances anyway).