### PR TITLE
Update Bulgarian localization

### DIFF
--- a/PowerEditor/installer/nativeLang/bulgarian.xml
+++ b/PowerEditor/installer/nativeLang/bulgarian.xml
@@ -3,7 +3,7 @@
 	## Bulgarian localization for Notepad++ ##
 
 	Translators:.....: 2007-2012 - Milen Metev (Tragedy); 2014-yyyy - RDD
-	Last revision:...: 26.12.2018 by RDD <astral_86[at]mail[dot]bg>
+	Last revision:...: 01.03.2019 by RDD <astral_86[at]mail[dot]bg>
 	Download:........: https://gist.github.com/rddim/bd37264898c3a17363e7437bcf1b4803
 -->
 <NotepadPlus>
@@ -142,6 +142,7 @@
 					<Item id="42072" name="&amp;прОиЗвоЛНо"/>
 						<!-- Подменю "Редове" -->
 					<Item id="42010" name="Дублиране на текущия ред"/>
+					<Item id="42077" name="Премахване на дублирани последователни редове"/>
 					<Item id="42012" name="Разделяне на редове"/>
 					<Item id="42013" name="Обединяване на редове"/>
 					<Item id="42059" name="Сортиране по възходящ ред"/>
@@ -365,20 +366,21 @@
 					<Item id="48017" name="Преки пътища и команди..."/>
 				<!-- Меню "Стартиране" край -->
 				<!-- Меню "Добавки" начало -->
-					<Item id="48015" name="Управление на добавки..."/>
+					<Item id="48014" name="Управление на добавки..."/>
+					<Item id="48015" name="Отваряне на папката с добавки..."/>
 				<!-- Меню "Добавки" край -->
 				<!-- Меню "?" начало -->
 					<Item id="47010" name="Параметри на командния ред..."/>
 					<Item id="47001" name="Notepad++ домашна страница"/>
 					<Item id="47002" name="Notepad++ страница на проекта"/>
 					<Item id="47004" name="Notepad++ общност (Форум)"/>
-					<Item id="47005" name="Още добавки"/>
+					<Item id="47011" name="Поддръжка в реално време"/>
+					<!-- <Item id="47005" name="Още добавки"/> за сега (от v7.6.4) е премахнато -->
 					<Item id="47003" name="Онлайн документация"/>
 					<Item id="47006" name="Обновяване на Notepad++"/>
 					<Item id="47009" name="Задаване на прокси за обновяване..."/>
-					<Item id="47000" name="Относно Notepad++"/>
-					<Item id="47011" name="Поддръжка в реално време"/>
 					<Item id="47012" name="Инфо за отстраняване на грешки..."/>
+					<Item id="47000" name="Относно Notepad++"/>
 				<!-- Меню "?" край -->
 				</Commands>
 			</Main>
@@ -1147,18 +1149,13 @@
 			<two-find-buttons-tip value="Режим за търсене с два бутона"/>
 			<find-status-top-reached value="Търсене: Намерено е първото съвпадение от краят. Началото на документа е достигнато."/>
 			<find-status-end-reached value="Търсене: Намерено е първото съвпадение от началото. Краят на документа е достигнат."/>
+			<find-status-invalid-re value="Търсене: Невалиден регулярен израз"/>
+			<find-status-cannot-find value="Търсене: Текстът &quot;$STR_REPLACE$&quot; не може да се намери"/>
 			<find-status-replaceinfiles-1-replaced value="Замяна във Файлове: беше заменено 1 съвпадение"/>
 			<find-status-replaceinfiles-nb-replaced value="Замяна във Файлове: бяха заменени $INT_REPLACE$ съвпадения"/>
 			<find-status-replaceinfiles-re-malformed value="Замяна в отворените файлове: Регулярният израз е неправилно  формиран"/>
 			<find-status-replaceinopenedfiles-1-replaced value="Замяна в отворените файлове: беше заменено 1 съвпадение"/>
 			<find-status-replaceinopenedfiles-nb-replaced value="Замяна в отворените файлове: бяха заменени $INT_REPLACE$ съвпадения"/>
-			<find-status-mark-re-malformed value="Маркиране: Регулярният израз за търсене е неправилно формиран"/>
-			<find-status-invalid-re value="Търсене: Невалиден регулярен израз"/>
-			<find-status-mark-1-match value="1 съвпадение"/>
-			<find-status-mark-nb-matches value="$INT_REPLACE$ съвпадения"/>
-			<find-status-count-re-malformed value="Брой: Регулярният израз за търсене е неправилно формиран"/>
-			<find-status-count-1-match value="Брой съвпадения: 1"/>
-			<find-status-count-nb-matches value="Брой съвпадения: $INT_REPLACE$"/>
 			<find-status-replaceall-re-malformed value="Замяна на всичко: Регулярният израз е неправилно  формиран"/>
 			<find-status-replaceall-1-replaced value="Замяна на всичко: беше заменено 1 съвпадение"/>
 			<find-status-replaceall-nb-replaced value="Замяна на всичко: бяха заменени $INT_REPLACE$ съвпадения"/>
@@ -1169,7 +1166,12 @@
 			<find-status-replaced-next-not-found value="Замяна: беше заменено 1 съвпадение. Следващото съвпадение не е намерено"/>
 			<find-status-replace-not-found value="Замяна: не беше намерено съвпадение"/>
 			<find-status-replace-readonly value="Замяна: Текста не може да се замени. Текущият документ е само за четене"/>
-			<find-status-cannot-find value="Търсене: Текстът &quot;$STR_REPLACE$&quot; не може да се намери"/>
+			<find-status-mark-re-malformed value="Маркиране: Регулярният израз за търсене е неправилно формиран"/>
+			<find-status-mark-1-match value="Маркиране: 1 съвпадение"/>
+			<find-status-mark-nb-matches value="Маркиране: $INT_REPLACE$ съвпадения"/>
+			<find-status-count-re-malformed value="Брой: Регулярният израз за търсене е неправилно формиран"/>
+			<find-status-count-1-match value="Брой съвпадения: 1"/>
+			<find-status-count-nb-matches value="Брой съвпадения: $INT_REPLACE$"/>
             <finder-find-in-finder value="Търсене в намерените резултати..."/>
             <finder-close-this value="Затваряне на това търсене"/>
             <finder-collapse-all value="Свиване на всички"/>


### PR DESCRIPTION
* follow up https://github.com/notepad-plus-plus/notepad-plus-plus/commit/4472620f3039d3e6fd61da8b2095b7f3c9b02551
* follow up https://github.com/notepad-plus-plus/notepad-plus-plus/commit/b381ea5353fb8957b1291cede7308582b6af8ae5 (added `<Item id="42077" name="Remove Consecutive Duplicate Lines"/>`)
* follow up https://github.com/notepad-plus-plus/notepad-plus-plus/commit/1dfa92c4b7e3f4acb26fe6dbfb632618c7a21d43 (rename `<Item id="48015" name="Plugins Admin..."/>` to `<Item id="48015" name="Open Plugins Folder..."/>` and added `<Item id="48014" name="Plugins Admin..."/>`)
* some strings re-organization