### PR TITLE
On program update, remove old autoCompletion directory if empty

### DIFF
--- a/PowerEditor/installer/nsisInclude/autoCompletion.nsh
+++ b/PowerEditor/installer/nsisInclude/autoCompletion.nsh
@@ -178,6 +178,9 @@ SectionGroup "Auto-completion Files" autoCompletionComponent
 		SetOutPath "$INSTDIR\autoCompletion"
 		File ".\APIs\autoit.xml"
 	${MementoSectionEnd}
+
+	; remove old autoCompletion directory if empty
+	RMDir "$INSTDIR\plugins\APIs\"
 SectionGroupEnd
 
 
@@ -302,7 +305,6 @@ SectionGroup un.autoCompletionComponent
 		Delete "$INSTDIR\plugins\APIs\lua.xml"
 		Delete "$INSTDIR\autoCompletion\lua.xml"
 	SectionEnd
-
 
 	Section un.autoit
 		Delete "$INSTDIR\plugins\APIs\autoit.xml"


### PR DESCRIPTION
As noted in https://github.com/notepad-plus-plus/notepad-plus-plus/pull/5277#issuecomment-464397468

ping @SinghRajenM :)