### PR TITLE
Disable integrity checks in Debug mode

### DIFF
--- a/PowerEditor/src/MISC/Common/verifySignedfile.cpp
+++ b/PowerEditor/src/MISC/Common/verifySignedfile.cpp
@@ -62,12 +62,21 @@ SecurityGard::SecurityGard()
 
 bool SecurityGard::checkModule(const std::wstring& filePath, NppModule module2check)
 {
+#ifndef _DEBUG
 	if (_securityMode == sm_certif)
 		return verifySignedLibrary(filePath, module2check);
 	else if (_securityMode == sm_sha256)
 		return checkSha256(filePath, module2check);
 	else
 		return false;
+#else
+	// Do not check integrity if npp is running in debug mode
+	// This is helpful for developers to skip signature checking
+	// while analyzing issue or modifying the lexer dll
+	(void)filePath;
+	(void)module2check;
+	return true;
+#endif
 }
 
 bool SecurityGard::checkSha256(const std::wstring& filePath, NppModule module2check)


### PR DESCRIPTION
Issue briefly discussed in #5538 - basically, recent changes to integrity checks (moving from certificate check towards checksum checking) were not disabled in Debug mode. As a result, self-compiled SciLexer or gup.exe would trigger failure even when debugging. With this PR, debugging is possible again without having to manually disable those checks.