### PR TITLE
Fix the crash due to NPPM_DESTROYSCINTILLAHANDLE message

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1248,10 +1248,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 			// Destroying allocated Scintilla makes Notepad++ crash
 			// because created Scintilla view's pointer is added into _referees of Buffer object automatically.
-			// the deallocated scintilla view in _referees is used in Buffer::nextUntitledNewNumber()
+			// The deallocated scintilla view in _referees is used in Buffer::nextUntitledNewNumber().
 
-			// So we do nothing here and let Notepad++ destroys allocated Scintilla while it exit
-			// and we keep this message for the sake of compability withe the existing plugins
+			// So we do nothing here and let Notepad++ destroy allocated Scintilla while it exits
+			// and we keep this message for the sake of compability withe the existing plugins.
 			return true;
 		}
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1244,7 +1244,15 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_DESTROYSCINTILLAHANDLE:
 		{
-			return _scintillaCtrls4Plugins.destroyScintilla(reinterpret_cast<HWND>(lParam));
+			//return _scintillaCtrls4Plugins.destroyScintilla(reinterpret_cast<HWND>(lParam));
+
+			// Destroying allocated Scintilla makes Notepad++ crash
+			// because created Scintilla view's pointer is added into _referees of Buffer object automatically.
+			// the deallocated scintilla view in _referees is used in Buffer::nextUntitledNewNumber()
+
+			// So we do nothing here and let Notepad++ destroys allocated Scintilla while it exit
+			// and we keep this message for the sake of compability withe the existing plugins
+			return true;
 		}
 
 		case NPPM_GETNBUSERLANG:

--- a/PowerEditor/src/ScitillaComponent/ScintillaCtrls.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaCtrls.cpp
@@ -58,6 +58,7 @@ ScintillaEditView * ScintillaCtrls::getScintillaEditViewFrom(HWND handle2Find)
 	return _scintVector[i];
 }
 
+/*
 bool ScintillaCtrls::destroyScintilla(HWND handle2Destroy)
 {
 	int i = getIndexFrom(handle2Destroy);
@@ -71,6 +72,7 @@ bool ScintillaCtrls::destroyScintilla(HWND handle2Destroy)
 	_scintVector.erase(it2delete);
 	return true;
 }
+*/
 
 void ScintillaCtrls::destroy() 
 {

--- a/PowerEditor/src/ScitillaComponent/ScintillaCtrls.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaCtrls.h
@@ -43,7 +43,7 @@ public :
 
 	HWND createSintilla(HWND hParent);
 	ScintillaEditView * getScintillaEditViewFrom(HWND handle2Find);
-	bool destroyScintilla(HWND handle2Destroy);
+	//bool destroyScintilla(HWND handle2Destroy);
 	void destroy();
 	
 private:


### PR DESCRIPTION
Destroying allocated Scintilla makes Notepad++ crash because created Scintilla view's pointer is added into _referees of Buffer object automatically.
The deallocated scintilla view in _referees is used in Buffer::nextUntitledNewNumber().

So we do nothing here and let Notepad++ destroy allocated Scintilla while it exits and we keep this message for the sake of compability withe the existing plugins.

Fix #4487, close #1500