### PR TITLE
Fixed File Monitoring Reload issue

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -458,6 +458,7 @@ private:
 	void checkSyncState();
 	void dropFiles(HDROP hdrop);
 	void checkModifiedDocument(bool bCheckOnlyCurrentBuffer);
+	void checkModifiedDocumentIfMonitoring();
 
     void getMainClientRect(RECT & rc) const;
 	void staticCheckMenuAndTB() const;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1532,6 +1532,13 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_INTERNAL_CHECKDOCSTATUS:
 		{
+			// This is an workaround to deal with Microsoft issue in ReadDirectoryChanges notification
+			// If command prompt is used to write file continuously (e.g. ping -t 8.8.8.8 > ping.log)
+			// Then ReadDirectoryChanges does not detect the change
+			// Fortunately, notification is sent if right click or double click happens on that file
+			// Let's leverage this as workaround to enhance npp file monitoring functionality.
+			checkModifiedDocumentIfMonitoring();
+
 			const NppGUI & nppgui = pNppParam->getNppGUI();
 			if (nppgui._fileAutoDetection != cdDisabled)
 			{

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -224,7 +224,10 @@ void Buffer::setFileName(const TCHAR *fn, LangType defaultLang)
 
 bool Buffer::checkFileState() // returns true if the status has been changed (it can change into DOC_REGULAR too). false otherwise
 {
- 	if (_currentStatus == DOC_UNNAMED)	//unsaved document cannot change by environment
+	// 1. Unsaved document cannot change by environment
+	// 2. Monitoring is sent by NPPM_INTERNAL_RELOADSCROLLTOEND
+	// So no need to check file status for both the above cases
+	if (_currentStatus == DOC_UNNAMED || isMonitoringOn())
 		return false;
 
 	WIN32_FILE_ATTRIBUTE_DATA attributes;


### PR DESCRIPTION
Fixed issue #5586 and #4847....

### Root cause:
In member function`void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)` below code gets executed ...
```C++
case DOC_NEEDRELOAD: // by log monitoring
			{
				doReload(buffer->getID(), false);
```
```doReload(buffer->getID(), false);``` calls ```activateBuffer(id, currentView());``` and ```activateBuffer(id, currentView());``` calls ```checkFileState()```.

Now in ```checkFileState()``` below code causes this issue. As I said [here](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5586#issuecomment-487273042), it's all about the thread timing. So timestamp in npp does not match with timestamp of actual file. Therefore, `_currentStatus` becomes `DOC_MODIFIED`.

```C++
		if (CompareFileTime(&_timeStamp, &attributes.ftLastWriteTime) != 0)
		{
			_timeStamp = attributes.ftLastWriteTime;
			mask |= BufferChangeTimestamp;
			_currentStatus = DOC_MODIFIED;
			mask |= BufferChangeStatus;	//status always 'changes', even if from modified to modified
		}
```

**P.S. Updating `Buffer.cpp` is enough to deal with this issue. But to be safer side, it is good to block reloading in `case DOC_MODIFIED:` in file `Notepad_plus.cpp` too.**

### Edit
Commit 2 deals with  https://github.com/notepad-plus-plus/notepad-plus-plus/pull/5591#issuecomment-487313886 which is because of Microsoft and described here (https://github.com/notepad-plus-plus/notepad-plus-plus/pull/5591#issuecomment-487341747) why it is MS.