### PR TITLE
Fixed build failure caused by jump bypassing variable initialization.

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -94,12 +94,13 @@ static WORD GetBinaryArchitectureType(const TCHAR *filePath)
 	if (addrHeader == NULL)
 		goto cleanup; // couldn't memory map the file
 
-	PIMAGE_NT_HEADERS peHdr = ImageNtHeader(addrHeader);
-	if (peHdr == NULL)
-		goto cleanup; // couldn't read the header
-
-	// Found the binary and architecture type
-	machine_type = peHdr->FileHeader.Machine;
+	{
+		PIMAGE_NT_HEADERS peHdr = ImageNtHeader(addrHeader);
+		if (peHdr == NULL)
+			goto cleanup; // couldn't read the header
+		// Found the binary and architecture type
+		machine_type = peHdr->FileHeader.Machine;
+	}
 
 cleanup: // release all of our handles
 	if (addrHeader != NULL)


### PR DESCRIPTION
Fix for https://github.com/notepad-plus-plus/notepad-plus-plus/issues/6053
For now I've just reduced variable scope so it will never be left in uninitialized state, however it would probably be a better idea to get rid of goto horrors completely.