### PR TITLE
Update rust keywords and types for 2018 edition

### DIFF
--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -316,8 +316,8 @@
             <Keywords name="instre1">ARGF ARGV BEGIN END ENV FALSE DATA NIL RUBY_PATCHLEVEL RUBY_PLATFORM RUBY_RELEASE_DATE RUBY_VERSION PLATFORM RELEASE_DATE STDERR STDIN STDOUT TOPLEVEL_BINDING TRUE __ENCODING__ __END__ __FILE__ __LINE__ alias and begin break case class def defined? do else elsif end ensure false for if in module next nil not or redo rescue retry return self super then true undef unless until when while yield</Keywords>
         </Language>
         <Language name="rust" ext="rs" commentLine="//" commentStart="/*" commentEnd="*/">
-            <Keywords name="instre1">alignof as be box break const continue crate do else enum extern false fn for if impl in let loop match mod mut offsetof once priv proc pub pure ref return self sizeof static struct super trait true type typeof unsafe unsized use virtual while yield</Keywords>
-            <Keywords name="instre2">bool char f32 f64 i16 i32 i64 i8 int str u16 u32 u64 u8 uint</Keywords>
+            <Keywords name="instre1">abstract as async become box break const continue crate do dyn else enum extern false final fn for if impl in let loop macro match mod move mut override priv pub ref return self static struct super trait true try type typeof unsafe unsized use virtual where while yield</Keywords>
+            <Keywords name="instre2">bool char f32 f64 i128 i16 i32 i64 i8 isize str u128 u16 u32 u64 u8 usize</Keywords>
             <Keywords name="type1">Self</Keywords>
             <Keywords name="type2"></Keywords>
             <Keywords name="type3"></Keywords>


### PR DESCRIPTION
Some of these are old changes, others are new for the 2018 edition.
- New reserved: **abstract async become dyn final macro move override try where**
- Unreserved: **alignof be offsetof once proc pure sizeof**
- **int**/**uint** changed to **isize**/**usize**
- **i128**/**u128** added in Rust 1.26


Sources:
https://doc.rust-lang.org/book/ch03-02-data-types.html
https://doc.rust-lang.org/book/appendix-01-keywords.html
(also verified against rustc source and various RFCs)