### PR TITLE
change.log typo fixed

### DIFF
--- a/PowerEditor/bin/change.log
+++ b/PowerEditor/bin/change.log
@@ -9,7 +9,7 @@ Notepad++ v7.7 new features and bug-fixes:
 7.  Add Ctrl + R shortcut for "Reload from disk" command.
 8.  Fix '\' display problem in CSS while using themes (Remove Batang font for CSS tags).
 9.  Fix crash while right clicking on DocSwitcher's column bar.
-10. Fix all plugins being removed problem while Plugin Admin romoves an old plugin (of old system).
+10. Fix all plugins being removed problem while Plugin Admin removes an old plugin (of old system).
 
 
 Included plugins:


### PR DESCRIPTION
change.log typo 'romoves' fixed to 'removes'