### PR TITLE
'-nosession' must not overwrite config.xml (Fix #3938)

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5679,7 +5679,7 @@ void NppParameters::createXmlTreeFromGUIParams()
 		GUIConfigElement->SetAttribute(TEXT("useCustumDir"), _nppGUI._useDir ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("dir"), _nppGUI._backupDir.c_str());
 
-		GUIConfigElement->SetAttribute(TEXT("isSnapshotMode"), _nppGUI.isSnapshotMode() ? TEXT("yes") : TEXT("no"));
+		GUIConfigElement->SetAttribute(TEXT("isSnapshotMode"), _nppGUI._isSnapshotMode ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("snapshotBackupTiming"), static_cast<int32_t>(_nppGUI._snapshotBackupTiming));
 	}
 


### PR DESCRIPTION
When `-nosession` is given as a command line parameter the attribute
`isSnapshotMode` in `config.xml` is overwritten with `no` regardless of
its original value.

    <GUIConfig name="Backup" action="0" useCustumDir="no"
               dir="" isSnapshotMode="yes" snapshotBackupTiming="7000" />

Change this to keep the original value.