### PR TITLE
Fix typo and improved algo for isAllDigits

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -45,11 +45,7 @@ static bool isAllDigits(const generic_string &str)
 {
 	for (const auto& i : str)
 	{
-		if (i < -i || i > 255)
-			return false;
-
-		bool isDigit = ::isdigit(int(i)) != 0;
-		if (!isDigit)
+		if (i < 48 || i > 57)
 			return false;
 	}
 	return true;


### PR DESCRIPTION
As explained https://github.com/notepad-plus-plus/notepad-plus-plus/commit/344850aedb595780c5a82667304331f4f65144ba#r33867431 I was trying to correct the typo.

Then I realized, as we are checking each character one by one, then do we really need to call `::isdigit`? So instead of calling `::isdigit` why don't we check ASCII value for 0~9 and return result accordingly.

**P.S. Still I favor PR #4530.**