### PR TITLE
Fix "Command Argument Help" MessageBox

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2855,7 +2855,7 @@ void Notepad_plus::command(int id)
 		case IDM_CMDLINEARGUMENTS:
 		{
 			// No translattable
-			::MessageBox(NULL, COMMAND_ARG_HELP, TEXT("Notepad++ Command Argument Help"), MB_OK);
+			::MessageBox(_pPublicInterface->getHSelf(), COMMAND_ARG_HELP, TEXT("Notepad++ Command Argument Help"), MB_OK | MB_APPLMODAL);
 			break;
 		}
 


### PR DESCRIPTION
Fix #4067

Prevent problems reported in [issuecomment-519245178](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/4067#issuecomment-519245178).
Makes "Command Argument Help" mbox behave the same as "Summary" mbox.