### PR TITLE
Update text displayed in summary panel

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1956,7 +1956,7 @@ void Notepad_plus::command(int id)
 				characterNumber += TEXT("\r");
 				characterNumber += TEXT("\r");
 			}
-			const TCHAR *nbCharLabel = TEXT("Characters (without blanks): ");
+			const TCHAR *nbCharLabel = TEXT("Characters (without line endings): ");
 			const TCHAR *nbWordLabel = TEXT("Words: ");
 			const TCHAR *nbLineLabel = TEXT("Lines: ");
 			const TCHAR *nbByteLabel = TEXT("Current document length: ");


### PR DESCRIPTION
User @buggalicious found the summary text is displaying a count of characters without line endings not blanks.
Patch should address #3849 by updating the text to describe what is actually being counted.