### PR TITLE
Regression: Fixed crash

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3783,20 +3783,20 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne)
 			return false;
 	}
 
-	bool isCurrBuffDetection = (NppParameters::getInstance()->getNppGUI()._fileAutoDetection & cdEnabledNew) ? true : false;
-
 	if (reload)
 	{
 		performPostReload(whichOne);
 	}
-	else if(isCurrBuffDetection)
+
+	notifyBufferActivated(id, whichOne);
+
+	bool isCurrBuffDetection = (NppParameters::getInstance()->getNppGUI()._fileAutoDetection & cdEnabledNew) ? true : false;
+	if (!reload && isCurrBuffDetection)
 	{
 		// Buffer has been activated, now check for file modification
 		// If enabled for current buffer
 		pBuf->checkFileState();
 	}
-
-	notifyBufferActivated(id, whichOne);
 	return true;
 }
 


### PR DESCRIPTION
@donho 
With new behavior in one particular scenario Npp crashes.
### Steps to reproduce crash
1. Open a.txt and b.txt
2. Make a.txt as active tab (**this is an important step for crash**)
3. Now delete b.txt file externally.
4. Come to Npp, _there is no modification notification which is expected_.
5. Now click on b.txt tab, _user will see file deleted file message which is also again expected_, now
     a) if userclicks on 'Yes' to keep the document, everything is fine here
     b) **but if user clicks on 'No', then Npp crashes.**

**Please note**: if b.txt is active tab in step 2 and step 3~5 are performed, then no crashed is seen.