### PR TITLE
Update change.log

### DIFF
--- a/PowerEditor/bin/change.log
+++ b/PowerEditor/bin/change.log
@@ -9,7 +9,7 @@ Notepad++ v7.7.1 enhancements and bug-fixes:
 7.  Add "Copy File Name" command in context menu of "Folder as Workspace".
 8.  Fix crash while sorting lines with numbers longer than 20 digits.
 9.  Enable Scintilla Virtual Space Option change from macro.
-10. Add Tcl, CMake and AutoIt keywords; add Python and SQL new syntax highlighting cathegories.
+10. Add Tcl, CMake and AutoIt keywords; add Python and SQL new syntax highlighting categories.
 
 
 Included plugins:


### PR DESCRIPTION
Fixed spelling mistake of 'cathegories' to 'categories'