### PR TITLE
Don't allow restricted characters for tab file rename

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1424,8 +1424,12 @@ bool Notepad_plus::fileRename(BufferID id)
 		// We are just going to rename the tab nothing else
 		// So just rename the tab and rename the backup file too if applicable
 
+		// https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file
+		// Reserved characters: < > : " / \ | ? *
+		std::wstring reservedChars = TEXT("<>:\"/\\|\?*");
+
 		StringDlg strDlg;
-		strDlg.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), TEXT("Rename Current Tab"), TEXT("New Name : "), buf->getFileName(), 0, true);
+		strDlg.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), TEXT("Rename Current Tab"), TEXT("New Name : "), buf->getFileName(), 0, reservedChars.c_str(), true);
 
 		TCHAR *tabNewName = reinterpret_cast<TCHAR *>(strDlg.doDialog());
 		if (tabNewName)

--- a/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
+++ b/PowerEditor/src/ScitillaComponent/UserDefineDialog.h
@@ -399,13 +399,17 @@ class StringDlg : public StaticDialog
 {
 public :
     StringDlg() : StaticDialog() {};
-	void init(HINSTANCE hInst, HWND parent, const TCHAR *title, const TCHAR *staticName, const TCHAR *text2Set, int txtLen = 0, bool bGotoCenter = false) {
+	void init(HINSTANCE hInst, HWND parent, const TCHAR *title, const TCHAR *staticName, const TCHAR *text2Set, int txtLen = 0, const TCHAR* restrictedChars = nullptr, bool bGotoCenter = false) {
 		Window::init(hInst, parent);
 		_title = title;
 		_static = staticName;
 		_textValue = text2Set;
 		_txtLen = txtLen;
 		_shouldGotoCenter = bGotoCenter;
+		if (restrictedChars && _tcslen(restrictedChars))
+		{
+			_restrictedChars = restrictedChars;
+		}
 	};
 
     INT_PTR doDialog() {
@@ -417,12 +421,20 @@ public :
 protected :
     INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM);
 
+	// Custom proc to subclass edit control
+	LRESULT static CALLBACK customEditProc(HWND hEdit, UINT msg, WPARAM wParam, LPARAM lParam);
+
+	bool isAllowed(const generic_string& txt);
+	void HandlePaste(HWND hEdit);
+
 private :
     generic_string _title;
     generic_string _textValue;
     generic_string _static;
+	generic_string _restrictedChars;
     int _txtLen = 0;
 	bool _shouldGotoCenter = false;
+	WNDPROC _oldEditProc = nullptr;
 };
 
 class StylerDlg


### PR DESCRIPTION
As promised in PR #5311, below items have been implemented now - 

- [x] Support localization for ```StringDlg``` 
=> This is done in PR #5323
- [x] Extend class ```StringDlg```, so that characters which are not allowed in a file name such as `|`, `:`, `>`, `<` etc. will be restricted for tab's new name so that there will be no problem while saving backup file. 
=> This is done in the current PR.