### PR TITLE
Crash fix for invalid input path

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -352,15 +352,18 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
             if (globbing)
             {
                 const TCHAR * substring = wcsrchr(fileName.c_str(), TCHAR('\\'));
-                size_t pos = substring - fileName.c_str();
+				if (substring)
+				{
+					size_t pos = substring - fileName.c_str();
 
-                patterns.push_back(substring + 1);
-                generic_string dir(fileName.c_str(), pos + 1); // use char * to evoke:
-                                                               // string (const char* s, size_t n);
-                                                               // and avoid to call (if pass string) :
-                                                               // string (const string& str, size_t pos, size_t len = npos);
+					patterns.push_back(substring + 1);
+					generic_string dir(fileName.c_str(), pos + 1); // use char * to evoke:
+																   // string (const char* s, size_t n);
+																   // and avoid to call (if pass string) :
+																   // string (const string& str, size_t pos, size_t len = npos);
 
-                getMatchedFileNames(dir.c_str(), patterns, fileNames, isRecursive, false);
+					getMatchedFileNames(dir.c_str(), patterns, fileNames, isRecursive, false);
+				}
             }
             else
             {

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -62,7 +62,7 @@ FileDialog::FileDialog(HWND hwnd, HINSTANCE hInst)
 	_ofn.lpfnHook = NULL;
 	_ofn.lpstrDefExt = NULL;  // No default extension
 	_ofn.lCustData = 0;
-	_ofn.Flags = OFN_PATHMUSTEXIST | OFN_EXPLORER | OFN_LONGNAMES | DS_CENTER | OFN_HIDEREADONLY;
+	_ofn.Flags = OFN_PATHMUSTEXIST | OFN_EXPLORER | OFN_LONGNAMES | OFN_HIDEREADONLY;
 	_ofn.pvReserved = NULL;
 	_ofn.dwReserved = 0;
 	_ofn.FlagsEx = 0;


### PR DESCRIPTION
Fixed issue #4946 
root cause is below line
```const TCHAR * substring = wcsrchr(fileName.c_str(), TCHAR('\\'));```

`substring` coming `NULL` as per reported case.

**Minor code enhancement:**
File `FileDialog.cpp` uses invalid flag in it. However, inclusion or exclusion of flag `DS_CENTER` does not have any impact as long flag `OFN_PATHMUSTEXIST` exists. Because the value is same for both the flags.