### PR TITLE
Add contextual menu for file encoding in status bar

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -418,23 +418,23 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			if (notification->nmhdr.hwndFrom == _statusBar.getHSelf())
 			{
 				LPNMMOUSE lpnm = (LPNMMOUSE)notification;
-				if (lpnm->dwItemSpec == DWORD(STATUSBAR_CUR_POS))
-				{
-					bool isFirstTime = !_goToLineDlg.isCreated();
-					_goToLineDlg.doDialog(_nativeLangSpeaker.isRTL());
-					if (isFirstTime)
-						_nativeLangSpeaker.changeDlgLang(_goToLineDlg.getHSelf(), "GoToLine");
-				}
-				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_DOC_SIZE))
-				{
-					command(IDM_VIEW_SUMMARY);
-				}
-				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_DOC_TYPE))
+				if (lpnm->dwItemSpec == DWORD(STATUSBAR_DOC_TYPE))
 				{
 					POINT p;
 					::GetCursorPos(&p);
 					HMENU hLangMenu = ::GetSubMenu(_mainMenuHandle, MENUINDEX_LANGUAGE);
 					TrackPopupMenu(hLangMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
+				}
+				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_DOC_SIZE))
+				{
+					command(IDM_VIEW_SUMMARY);
+				}
+				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_CUR_POS))
+				{
+					bool isFirstTime = !_goToLineDlg.isCreated();
+					_goToLineDlg.doDialog(_nativeLangSpeaker.isRTL());
+					if (isFirstTime)
+						_nativeLangSpeaker.changeDlgLang(_goToLineDlg.getHSelf(), "GoToLine");
 				}
 				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_EOF_FORMAT))
 				{

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -449,6 +449,13 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 						return TRUE;
 					TrackPopupMenu(hEolFormatMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
 				}
+				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_UNICODE_TYPE))
+				{
+					POINT p;
+					::GetCursorPos(&p);
+					HMENU hEncodingMenu = ::GetSubMenu(_mainMenuHandle, MENUINDEX_FORMAT);
+					TrackPopupMenu(hEncodingMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
+				}
 			}
 			break;
 		}
@@ -488,6 +495,13 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					if (!hEolFormatMenu)
 						return TRUE;
 					TrackPopupMenu(hEolFormatMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
+				}
+				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_UNICODE_TYPE))
+				{
+					POINT p;
+					::GetCursorPos(&p);
+					HMENU hEncodingMenu = ::GetSubMenu(_mainMenuHandle, MENUINDEX_FORMAT);
+					TrackPopupMenu(hEncodingMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
 				}
 				return TRUE;
 			}


### PR DESCRIPTION
Fixes #400 and #756.
That would be a simple but very convenient feature.

The implementation seems to be [very easy](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/9b5a39b58f7844e62e46d4952155c29964c7c6f3).
The only thing I can't say is if it works correctly on the "Character sets" submenu. If yes, that's wonderful!