### PR TITLE
Revert PR#4886 due to regressions and possible fix to original issue

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -31,7 +31,6 @@
 #include <uxtheme.h>
 #include <cassert>
 #include <codecvt>
-#include <locale>
 
 #include "StaticDialog.h"
 

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -669,7 +669,6 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			if (_isDragging)
 			{
                 exchangeItemData(p);
-				::CallWindowProc(_tabBarDefaultProc, hwnd, WM_LBUTTONDOWN, wParam, lParam);
 
 				// Get cursor position of "Screen"
 				// For using the function "WindowFromPoint" afterward!!!
@@ -1188,6 +1187,9 @@ void TabBarPlus::exchangeTabItemData(int oldTab, int newTab)
 
 	// Tell Notepad_plus to notifiy plugins that a D&D operation was done (so doc index has been changed)
 	::SendMessage(_hParent, NPPM_INTERNAL_DOCORDERCHANGED, 0, oldTab);
+
+	//2. set to focus
+	setActiveTab(newTab);
 }
 
 void TabBarPlus::exchangeItemData(POINT point)

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -776,6 +776,8 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			int currentTabOn = getTabIndexAt(xPos, yPos);
             if (_isDragging)
 			{
+				_isDragging = false;
+
 				if (::GetCapture() == _hSelf)
 					::ReleaseCapture();
 


### PR DESCRIPTION
Revert PR[#4886](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/4886) due to regressions [#5072](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5072) [#5450](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5450)

I could never replicate [#4885](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/4885). I figured it's probably related to ReactOS and/or WINE. A test of Npp++ on ReactOS revealed a very similar bug which I've patched here as "_Speculative fix for Issue#4885_"