### PR TITLE
Fixed crash Issue by checking & unchecking "Disable extension column" in preferences dialog

### DIFF
--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -122,6 +122,7 @@ void VerticalFileSwitcherListView::initList()
 		{
 			// resize "Name" column when "exts" won't fit
 			LVCOLUMN lvc;
+			lvc.mask = LVCF_WIDTH;
 			SendMessage(_hSelf, LVM_GETCOLUMN, 0, reinterpret_cast<LPARAM>(&lvc));
 			
 			if (lvc.cx + 50 > totalWidth)


### PR DESCRIPTION
Fixed Crash issue #4682 

**Also fixes additional issue** which can be seen only in x64 version (x86 version crashes 😉) with following steps.
1. Make sure both the checkbox ("Show" and "Disable extension column") are unchecked for "Document list panel". If not, then disable both of them and restart npp.
2. Now open preferences and check  "Disable extension column", then check "Show"
3. Observe "Doc switcher" panel. Only one column ("Name") is available.
4. Now uncheck "Disable extension column", and observe "Doc switcher" panel again. This time "Ext" is excepted but it is not visible.

![image](https://user-images.githubusercontent.com/14791461/43032599-b45ffda8-8cd8-11e8-8eb2-d143b60a6b21.png)


