### PR TITLE
Delete Shell Extension dll more effectively

### DIFF
--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -226,33 +226,21 @@ FunctionEnd
 
 Function removeOldContextMenu
    ; Context Menu Management : removing old version of Context Menu module
-	IfFileExists "$INSTDIR\nppcm.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\nppcm.dll"'
-		Delete "$INSTDIR\nppcm.dll"
-        
-    IfFileExists "$INSTDIR\NppShell.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell.dll"'
-		Delete "$INSTDIR\NppShell.dll"
-		
-    IfFileExists "$INSTDIR\NppShell_01.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
-		Delete "$INSTDIR\NppShell_01.dll"
-        
-    IfFileExists "$INSTDIR\NppShell_02.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
-		Delete "$INSTDIR\NppShell_02.dll"
-		
-    IfFileExists "$INSTDIR\NppShell_03.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
-		Delete "$INSTDIR\NppShell_03.dll"
-		
-	IfFileExists "$INSTDIR\NppShell_04.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
-		Delete "$INSTDIR\NppShell_04.dll"
-		
-	IfFileExists "$INSTDIR\NppShell_05.dll" 0 +3
-		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
-		Delete "$INSTDIR\NppShell_05.dll"
+	Exec 'regsvr32 /u /s "$INSTDIR\nppcm.dll"'
+	Exec 'regsvr32 /u /s "$INSTDIR\NppShell.dll"'
+	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
+	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
+	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
+	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
+	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
+
+	${safeDeleteFile} "$INSTDIR\nppcm.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_01.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_02.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_03.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_04.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_05.dll"
 FunctionEnd
 
 Function shortcutLinkManagement

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -64,12 +64,13 @@ Section un.explorerContextMenu
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_06.dll"'
-	Delete "$INSTDIR\NppShell_01.dll"
-	Delete "$INSTDIR\NppShell_02.dll"
-	Delete "$INSTDIR\NppShell_03.dll"
-	Delete "$INSTDIR\NppShell_04.dll"
-	Delete "$INSTDIR\NppShell_05.dll"
-	Delete "$INSTDIR\NppShell_06.dll"
+
+	${safeDeleteFile} "$INSTDIR\NppShell_01.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_02.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_03.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_04.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_05.dll"
+	${safeDeleteFile} "$INSTDIR\NppShell_06.dll"
 SectionEnd
 
 Section un.UnregisterFileExt


### PR DESCRIPTION
This is improved version of PR #2424. (instead of adding 1,2,3 so on, append current timestamp while moving `ShellDll` to %temp% so that nsis API `rename` does not fail.)

Fix issue #2404
As soon Npp shell dll is loaded (right click on any file). It is locked inside the explorer.exe. Therefore, uninstaller/installer could not delete the npp shell dll.

**Concept to resolve the issue is: move the locked dll to temp dir and delete that file on next reboot.**