### PR TITLE
[Installer] Fix initial checkbox state that was not handled

### DIFF
--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -112,6 +112,7 @@ Function ExtraOptions
 	${If} $1 == "$PROGRAMFILES"
 	${ORIF} $2 == "$PROGRAMFILES64"
 		${NSD_Uncheck} $NoUserDataCheckboxHandle
+		Call OnChange_NoUserDataCheckBox
 		EnableWindow $NoUserDataCheckboxHandle 0
 	${Else}
 		EnableWindow $NoUserDataCheckboxHandle 1

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -94,8 +94,9 @@ Function ExtraOptions
 
 	${NSD_CreateCheckbox} 0 0 100% 30u "Create Shortcut on Desktop"
 	Pop $ShortcutCheckboxHandle
-	StrCmp $WinVer "8" 0 +2
-	${NSD_Check} $ShortcutCheckboxHandle
+	${If} $WinVer == "8"
+		${NSD_Check} $ShortcutCheckboxHandle
+	${EndIf}
 	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
 	
 	${NSD_CreateCheckbox} 0 80 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -94,10 +94,10 @@ Function ExtraOptions
 
 	${NSD_CreateCheckbox} 0 0 100% 30u "Create Shortcut on Desktop"
 	Pop $ShortcutCheckboxHandle
+	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
 	${If} $WinVer == "8"
 		${NSD_Check} $ShortcutCheckboxHandle
 	${EndIf}
-	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
 	
 	${NSD_CreateCheckbox} 0 80 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."
 	Pop $NoUserDataCheckboxHandle

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -97,6 +97,7 @@ Function ExtraOptions
 	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
 	${If} $WinVer == "8"
 		${NSD_Check} $ShortcutCheckboxHandle
+		Call OnChange_ShortcutCheckBox
 	${EndIf}
 	
 	${NSD_CreateCheckbox} 0 80 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."


### PR DESCRIPTION
Follow-up to #5989.

As I guessed, the programmatic initial check of the checkbox was ineffective (unless the user clicks the checkbox).

I tried putting `NSD_OnClick` before `NSD_Check`, no change, and replacing `OnClick` with `OnChange`, event doesn't work at all.

`${NSD_Check}` just doesn't trigger that "click" event. Therefore the solution is to manually call the event handler.