### PR TITLE
Use SCI_TARGETWHOLEDOCUMENT and SCI_COUNTCHARACTERS

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1526,7 +1526,7 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_EOL2WS:
 			_pEditView->execute(SCI_BEGINUNDOACTION);
-			_pEditView->execute(SCI_SETTARGETRANGE, 0, _pEditView->getCurrentDocLen());
+			_pEditView->execute(SCI_TARGETWHOLEDOCUMENT);
 			_pEditView->execute(SCI_LINESJOIN);
 			_pEditView->execute(SCI_ENDUNDOACTION);
 			break;
@@ -1538,7 +1538,7 @@ void Notepad_plus::command(int id)
 			_pEditView->execute(SCI_BEGINUNDOACTION);
 			doTrim(lineTail);
 			doTrim(lineHeader);
-			_pEditView->execute(SCI_SETTARGETRANGE, 0, _pEditView->getCurrentDocLen());
+			_pEditView->execute(SCI_TARGETWHOLEDOCUMENT);
 			_pEditView->execute(SCI_LINESJOIN);
 			_pEditView->execute(SCI_ENDUNDOACTION);
 			break;

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -477,18 +477,11 @@ public:
 		// return -1 if it's multi-selection or rectangle selection
 		if ((execute(SCI_GETSELECTIONS) > 1) || execute(SCI_SELECTIONISRECTANGLE))
 			return -1;
-		auto size_selected = execute(SCI_GETSELTEXT);
-		char *selected = new char[size_selected + 1];
-		execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selected));
-		char *c = selected;
-		long length = 0;
-		while (*c != '\0')
-		{
-			if ( (*c & 0xC0) != 0x80)
-				++length;
-			++c;
-		}
-		delete [] selected;
+
+		long start = long(execute(SCI_GETSELECTIONSTART));
+		long end = long(execute(SCI_GETSELECTIONEND));
+		long length = long(execute(SCI_COUNTCHARACTERS, start, end));
+
 		return length;
 	};
 


### PR DESCRIPTION
This adds the use of `SCI_TARGETWHOLEDOCUMENT` which is a bit cleaner and readable to target the entire document.

It also uses `SCI_COUNTCHARACTERS` which lets Scintilla count the characters in the specified range. This avoids a *potentially* large memory allocation/copy since currently if a user selects all the text in a large file, it has to create an entire copy of the text to count the characters. This new message lets Scintilla do it all internally