### PR TITLE
Fixed Regression issue: Folder as workspace not updating dir changes

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -178,6 +178,14 @@ protected:
 	void openSelectFile();
 	void getDirectoryStructure(const TCHAR *dir, const std::vector<generic_string> & patterns, FolderInfo & directoryStructure, bool isRecursive, bool isInHiddenDir); 
 	HTREEITEM createFolderItemsFromDirStruct(HTREEITEM hParentItem, const FolderInfo & directoryStructure);
+
+private:
+	using DirChangeInfo = struct
+	{
+		generic_string rootPath, childItem;
+	};
+
+	std::vector<DirChangeInfo> getDirChangeInfo(const std::vector<generic_string>& changeInfo);
 };
 
 #endif // FILEBROWSER_H


### PR DESCRIPTION
Fixed issue #4644 

The simplest fix is changing below code in all the three messages (FB_ADDFILE, FB_RMFILE and FB_RNFILE)

from 
```C++
generic_string separator = TEXT("\\\\");
size_t sepPos = file2Change[0].find(separator);
``` 
to 
```C++
generic_string separator = TEXT("\\");
size_t sepPos = file2Change[0].find_last_of(separator);
``` 

But just to remove duplicate code from all three sections, new method ```std::vector<DirChangeInfo> getDirChangeInfo(const std::vector<generic_string>& changeInfo);``` is introduced.


This regression was introduced by one of my PR  #4257