### PR TITLE
Fixed issue and allow some more characters in UDL name

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2086,18 +2086,19 @@ void Notepad_plus::checkLangsMenu(int id) const
 			if (curBuf->isUserDefineLangExt())
 			{
 				const TCHAR *userLangName = curBuf->getUserDefineLangName();
-				const int nbChar = 16;
-				TCHAR menuLangName[nbChar];
+				TCHAR menuLangName[langNameLenMax];
 
 				for (int i = IDM_LANG_USER + 1 ; i <= IDM_LANG_USER_LIMIT ; ++i)
 				{
-					if (::GetMenuString(_mainMenuHandle, i, menuLangName, nbChar-1, MF_BYCOMMAND))
+					if (::GetMenuString(_mainMenuHandle, i, menuLangName, langNameLenMax, MF_BYCOMMAND))
+					{
 						if (!lstrcmp(userLangName, menuLangName))
 						{
 							HMENU _langMenuHandle = ::GetSubMenu(_mainMenuHandle, MENUINDEX_LANGUAGE);
 							doCheck(_langMenuHandle, i);
 							return;
 						}
+					}
 				}
 			}
 		}

--- a/PowerEditor/src/ScitillaComponent/UserDefineLangReference.h
+++ b/PowerEditor/src/ScitillaComponent/UserDefineLangReference.h
@@ -31,7 +31,7 @@
 
 #include "SciLexer.h"
 
-const int langNameLenMax = 33;
+const int langNameLenMax = 64;
 const int extsLenMax = 256;
 const int max_char = 1024*30;
 


### PR DESCRIPTION
Fixed issue #5400 and #4714

UDL name length has been extended to 64 characters as it is required. examples are as below - 

Generic printer Description language (GPD)
Generic Description Language (GDL)
page description language (PDL)
Printer Command Language (PCL)
PostScript Printer Description (PPD)