### PR TITLE
Feature: Support rename for unnamed tabs

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1995,7 +1995,7 @@ void Notepad_plus::checkDocState()
 	}
 
 	enableCommand(IDM_FILE_DELETE, isFileExisting, MENU);
-	enableCommand(IDM_FILE_RENAME, isFileExisting, MENU);
+	//enableCommand(IDM_FILE_RENAME, isFileExisting, MENU);
 	enableCommand(IDM_FILE_OPEN_CMD, isFileExisting, MENU);
 	enableCommand(IDM_FILE_OPEN_FOLDER, isFileExisting, MENU);
 	enableCommand(IDM_FILE_RELOAD, isFileExisting, MENU);

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -564,7 +564,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 			bool isFileExisting = PathFileExists(buf->getFullPathName()) != FALSE;
 			_tabPopupMenu.enableItem(IDM_FILE_DELETE, isFileExisting);
-			_tabPopupMenu.enableItem(IDM_FILE_RENAME, isFileExisting);
+			//_tabPopupMenu.enableItem(IDM_FILE_RENAME, isFileExisting);
 			_tabPopupMenu.enableItem(IDM_FILE_OPEN_FOLDER, isFileExisting);
 			_tabPopupMenu.enableItem(IDM_FILE_OPEN_CMD, isFileExisting);
 

--- a/PowerEditor/src/ScitillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScitillaComponent/UserDefineDialog.cpp
@@ -1449,7 +1449,10 @@ INT_PTR CALLBACK StringDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
             if (_txtLen)
                 ::SendDlgItemMessage(_hSelf, IDC_STRING_EDIT, EM_SETLIMITTEXT, _txtLen, 0);
 
-            return TRUE;
+			if (_shouldGotoCenter)
+				goToCenter();
+
+			return TRUE;
         }
 
         case WM_COMMAND :

--- a/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
+++ b/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
@@ -399,13 +399,14 @@ class StringDlg : public StaticDialog
 {
 public :
     StringDlg() : StaticDialog() {};
-    void init(HINSTANCE hInst, HWND parent, const TCHAR *title, const TCHAR *staticName, const TCHAR *text2Set, int txtLen = 0) {
-        Window::init(hInst, parent);
-        _title = title;
-        _static = staticName;
-        _textValue = text2Set;
-        _txtLen = txtLen;
-    };
+	void init(HINSTANCE hInst, HWND parent, const TCHAR *title, const TCHAR *staticName, const TCHAR *text2Set, int txtLen = 0, bool bGotoCenter = false) {
+		Window::init(hInst, parent);
+		_title = title;
+		_static = staticName;
+		_textValue = text2Set;
+		_txtLen = txtLen;
+		_shouldGotoCenter = bGotoCenter;
+	};
 
     INT_PTR doDialog() {
         return ::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_STRING_DLG), _hParent,  dlgProc, reinterpret_cast<LPARAM>(this));
@@ -421,6 +422,7 @@ private :
     generic_string _textValue;
     generic_string _static;
     int _txtLen = 0;
+	bool _shouldGotoCenter = false;
 };
 
 class StylerDlg


### PR DESCRIPTION
This PR implements request described in #3994.

ToDo: (Only if this feature sounds good, ToDo will be implemented)
 - [ ] Support localization for ```StringDlg```
 - [ ] Extend class ```StringDlg```, so that characters which are not allowed in a file name such as `|`, `:`, `>`, `<` etc. will be restricted for tab's new name so that there will be no problem while saving backup file.

![renametab](https://user-images.githubusercontent.com/14791461/52581322-73687e00-2e50-11e9-9254-793eca295ed3.gif)
