### PR TITLE
Update pluginsAdmin.h, using _TCHAR and _istdigit() 

### DIFF
--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -51,7 +51,7 @@ struct Version
 	generic_string toString();
 	bool isNumber(const generic_string& s) const {
 		return !s.empty() && 
-			find_if(s.begin(), s.end(), [](char c) { return !isdigit(c); }) == s.end();
+			find_if(s.begin(), s.end(), [](_TCHAR c) { return !_istdigit(c); }) == s.end();
 	};
 
 	int compareTo(const Version& v2c) const;


### PR DESCRIPTION
use _TCHAR and _istdigit() to avoid wchar/char mismatch, and possible undefined behavior.

https://en.cppreference.com/w/cpp/string/byte/isdigit