### PR TITLE
Include filename in error message if SciLexer.dll fails to load

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -229,7 +229,7 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 {
 	if (!_hLib)
 	{
-		throw std::runtime_error("ScintillaEditView::init : SCINTILLA ERROR - Can not load the dynamic library");
+		throw std::runtime_error("ScintillaEditView::init : SCINTILLA ERROR - Can not load the dynamic library SciLexer.dll");
 	}
 
 	Window::init(hInst, hPere);


### PR DESCRIPTION
This error can occur if Notepad++ is built & run from source without building a compatible version (32-bit/64-bit) of SciLexer.dll.