### PR TITLE
Performance improvement part 2

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -544,27 +544,29 @@ const char * WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, UI
 
 std::wstring string2wstring(const std::string & rString, UINT codepage)
 {
+	std::wstring retVal;
 	int len = MultiByteToWideChar(codepage, 0, rString.c_str(), -1, NULL, 0);
 	if (len > 0)
 	{
 		std::vector<wchar_t> vw(len);
 		MultiByteToWideChar(codepage, 0, rString.c_str(), -1, &vw[0], len);
-		return &vw[0];
+		retVal = std::wstring(vw.begin(), vw.end());
 	}
-	return std::wstring();
+	return retVal;
 }
 
 
 std::string wstring2string(const std::wstring & rwString, UINT codepage)
 {
+	std::string retVal;
 	int len = WideCharToMultiByte(codepage, 0, rwString.c_str(), -1, NULL, 0, NULL, NULL);
 	if (len > 0)
 	{
 		std::vector<char> vw(len);
 		WideCharToMultiByte(codepage, 0, rwString.c_str(), -1, &vw[0], len, NULL, NULL);
-		return &vw[0];
+		retVal = std::string(vw.begin(), vw.end());
 	}
-	return std::string();
+	return retVal;
 }
 
 

--- a/PowerEditor/src/MISC/Exception/MiniDumper.cpp
+++ b/PowerEditor/src/MISC/Exception/MiniDumper.cpp
@@ -40,8 +40,7 @@ MiniDumper::MiniDumper()
 
 bool MiniDumper::writeDump(EXCEPTION_POINTERS * pExceptionInfo)
 {
-	TCHAR szDumpPath[MAX_PATH];
-	TCHAR szScratch[MAX_PATH];
+	TCHAR szScratch[MAX_PATH] = {};
 	LPCTSTR szResult = NULL;
 	bool retval = false;
 
@@ -52,6 +51,7 @@ bool MiniDumper::writeDump(EXCEPTION_POINTERS * pExceptionInfo)
 		MINIDUMPWRITEDUMP pDump = (MINIDUMPWRITEDUMP)::GetProcAddress( hDll, "MiniDumpWriteDump" );
 		if (pDump)
 		{
+			TCHAR szDumpPath[MAX_PATH] = {};
 			::GetModuleFileName(NULL, szDumpPath, MAX_PATH);
 			::PathRemoveFileSpec(szDumpPath);
 			wcscat_s(szDumpPath, TEXT("\\NppDump.dmp"));

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -266,7 +266,7 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath)
 		pluginExceptionAlert(pluginFileName, e);
 		return -1;
 	}
-	catch (generic_string s)
+	catch (generic_string& s)
 	{
 		s += TEXT("\n\n");
 		s += pluginFileName;
@@ -328,7 +328,6 @@ bool PluginsManager::loadPluginsV2(const TCHAR* dir)
 		{
 			generic_string pluginsFullPathFilter = pluginsFolder;
 			PathAppend(pluginsFullPathFilter, foundFileName);
-			generic_string pluginsFolderPath = pluginsFullPathFilter;
 			generic_string  dllName = foundFileName;
 			dllName += TEXT(".dll");
 			PathAppend(pluginsFullPathFilter, dllName);

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -227,8 +227,7 @@ friend class FindIncrementDlg;
 public :
 	static FindOption _options;
 	static FindOption* _env;
-	FindReplaceDlg() : StaticDialog(), _pFinder(NULL), _isRTL(false),\
-		_fileNameLenMax(1024) {
+	FindReplaceDlg() : StaticDialog(), _fileNameLenMax(1024) {
 		_uniFileName = new char[(_fileNameLenMax + 3) * 2];
 		_winVer = (NppParameters::getInstance()).getWinVersion();
 		_env = &_options;
@@ -345,17 +344,17 @@ protected :
     void combo2ExtendedMode(int comboID);
 
 private :
-	RECT _initialWindowRect;
-	LONG _deltaWidth;
-	LONG _initialClientWidth;
+	RECT _initialWindowRect = {};
+	LONG _deltaWidth = 0;
+	LONG _initialClientWidth = 0;
 
 	DIALOG_TYPE _currentStatus;
-	RECT _findClosePos, _replaceClosePos, _findInFilesClosePos;
-	RECT _countInSelFramePos, _replaceInSelFramePos;
-	RECT _countInSelCheckPos, _replaceInSelCheckPos;
+	RECT _findClosePos = {}, _replaceClosePos = {}, _findInFilesClosePos = {};
+	RECT _countInSelFramePos = {}, _replaceInSelFramePos = {};
+	RECT _countInSelCheckPos = {}, _replaceInSelCheckPos = {};
 
-	ScintillaEditView **_ppEditView;
-	Finder  *_pFinder;
+	ScintillaEditView** _ppEditView = nullptr;
+	Finder* _pFinder = nullptr;
 
 	std::vector<Finder *> _findersOfFinder;
 
@@ -363,13 +362,13 @@ private :
 	HWND _2ButtonsTip = nullptr;
 
 
-	bool _isRTL;
+	bool _isRTL = false;
 
-	int _findAllResult;
-	TCHAR _findAllResultStr[1024];
+	int _findAllResult = 0;
+	TCHAR _findAllResultStr[1024] = {};
 
 	int _fileNameLenMax;
-	char *_uniFileName;
+	char* _uniFileName = nullptr;
 
 	TabBar _tab;
 	winVer _winVer;
@@ -452,6 +451,10 @@ public:
 	explicit Progress(HINSTANCE hInst);
 	~Progress();
 
+	// Disable copy construction and operator=
+	Progress(const Progress&) = delete;
+	Progress& operator=(const Progress&) = delete;
+
 	HWND open(HWND hCallerWnd = NULL, const TCHAR* header = NULL);
 	void close();
 
@@ -484,22 +487,18 @@ private:
 	static DWORD WINAPI threadFunc(LPVOID data);
 	static LRESULT APIENTRY wndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM lparam);
 
-	// Disable copy construction and operator=
-	Progress(const Progress&);
-	const Progress& operator=(const Progress&);
-
 	int thread();
 	int createProgressWindow();
 	RECT adjustSizeAndPos(int width, int height);
 
-	HINSTANCE _hInst;
-	volatile HWND _hwnd;
-	HWND _hCallerWnd;
-	TCHAR _header[128];
-	HANDLE _hThread;
-	HANDLE _hActiveState;
-	HWND _hPText;
-	HWND _hPBar;
-	HWND _hBtn;
+	HINSTANCE _hInst = nullptr;
+	volatile HWND _hwnd = nullptr;
+	HWND _hCallerWnd = nullptr;
+	TCHAR _header[128] = {};
+	HANDLE _hThread = nullptr;
+	HANDLE _hActiveState = nullptr;
+	HWND _hPText = nullptr;
+	HWND _hPBar = nullptr;
+	HWND _hBtn = nullptr;
 };
 

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -68,22 +68,6 @@ static LRESULT CALLBACK hookProcMouse(int nCode, WPARAM wParam, LPARAM lParam)
 
 DockingCont::DockingCont()
 {
-	_isMouseOver		= FALSE;
-	_isMouseClose		= FALSE;
-	_isMouseDown		= FALSE;
-	_isFloating			= false;
-	_isTopCaption		= CAPTION_TOP;
-	_dragFromTab		= FALSE;
-	_hContTab			= NULL;
-	_hDefaultTabProc	= NULL;
-	_beginDrag			= FALSE;
-	_prevItem			= 0;
-	_hFont				= NULL;
-	_bTabTTHover		= FALSE;
-	_bCaptionTT			= FALSE;
-	_bCapTTHover		= FALSE;
-	_hoverMPos			= posClose;
-	_bDrawOgLine		= TRUE;
 	_vTbData.clear();
 
 	_captionHeightDynamic = NppParameters::getInstance()._dpiManager.scaleY(_captionHeightDynamic);

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
@@ -183,53 +183,53 @@ protected :
 
 private:
 	// handles
-	BOOL					_isActive;
-	bool					_isFloating;
-	HWND					_hCaption;
-	HWND					_hContTab;
+	BOOL					_isActive = FALSE;
+	bool					_isFloating = false;
+	HWND					_hCaption = nullptr;
+	HWND					_hContTab = nullptr;
 
 	// horizontal font for caption and tab
-	HFONT					_hFont;
+	HFONT					_hFont = nullptr;
 
 	// caption params
-	BOOL					_isTopCaption;
+	BOOL					_isTopCaption = CAPTION_TOP;
 	generic_string		    _pszCaption;
 
-	BOOL					_isMouseDown;
-	BOOL					_isMouseClose;
-	BOOL					_isMouseOver;
-	RECT					_rcCaption;
+	BOOL					_isMouseDown = FALSE;
+	BOOL					_isMouseClose = FALSE;
+	BOOL					_isMouseOver = FALSE;
+	RECT					_rcCaption = {};
 	
 	// tab style
-	BOOL					_bDrawOgLine;
+	BOOL					_bDrawOgLine = TRUE;
 
 	// Important value for DlgMoving class
-	BOOL					_dragFromTab;
+	BOOL					_dragFromTab = FALSE;
 
 	// subclassing handle for caption
-	WNDPROC					_hDefaultCaptionProc;
+	WNDPROC					_hDefaultCaptionProc = nullptr;
 
 	// subclassing handle for tab
-	WNDPROC					_hDefaultTabProc;
+	WNDPROC					_hDefaultTabProc = nullptr;
 
 	// for moving and reordering
-	UINT					_prevItem;
-	BOOL					_beginDrag;
+	UINT					_prevItem = 0;
+	BOOL					_beginDrag = FALSE;
 
 	// Is tooltip
-	BOOL					_bTabTTHover;
-	INT						_iLastHovered;
+	BOOL					_bTabTTHover = FALSE;
+	INT						_iLastHovered = 0;
 
-	BOOL					_bCaptionTT;
-	BOOL					_bCapTTHover;
-	eMousePos				_hoverMPos;
+	BOOL					_bCaptionTT = FALSE;
+	BOOL					_bCapTTHover = FALSE;
+	eMousePos				_hoverMPos = posClose;
 
 	int _captionHeightDynamic = HIGH_CAPTION;
 	int _captionGapDynamic = CAPTION_GAP;
 	int _closeButtonPosLeftDynamic = CLOSEBTN_POS_LEFT;
 	int _closeButtonPosTopDynamic = CLOSEBTN_POS_TOP;
-	int _closeButtonWidth;
-	int _closeButtonHeight;
+	int _closeButtonWidth = 0;
+	int _closeButtonHeight = 0;
 
 	// data of added windows
 	std::vector<tTbData *>		_vTbData;

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -292,10 +292,10 @@ struct recordedMacroStep {
 	recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam, int codepage);
 	explicit recordedMacroStep(int iCommandID): _wParameter(iCommandID) {};
 
-	recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam, const TCHAR *sParam, int type)
-		: _message(iMessage), _wParameter(wParam), _lParameter(lParam), _macroType(MacroTypeIndex(type)){
-			_sParameter = (sParam)?generic_string(sParam):TEXT("");	
-	};
+	recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam, const TCHAR* sParam, int type)
+		: _message(iMessage), _wParameter(wParam), _lParameter(lParam), _macroType(MacroTypeIndex(type)),
+		_sParameter(sParam ? generic_string(sParam) : TEXT(""))
+	{}
 
 	bool isValid() const {
 		return true;


### PR DESCRIPTION
1. `Common.cpp` don't return reference of local variable. Though, there implicit conversion exist (from vector to string). But let's follow KISS principle.
2. `Minidumer.cpp` reduce the scope of local variables and keep them initialized during declaration.
3. `pluginmanager.cpp` catch exception by reference.
4. In rest all other four files, member variables are initialized (either using initialization list or in class initialization).