### PR TITLE
Minor fix for issue #5815, only use SC_IV_LOOKFORWARD for Python like folding.

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1235,8 +1235,11 @@ void ScintillaEditView::setLexer(int lexerID, LangType langType, int whichList)
 
 	if (svp._indentGuideLineShow)
 	{
-		auto currentIndentMode = execute(SCI_GETINDENTATIONGUIDES);
-		int docIndentMode = isFoldIndentationBased() ? SC_IV_LOOKFORWARD : SC_IV_LOOKBOTH;
+		const auto currentIndentMode = execute(SCI_GETINDENTATIONGUIDES);
+		// Python like indentation, excludes lexers (Nim, VB, YAML, etc.)
+		// that includes tailing empty or whitespace only lines in folding block.
+		const bool pythonLike = (lexerID == SCLEX_PYTHON || lexerID == SCLEX_COFFEESCRIPT || lexerID == SCLEX_HASKELL);
+		const int docIndentMode = pythonLike ? SC_IV_LOOKFORWARD : SC_IV_LOOKBOTH;
 		if (currentIndentMode != docIndentMode)
 			execute(SCI_SETINDENTATIONGUIDES, docIndentMode);
 	}


### PR DESCRIPTION
Code folding block for Nim, VB and YAML includes tailing empty or whitespace only lines, it's better for these lexers to use SC_IV_LOOKBOTH.

By the way, VB Script seems not supported by npp.