### PR TITLE
Fix "Explorer Here" from "Folder as Workspace" problem if folder name contains comma 

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -670,7 +670,7 @@ void FileBrowser::popupMenuCmd(int cmdID)
 			if (::PathFileExists(path.c_str()))
 			{
 				TCHAR cmdStr[1024];
-				wsprintf(cmdStr, TEXT("explorer /select,%s"), path.c_str());
+				wsprintf(cmdStr, TEXT("explorer /select,\"%s\""), path.c_str());
 				Command cmd(cmdStr);
 				cmd.run(nullptr);
 			}


### PR DESCRIPTION
Fixed issue  #4249 

Reference:
1. https://github.com/SublimeTextIssues/Core/issues/1168#issuecomment-212994030
2. https://ss64.com/nt/explorer.html