### PR TITLE
A potential crash fix

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -251,7 +251,7 @@ struct CmdLineParamsDTO
 	int _column2go = 0;
 	int _pos2go = 0;
 
-	LangType _langType;
+	LangType _langType = L_EXTERNAL;
 
 	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
 	{


### PR DESCRIPTION
Initializing a member variable avoids **a potential crash** while opening file using context menu.

### Scenario to reproduce crash:
In some case below comparison at [line 557](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppBigSwitch.cpp#L557) fails. I could not figure out yet why this if condition fails, but it fails..
```C++
if (sizeof(CmdLineParamsDTO) == cmdLineParamsSize) // make sure the structure is the same
{
	pNppParam->setCmdlineParam(*cmdLineParam);
}
else
{
#ifdef DEBUG 
	printStr(TEXT("sizeof(CmdLineParams) != cmdLineParamsSize\rCmdLineParams is formed by an instance of another version,\rwhereas your CmdLineParams has been modified in this instance."));
#endif
}
```
When this condition fails, then commandline params are not copied. Therefore later at [line 586](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppBigSwitch.cpp#L586), `cmdLineParams._langType` is initialized with garbage value which becomes cause for crash. Refer the below screenshot with call stack as proof.

![image](https://user-images.githubusercontent.com/14791461/60200216-48ad1e00-9863-11e9-9e79-f6b8f9767dda.png)


![image](https://user-images.githubusercontent.com/14791461/60200232-4f3b9580-9863-11e9-8305-3864ba5b6ae9.png)
