### PR TITLE
zulu and kurdish translation fix

### DIFF
--- a/PowerEditor/Test/FunctionList/cpp/unitTest
+++ b/PowerEditor/Test/FunctionList/cpp/unitTest
@@ -3773,6 +3773,8 @@ generic_string NppParameters::getLocPathFromStr(const generic_string & localizat
 		return TEXT("vietnamese.xml");
 	if (localizationCode == TEXT("cy-gb"))
 		return TEXT("welsh.xml");
+	if (localizationCode == TEXT("zu") || localizationCode == TEXT("zu-za"))
+		return TEXT("zulu.xml");
 
 	return generic_string();
 }

--- a/PowerEditor/installer/nativeLang/kurdish.xml
+++ b/PowerEditor/installer/nativeLang/kurdish.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <NotepadPlus>
     <Native-Langue name="كوردی" RTL="yes" filename="kurdish.xml" version="7.5">
         <Menu>

--- a/PowerEditor/installer/nativeLang/zulu.xml
+++ b/PowerEditor/installer/nativeLang/zulu.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 ***********************************************************************************
 	zulu language binary translations file for Notepad++ ::

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3926,6 +3926,8 @@ generic_string NppParameters::getLocPathFromStr(const generic_string & localizat
 		return TEXT("vietnamese.xml");
 	if (localizationCode == TEXT("cy-gb"))
 		return TEXT("welsh.xml");
+	if (localizationCode == TEXT("zu") || localizationCode == TEXT("zu-za"))
+		return TEXT("zulu.xml");
 
 	return generic_string();
 }

--- a/PowerEditor/src/localizationString.h
+++ b/PowerEditor/src/localizationString.h
@@ -116,5 +116,5 @@ LocalizationSwitcher::LocalizationDefinition localizationDefs[] =
 	{TEXT("Brezhoneg"), TEXT("breton.xml")},
 	{TEXT("کوردی‬"), TEXT("kurdish.xml")},
 	{TEXT("Pig latin"), TEXT("piglatin.xml")},
-        {TEXT("Zulu"), TEXT("zulu.xml")}
+	{TEXT("Zulu"), TEXT("zulu.xml")}
 };


### PR DESCRIPTION
- corrected xml encoding from UTF8 with BOM -> required UTF8 for zulu and kurdish
- added zulu to localization list, see also #5209
- space -> tab in localizationString.h according to the rest of the list