### PR TITLE
[Potential crash cause]: Fixed macro playback junk char issue

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2710,10 +2710,7 @@ void FindReplaceDlg::execSavedCommand(int cmd, uptr_t intValue, generic_string s
 						}
 						else
 						{
-							TCHAR moreInfo[128];
-							NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance())->getNativeLangSpeaker();
-							generic_string msg = pNativeSpeaker->getLocalizedStrFromID("find-status-invalid-re", TEXT("Find: Invalid regular expression"));
-							if (nbMarked <= 1)
+							if (nbMarked == 1)
 							{
 								result = pNativeSpeaker->getLocalizedStrFromID("find-status-mark-1-match", TEXT("1 match."));
 							}
@@ -2722,7 +2719,6 @@ void FindReplaceDlg::execSavedCommand(int cmd, uptr_t intValue, generic_string s
 								result = pNativeSpeaker->getLocalizedStrFromID("find-status-mark-nb-matches", TEXT("$INT_REPLACE$ matches."));
 								result = stringReplace(result, TEXT("$INT_REPLACE$"), std::to_wstring(nbMarked));
 							}
-							result = moreInfo;
 						}
 
 						setStatusbarMessage(result, FSMessage);
@@ -2741,7 +2737,7 @@ void FindReplaceDlg::execSavedCommand(int cmd, uptr_t intValue, generic_string s
 				throw std::runtime_error("Internal error: unknown SnR command!");
 		}
 	}
-	catch (std::runtime_error err)
+	catch (const std::runtime_error& err)
 	{
 		MessageBoxA(NULL, err.what(), "Play Macro Exception", MB_OK);
 	}


### PR DESCRIPTION
Fixed defect #5339

![image](https://user-images.githubusercontent.com/14791461/53303237-1c21cf00-388e-11e9-9e66-3313e60c4e63.png)



~~#### P.S: I know "0 matches" is not proper string, it should be "0 match". But is very minor and similar minor grammar mistakes can be found many places (as can been seen in below screenshot as well). The purpose of this is PR is to remove the junk character which eventually can be cause to crash.
![image](https://user-images.githubusercontent.com/14791461/53303291-a79b6000-388e-11e9-9948-f8aaf292b27d.png)~~
