### PR TITLE
Allow undo after file reload and don't purge undo buffer

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -116,7 +116,7 @@ public:
 private:
 	~FileManager();
 	int detectCodepage(char* buf, size_t len);
-	bool loadFileData(Document doc, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LangType & language, int & encoding, EolType & eolFormat);
+	bool loadFileData(Document doc, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LangType & language, int & encoding, EolType & eolFormat, bool keepUndo = false);
 	LangType detectLanguageFromTextBegining(const unsigned char *data, size_t dataLen);
 
 


### PR DESCRIPTION
This addresses https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5141 by keeping undo buffer on file reload thus allowing to undo the very action of file reloading too.

Very useful if `Update silently` option is set unknowingly.