### PR TITLE
Fixed issue: Last active tab is ignored on N++ restart

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1971,8 +1971,8 @@ bool NppParameters::getSessionFromXmlTree(TiXmlDocument *pSessionDoc, Session *p
 		return false;
 
 	TiXmlElement *actView = sessionRoot->ToElement();
-	size_t index;
-	const TCHAR *str = actView->Attribute(TEXT("activeView"), reinterpret_cast<int *>(&index));
+	int index = 0;
+	const TCHAR *str = actView->Attribute(TEXT("activeView"), &index);
 	if (str)
 	{
 		(*ptrSession)._activeView = index;
@@ -1986,9 +1986,9 @@ bool NppParameters::getSessionFromXmlTree(TiXmlDocument *pSessionDoc, Session *p
 	{
 		if (viewRoots[k])
 		{
-			size_t index2;
+			int index2 = 0;
 			TiXmlElement *actIndex = viewRoots[k]->ToElement();
-			str = actIndex->Attribute(TEXT("activeIndex"), reinterpret_cast<int *>(&index2));
+			str = actIndex->Attribute(TEXT("activeIndex"), &index2);
 			if (str)
 			{
 				if (k == 0)


### PR DESCRIPTION
Fixed issue #4716 and #4755.
As of now this issue is seen only on x64 bit and RCA is below - 
```C++
size_t index2;
TiXmlElement *actIndex = viewRoots[k]->ToElement();
str = actIndex->Attribute(TEXT("activeIndex"), reinterpret_cast<int *>(&index2));
```
casting `size_t` which is ```unsigned __int64``` to ```int``` causes this issue. There is no impact on 32 bit npp as ```size_t``` is ```unsigned int``` on 32 bit.

**Special note:**
1. This is little difficult to reproduce.
2. If variable `index2` is initialized to 0, then I could not reproduce.
3. If variable `index2` is initialized to higher value (e.g. `size_t index2 = 380316380316`), then it is reproduced.
4. As of now, this variable is not initialized, so it can be reproduced only when `index2` is assigned with higher garbage value. If you want to reproduce, just assign higher value during debug to `index2` variable.
5. There might few more places where similar code might exists which requires attention.


![image](https://user-images.githubusercontent.com/14791461/43480695-9ad9b1d4-9521-11e8-8a13-e7111a64739b.png)

See the value of `index2`. It should be `3`. Because of this below code gets affected.

![image](https://user-images.githubusercontent.com/14791461/43480753-cdd2ba04-9521-11e8-8f36-a36fd089b706.png)
