### PR TITLE
Fixed Doc switcher issue

### DIFF
--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -234,14 +234,15 @@ void VerticalFileSwitcherListView::setItemIconStatus(BufferID bufferID)
 		TaskLstFnStatus *tlfs = (TaskLstFnStatus *)(item.lParam);
 		if (tlfs->_bufID == bufferID)
 		{
+			tlfs->_fn = buf->getFullPathName();
 			item.mask = LVIF_TEXT | LVIF_IMAGE;
 			ListView_SetItem(_hSelf, &item);
 
 			if (isExtColumn)
 			{
 				ListView_SetItemText(_hSelf, i, 1, (LPTSTR)::PathFindExtension(buf->getFileName()));
-
 			}
+			break;
 		}
 	}
 }
@@ -286,7 +287,7 @@ int VerticalFileSwitcherListView::add(BufferID bufferID, int iView)
 	Buffer *buf = static_cast<Buffer *>(bufferID);
 	const TCHAR *fileName = buf->getFileName();
 
-	TaskLstFnStatus *tl = new TaskLstFnStatus(iView, 0, fileName, 0, (void *)bufferID);
+	TaskLstFnStatus *tl = new TaskLstFnStatus(iView, 0, buf->getFullPathName(), 0, (void *)bufferID);
 
 	TCHAR fn[MAX_PATH];
 	lstrcpy(fn, ::PathFindFileName(fileName));


### PR DESCRIPTION
Fixed issue: #4910

1. Make doc switcher tool tip is not consistent

- Now: tool tip for all the documents will show full path
- Then: Already opened documents (which get open along with Npp from session) show full path in tool tip, while newly opened (<kbd>Ctrl</kbd>+<kbd>O</kbd> or drag n drop or via context menu) shows only file name in tool tip.

2. Update tooltip on renaming

- Now: On renaming the document (within notepad++ via context menu), update the new full path for tooltip.
- Then: On renaming the document, old **filename** (note: filename, not fullpath) was shown.

3. Performance improve: come out of the loop once matched buffer is updated.

