### PR TITLE
Ignore deprecation warning for GetVersionEx

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -717,6 +717,8 @@ generic_string ThemeSwitcher::getThemeFromXmlFileName(const TCHAR *xmlFullPath) 
 }
 
 
+#pragma warning( push )
+#pragma warning( disable : 4996 ) // GetVersionEx was depreciated in Windows 8.1
 winVer NppParameters::getWindowsVersion()
 {
 	OSVERSIONINFOEX osvi;
@@ -819,6 +821,7 @@ winVer NppParameters::getWindowsVersion()
 
    return WV_UNKNOWN;
 }
+#pragma warning( pop )
 
 
 


### PR DESCRIPTION
GetVersionEx() was depreciated in Windows 8.1. (See https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversionexw)