### PR TITLE
Fixed use of deprecated function std::bind2nd.

### DIFF
--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -780,7 +780,7 @@ void WindowsDlg::doClose()
 						--(*itr);
 			}
 		}
-		_idxMap.erase(std::remove_if(_idxMap.begin(), _idxMap.end(), bind2nd(equal_to<int>(), -1)), _idxMap.end());
+		_idxMap.erase(remove_if(_idxMap.begin(), _idxMap.end(), bind(equal_to<int>(), placeholders::_1, -1)), _idxMap.end());
 	}
 	delete[] nmdlg.Items;
 


### PR DESCRIPTION
Fix for https://github.com/notepad-plus-plus/notepad-plus-plus/issues/6049
I took a straightforward approach and replaced `std::bind2nd` with `std::bind` though it would probably be better idea to use lambda or dedicated functor here.