### PR TITLE
Load plug-ins with LoadLibraryEx

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -114,6 +114,9 @@ cleanup: // release all of our handles
 	return machine_type;
 }
 
+#define	LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR	0x00000100
+#define	LOAD_LIBRARY_SEARCH_DEFAULT_DIRS	0x00001000
+
 int PluginsManager::loadPlugin(const TCHAR *pluginFilePath)
 {
 	const TCHAR *pluginFileName = ::PathFindFileName(pluginFilePath);
@@ -130,7 +133,8 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath)
 		if (GetBinaryArchitectureType(pluginFilePath) != ARCH_TYPE)
 			throw generic_string(ARCH_ERR_MSG);
 
-	    pi->_hLib = ::LoadLibrary(pluginFilePath);
+        const DWORD dwFlags = GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "AddDllDirectory") != NULL ? LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS : 0;
+        pi->_hLib = ::LoadLibraryEx(pluginFilePath, NULL, dwFlags);
         if (!pi->_hLib)
         {
 			generic_string lastErrorMsg = GetLastErrorAsString();


### PR DESCRIPTION
Allow plug-ins to load private DLL files from the plugins folder.

Close #5802


Loading plug-ins with `LoadLibraryEx` and the `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` flag allows for implicitly linked (Load-Time Dynamic Linking) plug-ins, which is currently not possible without user intervention.

To stay on the side of caution `LoadLibrary` is still used when running under Windows XP, while `LoadLibraryEx` is used when running under a more recent version of Windows.

Regarding compatibility, Windows XP users can still use implicitly linked plug-ins if they add the plug-in's directory (e.g. `%ProgramFiles%\Notepad++\plugins\LuaScript`) to the PATH environment variable.
