### PR TITLE
Fix menu bar for Hebrew

### DIFF
--- a/PowerEditor/installer/nativeLang/hebrew.xml
+++ b/PowerEditor/installer/nativeLang/hebrew.xml
@@ -12,10 +12,11 @@
 					<Item menuId="encoding" name="&amp;פורמט"/>
 					<Item menuId="language" name="&amp;שפה"/>
 					<Item menuId="settings" name="&amp;הגדרות"/>
+					<Item menuId="tools" name="&amp;כלים"/>
 					<Item menuId="macro" name="מאקרו מקשים"/>
 					<Item menuId="run" name="הפעלה"/>
 					<Item idName="Plugins" name="תוספים"/>
-					<Item idName="Window"  name="תמיכה"/>
+					<Item idName="Window"  name="חלון"/>
 
 				</Entries>
 


### PR DESCRIPTION
Also, I'll commence work on closing the gap on the Hebrew translation (bring it up to par with the English source).
I'm bilingual, Hebrew is my native tongue and I have excellent command of it.
Back in the day (i.e. 2006) I localized [CUPS](https://github.com/apple/cups) to Hebrew.