### PR TITLE
Avoiding loading / verifying SciLexer.dll in a static initializer.

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -47,7 +47,7 @@ TCHAR * getSciLexerFullPathName(TCHAR * moduleFileName, size_t len)
 	return moduleFileName;
 };
 
-HINSTANCE ScintillaEditView::_hLib = loadSciLexerDll();
+HINSTANCE ScintillaEditView::_hLib = NULL;
 int ScintillaEditView::_refCount = 0;
 UserDefineDialog ScintillaEditView::_userDefineDlg;
 
@@ -225,7 +225,11 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 {
 	if (!_hLib)
 	{
-		throw std::runtime_error("ScintillaEditView::init : SCINTILLA ERROR - Can not load the dynamic library");
+		_hLib = loadSciLexerDll();
+		if (!_hLib)
+		{
+			throw std::runtime_error("ScintillaEditView::init : SCINTILLA ERROR - Can not load the dynamic library");
+		}
 	}
 
 	Window::init(hInst, hPere);


### PR DESCRIPTION
Tested with `Unicode Debug|x64` and `Unicode Release|x64`. With the proposed change, SciLexer.dll will be loaded and verified on WM_CREATE, during the initialization the Scintilla views. The loading only takes place once; if it fails the program exists. Nothing really changes in the error handling timing. Fixes #4952.