### PR TITLE
Crash Fixed: Regression

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/FileDialog.cpp
@@ -122,7 +122,7 @@ int FileDialog::setExtsFilter(const TCHAR *extText, const TCHAR *exts)
 	extFilter += TEXT(")");	
 	
 	// Resize filter buffer
-	int nbCharAdditional = static_cast<int32_t>(extFilter.length() + lstrlen(exts) + 3); // 3 additional for nulls
+	int nbCharAdditional = static_cast<int32_t>(extFilter.length() + _tcsclen(exts) + 3); // 3 additional for nulls
 	if (_fileExt)
 	{
 		oldFilter = new TCHAR[_nbCharFileExt];
@@ -146,14 +146,14 @@ int FileDialog::setExtsFilter(const TCHAR *extText, const TCHAR *exts)
 
 	// Append new filter    
     TCHAR *pFileExt = _fileExt + _nbCharFileExt;
-	int curLen = nbCharNewFileExt - _nbCharFileExt;
+	auto curLen = extFilter.length() + 1;
 	wcscpy_s(pFileExt, curLen, extFilter.c_str());
-	_nbCharFileExt += static_cast<int32_t>(extFilter.length()) + 1;
+	_nbCharFileExt += static_cast<int32_t>(curLen);
     
     pFileExt = _fileExt + _nbCharFileExt;
-	curLen = nbCharNewFileExt - _nbCharFileExt;
+	curLen = _tcsclen(exts) + 1;
 	wcscpy_s(pFileExt, curLen, exts);
-    _nbCharFileExt += lstrlen(exts) + 1;
+	_nbCharFileExt += static_cast<int32_t>(curLen);
 
 	// Set file dialog pointer
 	_ofn.lpstrFilter = _fileExt;


### PR DESCRIPTION
When try to save an unsaved file, crash happens. This regression caused by 7fe3cda1d09d133b3d5cdb982c8ffd4b7c7fdd12

![image](https://user-images.githubusercontent.com/14791461/52657313-63b76b00-2f1e-11e9-8110-837659b14ac7.png)
