### PR TITLE
Fixed file association bugs and enhancement

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -193,6 +193,7 @@ Section -"Notepad++" mainSection
 	${If} $diffArchDir2Remove != ""
 		!insertmacro uninstallRegKey
 		!insertmacro uninstallDir $diffArchDir2Remove 
+		Call unRregisterApplication
 	${endIf}
 
 	Call copyCommonFiles
@@ -203,6 +204,8 @@ Section -"Notepad++" mainSection
 	
 	Call shortcutLinkManagement
 	
+	Call registerApplication
+
 SectionEnd
 
 ; Please **DONOT** move this function (SetRoughEstimation) anywhere else

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -282,4 +282,17 @@ Function shortcutLinkManagement
 	SetShellVarContext current
 FunctionEnd
 
+Function registerApplication
+	; Register progID
+	; using class as "Notepad++_File" as it was used in npp source code as well
+	WriteRegStr HKLM "SOFTWARE\Classes\Notepad++_File" "" "Notepad++ Document"
+	WriteRegStr HKLM "SOFTWARE\Classes\Notepad++_File\DefaultIcon" "" '"$INSTDIR\notepad++.exe", 0'
+	WriteRegStr HKLM "SOFTWARE\Classes\Notepad++_File\shell\open\command" "" '"$INSTDIR\notepad++.exe" "%1"'
+
+	; Register subkeys and values
+	WriteRegStr HKLM "SOFTWARE\Classes\Applications\notepad++.exe\shell\open\command" "" '"$INSTDIR\notepad++.exe" "%1"'
+
+	; Registered Application : no need at this moment
+
+FunctionEnd
 

--- a/PowerEditor/src/MISC/RegExt/regExtDlg.h
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.h
@@ -26,8 +26,7 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 
-#ifndef REG_EXT_DLG_H
-#define REG_EXT_DLG_H
+#pragma once
 
 #include "regExtDlgRc.h"
 #include "StaticDialog.h"
@@ -36,34 +35,42 @@ const int extNameLen = 32;
 
 class RegExtDlg : public StaticDialog
 {
-public :
-	RegExtDlg() : _isCustomize(false){};
-	~RegExtDlg(){};
+public:
+	RegExtDlg() = default;
+	~RegExtDlg() = default;
 	void doDialog(bool isRTL = false);
 
 
-private :
-	bool _isCustomize;
+private:
+	bool _isCustomize = false;
 
 	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
 
 	void getRegisteredExts();
 	void getDefSupportedExts();
+
 	void addExt(TCHAR *ext);
+
 	bool deleteExts(const TCHAR *ext2Delete);
-	void writeNppPath();
+	LONG deleteExts(HKEY hRootKey, const generic_string& regPath);
 
-	int getNbSubKey(HKEY hKey) const {
-		int nbSubKey;
-		long result = ::RegQueryInfoKey(hKey, NULL, NULL, NULL, (LPDWORD)&nbSubKey, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-		return (result == ERROR_SUCCESS)?nbSubKey:0;
+	void writeNppPathIfNeeded();
+	bool isNppPathExists(HKEY hRootKey, const generic_string& regPath) const;
+
+	DWORD getNbSubKey(HKEY hKey) const {
+		DWORD dwSubKey = 0;
+		long result = ::RegQueryInfoKey(hKey, NULL, NULL, NULL, &dwSubKey, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+		return (result == ERROR_SUCCESS) ? dwSubKey : 0;
 	}
 
-	int getNbSubValue(HKEY hKey) const {
-		int nbSubValue;
-		long result = ::RegQueryInfoKey(hKey, NULL, NULL, NULL, NULL, NULL, NULL, (LPDWORD)&nbSubValue, NULL, NULL, NULL, NULL);
-		return (result == ERROR_SUCCESS)?nbSubValue:0;
+	DWORD getNbSubValue(HKEY hKey) const {
+		DWORD dwSubValue = 0;
+		long result = ::RegQueryInfoKey(hKey, NULL, NULL, NULL, NULL, NULL, NULL, &dwSubValue, NULL, NULL, NULL, NULL);
+		return (result == ERROR_SUCCESS) ? dwSubValue : 0;
 	}
+
+	generic_string getNppPath() const;
+
+	void NotifyShell() const;
 };
 
-#endif //REG_EXT_DLG_H


### PR DESCRIPTION
This PR is can be broken into two pieces:
1. Fixes below defects
	#1052
	#2817
	#3101
	#2440
	#1786
may be few others
**[Edit]**
#4065

	Nsis script is changed to handled these cases.
	1. Application is registered in global scope (HKLM registry is written) which helps to associate an extension properly.
	2. Whenever, there is an upgrade from x86 to x64 or vice versa, registry should details should be updated. So that existing file extensions will not be broken.
	3. On uninstall, 
		3.1 Un register the application from the global and user scope.
		3.2 Refresh shell icons so that npp icon from the associated file extensions will be changed. 
	
2. Enhance File association
	1. File extension can't be associated from "Settings->Preferences->File Association" if user does not have administrative rights. Moreover, writing HKCR is not recommended way to associate file extensions. As per [MSDN](https://docs.microsoft.com/en-us/windows/desktop/sysinfo/hkey-classes-root-key), HKCR is merged view of HKCU and HKLM and it is primarily intended for compatibility with the registry in 16-bit Windows. So instead of writing to HKCR, write to HKCU which does not require admin access.
	2. Refresh the shell to update icon of files whenever file extension is registered or de-registered to/from npp.