### PR TITLE
Encoding Menu : add new options UCS-2 BE and UCS-2 LE

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -265,21 +265,25 @@
                     <Item id="45002" name="Unix (LF)"/>
                     <Item id="45003" name="Macintosh (CR)"/>
                     <Item id="45004" name="ANSI"/>
-                    <Item id="45005" name="UTF-8-BOM"/>
+                    <Item id="45005" name="UTF-8 BOM"/>
                     <Item id="45006" name="UCS-2 BE BOM"/>
                     <Item id="45007" name="UCS-2 LE BOM"/>
                     <Item id="45008" name="UTF-8"/>
-                    <Item id="45009" name="Convert to ANSI"/>
-                    <Item id="45010" name="Convert to UTF-8"/>
-                    <Item id="45011" name="Convert to UTF-8-BOM"/>
-                    <Item id="45012" name="Convert to UCS-2 BE BOM"/>
-                    <Item id="45013" name="Convert to UCS-2 LE BOM"/>
+                    <Item id="45014" name="UCS-2 BE"/>
+                    <Item id="45015" name="UCS-2 LE"/>
                     <Item id="45060" name="Big5 (Traditional)"/>
                     <Item id="45061" name="GB2312 (Simplified)"/>
                     <Item id="45054" name="OEM 861: Icelandic"/>
                     <Item id="45057" name="OEM 865: Nordic"/>
                     <Item id="45053" name="OEM 860: Portuguese"/>
                     <Item id="45056" name="OEM 863: French"/>
+                    <Item id="45900" name="Convert to ANSI"/>
+                    <Item id="45901" name="Convert to UTF-8"/>
+                    <Item id="45902" name="Convert to UTF-8 BOM"/>
+                    <Item id="45903" name="Convert to UCS-2 BE BOM"/>
+                    <Item id="45904" name="Convert to UCS-2 LE BOM"/>
+                    <Item id="45905" name="Convert to UCS-2 BE"/>
+                    <Item id="45906" name="Convert to UCS-2 LE"/>
 
                     <Item id="10001" name="Move to Other View"/>
                     <Item id="10002" name="Clone to Other View"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -265,21 +265,25 @@
                     <Item id="45002" name="Unix (LF)"/>
                     <Item id="45003" name="Macintosh (CR)"/>
                     <Item id="45004" name="ANSI"/>
-                    <Item id="45005" name="UTF-8-BOM"/>
+                    <Item id="45005" name="UTF-8 BOM"/>
                     <Item id="45006" name="UCS-2 BE BOM"/>
                     <Item id="45007" name="UCS-2 LE BOM"/>
                     <Item id="45008" name="UTF-8"/>
-                    <Item id="45009" name="Convert to ANSI"/>
-                    <Item id="45010" name="Convert to UTF-8"/>
-                    <Item id="45011" name="Convert to UTF-8-BOM"/>
-                    <Item id="45012" name="Convert to UCS-2 BE BOM"/>
-                    <Item id="45013" name="Convert to UCS-2 LE BOM"/>
+                    <Item id="45014" name="UCS-2 BE"/>
+                    <Item id="45015" name="UCS-2 LE"/>
                     <Item id="45060" name="Big5 (Traditional)"/>
                     <Item id="45061" name="GB2312 (Simplified)"/>
                     <Item id="45054" name="OEM 861: Icelandic"/>
                     <Item id="45057" name="OEM 865: Nordic"/>
                     <Item id="45053" name="OEM 860: Portuguese"/>
                     <Item id="45056" name="OEM 863: French"/>
+                    <Item id="45900" name="Convert to ANSI"/>
+                    <Item id="45901" name="Convert to UTF-8"/>
+                    <Item id="45902" name="Convert to UTF-8 BOM"/>
+                    <Item id="45903" name="Convert to UCS-2 BE BOM"/>
+                    <Item id="45904" name="Convert to UCS-2 LE BOM"/>
+                    <Item id="45905" name="Convert to UCS-2 BE"/>
+                    <Item id="45906" name="Convert to UCS-2 LE"/>
 
                     <Item id="10001" name="Move to Other View"/>
                     <Item id="10002" name="Clone to Other View"/>

--- a/PowerEditor/installer/nativeLang/french.xml
+++ b/PowerEditor/installer/nativeLang/french.xml
@@ -272,25 +272,31 @@
                     <Item id="45002" name="Convertir en format UNIX (LF)"/>
                     <Item id="45003" name="Convertir en format Mac (CR)"/>
                     <Item id="45004" name="ANSI"/>
-                    <Item id="45005" name="UTF-8-BOM"/>
+                    <Item id="45005" name="UTF-8 BOM"/>
                     <Item id="45006" name="UCS-2 BE BOM"/>
                     <Item id="45007" name="UCS-2 LE BOM"/>
                     <Item id="45008" name="UTF-8"/>
-                    <Item id="45009" name="Convertir en ANSI"/>
-                    <Item id="45010" name="Convertir en UTF-8"/>
-                    <Item id="45011" name="Convertir en UTF-8-BOM"/>
-                    <Item id="45012" name="Convertir en UCS-2 BE BOM"/>
-                    <Item id="45013" name="Convertir en UCS-2 LE BOM"/>
+                    <Item id="45014" name="UCS-2 BE"/>
+                    <Item id="45015" name="UCS-2 LE"/>
                     <Item id="45060" name="Big5 (traditionnel)"/>
                     <Item id="45061" name="GB2312 (simplifié)"/>
                     <Item id="45054" name="OEM 861: islandais"/>
                     <Item id="45057" name="OEM 865: danois &amp;&amp; norvégien"/>
                     <Item id="45053" name="OEM 860: portugais"/>
                     <Item id="45056" name="OEM 863: français"/>
+                    <Item id="45900" name="Convertir en ANSI"/>
+                    <Item id="45901" name="Convertir en UTF-8"/>
+                    <Item id="45902" name="Convertir en UTF-8 BOM"/>
+                    <Item id="45903" name="Convertir en UCS-2 BE BOM"/>
+                    <Item id="45904" name="Convertir en UCS-2 LE BOM"/>
+                    <Item id="45905" name="Convertir en UCS-2 BE"/>
+                    <Item id="45906" name="Convertir en UCS-2 LE"/>
+
                     <Item id="46001" name="Configurateur de coloration syntaxique..."/>
                     <Item id="46250" name="Définir votre langage..."/>
                     <Item id="46300" name="Ovrir le dossier des Langages utilisateur..."/>
                     <Item id="46180" name="Langage utilisateur"/>
+
                     <Item id="47000" name="À propos de Notepad++..."/>
                     <Item id="47001" name="Site officiel Notepad++"/>
                     <Item id="47002" name="Projet de développement de Notepad++"/>

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2458,15 +2458,15 @@ void Notepad_plus::setUniModeText()
 		switch (um)
 		{
 			case uniUTF8:
-				uniModeTextString = TEXT("UTF-8-BOM"); break;
+				uniModeTextString = TEXT("UTF-8 BOM"); break;
 			case uni16BE:
 				uniModeTextString = TEXT("UCS-2 BE BOM"); break;
 			case uni16LE:
 				uniModeTextString = TEXT("UCS-2 LE BOM"); break;
 			case uni16BE_NoBOM:
-				uniModeTextString = TEXT("UCS-2 Big Endian"); break;
+				uniModeTextString = TEXT("UCS-2 BE"); break;
 			case uni16LE_NoBOM:
-				uniModeTextString = TEXT("UCS-2 Little Endian"); break;
+				uniModeTextString = TEXT("UCS-2 LE"); break;
 			case uniCookie:
 				uniModeTextString = TEXT("UTF-8"); break;
 			default :
@@ -3958,6 +3958,8 @@ void Notepad_plus::checkUnicodeMenuItems() const
 		case uni16LE   : id = IDM_FORMAT_UCS_2LE; break;
 		case uniCookie : id = IDM_FORMAT_AS_UTF_8; break;
 		case uni8Bit   : id = IDM_FORMAT_ANSI; break;
+		case uni16BE_NoBOM : id = IDM_FORMAT_AS_UCS_2BE; break;
+		case uni16LE_NoBOM : id = IDM_FORMAT_AS_UCS_2LE; break;
 	}
 
 	if (encoding == -1)
@@ -3969,12 +3971,12 @@ void Notepad_plus::checkUnicodeMenuItems() const
 		if (id == -1) //um == uni16BE_NoBOM || um == uni16LE_NoBOM
 		{
 			// Uncheck all in the main encoding menu
-			::CheckMenuRadioItem(_mainMenuHandle, IDM_FORMAT_ANSI, IDM_FORMAT_AS_UTF_8, IDM_FORMAT_ANSI, MF_BYCOMMAND);
+			::CheckMenuRadioItem(_mainMenuHandle, IDM_FORMAT_ANSI, IDM_FORMAT_END, IDM_FORMAT_ANSI, MF_BYCOMMAND);
 			::CheckMenuItem(_mainMenuHandle, IDM_FORMAT_ANSI, MF_UNCHECKED | MF_BYCOMMAND);
 		}
 		else
 		{
-			::CheckMenuRadioItem(_mainMenuHandle, IDM_FORMAT_ANSI, IDM_FORMAT_AS_UTF_8, id, MF_BYCOMMAND);
+			::CheckMenuRadioItem(_mainMenuHandle, IDM_FORMAT_ANSI, IDM_FORMAT_END, id, MF_BYCOMMAND);
 		}
 	}
 	else

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -175,7 +175,7 @@ public:
 	//@{
 	//The doXXX functions apply to a single buffer and dont need to worry about views, with the excpetion of doClose, since closing one view doesnt have to mean the document is gone
 	BufferID doOpen(const generic_string& fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const TCHAR *backupFileName = NULL, FILETIME fileNameTimestamp = {});
-	bool doReload(BufferID id, bool alert = true);
+	bool doReload(BufferID id, bool alert = true, bool forceEncodeMode = false, UniMode encodeMode = uniEnd, int encoding = -1);
 	bool doSave(BufferID, const TCHAR * filename, bool isSaveCopy = false);
 	void doClose(BufferID, int whichOne, bool doDeleteBackup = false);
 	//bool doDelete(const TCHAR *fileName) const {return ::DeleteFile(fileName) != 0;};
@@ -183,6 +183,7 @@ public:
 	void fileOpen();
 	void fileNew();
     bool fileReload();
+	bool fileReloadWithSpecificEncode(UniMode EncodeMode, int Encoding);
 	bool fileClose(BufferID id = BUFFER_INVALID, int curView = -1);	//use curView to override view to close from
 	bool fileCloseAll(bool doDeleteBackup, bool isSnapshotMode = false);
 	bool fileCloseAllButCurrent();

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -569,10 +569,12 @@ BEGIN
     POPUP "E&ncoding"
     BEGIN
         MENUITEM "ANSI",                    IDM_FORMAT_ANSI
+        MENUITEM "UTF-8 BOM",               IDM_FORMAT_UTF_8
         MENUITEM "UTF-8",                   IDM_FORMAT_AS_UTF_8
-        MENUITEM "UTF-8-BOM",               IDM_FORMAT_UTF_8
         MENUITEM "UCS-2 BE BOM",            IDM_FORMAT_UCS_2BE
+        MENUITEM "UCS-2 BE",                IDM_FORMAT_AS_UCS_2BE
         MENUITEM "UCS-2 LE BOM",            IDM_FORMAT_UCS_2LE
+        MENUITEM "UCS-2 LE",                IDM_FORMAT_AS_UCS_2LE
         POPUP "Character sets"
         BEGIN
             POPUP "Arabic"
@@ -686,10 +688,12 @@ BEGIN
         END
         MENUITEM SEPARATOR
         MENUITEM "Convert to ANSI",            IDM_FORMAT_CONV2_ANSI
+        MENUITEM "Convert to UTF-8 BOM",       IDM_FORMAT_CONV2_UTF_8
         MENUITEM "Convert to UTF-8",           IDM_FORMAT_CONV2_AS_UTF_8
-        MENUITEM "Convert to UTF-8-BOM",       IDM_FORMAT_CONV2_UTF_8
         MENUITEM "Convert to UCS-2 BE BOM",    IDM_FORMAT_CONV2_UCS_2BE
+        MENUITEM "Convert to UCS-2 BE",        IDM_FORMAT_CONV2_AS_UCS_2BE
         MENUITEM "Convert to UCS-2 LE BOM",    IDM_FORMAT_CONV2_UCS_2LE
+        MENUITEM "Convert to UCS-2 LE",        IDM_FORMAT_CONV2_AS_UCS_2LE
     END
 
     POPUP "&Language"

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2197,6 +2197,8 @@ void Notepad_plus::command(int id)
 		case IDM_FORMAT_UCS_2BE :
 		case IDM_FORMAT_UCS_2LE :
 		case IDM_FORMAT_AS_UTF_8 :
+		case IDM_FORMAT_AS_UCS_2BE :
+		case IDM_FORMAT_AS_UCS_2LE :
 		{
 			Buffer * buf = _pEditView->getCurrentBuffer();
 
@@ -2220,6 +2222,17 @@ void Notepad_plus::command(int id)
 				case IDM_FORMAT_UCS_2LE:
 					um = uni16LE;
 					break;
+
+				case IDM_FORMAT_AS_UCS_2BE :
+					um = uni16BE_NoBOM;
+					break;
+
+
+				case IDM_FORMAT_AS_UCS_2LE :
+					um = uni16LE_NoBOM;
+					break;
+
+
 
 				default : // IDM_FORMAT_ANSI
 					shoulBeDirty = buf->getUnicodeMode() != uniCookie;
@@ -2379,6 +2392,8 @@ void Notepad_plus::command(int id)
 		case IDM_FORMAT_CONV2_UTF_8:
 		case IDM_FORMAT_CONV2_UCS_2BE:
 		case IDM_FORMAT_CONV2_UCS_2LE:
+		case IDM_FORMAT_CONV2_AS_UCS_2BE:
+		case IDM_FORMAT_CONV2_AS_UCS_2LE:
 		{
 			int idEncoding = -1;
 			Buffer *buf = _pEditView->getCurrentBuffer();
@@ -2500,6 +2515,52 @@ void Notepad_plus::command(int id)
 					}
 					break;
 				}
+				case IDM_FORMAT_CONV2_AS_UCS_2BE:
+				{
+                    if (encoding != -1)
+                    {
+                        buf->setDirty(true);
+                        buf->setUnicodeMode(uni16BE_NoBOM);
+                        buf->setEncoding(-1);
+                        return;
+                    }
+
+					idEncoding = IDM_FORMAT_AS_UCS_2BE;
+					if (um == uni16BE_NoBOM)
+						return;
+
+					if (um != uni8Bit)
+					{
+                        buf->setUnicodeMode(uni16BE_NoBOM);
+                        buf->setDirty(true);
+						_pEditView->execute(SCI_EMPTYUNDOBUFFER);
+						return;
+					}
+					break;
+				}
+
+				case IDM_FORMAT_CONV2_AS_UCS_2LE:
+				{
+                    if (encoding != -1)
+                    {
+                        buf->setDirty(true);
+                        buf->setUnicodeMode(uni16LE_NoBOM);
+                        buf->setEncoding(-1);
+                        return;
+                    }
+
+					idEncoding = IDM_FORMAT_AS_UCS_2LE;
+					if (um == uni16LE_NoBOM)
+						return;
+					if (um != uni8Bit)
+					{
+                        buf->setUnicodeMode(uni16LE_NoBOM);
+                        buf->setDirty(true);
+						_pEditView->execute(SCI_EMPTYUNDOBUFFER);
+						return;
+					}
+					break;
+				}
 			}
 
 			if (idEncoding != -1) // "Encode in ANSI" or "Encode From ANSI"
@@ -2549,7 +2610,17 @@ void Notepad_plus::command(int id)
                         newUm = uni16LE;
                         break;
 
-                    default : // IDM_FORMAT_ANSI
+                    case IDM_FORMAT_AS_UCS_2BE:
+                        shoulBeDirty = true;
+                        newUm = uni16BE_NoBOM;
+                        break;
+
+                    case IDM_FORMAT_AS_UCS_2LE:
+                        shoulBeDirty = true;
+                        newUm = uni16LE_NoBOM;
+                        break;
+
+                  default : // IDM_FORMAT_ANSI
                         shoulBeDirty = um != uniCookie;
                         newUm = uni8Bit;
                 }

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2390,6 +2390,8 @@ void Notepad_plus::command(int id)
 			Buffer *buf = _pEditView->getCurrentBuffer();
             UniMode um = buf->getUnicodeMode();
             int encoding = buf->getEncoding();
+            bool shoulBeDirty = true;
+			UniMode newUm;
 
 			switch(id)
 			{
@@ -2426,7 +2428,8 @@ void Notepad_plus::command(int id)
 
 					if (um != uni8Bit)
 					{
-						::SendMessage(_pPublicInterface->getHSelf(), WM_COMMAND, idEncoding, 0);
+                        buf->setUnicodeMode(uniCookie);
+                        buf->setDirty(true);
 						_pEditView->execute(SCI_EMPTYUNDOBUFFER);
 						return;
 					}
@@ -2449,7 +2452,8 @@ void Notepad_plus::command(int id)
 
 					if (um != uni8Bit)
 					{
-						::SendMessage(_pPublicInterface->getHSelf(), WM_COMMAND, idEncoding, 0);
+                        buf->setUnicodeMode(uniUTF8);
+                        buf->setDirty(true);
 						_pEditView->execute(SCI_EMPTYUNDOBUFFER);
 						return;
 					}
@@ -2472,7 +2476,8 @@ void Notepad_plus::command(int id)
 
 					if (um != uni8Bit)
 					{
-						::SendMessage(_pPublicInterface->getHSelf(), WM_COMMAND, idEncoding, 0);
+                        buf->setUnicodeMode(uni16BE);
+                        buf->setDirty(true);
 						_pEditView->execute(SCI_EMPTYUNDOBUFFER);
 						return;
 					}
@@ -2494,7 +2499,8 @@ void Notepad_plus::command(int id)
 						return;
 					if (um != uni8Bit)
 					{
-						::SendMessage(_pPublicInterface->getHSelf(), WM_COMMAND, idEncoding, 0);
+                        buf->setUnicodeMode(uni16LE);
+                        buf->setDirty(true);
 						_pEditView->execute(SCI_EMPTYUNDOBUFFER);
 						return;
 					}
@@ -2502,7 +2508,7 @@ void Notepad_plus::command(int id)
 				}
 			}
 
-			if (idEncoding != -1)
+			if (idEncoding != -1) // "Encode in ANSI" or "Encode From ANSI"
 			{
 				// Save the current clipboard content
 				::OpenClipboard(_pPublicInterface->getHSelf());
@@ -2527,7 +2533,36 @@ void Notepad_plus::command(int id)
 
 				// Change to the proper buffer, save buffer status
 
-				::SendMessage(_pPublicInterface->getHSelf(), WM_COMMAND, idEncoding, 0);
+                switch (idEncoding)
+                {
+                    case IDM_FORMAT_AS_UTF_8:
+                        shoulBeDirty = um != uni8Bit;
+                        newUm = uniCookie;
+                        break;
+
+                    case IDM_FORMAT_UTF_8:
+                        shoulBeDirty = true;
+                        newUm = uniUTF8;
+                        break;
+
+                    case IDM_FORMAT_UCS_2BE:
+                        shoulBeDirty = true;
+                        newUm = uni16BE;
+                        break;
+
+                    case IDM_FORMAT_UCS_2LE:
+                        shoulBeDirty = true;
+                        newUm = uni16LE;
+                        break;
+
+                    default : // IDM_FORMAT_ANSI
+                        shoulBeDirty = um != uniCookie;
+                        newUm = uni8Bit;
+                }
+
+                buf->setUnicodeMode(newUm);
+                if (shoulBeDirty)
+                    buf->setDirty(true);
 
 				// Paste the texte, restore buffer status
 				_pEditView->execute(SCI_PASTE);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2261,21 +2261,17 @@ void Notepad_plus::command(int id)
 						return;
 				}
 
-				buf->setEncoding(-1);
 
 				if (um == uni8Bit)
 					_pEditView->execute(SCI_SETCODEPAGE, CP_ACP);
-				else
-					buf->setUnicodeMode(um);
-				fileReload();
+
+				fileReloadWithSpecificEncode(um, -1);
 			}
 			else
 			{
 				if (buf->getUnicodeMode() != um)
 				{
-					buf->setUnicodeMode(um);
-					if (shoulBeDirty)
-						buf->setDirty(true);
+					fileReloadWithSpecificEncode(um, -1);
 				}
 			}
 			break;
@@ -2372,9 +2368,7 @@ void Notepad_plus::command(int id)
 
             if (not buf->isDirty())
             {
-				buf->setEncoding(encoding);
-				buf->setUnicodeMode(uniCookie);
-				fileReload();
+				fileReloadWithSpecificEncode(uniCookie, encoding);
             }
 			break;
 		}

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -440,7 +440,7 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
 }
 
 
-bool Notepad_plus::doReload(BufferID id, bool alert)
+bool Notepad_plus::doReload(BufferID id, bool alert, bool forceEncodeMode, UniMode encodeMode, int encoding)
 {
 	if (alert)
 	{
@@ -451,6 +451,11 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 			MB_YESNO | MB_ICONEXCLAMATION | MB_APPLMODAL);
 		if (answer != IDYES)
 			return false;
+	}
+	if (forceEncodeMode)
+	{
+		id->setUnicodeMode(encodeMode);
+		id->setEncoding(encoding);
 	}
 
 	//In order to prevent Scintilla from restyling the entire document,
@@ -474,7 +479,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 		return MainFileManager.reloadBufferDeferred(id);
 	}
 
-	bool res = MainFileManager.reloadBuffer(id);
+	bool res = MainFileManager.reloadBuffer(id, forceEncodeMode);
 	Buffer * pBuf = MainFileManager.getBufferByID(id);
 	if (mainVisisble)
 	{
@@ -1802,9 +1807,15 @@ bool Notepad_plus::fileReload()
 {
 	assert(_pEditView != nullptr);
 	BufferID buf = _pEditView->getCurrentBufferID();
-	return doReload(buf, buf->isDirty());
+	return doReload(buf, buf->isDirty(), false);
 }
 
+bool Notepad_plus::fileReloadWithSpecificEncode(UniMode EncodeMode, int Encoding)
+{
+	assert(_pEditView != nullptr);
+	BufferID buf = _pEditView->getCurrentBufferID();
+	return doReload(buf, buf->isDirty(), true, EncodeMode, Encoding);
+}
 
 bool Notepad_plus::isFileSession(const TCHAR * filename)
 {

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -308,10 +308,12 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{ VK_NULL,    IDM_VIEW_MONITORING,                          false, false, false, nullptr },
 
 	{ VK_NULL,    IDM_FORMAT_ANSI,                              false, false, false, nullptr },
-	{ VK_NULL,    IDM_FORMAT_AS_UTF_8,                          false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_UTF_8,                             false, false, false, nullptr },
+	{ VK_NULL,    IDM_FORMAT_AS_UTF_8,                          false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_UCS_2BE,                           false, false, false, nullptr },
+	{ VK_NULL,    IDM_FORMAT_AS_UCS_2BE,                        false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_UCS_2LE,                           false, false, false, nullptr },
+	{ VK_NULL,    IDM_FORMAT_AS_UCS_2LE,                        false, false, false, nullptr },
 
 	{ VK_NULL,    IDM_FORMAT_ISO_8859_6,                        false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_WIN_1256,                          false, false, false, nullptr },
@@ -362,10 +364,12 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{ VK_NULL,    IDM_FORMAT_ISO_8859_1,                        false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_WIN_1258,                          false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_CONV2_ANSI,                        false, false, false, nullptr },
-	{ VK_NULL,    IDM_FORMAT_CONV2_AS_UTF_8,                    false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_CONV2_UTF_8,                       false, false, false, nullptr },
+	{ VK_NULL,    IDM_FORMAT_CONV2_AS_UTF_8,                    false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_CONV2_UCS_2BE,                     false, false, false, nullptr },
+	{ VK_NULL,    IDM_FORMAT_CONV2_AS_UCS_2BE,                  false, false, false, nullptr },
 	{ VK_NULL,    IDM_FORMAT_CONV2_UCS_2LE,                     false, false, false, nullptr },
+	{ VK_NULL,    IDM_FORMAT_CONV2_AS_UCS_2LE,                  false, false, false, nullptr },
 
 	{ VK_NULL,    IDM_LANG_USER_DLG,                            false, false, false, nullptr },
 	{ VK_NULL,    IDM_LANG_USER,                                false, false, false, nullptr },

--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -99,7 +99,7 @@ public:
 	BufferID getBufferFromDocument(Document doc);
 
 	void setLoadedBufferEncodingAndEol(Buffer* buf, const Utf8_16_Read& UnicodeConvertor, int encoding, EolType bkformat);
-	bool reloadBuffer(BufferID id);
+	bool reloadBuffer(BufferID id, bool forceEncodeMode = false);
 	bool reloadBufferDeferred(BufferID id);
 	bool saveBuffer(BufferID id, const TCHAR* filename, bool isCopy = false, generic_string * error_msg = NULL);
 	bool backupCurrentBuffer();
@@ -136,7 +136,7 @@ private:
 	FileManager& operator=(FileManager&&) = delete;
 
 	int detectCodepage(char* buf, size_t len);
-	bool loadFileData(Document doc, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat);
+	bool loadFileData(Document doc, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat, bool forceEncodeMode = false);
 	LangType detectLanguageFromTextBegining(const unsigned char *data, size_t dataLen);
 
 

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -104,10 +104,10 @@ protected:
 enum u78 {utf8NoBOM=0, ascii7bits=1, ascii8bits=2};
 class Utf8_16_Read : public Utf8_16 {
 public:
-	Utf8_16_Read();
+	Utf8_16_Read(bool forceEncodeMode = false, UniMode encoding = uni8Bit);
 	~Utf8_16_Read();
 
-	size_t convert(char* buf, size_t len);
+	size_t convert(char* buf, size_t len, bool forceUnicodeMode = false);
 	const char* getNewBuf() const { return (const char*) m_pNewBuf; }
 	size_t getNewSize() const { return m_nNewBufSize; }
 
@@ -117,6 +117,7 @@ public:
 
 protected:
 	void determineEncoding();
+    void ForceEncoding(UniMode unicodeMode);
 
 	u78 utf8_7bits_8bits();
 private:

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -371,11 +371,20 @@
     #define    IDM_FORMAT_UCS_2BE           (IDM_FORMAT + 6)
     #define    IDM_FORMAT_UCS_2LE           (IDM_FORMAT + 7)
     #define    IDM_FORMAT_AS_UTF_8          (IDM_FORMAT + 8)
-    #define    IDM_FORMAT_CONV2_ANSI        (IDM_FORMAT + 9)
-    #define    IDM_FORMAT_CONV2_AS_UTF_8    (IDM_FORMAT + 10)
-    #define    IDM_FORMAT_CONV2_UTF_8       (IDM_FORMAT + 11)
-    #define    IDM_FORMAT_CONV2_UCS_2BE     (IDM_FORMAT + 12)
-    #define    IDM_FORMAT_CONV2_UCS_2LE     (IDM_FORMAT + 13)
+    #define    IDM_FORMAT_AS_UCS_2BE        (IDM_FORMAT + 14)
+    #define    IDM_FORMAT_AS_UCS_2LE        (IDM_FORMAT + 15)
+    #define    IDM_FORMAT_END               IDM_FORMAT_AS_UCS_2LE
+
+
+    #define    IDM_FORMAT_CONV2             (IDM_FORMAT + 900)
+    #define    IDM_FORMAT_CONV2_ANSI        (IDM_FORMAT_CONV2 + 0)
+    #define    IDM_FORMAT_CONV2_AS_UTF_8    (IDM_FORMAT_CONV2 + 1)
+    #define    IDM_FORMAT_CONV2_UTF_8       (IDM_FORMAT_CONV2 + 2)
+    #define    IDM_FORMAT_CONV2_UCS_2BE     (IDM_FORMAT_CONV2 + 3)
+    #define    IDM_FORMAT_CONV2_UCS_2LE     (IDM_FORMAT_CONV2 + 4)
+    #define    IDM_FORMAT_CONV2_AS_UCS_2BE  (IDM_FORMAT_CONV2 + 5)
+    #define    IDM_FORMAT_CONV2_AS_UCS_2LE  (IDM_FORMAT_CONV2 + 6)
+    #define    IDM_FORMAT_CONV2_END         IDM_FORMAT_CONV2_AS_UCS_2LE
 
     #define    IDM_FORMAT_ENCODE            (IDM_FORMAT + 20)
     #define    IDM_FORMAT_WIN_1250          (IDM_FORMAT_ENCODE + 0)


### PR DESCRIPTION
Hi,

Fix #5899
Add option in Ecoding Menu:
- Encode in UCS-2 BE
- Encode in UCS-2 LE
- Convert to UCS-2 BE
- Convert to UCS-2 LE


1st Commit is PR #3836 (required to add new options)
2nd Commit add options (https://github.com/notepad-plus-plus/notepad-plus-plus/pull/5900/commits/7b7d0bd8b2a8aa2732170fd09a7d80db8dcecafc)


![FixAndAddEncoding_missing](https://user-images.githubusercontent.com/12849364/60768436-341f2000-a0c4-11e9-9055-a4aa6d27f201.jpg)



