### PR TITLE
Update for new WinGup

### DIFF
--- a/PowerEditor/installer/nsisInclude/binariesComponents.nsh
+++ b/PowerEditor/installer/nsisInclude/binariesComponents.nsh
@@ -100,6 +100,7 @@ ${MementoSection} "Auto-Updater" AutoUpdater
 	File "..\bin\updater\LICENSE"
 	File "..\bin\updater\README.md"
 !endif
+	File /oname=$INSTDIR\updater\npp_updater.ico ".\images\npp_inst.ico"
 ${MementoSectionEnd}
 
 ;Uninstall section
@@ -151,5 +152,6 @@ Section un.AutoUpdater
 	Delete "$INSTDIR\updater\readme.txt"
 	Delete "$INSTDIR\updater\README.md"
 	Delete "$INSTDIR\updater\getDownLoadUrl.php"
+	Delete "$INSTDIR\updater\npp_updater.ico"
 	RMDir "$INSTDIR\updater"
 SectionEnd 


### PR DESCRIPTION
If there is a plan to update WinGUP as per [WinGup PR](https://github.com/gup4win/wingup/pull/24) then merge this PR as well for notepad to use proper icon.

@donho please have a look  at  [WinGup PR](https://github.com/gup4win/wingup/pull/24) which fixes many updater related issues such as #1730, #4666 and #4069.