### PR TITLE
Bookmark all lines of multiline match (iss 6018)

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2134,10 +2134,15 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				if (_env->_doMarkLine)
 				{
 					auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
-					auto state = pEditView->execute(SCI_MARKERGET, lineNumber);
+					auto lineNumberEnd = pEditView->execute(SCI_LINEFROMPOSITION, targetEnd - 1);
 
-					if (!(state & (1 << MARK_BOOKMARK)))
-						pEditView->execute(SCI_MARKERADD, lineNumber, MARK_BOOKMARK);
+					for (auto i = lineNumber; i <= lineNumberEnd; ++i)
+					{
+						auto state = pEditView->execute(SCI_MARKERGET, i);
+
+						if (!(state & (1 << MARK_BOOKMARK)))
+							pEditView->execute(SCI_MARKERADD, i, MARK_BOOKMARK);
+					}
 				}
 				break; 
 			}


### PR DESCRIPTION
Fixes #6018 .

Note usage of `targetEnd - 1`.  The `- 1` part is necessary because if the expression to be marked ends with a line-ending, using `targetEnd` will result in the following line (not part of the match) also being bookmarked.  As a marking operation won't ever hit zero-length matches, `targetEnd - 1` is always >= `targetStart`.

Suggested `change.log` entry, if merged:  `Mark's Bookmark Lines feature now marks all lines of a multi-line match, instead of bookmarking only the first matching line.`