### PR TITLE
Add Command Line Open-As-Workspace Flag (Issue #4253)

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -31,7 +31,7 @@
 
 const TCHAR COMMAND_ARG_HELP[] = TEXT("Usage :\r\
 \r\
-notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-LlangCode] [-nLineNumber] [-cColumnNumber] [-pPosition] [-xLeftPos] [-yTopPos] [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime] [-alwaysOnTop] [-openSession] [-r] [-qnEasterEggName | -qtText | -qfCntentFileName] [-qSpeed1|2|3] [-quickPrint] [filePath]\r\
+notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-LlangCode] [-nLineNumber] [-cColumnNumber] [-pPosition] [-xLeftPos] [-yTopPos] [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime] [-alwaysOnTop] [-openSession] [-r] [-qnEasterEggName | -qtText | -qfCntentFileName] [-qSpeed1|2|3] [-quickPrint] [-dirAsWorkspace] [filePath]\r\
 \r\
 --help : This help message\r\
 -multiInst : Launch another Notepad++ instance\r\
@@ -50,6 +50,8 @@ notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-LlangCode] [-nLineNum
 -loadingTime : Display Notepad++ loading time\r\
 -alwaysOnTop : Make Notepad++ always on top\r\
 -openSession : Open a session. filePath must be a session file\r\
+-dirAsWorkspace : directorys in filePath are opened as a workspace\r\
+                  rather than loading all contained files.\r\
 -r : Open files recursively. This argument will be ignored\r\
      if filePath contain no wildcard character\r\
 -qn : Launch ghost typing to display easter egg via its name\r\

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -216,6 +216,7 @@ struct CmdLineParams
 
 	bool _isSessionFile = false;
 	bool _isRecursive = false;
+	bool _isLoadingWorkspace = false;
 
 	LangType _langType = L_EXTERNAL;
 	generic_string _localizationPath;
@@ -242,6 +243,7 @@ struct CmdLineParamsDTO
 	bool _isNoSession;
 	bool _isSessionFile;
 	bool _isRecursive;
+	bool _isLoadingWorkspace;
 
 	int _line2go;
 	int _column2go;
@@ -256,6 +258,7 @@ struct CmdLineParamsDTO
 		dto._isNoSession = params._isNoSession;
 		dto._isSessionFile = params._isSessionFile;
 		dto._isRecursive = params._isRecursive;
+		dto._isLoadingWorkspace = params._isLoadingWorkspace;
 
 		dto._line2go = params._line2go;
 		dto._column2go = params._column2go;

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -283,6 +283,7 @@ const TCHAR FLAG_RECURSIVE[] = TEXT("-r");
 const TCHAR FLAG_FUNCLSTEXPORT[] = TEXT("-export=functionList");
 const TCHAR FLAG_PRINTANDQUIT[] = TEXT("-quickPrint");
 const TCHAR FLAG_NOTEPAD_COMPATIBILITY[] = TEXT("-notepadStyleCmdline");
+const TCHAR FLAG_DIRECTORYASWORKSPACE[] = TEXT("-dirAsWorkspace");
 
 
 void doException(Notepad_plus_Window & notepad_plus_plus)
@@ -346,6 +347,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 	cmdLineParams._alwaysOnTop = isInList(FLAG_ALWAYS_ON_TOP, params);
 	cmdLineParams._showLoadingTime = isInList(FLAG_LOADINGTIME, params);
 	cmdLineParams._isSessionFile = isInList(FLAG_OPENSESSIONFILE, params);
+	cmdLineParams._isLoadingWorkspace = isInList(FLAG_DIRECTORYASWORKSPACE, params);
 	cmdLineParams._isRecursive = isInList(FLAG_RECURSIVE, params);
 	cmdLineParams._langType = getLangTypeFromParam(params);
 	cmdLineParams._localizationPath = getLocalizationPathFromParam(params);
@@ -389,6 +391,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int)
 		isMultiInst = true;
 		cmdLineParams._isNoTab = true;
 		cmdLineParams._isNoSession = true;
+		cmdLineParams._isLoadingWorkspace = false;
 	}
 
 	// override the settings if multiInst is choosen by user in the preference dialog


### PR DESCRIPTION
In order to use Notepad++ as an editor for the new Github Desktop, support for opening a directory is required.

Notepad++ already has the ability to open a directory as a workspace, however this is not possible from the command line as the default behaviour is to open all files in any supplied directory.

In this commit, a new flag, "-dirAsWorkspace" has been added which will treat any directory in the CLI fileName input as a workspace and open it as such. Any files will be treated as files and opened as usual.

Basically this PR would allow https://github.com/desktop/desktop/pull/4120 to be completed and get Notepad++ back as an editor in Github Desktop.