### PR TITLE
Make 'Clear all marks' and 'Inverse Bookmark' macroable (fixes # 1948)'

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3383,6 +3383,7 @@ void Notepad_plus::command(int id)
 			case IDM_SEARCH_NEXT_BOOKMARK:
 			case IDM_SEARCH_PREV_BOOKMARK:
 			case IDM_SEARCH_CLEAR_BOOKMARKS:
+			case IDM_SEARCH_INVERSEMARKS:
 			case IDM_EDIT_SELECTALL:
 			case IDM_EDIT_INS_TAB:
 			case IDM_EDIT_RMV_TAB:

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -1331,6 +1331,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				{
 					if (_currentStatus == MARK_DLG)
 					{
+						if (isMacroRecording) saveInMacro(wParam, FR_OP_FIND);
 						(*_ppEditView)->clearIndicator(SCE_UNIVERSAL_FOUND_STYLE);
 						(*_ppEditView)->execute(SCI_MARKERDELETEALL, MARK_BOOKMARK);
 						setStatusbarMessage(TEXT(""), FSNoMessage);
@@ -2509,7 +2510,7 @@ void FindReplaceDlg::saveInMacro(size_t cmd, int cmdType)
 {
 	int booleans = 0;
 	::SendMessage(_hParent, WM_FRSAVE_INT, IDC_FRCOMMAND_INIT, 0);
-	::SendMessage(_hParent, WM_FRSAVE_STR, IDFINDWHAT,  reinterpret_cast<LPARAM>(_options._str2Search.c_str()));
+	::SendMessage(_hParent, WM_FRSAVE_STR, IDFINDWHAT,  reinterpret_cast<LPARAM>(cmd == IDC_CLEAR_ALL ? TEXT("") : _options._str2Search.c_str()));
 	booleans |= _options._isWholeWord?IDF_WHOLEWORD:0;
 	booleans |= _options._isMatchCase?IDF_MATCHCASE:0;
 	booleans |= _options._dotMatchesNewline?IDF_REDOTMATCHNL:0;
@@ -2534,6 +2535,10 @@ void FindReplaceDlg::saveInMacro(size_t cmd, int cmdType)
 		booleans |= _options._isInSelection?IDF_IN_SELECTION_CHECK:0;
 		booleans |= _options._isWrapAround?IDF_WRAP:0;
 		booleans |= _options._whichDirection?IDF_WHICH_DIRECTION:0;
+	}
+	if (cmd == IDC_CLEAR_ALL)
+	{
+		booleans = 0;
 	}
 	::SendMessage(_hParent, WM_FRSAVE_INT, IDC_FRCOMMAND_BOOLEANS, booleans);
 	::SendMessage(_hParent, WM_FRSAVE_INT, IDC_FRCOMMAND_EXEC, cmd);
@@ -2761,6 +2766,13 @@ void FindReplaceDlg::execSavedCommand(int cmd, uptr_t intValue, const generic_st
 						}
 
 						setStatusbarMessage(result, FSMessage);
+						break;
+					}
+
+					case IDC_CLEAR_ALL:
+					{
+						(*_ppEditView)->clearIndicator(SCE_UNIVERSAL_FOUND_STYLE);
+						(*_ppEditView)->execute(SCI_MARKERDELETEALL, MARK_BOOKMARK);
 						break;
 					}
 


### PR DESCRIPTION
Fixes #1948 .

1948 describes two problems with bookmarking and macros, split into Case I (clear marks) and Case II (invert bookmarks).  This PR addresses both problems.  The Case I fix is entirely in `FindReplaceDlg.cpp` and the Case II fix is fully in `NppCommands.cpp`.

This is my second try at a PR for this, so fingers crossed.