### PR TITLE
Fix "Close all but this" behaviour if multiple views are present

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3528,12 +3528,8 @@ int Notepad_plus::switchEditViewTo(int gid)
 
 	_activeView = newView;
 	//Good old switcheroo
-	DocTabView * tempTab = _pDocTab;
-	_pDocTab = _pNonDocTab;
-	_pNonDocTab = tempTab;
-	ScintillaEditView * tempView = _pEditView;
-	_pEditView = _pNonEditView;
-	_pNonEditView = tempView;
+	std::swap(_pDocTab, _pNonDocTab);
+	std::swap(_pEditView, _pNonEditView);
 
 	_pEditView->beSwitched();
     _pEditView->getFocus();	//set the focus

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1096,6 +1096,7 @@ bool Notepad_plus::fileCloseAllButCurrent()
 {
 	BufferID current = _pEditView->getCurrentBufferID();
 	int active = _pDocTab->getCurrentTabIndex();
+	const int activeViewID = currentView();
 	//closes all documents, makes the current view the only one visible
 
 	//first check if we need to save any file
@@ -1155,28 +1156,33 @@ bool Notepad_plus::fileCloseAllButCurrent()
 		}
 	}
 
+	// We may have to restore previous view after saving new files
+	switchEditViewTo(activeViewID);
+
 	bool isSnapshotMode = NppParameters::getInstance()->getNppGUI().isSnapshotMode();
 	//Then start closing, inactive view first so the active is left open
     if (bothActive())
     {
 		//first close all docs in non-current view, which gets closed automatically
 		//Set active tab to the last one closed.
-		activateBuffer(_pNonDocTab->getBufferByIndex(0), otherView());
+		const int viewNo = otherView();
+		activateBuffer(_pNonDocTab->getBufferByIndex(0), viewNo);
 
 		for (int32_t i = static_cast<int32_t>(_pNonDocTab->nbItem()) - 1; i >= 0; i--) 	//close all from right to left
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), otherView(), isSnapshotMode);
+			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
 		}
     }
 
-	activateBuffer(_pDocTab->getBufferByIndex(0), currentView());
+	const int viewNo = currentView();
+	activateBuffer(_pDocTab->getBufferByIndex(0), viewNo);
 	for (int32_t i = static_cast<int32_t>(_pDocTab->nbItem()) - 1; i >= 0; i--)	//close all from right to left
 	{
 		if (i == active)	//dont close active index
 		{
 			continue;
 		}
-		doClose(_pDocTab->getBufferByIndex(i), currentView(), isSnapshotMode);
+		doClose(_pDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
 	}
 	return true;
 }


### PR DESCRIPTION
This pull request fixes #4911.

This PR contains three types of changes:
- Actual bug fix. This bug appeared, because prior to closing files, "Close all but this" attempts to save modified files, and for that it needs to switch views. Those views were not restored after that, however - so further actions could end up being executed on a wrong view. Those are changed commented with `// We may have to restore previous view after saving new files`.
- Another **potential** bug fix. Closing files in both views could result in views being switched (it may or may not, I did not manage to unambiguously find that out from the code). To prevent any possible issues, I stored view IDs in `viewNo`. If those could never switch, then the code changes nothing - but if they could, it fixes a potential bug.
- Code clarity fix in `Notepad_plus::switchEditViewTo`. `std::swap` makes it more obvious this code is there **only** to swap values around!