### PR TITLE
[Installer] Improve configurability of shortcuts creation

### DIFF
--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -183,11 +183,9 @@ Function shortcutLinkManagement
 	Delete "$SMPROGRAMS\${APPNAME}\Uninstall.lnk"
 	RMDir "$SMPROGRAMS\${APPNAME}"
 		
-	; detect the right of 
-	UserInfo::GetAccountType
-	Pop $1
-	StrCmp $1 "Admin" 0 +2
-	SetShellVarContext all
+	${If} $shortcutsAllUsersSelected == ${BST_CHECKED}
+		SetShellVarContext all
+	${EndIf}
 	
 	; set the shortcuts working directory
 	; http://nsis.sourceforge.net/Docs/Chapter4.html#createshortcut

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -192,8 +192,10 @@ Function shortcutLinkManagement
 	SetOutPath "$INSTDIR\"
 	
 	; add all the npp shortcuts for all user or current user
-	CreateShortCut "$SMPROGRAMS\Notepad++.lnk" "$INSTDIR\notepad++.exe"
-	${If} $createShortcutChecked == ${BST_CHECKED}
+	${If} $createStartMenuShortcutChecked == ${BST_CHECKED}
+		CreateShortCut "$SMPROGRAMS\Notepad++.lnk" "$INSTDIR\notepad++.exe"
+	${EndIf}
+	${If} $createDesktopShortcutChecked == ${BST_CHECKED}
 		CreateShortCut "$DESKTOP\Notepad++.lnk" "$INSTDIR\notepad++.exe"
 	${EndIf}
 	

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -81,6 +81,8 @@ FunctionEnd
 ;Installer Functions
 Var Dialog
 Var ShortcutCheckboxHandle
+Var AllUsersRadioHandle
+Var CurrentUserRadioHandle
 Var NoUserDataCheckboxHandle
 Var WinVer
 
@@ -98,7 +100,22 @@ Function ExtraOptions
 	${NSD_Check} $ShortcutCheckboxHandle
 	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
 	
-	${NSD_CreateCheckbox} 0 80 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."
+	; detect the right of 
+	UserInfo::GetAccountType
+	Pop $1
+	StrCmp $1 "Admin" 0 AllUsersCurrentUserRadios_Done
+		${NSD_CreateRadioButton} 0 50 100% 30u "Create Shortcuts for All Users"
+		Pop $AllUsersRadioHandle
+		${NSD_AddStyle} $AllUsersRadioHandle ${WS_GROUP}
+		${NSD_Check} $AllUsersRadioHandle
+		${NSD_OnClick} $AllUsersRadioHandle OnChange_AllUsersRadio
+
+		${NSD_CreateRadioButton} 0 75 100% 30u "Create Shortcuts for Current User"
+		Pop $CurrentUserRadioHandle
+		${NSD_OnClick} $CurrentUserRadioHandle OnChange_AllUsersRadio
+	AllUsersCurrentUserRadios_Done:
+
+	${NSD_CreateCheckbox} 0 125 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."
 	Pop $NoUserDataCheckboxHandle
 	${NSD_OnClick} $NoUserDataCheckboxHandle OnChange_NoUserDataCheckBox
 	
@@ -135,11 +152,18 @@ Function preventInstallInWin9x
 FunctionEnd
 
 Var createShortcutChecked
+Var shortcutsAllUsersSelected
+Var shortcutsCurrentUserSelected
 Var noUserDataChecked
 
-; The definition of "OnChange" event for checkbox
+; The definition of "OnChange" event for checkboxes and radios
 Function OnChange_ShortcutCheckBox
 	${NSD_GetState} $ShortcutCheckboxHandle $createShortcutChecked
+FunctionEnd
+
+Function OnChange_AllUsersRadio
+	${NSD_GetState} $AllUsersRadioHandle $shortcutsAllUsersSelected
+	${NSD_GetState} $CurrentUserRadioHandle $shortcutsCurrentUserSelected
 FunctionEnd
 
 Function OnChange_NoUserDataCheckBox

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -114,11 +114,12 @@ Function ExtraOptions
 		Pop $AllUsersRadioHandle
 		${NSD_AddStyle} $AllUsersRadioHandle ${WS_GROUP}
 		${NSD_OnClick} $AllUsersRadioHandle OnChange_AllUsersRadio
-		${NSD_Check} $AllUsersRadioHandle
 
 		${NSD_CreateRadioButton} 0 50u 100% 12u "Create Shortcuts for Current User"
 		Pop $CurrentUserRadioHandle
 		${NSD_OnClick} $CurrentUserRadioHandle OnChange_AllUsersRadio
+
+		${NSD_Check} $AllUsersRadioHandle
 	AllUsersCurrentUserRadios_Done:
 
 	${NSD_CreateCheckbox} 0 80u 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -80,7 +80,8 @@ FunctionEnd
 
 ;Installer Functions
 Var Dialog
-Var ShortcutCheckboxHandle
+Var StartMenuShortcutCheckboxHandle
+Var DesktopShortcutCheckboxHandle
 Var AllUsersRadioHandle
 Var CurrentUserRadioHandle
 Var NoUserDataCheckboxHandle
@@ -94,28 +95,33 @@ Function ExtraOptions
 		Abort
 	${EndIf}
 
-	${NSD_CreateCheckbox} 0 0 100% 30u "Create Shortcut on Desktop"
-	Pop $ShortcutCheckboxHandle
+	${NSD_CreateCheckbox} 0 0 100% 12u "Create Shortcut in Start Menu"
+	Pop $StartMenuShortcutCheckboxHandle
+	${NSD_Check} $StartMenuShortcutCheckboxHandle
+	${NSD_OnClick} $StartMenuShortcutCheckboxHandle OnChange_StartMenuShortcutCheckBox
+	
+	${NSD_CreateCheckbox} 0 15u 100% 12u "Create Shortcut on Desktop"
+	Pop $DesktopShortcutCheckboxHandle
 	StrCmp $WinVer "8" 0 +2
-	${NSD_Check} $ShortcutCheckboxHandle
-	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
+	${NSD_Check} $DesktopShortcutCheckboxHandle
+	${NSD_OnClick} $DesktopShortcutCheckboxHandle OnChange_DesktopShortcutCheckBox
 	
 	; detect the right of 
 	UserInfo::GetAccountType
 	Pop $1
 	StrCmp $1 "Admin" 0 AllUsersCurrentUserRadios_Done
-		${NSD_CreateRadioButton} 0 50 100% 30u "Create Shortcuts for All Users"
+		${NSD_CreateRadioButton} 0 35u 100% 12u "Create Shortcuts for All Users"
 		Pop $AllUsersRadioHandle
 		${NSD_AddStyle} $AllUsersRadioHandle ${WS_GROUP}
 		${NSD_Check} $AllUsersRadioHandle
 		${NSD_OnClick} $AllUsersRadioHandle OnChange_AllUsersRadio
 
-		${NSD_CreateRadioButton} 0 75 100% 30u "Create Shortcuts for Current User"
+		${NSD_CreateRadioButton} 0 50u 100% 12u "Create Shortcuts for Current User"
 		Pop $CurrentUserRadioHandle
 		${NSD_OnClick} $CurrentUserRadioHandle OnChange_AllUsersRadio
 	AllUsersCurrentUserRadios_Done:
 
-	${NSD_CreateCheckbox} 0 125 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."
+	${NSD_CreateCheckbox} 0 80u 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."
 	Pop $NoUserDataCheckboxHandle
 	${NSD_OnClick} $NoUserDataCheckboxHandle OnChange_NoUserDataCheckBox
 	
@@ -151,14 +157,19 @@ Function preventInstallInWin9x
 		Abort
 FunctionEnd
 
-Var createShortcutChecked
+Var createStartMenuShortcutChecked
+Var createDesktopShortcutChecked
 Var shortcutsAllUsersSelected
 Var shortcutsCurrentUserSelected
 Var noUserDataChecked
 
 ; The definition of "OnChange" event for checkboxes and radios
-Function OnChange_ShortcutCheckBox
-	${NSD_GetState} $ShortcutCheckboxHandle $createShortcutChecked
+Function OnChange_StartMenuShortcutCheckBox
+	${NSD_GetState} $StartMenuShortcutCheckboxHandle $createStartMenuShortcutChecked
+FunctionEnd
+
+Function OnChange_DesktopShortcutCheckBox
+	${NSD_GetState} $DesktopShortcutCheckboxHandle $createDesktopShortcutChecked
 FunctionEnd
 
 Function OnChange_AllUsersRadio

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -80,8 +80,8 @@ FunctionEnd
 
 ;Installer Functions
 Var Dialog
-Var NoUserDataCheckboxHandle
 Var ShortcutCheckboxHandle
+Var NoUserDataCheckboxHandle
 Var WinVer
 
 Function ExtraOptions
@@ -134,16 +134,16 @@ Function preventInstallInWin9x
 		Abort
 FunctionEnd
 
-Var noUserDataChecked
 Var createShortcutChecked
+Var noUserDataChecked
 
 ; The definition of "OnChange" event for checkbox
-Function OnChange_NoUserDataCheckBox
-	${NSD_GetState} $NoUserDataCheckboxHandle $noUserDataChecked
-FunctionEnd
-
 Function OnChange_ShortcutCheckBox
 	${NSD_GetState} $ShortcutCheckboxHandle $createShortcutChecked
+FunctionEnd
+
+Function OnChange_NoUserDataCheckBox
+	${NSD_GetState} $NoUserDataCheckboxHandle $noUserDataChecked
 FunctionEnd
 
 

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -97,14 +97,14 @@ Function ExtraOptions
 
 	${NSD_CreateCheckbox} 0 0 100% 12u "Create Shortcut in Start Menu"
 	Pop $StartMenuShortcutCheckboxHandle
-	${NSD_Check} $StartMenuShortcutCheckboxHandle
 	${NSD_OnClick} $StartMenuShortcutCheckboxHandle OnChange_StartMenuShortcutCheckBox
+	${NSD_Check} $StartMenuShortcutCheckboxHandle
 	
 	${NSD_CreateCheckbox} 0 15u 100% 12u "Create Shortcut on Desktop"
 	Pop $DesktopShortcutCheckboxHandle
+	${NSD_OnClick} $DesktopShortcutCheckboxHandle OnChange_DesktopShortcutCheckBox
 	StrCmp $WinVer "8" 0 +2
 	${NSD_Check} $DesktopShortcutCheckboxHandle
-	${NSD_OnClick} $DesktopShortcutCheckboxHandle OnChange_DesktopShortcutCheckBox
 	
 	; detect the right of 
 	UserInfo::GetAccountType
@@ -113,8 +113,8 @@ Function ExtraOptions
 		${NSD_CreateRadioButton} 0 35u 100% 12u "Create Shortcuts for All Users"
 		Pop $AllUsersRadioHandle
 		${NSD_AddStyle} $AllUsersRadioHandle ${WS_GROUP}
-		${NSD_Check} $AllUsersRadioHandle
 		${NSD_OnClick} $AllUsersRadioHandle OnChange_AllUsersRadio
+		${NSD_Check} $AllUsersRadioHandle
 
 		${NSD_CreateRadioButton} 0 50u 100% 12u "Create Shortcuts for Current User"
 		Pop $CurrentUserRadioHandle


### PR DESCRIPTION
* If user is admin: allow choosing (default: create for all users).
* If user is not admin: hide controls, create for current user.