### PR TITLE
Use the _isFolding flag to fix several overlooked edge case hangs.

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3722,14 +3722,22 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne)
 	if (whichOne == MAIN_VIEW)
 	{
 		if (_mainDocTab.activateBuffer(id))	//only activate if possible
+		{
+			_isFolding = true;
 			_mainEditView.activateBuffer(id);
+			_isFolding = false;
+		}
 		else
 			return false;
 	}
 	else
 	{
 		if (_subDocTab.activateBuffer(id))
+		{
+			_isFolding = true;
 			_subEditView.activateBuffer(id);
+			_isFolding = false;
+		}
 		else
 			return false;
 	}

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1661,7 +1661,11 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 		}
 	}
 	if (mainIndex2Update != -1)
+	{
+		_isFolding = true;
 		_mainEditView.syncFoldStateWith(session._mainViewFiles[mainIndex2Update]._foldStates);
+		_isFolding = false;
+	}
 
 
 	showView(SUB_VIEW);
@@ -1772,7 +1776,11 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 		}
 	}
 	if (subIndex2Update != -1)
+	{
+		_isFolding = true;
 		_subEditView.syncFoldStateWith(session._subViewFiles[subIndex2Update]._foldStates);
+		_isFolding = false;
+	}
 
 	_mainEditView.restoreCurrentPos();
 	_subEditView.restoreCurrentPos();


### PR DESCRIPTION
This pull request fixes additional hangs I found after #4867 when working with deeply-nested fully-folded files. The hangs are easy to reproduce by following these steps:

- Download the sample file https://raw.githubusercontent.com/notepad-plus-plus/notepad-plus-plus/master/PowerEditor/src/Parameters.cpp
- Open the downloaded file by itself in NPP and fold it using Alt-0
- Create a new empty tab and remain focused on it
- Perform the six actions below, each of which will produce a hang as NPP tries to change focus back to the first tab. On my machine, each hang lasts about 30 seconds. After control returns, refocus the empty tab again and try the next action.
1. Use File>>Open to reopen the downloaded file, even though it is already open
2. Drag and drop the downloaded file onto NPP to reopen it
3. Double-click the downloaded file to reopen it
4. Right-click the downloaded file and select *Edit with Notepad++* in the context menu
5. Open the downloaded file from the command line: *C:\Program Files (x86)\Notepad++\notepad++.exe" .\Parameters.cpp*
6. Click the red [X] in the upper right corner to close NPP

- After applying the patch, none of the hangs should happen any more.