### PR TITLE
Add comment on shortcut(installer)

### DIFF
--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -276,9 +276,9 @@ Function shortcutLinkManagement
 	SetOutPath "$INSTDIR\"
 	
 	; add all the npp shortcuts for all user or current user
-	CreateShortCut "$SMPROGRAMS\Notepad++.lnk" "$INSTDIR\notepad++.exe"
+	CreateShortCut "$SMPROGRAMS\Notepad++.lnk" "$INSTDIR\notepad++.exe" "" "" "" "${Description}"
 	${If} $createShortcutChecked == ${BST_CHECKED}
-		CreateShortCut "$DESKTOP\Notepad++.lnk" "$INSTDIR\notepad++.exe"
+		CreateShortCut "$DESKTOP\Notepad++.lnk" "$INSTDIR\notepad++.exe" "" "" "" "${Description}"
 	${EndIf}
 	
 	SetShellVarContext current


### PR DESCRIPTION
Add a little comment in the installer, since all major programs do it.
This is a minor pull request. Maybe it should me merged manually.