### PR TITLE
Added workspace file sorting

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -151,6 +151,8 @@ public:
 	HTREEITEM findInTree(const generic_string& rootPath, HTREEITEM node, std::vector<generic_string> linarPathArray);
 	bool deleteFromTree(const generic_string& rootPath, HTREEITEM node, std::vector<generic_string> linarPathArray);
 	bool renameInTree(const generic_string& rootPath, HTREEITEM node, std::vector<generic_string> linarPathArrayFrom, const generic_string & renameTo);
+	void sortTreeByName(const generic_string& rootPath);
+	void sortTree(HTREEITEM node);
 
 	std::vector<generic_string> getRoots() const;
 	generic_string getSelectedItemPath() const;
@@ -177,4 +179,6 @@ protected:
 	void openSelectFile();
 	void getDirectoryStructure(const TCHAR *dir, const std::vector<generic_string> & patterns, FolderInfo & directoryStructure, bool isRecursive, bool isInHiddenDir); 
 	HTREEITEM createFolderItemsFromDirStruct(HTREEITEM hParentItem, const FolderInfo & directoryStructure);
+
+	static int CALLBACK CompareFunc(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort);
 };

--- a/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/TreeView.cpp
@@ -136,9 +136,17 @@ bool TreeView::renameItem(HTREEITEM Item2Set, const TCHAR *newName)
 
 	TVITEM tvItem;
 	tvItem.hItem = Item2Set;
-	tvItem.mask = TVIF_TEXT;
+	tvItem.mask = TVIF_TEXT | TVIF_PARAM;;
 	tvItem.pszText = (LPWSTR)newName;
 	tvItem.cchTextMax = MAX_PATH;
+
+	//Get new file path from old one
+	generic_string filePath = *reinterpret_cast<generic_string*>(getItemParam(Item2Set));
+	filePath = filePath.substr(0, filePath.find_last_of('\\') + 1);
+	filePath.append(newName);
+
+	tvItem.lParam = reinterpret_cast<LPARAM>(new generic_string(filePath));
+
 	SendMessage(_hSelf, TVM_SETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
 	return true;
 }


### PR DESCRIPTION
- Workspace sorts files by file name alphabetically and the folders stay at the top, also sorted by name. 
- It re-sorts whenever a file is renamed or a file is added to the workspace. 

Closes #1541, closes #1743, closes #1613.