### PR TITLE
Fixed Issue : Typo creates localization issue

### DIFF
--- a/PowerEditor/installer/nativeLang/arabic.xml
+++ b/PowerEditor/installer/nativeLang/arabic.xml
@@ -1126,8 +1126,8 @@
             <find-status-replaceall-readonly value="استبدال الكل: لا يمكن استبدال النص. المستند الحالي للقراءة فقط."/>
             <find-status-replace-end-reached value="الاستبدال: تم استبدال أول تكرار من أعلى. تم الوصل إلى نهاية المستند."/>
             <find-status-replace-top-reached value="الاستبدال: تم استبدال أول تكرار من أسفل. تم الوصل إلى بداية المستند."/>
-            <find-status-relaced-next-found value="الاستبدال: 1 تكرار تم استبداله. تم العثور على التكرار التالي."/>
-            <find-status-relaced-next-not-found value="الاستبدال: 1 تكرار تم استبداله. لم يتم العثور على التكرار التالي."/>
+            <find-status-replaced-next-found value="الاستبدال: 1 تكرار تم استبداله. تم العثور على التكرار التالي."/>
+            <find-status-replaced-next-not-found value="الاستبدال: 1 تكرار تم استبداله. لم يتم العثور على التكرار التالي."/>
             <find-status-replace-not-found value="الاستبدال: لم يتم العثور على أي تكرار."/>
             <find-status-replace-readonly value="الاستبدال: لا يمكن استبدال النص. المستند الحالي للقراءة فقط."/>
             <find-status-cannot-find value="البحث: لا يمكن العثور على النص &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/belarusian.xml
+++ b/PowerEditor/installer/nativeLang/belarusian.xml
@@ -1127,8 +1127,8 @@
             <ind-status-replaceall-readonly value="Замяніць усе: немагчыма замяніць тэкст. Бягучы дакумент мае правы толькі не чытанне"/>
             <find-status-replace-end-reached value="Замяніць: заменена першае супадзенне зверху. Быў дасягнуты канец дакумента"/>
             <find-status-replace-top-reached value="Замяніць: заменена першае супадзенне знізу. Быў дасягнуты пачатак дакумента"/>
-            <find-status-relaced-next-found value="Замяніць: выканана адна замена. Знойдзена наступнае супадзенне"/>
-            <find-status-relaced-next-not-found value="Замяніць: выканана адна замена. Наступнае супадзенне не знойдзена"/>
+            <find-status-replaced-next-found value="Замяніць: выканана адна замена. Знойдзена наступнае супадзенне"/>
+            <find-status-replaced-next-not-found value="Замяніць: выканана адна замена. Наступнае супадзенне не знойдзена"/>
             <find-status-replace-not-found value="Замяніць: наступнае супадзенне не знойдзена"/>
             <find-status-replace-readonly value="Замяніць: немагчыма замяніць тэкст. Бягучы дакумент мае правы толькі на чытанне"/>
             <find-status-cannot-find value="Знайсці: не магчыма знайсці тэкст &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
+++ b/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
@@ -1155,8 +1155,8 @@ Deseja iniciar o Notepad++ no modo Administrador?"/>
             <find-status-replaceall-readonly value="Replace All: Cannot replace text. The current document is read only"/>
             <find-status-replace-end-reached value="Replace: Replaced the 1st occurrence from the top. The end of document has been reached"/>
             <find-status-replace-top-reached value="Replace: Replaced the 1st occurrence from the bottom. The begin of document has been reached"/>
-            <find-status-relaced-next-found value="Replace: 1 occurrence was replaced. The next occurrence found"/>
-            <find-status-relaced-next-not-found value="Replace: 1 occurrence was replaced. The next occurrence not found"/>
+            <find-status-replaced-next-found value="Replace: 1 occurrence was replaced. The next occurrence found"/>
+            <find-status-replaced-next-not-found value="Replace: 1 occurrence was replaced. The next occurrence not found"/>
             <find-status-replace-not-found value="Replace: no occurrence was found"/>
             <find-status-replace-readonly value="Replace: Cannot replace text. The current document is read only"/>
             <find-status-cannot-find value="Find: Can't find the text &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/bulgarian.xml
+++ b/PowerEditor/installer/nativeLang/bulgarian.xml
@@ -1135,8 +1135,8 @@
 			<find-status-replaceall-readonly value="Замяна на всичко: Текста не може да се замени. Текущият документ е само за четене"/>
 			<find-status-replace-end-reached value="Замяна: Заменено е първото съвпадение от началото. Краят на документа е достигнат"/>
 			<find-status-replace-top-reached value="Замяна: Заменено е първото съвпадение от краят. Началото на документа е достигнато"/>
-			<find-status-relaced-next-found value="Замяна: беше заменено 1 съвпадение. Намерено е следващото съвпадение"/>
-			<find-status-relaced-next-not-found value="Замяна: беше заменено 1 съвпадение. Следващото съвпадение не е намерено"/>
+			<find-status-replaced-next-found value="Замяна: беше заменено 1 съвпадение. Намерено е следващото съвпадение"/>
+			<find-status-replaced-next-not-found value="Замяна: беше заменено 1 съвпадение. Следващото съвпадение не е намерено"/>
 			<find-status-replace-not-found value="Замяна: не беше намерено съвпадение"/>
 			<find-status-replace-readonly value="Замяна: Текста не може да се замени. Текущият документ е само за четене"/>
 			<find-status-cannot-find value="Търсене: Текстът &quot;$STR_REPLACE$&quot; не може да се намери"/>

--- a/PowerEditor/installer/nativeLang/catalan.xml
+++ b/PowerEditor/installer/nativeLang/catalan.xml
@@ -1109,8 +1109,8 @@ By Hiro5 <groccat at gmail>
 			<find-status-replaceall-readonly value="Reemplaça-ho tot: No es pot reemplaçar el text. El document actual és de només lectura"/>
 			<find-status-replace-end-reached value="Reemplaça: Reemplaçat el 1er resultat des de dalt. S'ha arribat al final del document"/>
 			<find-status-replace-top-reached value="Reemplaça: Reemplaçat el 1er resultat des de baix. S'ha arribat al principi del document"/>
-			<find-status-relaced-next-found value="Reemplaça: 1 resultat reemplaçat. Següent resultat trobat"/>
-			<find-status-relaced-next-not-found value="Reemplaça: 1 resultat reemplaçat. Següent resultat no trobat"/>
+			<find-status-replaced-next-found value="Reemplaça: 1 resultat reemplaçat. Següent resultat trobat"/>
+			<find-status-replaced-next-not-found value="Reemplaça: 1 resultat reemplaçat. Següent resultat no trobat"/>
 			<find-status-replace-not-found value="Reemplaça: cap resultat trobat"/>
 			<find-status-replace-readonly value="Reemplaça: No es pot reemplaçar el text. El document actual és de només lectura"/>
 			<find-status-cannot-find value="Cerca: No s'ha trobat el text &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/chineseSimplified.xml
+++ b/PowerEditor/installer/nativeLang/chineseSimplified.xml
@@ -1143,8 +1143,8 @@
             <find-status-replaceall-readonly value="全部替换：无法替换文本，当前文件只读。"/>
             <find-status-replace-end-reached value="替换：替换到从上到下的首个匹配项。已查找至文档最底部。"/>
             <find-status-replace-top-reached value="替换：替换到从下到上的首个匹配项。已查找至文档最顶部。"/>
-            <find-status-relaced-next-found value="替换：已替换1个匹配项，并找到了下一个。"/>
-            <find-status-relaced-next-not-found value="替换：已替换1个匹配项，没有找到下一个。"/>
+            <find-status-replaced-next-found value="替换：已替换1个匹配项，并找到了下一个。"/>
+            <find-status-replaced-next-not-found value="替换：已替换1个匹配项，没有找到下一个。"/>
             <find-status-replace-not-found value="替换：没有找到匹配项。"/>
             <find-status-replace-readonly value="替换：无法替换文本，当前文件只读。"/>
             <find-status-cannot-find value="查找：无法找到文本“$STR_REPLACE$”"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -1167,8 +1167,8 @@ Vulete dimarrà Notepad++ in modu Amministratore ?"/>
             <find-status-replaceall-readonly value="Rimpiazzà Tutti : Ùn si pò rimpiazzà u testu. U ducumentu attuale pò solu si leghje"/>
             <find-status-replace-end-reached value="Rimpiazzà : 1a occurrenza rimpiazzata da u principiu. A fine di u ducumentu hè stata tocca"/>
             <find-status-replace-top-reached value="Rimpiazzà : 1a occurrenza rimpiazzata da a fine. U principiu di u ducumentu hè statu toccu"/>
-            <find-status-relaced-next-found value="Rimpiazzà : 1 occurrenza hè stata rimpiazzata. A prossima occurrenza trova"/>
-            <find-status-relaced-next-not-found value="Rimpiazzà : 1 occurrenza hè stata rimpiazzata. A prossima occurrenza micca trova"/>
+            <find-status-replaced-next-found value="Rimpiazzà : 1 occurrenza hè stata rimpiazzata. A prossima occurrenza trova"/>
+            <find-status-replaced-next-not-found value="Rimpiazzà : 1 occurrenza hè stata rimpiazzata. A prossima occurrenza micca trova"/>
             <find-status-replace-not-found value="Rimpiazzà : alcuna occurrenza trova"/>
             <find-status-replace-readonly value="Rimpiazzà : Ùn si pò rimpiazzà u testu. U ducumentu attuale pò solu si leghje"/>
             <find-status-cannot-find value="Circà : Ùn si pò truvà u testu &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/czech.xml
+++ b/PowerEditor/installer/nativeLang/czech.xml
@@ -1201,8 +1201,8 @@
 			<find-status-replaceall-readonly value = "Nahrazování všeho: Nemohu nahradit text. Současný dokument je pouze pro čtení"/>
 			<find-status-replace-end-reached value = "Nahrazování: Nahrazen první výskyt od začátku. Bylo dosaženo konce dokumentu"/>
 			<find-status-replace-top-reached value = "Nahrazování: Nahrazen první výskyt od konce. Bylo dosaženo začátku dokumentu"/>
-			<find-status-relaced-next-found value = "Nahrazování: 1 výskyt byl nahrazen. Další výskyt nalezen"/>
-			<find-status-relaced-next-not-found value = "Nahrazování: 1 výskyt byl nahrazen. Další výskyt nenalezen"/>
+			<find-status-replaced-next-found value = "Nahrazování: 1 výskyt byl nahrazen. Další výskyt nalezen"/>
+			<find-status-replaced-next-not-found value = "Nahrazování: 1 výskyt byl nahrazen. Další výskyt nenalezen"/>
 			<find-status-replace-not-found value = "Nahrazování: žádný výskyt nebyl nalezen"/>
 			<find-status-replace-readonly value = "Nahrazování: Nemohu nahradit text. Současný dokument je pouze pro čtení"/>
 			<find-status-cannot-find value = "Vyhledávání: Nemohu nalézt text &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/danish.xml
+++ b/PowerEditor/installer/nativeLang/danish.xml
@@ -1133,8 +1133,8 @@ giv venligst et andet."/>
             <find-status-replaceall-readonly value="Erstat alle: Kan ikke erstatte tekst. Det nuværende dokument er skrivebeskyttet"/>
             <find-status-replace-end-reached value="Erstat: Erstattet den første forekomst fra toppen. Slutningen af dokumentet er nået"/>
             <find-status-replace-top-reached value="Erstat: Erstattet den første forekomst fra bunden. Begyndelsen af dokumentet er nået"/>
-            <find-status-relaced-next-found value="Erstat: 1 forekomst blev erstattet. Den næste forekomst blev fundet"/>
-            <find-status-relaced-next-not-found value="Erstat: 1 forekomst blev erstattet. Den næste forekomst blev ikke fundet"/>
+            <find-status-replaced-next-found value="Erstat: 1 forekomst blev erstattet. Den næste forekomst blev fundet"/>
+            <find-status-replaced-next-not-found value="Erstat: 1 forekomst blev erstattet. Den næste forekomst blev ikke fundet"/>
             <find-status-replace-not-found value="Erstat: ingen forekomster blev fundet"/>
             <find-status-replace-readonly value="Erstat: Kan ikke erstatte tekst. Det nuværende dokument er skrivebeskyttet"/>
             <find-status-cannot-find value="Søg: Kan ikke finde teksten &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/dutch.xml
+++ b/PowerEditor/installer/nativeLang/dutch.xml
@@ -1342,10 +1342,10 @@
 			<find-status-replace-top-reached
 				value="Vervangen: Tekst is op 1 locatie vervangen. Start van het document is gepasseerd"
 			/>
-			<find-status-relaced-next-found
+			<find-status-replaced-next-found
 				value="Vervangen: Tekst is op 1 locatie vervangen. Nieuwe locatie gevonden"
 			/>
-			<find-status-relaced-next-not-found
+			<find-status-replaced-next-not-found
 				value="Vervangen: Tekst is op 1 locatie vervangen. Geen nieuwe locatie gevonden"
 			/>
 			<find-status-replace-not-found

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1155,8 +1155,8 @@ Do you want to launch Notepad++ in Administrator mode?"/>
             <find-status-replaceall-readonly value="Replace All: Cannot replace text. The current document is read only"/>
             <find-status-replace-end-reached value="Replace: Replaced the 1st occurrence from the top. The end of document has been reached"/>
             <find-status-replace-top-reached value="Replace: Replaced the 1st occurrence from the bottom. The begin of document has been reached"/>
-            <find-status-relaced-next-found value="Replace: 1 occurrence was replaced. The next occurrence found"/>
-            <find-status-relaced-next-not-found value="Replace: 1 occurrence was replaced. The next occurrence not found"/>
+            <find-status-replaced-next-found value="Replace: 1 occurrence was replaced. The next occurrence found"/>
+            <find-status-replaced-next-not-found value="Replace: 1 occurrence was replaced. The next occurrence not found"/>
             <find-status-replace-not-found value="Replace: no occurrence was found"/>
             <find-status-replace-readonly value="Replace: Cannot replace text. The current document is read only"/>
             <find-status-cannot-find value="Find: Can't find the text &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1155,8 +1155,8 @@ Do you want to launch Notepad++ in Administrator mode?"/>
             <find-status-replaceall-readonly value="Replace All: Cannot replace text. The current document is read only"/>
             <find-status-replace-end-reached value="Replace: Replaced the 1st occurrence from the top. The end of document has been reached"/>
             <find-status-replace-top-reached value="Replace: Replaced the 1st occurrence from the bottom. The begin of document has been reached"/>
-            <find-status-relaced-next-found value="Replace: 1 occurrence was replaced. The next occurrence found"/>
-            <find-status-relaced-next-not-found value="Replace: 1 occurrence was replaced. The next occurrence not found"/>
+            <find-status-replaced-next-found value="Replace: 1 occurrence was replaced. The next occurrence found"/>
+            <find-status-replaced-next-not-found value="Replace: 1 occurrence was replaced. The next occurrence not found"/>
             <find-status-replace-not-found value="Replace: no occurrence was found"/>
             <find-status-replace-readonly value="Replace: Cannot replace text. The current document is read only"/>
             <find-status-cannot-find value="Find: Can't find the text &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -1143,8 +1143,8 @@
 			<find-status-replaceall-readonly value="Alle ersetzen: Konnte Text wegen schreibgeschützter Datei nicht ersetzen"/>
 			<find-status-replace-end-reached value="Ersetzen: 1. Vorkommen von oben wurde ersetzt. Das Ende des Dokumentes wurde erreicht"/>
 			<find-status-replace-top-reached value="Ersetzen: 1. Vorkommen von unten wurde ersetzt. Der Anfang des Dokumentes wurde erreicht"/>
-			<find-status-relaced-next-found value="Ersetzen: 1 Vorkommen wurde ersetzt. Nächster Treffer gefunden"/>
-			<find-status-relaced-next-not-found value="Ersetzen: 1 Vorkommen wurde ersetzt. Kein weiterer Treffer gefunden"/>
+			<find-status-replaced-next-found value="Ersetzen: 1 Vorkommen wurde ersetzt. Nächster Treffer gefunden"/>
+			<find-status-replaced-next-not-found value="Ersetzen: 1 Vorkommen wurde ersetzt. Kein weiterer Treffer gefunden"/>
 			<find-status-replace-not-found value="Ersetzen: Kein Vorkommen gefunden"/>
 			<find-status-replace-readonly value="Ersetzen: Konnte Text wegen schreibgeschützter Datei nicht ersetzen"/>
 			<find-status-cannot-find value="Suche: Konnte Text &quot;$STR_REPLACE$&quot; nicht finden"/>

--- a/PowerEditor/installer/nativeLang/hindi.xml
+++ b/PowerEditor/installer/nativeLang/hindi.xml
@@ -1149,8 +1149,8 @@
 		<find-status-replaceall-readonly value="सभी बदलें: टेक्स्ट नहीं बदल सके। वर्तमान डॉक्यूमेंट रीड-ओनली है।"/>
 		<find-status-replace-end-reached value="बदलें: ऊपर से 1st मिलान बदल दिया गया है। डॉक्यूमेंट के अंत पर पहुँच चुकें हैं।"/>
 		<find-status-replace-top-reached value="बदलें: नीचे से 1st मिलान बदल दिया गया है। डॉक्यूमेंट की शुरुआत पर पहुँच चुकें हैं।"/>
-		<find-status-relaced-next-found value="बदलें: 1 मिलान को बदल दिया गया है। अगला मिलान मिला।"/>
-		<find-status-relaced-next-not-found value="बदलें: 1 मिलान को बदल दिया गया है। अगला मिलान नहीं मिला।"/>
+		<find-status-replaced-next-found value="बदलें: 1 मिलान को बदल दिया गया है। अगला मिलान मिला।"/>
+		<find-status-replaced-next-not-found value="बदलें: 1 मिलान को बदल दिया गया है। अगला मिलान नहीं मिला।"/>
 		<find-status-replace-not-found value="बदलें: कोई मिलान नहीं मिला।"/>
 		<find-status-replace-readonly value="बदलें: Text नहीं बदल सके। वर्तमान डॉक्यूमेंट रीड-ओनली है।"/>
 		<find-status-cannot-find value="खोज: Text नहीं ढूंढ सके &quot;$STR_REPLACE$&quot;।"/>

--- a/PowerEditor/installer/nativeLang/hungarian.xml
+++ b/PowerEditor/installer/nativeLang/hungarian.xml
@@ -1167,8 +1167,8 @@ Elindítja a Notepad++-t rendszergazdaként?"/>
             <find-status-replaceall-readonly value="Összes cseréje: A szöveg nem cserélhető. A jelenlegi dokumentum írásvédett."/>
             <find-status-replace-end-reached value="Csere: Első előfordulás cserélve felülről. A dokumentum végét elértük."/>
             <find-status-replace-top-reached value="Csere: Első előfordulás cserélve alulról. A dokumentum elejét elértük."/>
-            <find-status-relaced-next-found value="Csere: 1 találat cserélve. A következő találatot elértük."/>
-            <find-status-relaced-next-not-found value="Csere: 1 találat cserélve. A következő előfordulás nem található."/>
+            <find-status-replaced-next-found value="Csere: 1 találat cserélve. A következő találatot elértük."/>
+            <find-status-replaced-next-not-found value="Csere: 1 találat cserélve. A következő előfordulás nem található."/>
             <find-status-replace-not-found value="Csere: Nem található előfordulás"/>
             <find-status-replace-readonly value="Csere: A szöveg nem cserélhető. A jelenlegi dokumentum írásvédett."/>
             <find-status-cannot-find value="Keresés: Nem található ez a szöveg: &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/indonesian.xml
+++ b/PowerEditor/installer/nativeLang/indonesian.xml
@@ -1074,8 +1074,8 @@
             <find-status-replaceall-readonly value="Ganti Semua: Tidak dapat mengganti teks. Dokumen ini hanya bisa dibaca"/>
             <find-status-replace-end-reached value="Ganti: Mengganti kejadian pertama dari atas. Akhir dokumen telah tercapai"/>
             <find-status-replace-top-reached value="Ganti: Mengganti kejadian pertama dari bawah. Awal dokumen telah tercapai"/>
-            <find-status-relaced-next-found value="Ganti: 1 kejadian diganti. Kejadian selanjutnya ditemukan"/>
-            <find-status-relaced-next-not-found value="Ganti: 1 kejadian diganti. Kejadian selanjutnya tidak ditemukan"/>
+            <find-status-replaced-next-found value="Ganti: 1 kejadian diganti. Kejadian selanjutnya ditemukan"/>
+            <find-status-replaced-next-not-found value="Ganti: 1 kejadian diganti. Kejadian selanjutnya tidak ditemukan"/>
             <find-status-replace-not-found value="Ganti: tidak ada kejadian yang ditemukan"/>
             <find-status-replace-readonly value="Ganti: Tidak dapat mengganti teks. Dokumen ini hanya bisa dibaca"/>
             <find-status-cannot-find value="Cari: Tidak dapat menemukan teks &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -1169,8 +1169,8 @@ Vuoi avviare Notepad++ come amministratore?" />
             <find-status-replaceall-readonly value = "Sostituisci tutti: impossibile sostituire il testo. Il documento corrente è in sola lettura" />
             <find-status-replace-end-reached value = "Sostituisci: sostituita la prima occorrenza dall'&apos;alto. È stata raggiunta la fine del documento " />
             <find-status-replace-top-reached value = "Sostituisci: sostituita la prima occorrenza dal basso. È stato raggiunto l&apos;inizio del documento" />
-            <find-status-relaced-next-found value = "Sostituisci: 1 occorrenza è stata sostituita. Trovata l'occorrenza successiva" />
-            <find-status-relaced-next-not-found value = "Sostituisci:1 occorrenza è stata sostituita. Nessuna occorrenza successiva" />
+            <find-status-replaced-next-found value = "Sostituisci: 1 occorrenza è stata sostituita. Trovata l'occorrenza successiva" />
+            <find-status-replaced-next-not-found value = "Sostituisci:1 occorrenza è stata sostituita. Nessuna occorrenza successiva" />
             <find-status-replace-not-found value = "Sostituisci: nessuna occorrenza trovata" />
             <find-status-replace-readonly value = "Sostituisci: impossibile sostituire il testo. Il documento corrente è in sola lettura" />
             <find-status-cannot-find value = "Cerca: impossibile trovare il testo &quot;$STR_REPLACE$&quot;" />

--- a/PowerEditor/installer/nativeLang/japanese.xml
+++ b/PowerEditor/installer/nativeLang/japanese.xml
@@ -1168,8 +1168,8 @@ Notepad++ を管理者権限で立ち上げますか？"/>
             <find-status-replaceall-readonly value="すべて置換：置換できません。この文書は読み取り専用です"/>
             <find-status-replace-end-reached value="置換：先頭からの最初の一致を置換しました。文書の末尾を通過しました"/>
             <find-status-replace-top-reached value="置換：末尾からの最初の一致を置換しました。文書の先頭を通過しました"/>
-            <find-status-relaced-next-found value="置換：1 件を置換しました。次の一致が見つかりました"/>
-            <find-status-relaced-next-not-found value="置換：1 件を置換しました。一致するものはありません"/>
+            <find-status-replaced-next-found value="置換：1 件を置換しました。次の一致が見つかりました"/>
+            <find-status-replaced-next-not-found value="置換：1 件を置換しました。一致するものはありません"/>
             <find-status-replace-not-found value="置換：一致するものはありません"/>
             <find-status-replace-readonly value="置換：置換できません。この文書は読み取り専用です"/>
             <find-status-cannot-find value="検索：見つかりません。&quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/lithuanian.xml
+++ b/PowerEditor/installer/nativeLang/lithuanian.xml
@@ -1161,8 +1161,8 @@ Ar norite paleisti Notepad++ administratoriaus teisėmis?"/>
             <find-status-replaceall-readonly value="Keitimas visų: Keitimas nepavyko. Dokumentas tik skaitomas"/>
             <find-status-replace-end-reached value="Keitimas: Pakeistas pirmas atitikmuo nuo pradžios. Buvo pasiekta dokumento pabaiga"/>
             <find-status-replace-top-reached value="Keitimas: Pakeistas pirmas atitikmuo nuo galo. Buvo pasiekta dokumento pradžia"/>
-            <find-status-relaced-next-found value="Keitimas: 1 atitikmuo buvo pakeistas. Rastas kitas atitikmuo"/>
-            <find-status-relaced-next-not-found value="Keitimas: 1 atitikmuo buvo pakeistas. Kitas atitikmuo nerastas"/>
+            <find-status-replaced-next-found value="Keitimas: 1 atitikmuo buvo pakeistas. Rastas kitas atitikmuo"/>
+            <find-status-replaced-next-not-found value="Keitimas: 1 atitikmuo buvo pakeistas. Kitas atitikmuo nerastas"/>
             <find-status-replace-not-found value="Keitimas: atitikimų nerasta"/>
             <find-status-replace-readonly value="Keitimas: Keitimas nepavyko. Dokumentas tik skaitomas"/>
             <find-status-cannot-find value="Paieška: Nepavyko rasti teksto &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/occitan.xml
+++ b/PowerEditor/installer/nativeLang/occitan.xml
@@ -1143,8 +1143,8 @@ Deuretz tornar lançar Notepad++ per que siá efectiu."/>
 			<find-status-replaceall-readonly value="Remplaçar tot : Impossible de remplaçar lo tèxt. Lo document actiu es en lectura sola"/>
 			<find-status-replace-end-reached value="Remplaçar : 1èra ocurréncia dempuèi lo naut remplaçada. Fin del document atenguda"/>
 			<find-status-replace-top-reached value="Remplaçar : 1èra ocurréncia dempuèi lo bas remplaçada. Debuta del document atenguda."/>
-			<find-status-relaced-next-found value="Remplaçar : 1 occurrence was replaced. Ocurréncia seguenta trobada"/>
-			<find-status-relaced-next-not-found value="Remplaçar : 1 occurrence was replaced. Ocurréncia seguenta pas trobada"/>
+			<find-status-replaced-next-found value="Remplaçar : 1 occurrence was replaced. Ocurréncia seguenta trobada"/>
+			<find-status-replaced-next-not-found value="Remplaçar : 1 occurrence was replaced. Ocurréncia seguenta pas trobada"/>
 			<find-status-replace-not-found value="Remplaçar : cap d'ocurrénia trobada"/>
 			<find-status-replace-readonly value="Remplaçar : Impossible de remplaçar lo tèxt. Lo document actiu es en lectura sola"/>
 			<find-status-cannot-find value="Recèrca : Impossible de trobar lo tèxt &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/romanian.xml
+++ b/PowerEditor/installer/nativeLang/romanian.xml
@@ -1132,8 +1132,8 @@ alegeți altul."/>
             <find-status-replaceall-readonly value="Înlocuire toate: textul nu poate fi înlocuit. Documentul curent are blocată salvarea modificărilor."/>
             <find-status-replace-end-reached value="Înlocuire: s-a înlocuit prima potrivire de sus. S-a atins sfârșitul documentului."/>
             <find-status-replace-top-reached value="Înlocuire: s-a înlocuit prima potrivire de jos. S-a atins începutul documentului."/>
-            <find-status-relaced-next-found value="Înlocuire: s-a înlocuit o potrivire. S-a mai găsit o potrivire."/>
-            <find-status-relaced-next-not-found value="Înlocuire: s-a înlocuit o potrivire. Nu s-au mai găsit potriviri."/>
+            <find-status-replaced-next-found value="Înlocuire: s-a înlocuit o potrivire. S-a mai găsit o potrivire."/>
+            <find-status-replaced-next-not-found value="Înlocuire: s-a înlocuit o potrivire. Nu s-au mai găsit potriviri."/>
             <find-status-replace-not-found value="Înlocuire: nu s-au găsit potriviri"/>
             <find-status-replace-readonly value="Înlocuire: textul nu poate fi înlocuit. Documentul curent are blocată salvarea modificărilor."/>
             <find-status-cannot-find value="Căutare: nu se poate găsi textul &quot;$STR_REPLACE$&quot;."/>

--- a/PowerEditor/installer/nativeLang/russian.xml
+++ b/PowerEditor/installer/nativeLang/russian.xml
@@ -1050,8 +1050,8 @@
             <find-status-replaceall-readonly value="Замена всего: Невозможно заменить текст. Текущий документ доступен только для чтения"/>
             <find-status-replace-end-reached value="Замена: Заменено первое совпадение сверху. Достигнут конец документа"/>
             <find-status-replace-top-reached value="Замена: Заменено первое совпадение снизу. Достигнуто начало документа"/>
-            <find-status-relaced-next-found value="Замена: 1 совпадение заменено. Найдено следующее совпадение"/>
-            <find-status-relaced-next-not-found value="Замена: 1 совпадение заменено. Следующее совпадение не найдено"/>
+            <find-status-replaced-next-found value="Замена: 1 совпадение заменено. Найдено следующее совпадение"/>
+            <find-status-replaced-next-not-found value="Замена: 1 совпадение заменено. Следующее совпадение не найдено"/>
             <find-status-replace-not-found value="Замена: ничего не найдено"/>
             <find-status-replace-readonly value="Замена: Невозможно заменить текст. Текущий документ доступен только для чтения"/>
             <find-status-cannot-find value="Поиск: Не удается найти текст &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/slovak.xml
+++ b/PowerEditor/installer/nativeLang/slovak.xml
@@ -1139,8 +1139,8 @@
             <find-status-replaceall-readonly value="Nahradiť všetko: Text nie je možné nahradiť. Aktuálny dokument je iba na čítanie."/>
             <find-status-replace-end-reached value="Nahradiť: Bol nahradený prvý prípad hľadaného výrazu. Dospeli ste na koniec dokumentu."/>
             <find-status-replace-top-reached value="Nahradiť: Bol nahradený posledný prípad hľadaného výrazu. Dospeli ste na začiatok dokumentu."/>
-            <find-status-relaced-next-found value="Nahradiť: Bol nahradený 1 prípad hľadaného výrazu. Našla sa ďalšia zhoda."/>
-            <find-status-relaced-next-not-found value="Nahradiť: Bol nahradený 1 prípad hľadaného výrazu. Ďalšia zhoda sa nenašla."/>
+            <find-status-replaced-next-found value="Nahradiť: Bol nahradený 1 prípad hľadaného výrazu. Našla sa ďalšia zhoda."/>
+            <find-status-replaced-next-not-found value="Nahradiť: Bol nahradený 1 prípad hľadaného výrazu. Ďalšia zhoda sa nenašla."/>
             <find-status-replace-not-found value="Nahradiť: Nenašla sa žiadna zhoda."/>
             <find-status-replace-readonly value="Nahradiť: Text nie je možné nahradiť. Aktuálny dokument je iba na čítanie."/>
             <find-status-cannot-find value="Hľadať: Text &quot;$STR_REPLACE$&quot; sa nepodarilo nájsť."/>

--- a/PowerEditor/installer/nativeLang/swedish.xml
+++ b/PowerEditor/installer/nativeLang/swedish.xml
@@ -1155,8 +1155,8 @@ Vill du starta Notepad++ i administratörsläge?"/>
 			<find-status-replaceall-readonly value="Ersätt alla: Kan inte ersätta text. Aktuellt dokument är skrivskyddat"/>
 			<find-status-replace-end-reached value="Ersätt: Ersatte första förekomsten från början. Slutet av dokumentet har passerats"/>
 			<find-status-replace-top-reached value="Ersätt: Ersatte första förekomsten från slutet. Början av dokumentet har passerats"/>
-			<find-status-relaced-next-found value="Ersätt: 1 förekomst har ersatts. Nästa förekomst har hittats"/>
-			<find-status-relaced-next-not-found value="Ersätt: 1 förekomst har ersatts. Hittade inte nästa förekomst"/>
+			<find-status-replaced-next-found value="Ersätt: 1 förekomst har ersatts. Nästa förekomst har hittats"/>
+			<find-status-replaced-next-not-found value="Ersätt: 1 förekomst har ersatts. Hittade inte nästa förekomst"/>
 			<find-status-replace-not-found value="Ersätt: Inga förekomster hittades"/>
 			<find-status-replace-readonly value="Ersätt: Kan inte ersätta text. Aktuellt dokument är skrivskyddat"/>
 			<find-status-cannot-find value="Sök: Kan inte hitta texten &quot;$STR_REPLACE$&quot;"/>

--- a/PowerEditor/installer/nativeLang/turkish.xml
+++ b/PowerEditor/installer/nativeLang/turkish.xml
@@ -1157,8 +1157,8 @@ Notepad++ı Yönetici olarak başlatmak ister misiniz?"/>
 			<find-status-replaceall-readonly value="Tümünü Değiştir: Yazı değiştirilemez. Şu anki dosya yalnızca okunabilir"/>
 			<find-status-replace-end-reached value="Değiştir: Baştan 1. eşleşme değiştirildi. Dosyanın sonuna ulaşıldı"/>
 			<find-status-replace-top-reached value="Değiştir: Sondan 1. eşleşme değiştirildi. Dosyanın başına ulaşıldı"/>
-			<find-status-relaced-next-found value="Değiştir: 1 eşleşme değiştirildi. Sonraki eşleşme bulundu"/>
-			<find-status-relaced-next-not-found value="Değiştir: 1 eşleşme değiştirildi. Sonraki eşleşme bulunamadı"/>
+			<find-status-replaced-next-found value="Değiştir: 1 eşleşme değiştirildi. Sonraki eşleşme bulundu"/>
+			<find-status-replaced-next-not-found value="Değiştir: 1 eşleşme değiştirildi. Sonraki eşleşme bulunamadı"/>
 			<find-status-replace-not-found value="Değiştir: hiçbir eşleşme bulunamadı"/>
 			<find-status-replace-readonly value="Değiştir: Yazı değiştirilemez. Şu anki dosya yalnızca okunabilir"/>
 			<find-status-cannot-find value="Bulma: &quot;$STR_REPLACE$&quot; yazısı bulunamadı"/>

--- a/PowerEditor/installer/nativeLang/ukrainian.xml
+++ b/PowerEditor/installer/nativeLang/ukrainian.xml
@@ -1150,8 +1150,8 @@
             <find-status-replaceall-readonly value="Замінити все: Неможливо замінити текст. Цей документ призначений тільки для читання"/>
             <find-status-replace-end-reached value="Замінити: Замінено 1-й збіг згори. Було досягнуто кінця документа"/>
             <find-status-replace-top-reached value="Замінити: Замінено 1-й збіг знизу. Було досягнуто початку документа"/>
-            <find-status-relaced-next-found value="Замінити: Виконано 1 заміну. Знайдено наступний збіг"/>
-            <find-status-relaced-next-not-found value="Замінити: Виконано 1 заміну. Наступного збігу не знайдено"/>
+            <find-status-replaced-next-found value="Замінити: Виконано 1 заміну. Знайдено наступний збіг"/>
+            <find-status-replaced-next-not-found value="Замінити: Виконано 1 заміну. Наступного збігу не знайдено"/>
             <find-status-replace-not-found value="Замінити: Жодного збігу не знайдено"/>
             <find-status-replace-readonly value="Замінити: Неможливо замінити текст. Цей документ призначений тільки для читання"/>
             <find-status-cannot-find value="Знайти: Неможливо знайти текст &quot;$STR_REPLACE$&quot;"/>


### PR DESCRIPTION
Fixed issue #4842 
Unfortunately, there is no typo in code. Therefore, localization is affected.


![image](https://user-images.githubusercontent.com/14791461/46416165-9bc6ca00-c744-11e8-9699-2386a804e168.png)
