### PR TITLE
No more dummy in config file

### DIFF
--- a/PowerEditor/src/EncodingMapper.h
+++ b/PowerEditor/src/EncodingMapper.h
@@ -44,6 +44,6 @@ private:
 	EncodingMapper(){};
 	~EncodingMapper(){};
     static EncodingMapper *_pSelf;
-    EncodingUnit *_encodings;
+	EncodingUnit* _encodings = nullptr;
 };
 

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -63,6 +63,7 @@ const bool dirDown = false;
 #define generic_fopen _wfopen
 #define generic_fgets fgetws
 #define COPYDATA_FILENAMES COPYDATA_FILENAMESW
+#define NPP_INTERNAL_FUCTION_STR TEXT("Notepad++::InternalFunction")
 
 typedef std::basic_string<TCHAR> generic_string;
 typedef std::basic_stringstream<TCHAR> generic_stringstream;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -57,8 +57,6 @@ enum tb_stat {tb_saved, tb_unsaved, tb_ro};
 #define DIR_LEFT true
 #define DIR_RIGHT false
 
-#define NPP_INTERNAL_FUCTION_STR TEXT("Notepad++::InternalFunction")
-
 int docTabIconIDs[] = {IDI_SAVED_ICON, IDI_UNSAVED_ICON, IDI_READONLY_ICON, IDI_MONITORING_ICON};
 
 ToolBarButtonUnit toolBarIcons[] = {

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2180,7 +2180,7 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		data.hIconTab = (HICON)::LoadImage(_hInst, MAKEINTRESOURCE(IDI_FIND_RESULT_ICON), IMAGE_ICON, 0, 0, LR_LOADMAP3DCOLORS | LR_LOADTRANSPARENT);
 		data.pszAddInfo = _findAllResultStr;
 
-		data.pszModuleName = TEXT("dummy");
+		data.pszModuleName = NPP_INTERNAL_FUCTION_STR;
 
 		// the dlgDlg should be the index of funcItem where the current function pointer is
 		// in this case is DOCKABLE_DEMO_INDEX
@@ -2272,7 +2272,7 @@ Finder * FindReplaceDlg::createFinder()
 	data.hIconTab = (HICON)::LoadImage(_hInst, MAKEINTRESOURCE(IDI_FIND_RESULT_ICON), IMAGE_ICON, 0, 0, LR_LOADMAP3DCOLORS | LR_LOADTRANSPARENT);
 	data.pszAddInfo = _findAllResultStr;
 
-	data.pszModuleName = TEXT("dummy");
+	data.pszModuleName = NPP_INTERNAL_FUCTION_STR;
 
 	// the dlgDlg should be the index of funcItem where the current function pointer is
 	// in this case is DOCKABLE_DEMO_INDEX


### PR DESCRIPTION
This PR does not intend to fix any defect. It is internal to notepad++ that writing/updating the config should be uniform across.

Example: "Document map", "Function List", "Folder as Workspace" etc. writes plugin name as "Notepad++::InternalFunction" for their docking window, then why not "Find result"?


![image](https://user-images.githubusercontent.com/14791461/51842925-032e0880-2338-11e9-8970-0026639c3530.png)

Though, ```data.dlgID``` also can be written which are currently set to ```0```. But it is not needed as of now.