### PR TITLE
Handle Ctrl+A keyboard shortcut in MD5/SHA256 Generator

### DIFF
--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -265,8 +265,15 @@ INT_PTR CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			HFONT hFont = ::CreateFontA(fontDpiDynamicalHeight, 0, 0, 0, 0, FALSE, FALSE, FALSE, ANSI_CHARSET,
 				OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY,
 				DEFAULT_PITCH | FF_DONTCARE, "Courier New");
-			::SendMessage(::GetDlgItem(_hSelf, IDC_HASH_TEXT_EDIT), WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
-			::SendMessage(::GetDlgItem(_hSelf, IDC_HASH_RESULT_FOMTEXT_EDIT), WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
+
+			const HWND hHashResultFromTextEdit = ::GetDlgItem(_hSelf, IDC_HASH_RESULT_FOMTEXT_EDIT);
+			const HWND hHashTextEdit = ::GetDlgItem(_hSelf, IDC_HASH_TEXT_EDIT);
+
+			::SendMessage(hHashResultFromTextEdit, WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
+			::SendMessage(hHashTextEdit, WM_SETFONT, reinterpret_cast<WPARAM>(hFont), TRUE);
+
+			::SetWindowLongPtr(hHashTextEdit, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
+			_HashTextEditProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(hHashTextEdit, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(HashTextEditStaticProc)));
 		}
 		return TRUE;
 
@@ -332,6 +339,27 @@ INT_PTR CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 void HashFromTextDlg::setHashType(hashType hashType2set)
 {
 	_ht = hashType2set;
+}
+
+LRESULT HashFromTextDlg::HashTextEditRunProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	switch (message)
+	{
+		case WM_CHAR:
+		{
+			// Select All if Ctrl + A
+			if (wParam == 1)
+			{
+				::SendDlgItemMessage(_hSelf, IDC_HASH_TEXT_EDIT, EM_SETSEL, 0, -1);
+				return TRUE;
+			}
+			break;
+		}
+
+		default:
+			break;
+	}
+	return ::CallWindowProc(_HashTextEditProc, hwnd, message, wParam, lParam);
 }
 
 void HashFromTextDlg::doDialog(bool isRTL)

--- a/PowerEditor/src/MISC/md5/md5Dlgs.h
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.h
@@ -49,5 +49,14 @@ public :
 protected :
 	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	hashType _ht = hash_md5;
+
+	LRESULT HashTextEditRunProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK HashTextEditStaticProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
+	{
+		return (((HashFromTextDlg *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->HashTextEditRunProc(hwnd, message, wParam, lParam));
+	};
+
+private :
+	WNDPROC _HashTextEditProc = nullptr;
 };
 


### PR DESCRIPTION
Added a new window procedure for the HASH_TEXT_EDIT control,
where Ctrl+A is now processed.

Fix #3863, close #3898, close #6034

@donho 
This is the rebased (and slightly adjusted) version of PR #3898.

According to [Microsoft ‘WM_CHAR message’ documentation](https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-char) `wParam` contains “the character code of the key.” For Ctr+A that would be 0x0001 (UTF-16).