### PR TITLE
Adds missing translation entries for menu items

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -270,6 +270,10 @@
                     <Item id="45012" name="Convert to UCS-2 BE BOM"/>
                     <Item id="45013" name="Convert to UCS-2 LE BOM"/>
 
+                    <Item id="44212" name="Hide Line Number Margin"/>
+                    <Item id="44213" name="Hide Bookmark Margin"/>
+                    <Item id="44214" name="Hide Folder Margin"/>
+
                     <Item id="10001" name="Move to Other View"/>
                     <Item id="10002" name="Clone to Other View"/>
                     <Item id="10003" name="Move to New Instance"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -270,6 +270,10 @@
                     <Item id="45012" name="Convert to UCS-2 BE BOM"/>
                     <Item id="45013" name="Convert to UCS-2 LE BOM"/>
 
+                    <Item id="44212" name="Hide Line Number Margin"/>
+                    <Item id="44213" name="Hide Bookmark Margin"/>
+                    <Item id="44214" name="Hide Folder Margin"/>
+
                     <Item id="10001" name="Move to Other View"/>
                     <Item id="10002" name="Clone to Other View"/>
                     <Item id="10003" name="Move to New Instance"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -283,6 +283,10 @@
 					<Item id="45012" name="Konve&amp;rtiere zu UCS-2 BE-BOM"/>
 					<Item id="45013" name="Konver&amp;tiere zu UCS-2 LE-BOM"/>
 
+					<Item id="44212" name="Verberge Zeilennummernrand"/>
+					<Item id="44213" name="Verberge Lesezeichenrand"/>
+					<Item id="44214" name="Verberge Textblockrand"/>
+
 					<Item id="10001" name="In zweite Ansicht &amp;verschieben"/>
 					<Item id="10002" name="In zweite Ansicht &amp;duplizieren"/>
 					<Item id="10003" name="In &amp;neue Instanz verschieben"/>


### PR DESCRIPTION
Adds missing translation entries for menu items to English, English (customizable) and German language files.

Fixes #5074 