### PR TITLE
Fix crash when sorting out_of_range columns

### DIFF
--- a/PowerEditor/src/MISC/Common/Sorters.h
+++ b/PowerEditor/src/MISC/Common/Sorters.h
@@ -48,6 +48,12 @@ protected:
 	{
 		if (isSortingSpecificColumns())
 		{
+			// prevent an std::out_of_range exception
+			if (input.length() < _fromColumn)
+			{
+				return TEXT("");
+			}
+
 			return input.substr(_fromColumn, 1 + _toColumn - _fromColumn);
 		}
 		else


### PR DESCRIPTION
Fixes [Issue#5865](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5865)

Reproduce crash with **alt+mouse** to [column select](https://notepad-plus-plus.org/features/column-mode-editing.html) past the first character on several lines then use any **Edit->Line Operations->Sort Lines** option.

**Input**:
```
100/20 = 5

1/3    = 0.333

22/7   = 3.14285714286
```