### PR TITLE
Fix regression in PR#5555

### DIFF
--- a/PowerEditor/src/MISC/Common/Sorters.h
+++ b/PowerEditor/src/MISC/Common/Sorters.h
@@ -161,16 +161,7 @@ public:
 						// Maximum value for a variable of type unsigned long long | 18446744073709551615
 						// So take the max length 18 to convert the number
 						const size_t maxLen = 18;
-						size_t aLen = a.length() - i, bLen = b.length() - i;
-						if (aLen > maxLen || bLen > maxLen)
-						{
-							delta = min(min(aLen, bLen), maxLen);
-							compareResult = std::stoll(a.substr(i, delta)) - std::stoll(b.substr(i, delta));
-						}
-						else
-						{
-							compareResult = std::stoll(a.substr(i)) - std::stoll(b.substr(i), &delta);
-						}
+						compareResult = std::stoll(a.substr(i, maxLen)) - std::stoll(b.substr(i, maxLen), &delta);
 						i += delta;
 					}
 					// Both are strings
@@ -225,16 +216,7 @@ public:
 						// Maximum value for a variable of type unsigned long long | 18446744073709551615
 						// So take the max length 18 to convert the number
 						const size_t maxLen = 18;
-						size_t aLen = a.length() - i, bLen = b.length() - i;
-						if (aLen > maxLen || bLen > maxLen)
-						{
-							delta = min(min(aLen, bLen), maxLen);
-							compareResult = std::stoll(a.substr(i, delta)) - std::stoll(b.substr(i, delta));
-						}
-						else
-						{
-							compareResult = std::stoll(a.substr(i)) - std::stoll(b.substr(i), &delta);
-						}
+						compareResult = std::stoll(a.substr(i, maxLen)) - std::stoll(b.substr(i, maxLen), &delta);
 						i += delta;
 					}
 					// Both are strings


### PR DESCRIPTION
Fix regression in [PR#5555](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/5555) as seen in [Issue#5839](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5839) (shown in **Scenario 2**). Also this PR is an impromptu discussion about clearing up confusion with "sort as Integer" 😊

[Natural sorting](https://en.wikipedia.org/wiki/Natural_sort_order) **is broken** in "sort as Integer" (see **Scenario 1** vs **Scenario 2** AND **Scenario 2** vs **Scenario 3**).

**The possible solutions are:**

- restore natural sorting on >18 length (**which is this PR**) and maybe rename integer sorting to natural order or something comprehensive like "standard" or "default" sorting (since it's the kind of sorting most people expect).
- or refuse to sort when non-digits are present
- or char scan and skip until the first digit and then crop any non-digits that follow
- or similar to above, but crop it all when starting with non-digits

Although personally, these "integer" sorting ideas are pretty worthless, and I can't think of any common situations where it would be useful. I believe natural sorting was very useful and should be fixed, and "sort as Integer" possibly renamed.

----------------------------------------------
**Scenario 1:**
----------------------------------------------
Input: (<18 length)

> 1.2.1234567
> **1.3.1234567**
> 1.1.1234567

Now run _**Line Operations->Sort Lines As Integers Ascending**_

v7.7.1 Output
> 1.1.1234567
> 1.2.1234567
> **1.3.1234567**

Corrected Output
> 1.1.1234567
> 1.2.1234567
> **1.3.1234567**

----------------------------------------------
**Scenario 2:**
----------------------------------------------
Input: (>18 length)
> 1.2.1234567890123456789 
> **1.3.1234567890123456789** 
> 1.1.1234567890123456789 

Now run _**Line Operations->Sort Lines As Integers Ascending**_

v7.7.1 Output **--- Inconsistent**
> 1.2.1234567890123456789 
> **1.3.1234567890123456789** 
> 1.1.1234567890123456789 

Corrected Output
> 1.1.1234567890123456789 
> 1.2.1234567890123456789 
> **1.3.1234567890123456789** 
----------------------------------------------
**Scenario 3:**
----------------------------------------------
Input: (>18 length)
> 1234567890123456789.1.2
> **1234567890123456789.1.3**
> 1234567890123456789.1.1

Now run _**Line Operations->Sort Lines As Integers Ascending**_

v7.7.1 Output
> 1234567890123456789.1.1
> 1234567890123456789.1.2
> **1234567890123456789.1.3**

Corrected Output
> 1234567890123456789.1.1
> 1234567890123456789.1.2
> **1234567890123456789.1.3**