### PR TITLE
Add "hasOwnProperty" method to the JavaScript autocompletion

### DIFF
--- a/PowerEditor/installer/APIs/javascript.xml
+++ b/PowerEditor/installer/APIs/javascript.xml
@@ -258,6 +258,7 @@
 		<KeyWord name="hasAttributeNS" />
 		<KeyWord name="hasAttributes" />
 		<KeyWord name="hasFocus" />
+		<KeyWord name="hasOwnProperty" />
 		<KeyWord name="hash" />
 		<KeyWord name="height" />
 		<KeyWord name="Hidden" />


### PR DESCRIPTION
Just adding the missing [`hasOwnProperty`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) JavaScript basic method :)