### PR TITLE
Fix bug in IDM_EDIT_CLEARREADONLY

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1568,7 +1568,7 @@ void Notepad_plus::command(int id)
 			Buffer * buf = _pEditView->getCurrentBuffer();
 
 			DWORD dwFileAttribs = ::GetFileAttributes(buf->getFullPathName());
-			dwFileAttribs ^= FILE_ATTRIBUTE_READONLY;
+			dwFileAttribs &= ~FILE_ATTRIBUTE_READONLY;
 
 			::SetFileAttributes(buf->getFullPathName(), dwFileAttribs);
 			buf->setFileReadOnly(false);


### PR DESCRIPTION
Using ^= for the readonly attribute will cause it to always change the bit.  So if CLEARREADONLY is called on a file that isn't read only, the file will become read only.

Changing it to &= ~FILE_ATTRIBUTE_READONLY; will result in it always clearing the readonly flag.