### PR TITLE
URI parsing: enhance URI identification ignoring loose trailing characters

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2510,6 +2510,12 @@ void Notepad_plus::addHotSpot(int urlAction)
 
 		_pEditView->execute(SCI_SETTARGETRANGE, posFound + foundTextLen, endPos);
 
+		// remove URL style from characters directly after URL match which was potentially set previously
+		unsigned char style;
+		int pos = posFound + foundTextLen;
+		while (pos < endPos && (style = static_cast<unsigned char>(_pEditView->execute(SCI_GETSTYLEAT, pos++))) == (style & mask))
+			_pEditView->execute(SCI_SETSTYLING, 1, style & ~mask);
+
 	}
 
 	_pEditView->execute(SCI_STARTSTYLING, endStyle);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2370,7 +2370,7 @@ void Notepad_plus::setUniModeText()
 }
 
 
-void Notepad_plus::addHotSpot()
+void Notepad_plus::addHotSpot(int urlAction)
 {
 	int startPos = 0;
 	int endPos = -1;
@@ -2458,11 +2458,7 @@ void Notepad_plus::addHotSpot()
 			auto isBold = _pEditView->execute(SCI_STYLEGETBOLD, idStyleMSBunset);
 			auto isItalic = _pEditView->execute(SCI_STYLEGETITALIC, idStyleMSBunset);
 			auto isUnderline = _pEditView->execute(SCI_STYLEGETUNDERLINE, idStyleMSBunset);
-			hotspotStyle._fontStyle = (isBold?FONTSTYLE_BOLD:0) | (isItalic?FONTSTYLE_ITALIC:0) | (isUnderline?FONTSTYLE_UNDERLINE:0);
-
-			int urlAction = (NppParameters::getInstance())->getNppGUI()._styleURL;
-			if (urlAction == 2)
-				hotspotStyle._fontStyle |= FONTSTYLE_UNDERLINE;
+			hotspotStyle._fontStyle = (isBold?FONTSTYLE_BOLD:0) | (isItalic?FONTSTYLE_ITALIC:0) | ((isUnderline || urlAction) ?FONTSTYLE_UNDERLINE:0);
 
 			_pEditView->setHotspotStyle(hotspotStyle);
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2386,17 +2386,17 @@ void Notepad_plus::addHotSpot(int urlAction)
 
 	unsigned char style_hotspot = 0;
 	unsigned char mask = INDIC1_MASK;
-	// INDIC2_MASK == 255 and it represents MSB bit		
-	// only LEX_HTML and LEX_POSTSCRIPT use use INDIC2_MASK bit internally		
-	// LEX_HTML is using INDIC2_MASK bit even though it has only 127 states, so it is safe to overwrite 8th bit		
-	// INDIC2_MASK will be used for LEX_HTML		
+	// INDIC2_MASK == 255 and it represents the MSB bit.
+	// Only LEX_HTML and LEX_POSTSCRIPT use the INDIC2_MASK bit internally.
+	// LEX_HTML is using INDIC2_MASK bit even though it has only 127 states, so it is safe to overwrite the 8th bit.
+	// INDIC2_MASK will be used for LEX_HTML.
 
-	// LEX_POSTSCRIPT is using INDIC2_MASK bit for "tokenization", and is using mask=31 in lexer,		
-	// therefore hotspot in LEX_POSTSCRIPT will be saved to 5th bit		
-	// there are only 15 states in LEX_POSTSCRIPT, so it is safe to overwrite 5th bit		
+	// LEX_POSTSCRIPT is using the INDIC2_MASK bit for "tokenization", and is using mask=31 in the lexer,
+	// therefore the hotspot in LEX_POSTSCRIPT will be saved to the 5th bit.
+	// There are only 15 states in LEX_POSTSCRIPT, so it is safe to override the 5th bit.
 
-	// rule of the thumb is, any lexet that calls: styler.StartAt(startPos, 255);		
-	// must have special processing here, all other lexers are fine with INDIC1_MASK (7th bit)		
+	// Rule of the thumb is, any lexet that calls styler.StartAt(startPos, 255);
+	// must have special processing here, all other lexers are fine with INDIC1_MASK (7th bit).
 
 	LangType type = _pEditView->getCurrentBuffer()->getLangType();
 
@@ -2459,7 +2459,7 @@ void Notepad_plus::addHotSpot(int urlAction)
 			{
 				fs = hotspotPairs[i];
 				_pEditView->execute(SCI_STYLEGETFORE, fs);
-					break;
+				break;
 			}
 		}
 
@@ -2508,6 +2508,7 @@ void Notepad_plus::addHotSpot(int urlAction)
 		_pEditView->execute(SCI_STARTSTYLING, start);
 		_pEditView->execute(SCI_SETSTYLING, foundTextLen, fs);
 
+		// shift regular expression search scope
 		_pEditView->execute(SCI_SETTARGETRANGE, posFound + foundTextLen, endPos);
 
 		// remove URL style from characters directly after URL match which was potentially set previously

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2463,13 +2463,8 @@ void Notepad_plus::addHotSpot(int urlAction)
 			}
 		}
 
-		// if we found it then use it to colourize
-		if (fs != -1)
-		{
-			_pEditView->execute(SCI_STARTSTYLING, start, 0xFF);
-			_pEditView->execute(SCI_SETSTYLING, foundTextLen, fs);
-		}
-		else // generalize a new style and add it into a array
+		// if we didn't find it, generalize a new style and add it into a array
+		if (fs == -1)
 		{
 			style_hotspot = idStyle | mask;	// set "hotspot bit"
 			hotspotPairs.push_back(style_hotspot);
@@ -2506,16 +2501,18 @@ void Notepad_plus::addHotSpot(int urlAction)
 			_pEditView->execute(SCI_SETHOTSPOTACTIVEFORE, TRUE, activeFG);
 			_pEditView->execute(SCI_SETHOTSPOTSINGLELINE, style_hotspot, 0);
 
-			// colourize it!
-			_pEditView->execute(SCI_STARTSTYLING, start, 0xFF);
-			_pEditView->execute(SCI_SETSTYLING, foundTextLen, style_hotspot);
+			fs = style_hotspot;
 		}
+
+		// set hotspot style to matching URL characters
+		_pEditView->execute(SCI_STARTSTYLING, start);
+		_pEditView->execute(SCI_SETSTYLING, foundTextLen, fs);
 
 		_pEditView->execute(SCI_SETTARGETRANGE, posFound + foundTextLen, endPos);
 
 	}
 
-	_pEditView->execute(SCI_STARTSTYLING, endStyle, 0xFF);
+	_pEditView->execute(SCI_STARTSTYLING, endStyle);
 	_pEditView->execute(SCI_SETSTYLING, 0, 0);
 }
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -61,8 +61,6 @@
 #define MENU 0x01
 #define TOOLBAR 0x02
 
-#define URL_REG_EXPR "[A-Za-z]+://[A-Za-z0-9_\\-\\+~.:?&@=/%#,;\\{\\}\\(\\)\\[\\]\\|\\*\\!\\\\]+"
-
 enum FileTransferMode {
 	TransferClone		= 0x01,
 	TransferMove		= 0x02

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -483,7 +483,7 @@ private:
 	int findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol);
 	void maintainIndentation(TCHAR ch);
 
-	void addHotSpot();
+	void addHotSpot(int urlAction);
 
     void bookmarkAdd(int lineno) const
 	{

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -615,7 +615,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				{
 					int urlAction = (NppParameters::getInstance())->getNppGUI()._styleURL;
 					if ((urlAction == 1) || (urlAction == 2))
-						addHotSpot();
+						addHotSpot(urlAction);
 				}
 
 				if (_pDocMap)
@@ -808,7 +808,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			{
 				int urlAction = (NppParameters::getInstance())->getNppGUI()._styleURL;
 				if ((urlAction == 1) || (urlAction == 2))
-					addHotSpot();
+					addHotSpot(urlAction);
 			}
 
 			// if it's searching/replacing, then do nothing
@@ -972,7 +972,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			{
 				int urlAction = (NppParameters::getInstance())->getNppGUI()._styleURL;
 				if ((urlAction == 1) || (urlAction == 2))
-					addHotSpot();
+					addHotSpot(urlAction);
 				_linkTriggered = false;
 			}
 


### PR DESCRIPTION
Suggested fix for #5029, #3353 using a simple technique to deal with trailing closing brackets by searching for matching leading opening brackets.