### PR TITLE
Only checking for filesystem changes when the tab is selected

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3308,10 +3308,10 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 	}
 }
 
-void Notepad_plus::checkModifiedDocument()
+void Notepad_plus::checkModifiedDocument(BufferID buff_id)
 {
 	//this will trigger buffer updates. If the status changes, Notepad++ will be informed and can do its magic
-	MainFileManager->checkFilesystemChanges();
+	MainFileManager->checkFilesystemChanges(buff_id);
 }
 
 void Notepad_plus::getMainClientRect(RECT &rc) const
@@ -3730,6 +3730,7 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne)
 	bool isSnapshotMode = NppParameters::getInstance()->getNppGUI().isSnapshotMode();
 	if (isSnapshotMode)
 	{
+        MainFileManager->checkFilesystemChanges(id);
 		// Before switching off, synchronize backup file
 		MainFileManager->backupCurrentBuffer();
 	}

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -456,7 +456,7 @@ private:
 	void checkMacroState();
 	void checkSyncState();
 	void dropFiles(HDROP hdrop);
-	void checkModifiedDocument();
+	void checkModifiedDocument(BufferID buf_id);
 
     void getMainClientRect(RECT & rc) const;
 	void staticCheckMenuAndTB() const;

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -311,7 +311,6 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	bool isSnapshotMode = nppGUI.isSnapshotMode();
 	if (isSnapshotMode)
 	{
-		_notepad_plus_plus_core.checkModifiedDocument();
 		// Lauch backup task
 		_notepad_plus_plus_core.launchDocumentBackupTask();
 	}

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -45,12 +45,6 @@ using namespace std;
 #define WM_DPICHANGED 0x02E0
 
 
-DWORD WINAPI CheckModifiedDocumentThread(LPVOID)
-{
-	MainFileManager->checkFilesystemChanges();
-	return 0;
-}
-
 struct SortTaskListPred final
 {
 	DocTabView *_views[2];
@@ -1531,19 +1525,17 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_ACTIVATEAPP:
 		{
-			if (wParam == TRUE) // if npp is about to be activated
-			{
-				::PostMessage(hwnd, NPPM_INTERNAL_CHECKDOCSTATUS, 0, 0);
-			}
+            MainFileManager->checkFilesystemChanges(_pDocTab->getBufferByIndex(_pDocTab->getCurrentTabIndex()));
 			return FALSE;
 		}
 
 		case NPPM_INTERNAL_CHECKDOCSTATUS:
 		{
+            BufferID buf_id = reinterpret_cast<BufferID>(wParam);
 			const NppGUI & nppgui = pNppParam->getNppGUI();
 			if (nppgui._fileAutoDetection != cdDisabled)
 			{
-				checkModifiedDocument();
+				checkModifiedDocument(buf_id);
 				return TRUE;
 			}
 			return FALSE;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1385,7 +1385,7 @@ bool Notepad_plus::fileSaveAs(BufferID id, bool isSaveCopy)
 	}
 	else // cancel button is pressed
     {
-        checkModifiedDocument();
+        checkModifiedDocument(id);
 		return false;
     }
 }

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -510,6 +510,14 @@ void FileManager::init(Notepad_plus * pNotepadPlus, ScintillaEditView * pscratch
 	_pscratchTilla->execute(SCI_ADDREFDOCUMENT, 0, _scratchDocDefault);
 }
 
+void FileManager::checkFilesystemChanges(BufferID buffer_id)
+{
+    if (buffer_id)
+    {
+        buffer_id->checkFileState();	//something has changed. Triggers update automatically
+    }
+
+}
 void FileManager::checkFilesystemChanges()
 {
 	for (int i = int(_nbBufs) - 1; i >= 0 ; i--)

--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -75,6 +75,7 @@ public:
 
 	//void activateBuffer(int index);
 	void checkFilesystemChanges();
+	void checkFilesystemChanges(BufferID buffer_id);
 
 	size_t getNbBuffers() { return _nbBufs; };
 	int getBufferIndexByID(BufferID id);


### PR DESCRIPTION
A simple fix to avoid having to close every externally modified file notification at once.
Issue fixed: notepad-plus-plus#1087