### PR TITLE
Fixed defect #5516

### DIFF
--- a/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
+++ b/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
@@ -37,17 +37,6 @@ bool Splitter::_isVerticalFixedRegistered = false;
 
 #define SPLITTER_SIZE 8
 
-
-
-Splitter::Splitter()
-{
-	_rect.left   = 0; // x axis
-	_rect.top    = 0; // y axis
-	_rect.right  = 0; // Width of the spliter.
-	_rect.bottom = 0; // Height of the spliter
-}
-
-
 void Splitter::init( HINSTANCE hInst, HWND hPere, int splitterSize, double iSplitRatio, DWORD dwFlags)
 {
 	if (hPere == NULL)
@@ -274,7 +263,7 @@ LRESULT CALLBACK Splitter::spliterWndProc(UINT uMsg, WPARAM wParam, LPARAM lPara
 
 			if ((isInRightBottomZone(p))&&(wParam == MK_LBUTTON))
 			{
-				gotoRightBouuom();
+				gotoRightBottom();
 				return TRUE;
 			}
 
@@ -282,6 +271,7 @@ LRESULT CALLBACK Splitter::spliterWndProc(UINT uMsg, WPARAM wParam, LPARAM lPara
 			{
 				::SetCapture(_hSelf);
 				_isDraged = true;
+				_isLeftButtonDown = true;
 			}
 
 			return 0;
@@ -306,7 +296,7 @@ LRESULT CALLBACK Splitter::spliterWndProc(UINT uMsg, WPARAM wParam, LPARAM lPara
 				return TRUE;
 			}
 
-			if ((!_isFixed) && (wParam == MK_LBUTTON))
+			if ((!_isFixed) && (wParam == MK_LBUTTON) && _isLeftButtonDown)
 			{
 				POINT pt; RECT rt;
 				::GetClientRect(_hParent, &rt);
@@ -389,9 +379,10 @@ LRESULT CALLBACK Splitter::spliterWndProc(UINT uMsg, WPARAM wParam, LPARAM lPara
 
 		case WM_LBUTTONUP:
 		{
-			if (!_isFixed)
+			if (!_isFixed && _isLeftButtonDown)
 			{
 				ReleaseCapture();
+				_isLeftButtonDown = false;
 			}
 			return 0;
 		}
@@ -495,7 +486,7 @@ void Splitter::gotoTopLeft()
 }
 
 
-void Splitter::gotoRightBouuom()
+void Splitter::gotoRightBottom()
 {
 	if ((_dwFlags & SV_ENABLERDBLCLK) && (!_isFixed) && (_splitPercent < 99))
 	{

--- a/PowerEditor/src/WinControls/SplitterContainer/Splitter.h
+++ b/PowerEditor/src/WinControls/SplitterContainer/Splitter.h
@@ -64,7 +64,7 @@ enum class SplitterMode: std::uint8_t
 class Splitter : public Window
 {
 public:
-	Splitter();
+	Splitter() = default;
 	virtual ~Splitter() = default;
 
 	virtual void destroy() override;
@@ -80,10 +80,11 @@ public:
 
 
 private:
-	RECT _rect;
+	RECT _rect = {};
 	double _splitPercent = 0.;
 	int _splitterSize = 0;
 	bool _isDraged = false;
+	bool _isLeftButtonDown = false;
 	DWORD _dwFlags = 0;
 	bool _isFixed = false;
 	static bool _isHorizontalRegistered;
@@ -102,7 +103,7 @@ private:
 	bool isVertical() const {return (_dwFlags & SV_VERTICAL) != 0;};
 	void paintArrow(HDC hdc, const RECT &rect, Arrow arrowDir);
 	void gotoTopLeft();
-	void gotoRightBouuom();
+	void gotoRightBottom();
 
 	bool isInLeftTopZone(const POINT& p) const
 	{


### PR DESCRIPTION
Fixes #680, #2097 and #5516

1. Resizing any dockable window (e.g. search result, function list, folder as workspace) also resizes the doc splitter (other view).
2. Corrected typo (`gotoRightBouuom` => `gotoRightBottom`)
3. Make use of in class initialization. (`RECT _rect` => `RECT _rect = {};`). 