### PR TITLE
* fix non-idomatic use of std::remove_if

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -464,11 +464,10 @@ void Notepad_plus::command(int id)
 			if (nppGui._searchEngineChoice == nppGui.se_custom)
 			{
 				url = nppGui._searchEngineCustom;
-				remove_if(url.begin(), url.end(), isspace);
-
+				url.erase(std::remove_if(url.begin(), url.end(), [](_TUCHAR x){return _istspace(x);}),
+						  url.end());
 				auto httpPos = url.find(TEXT("http://"));
 				auto httpsPos = url.find(TEXT("https://"));
-
 				if (url.empty() || (httpPos != 0 && httpsPos != 0)) // if string is not a url (for launching only browser)
 				{
 					url = TEXT("https://www.google.com/search?q=$(CURRENT_WORD)");


### PR DESCRIPTION
1.  **erase-remove idiom**
please refer to the example code at [https://en.cppreference.com/w/cpp/algorithm/remove](https://en.cppreference.com/w/cpp/algorithm/remove)

2.  **the lambda predicate and** **`_istspace()`**,  **`_TUCHAR`** 
     Use such [Generic-Text Mappings](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/isspace-iswspace-isspace-l-iswspace-l?view=vs-2019#generic-text-routine-mappings) to align with the use of **`generic_string`**.
    When non-Unicode, [_TUCHAR ](https://docs.microsoft.com/en-us/cpp/text/generic-text-mappings-in-tchar-h?view=vs-2015#generic-text-data-type-mappings)is `unsigned char`; otherwise it is `wchar_t`. 
    Under both  situation we can avoid the undefined behavior of [isspace()](https://en.cppreference.com/w/cpp/string/byte/isspace) and [iswspace()](https://en.cppreference.com/w/cpp/string/wide/iswspace).
 


