### PR TITLE
Support old Mac line endings in "Remove Consecutive Duplicate Lines" command

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1408,13 +1408,13 @@ void Notepad_plus::removeDuplicateLines()
 	// whichPart : line head or line tail
 	FindOption env;
 
-	env._str2Search = TEXT("^(.*\\r?\\n)(\\1)+");
+	env._str2Search = TEXT("^(.*(?:\\r\\n|\\n|\\r))(\\1)+");
 	env._str4Replace = TEXT("\\1");
     env._searchType = FindRegex;
 	_findReplaceDlg.processAll(ProcessReplaceAll, &env, true);
 
 	// remove the last line if it's a duplicate line.
-	env._str2Search = TEXT("^(.+)\\r?\\n(\\1)$");
+	env._str2Search = TEXT("^(.+)(?:\\r\\n|\\n|\\r)(\\1)$");
 	env._str4Replace = TEXT("\\1");
     env._searchType = FindRegex;
 	_findReplaceDlg.processAll(ProcessReplaceAll, &env, true);


### PR DESCRIPTION
See https://github.com/notepad-plus-plus/notepad-plus-plus/commit/0467b7d6cd19aa9bea373a9eabb44e73de0cea62#commitcomment-32962912.

As usual with such code, it's important the "\r\n" occurs before the "\r".