### PR TITLE
fix so that Find-All-in-All-Opened-Docs doesn't search cloned doc 2 times

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1802,6 +1802,10 @@ bool Notepad_plus::findInOpenedFiles()
 		for (size_t i = 0, len2 = _subDocTab.nbItem(); i < len2 ; ++i)
 	    {
 			pBuf = MainFileManager.getBufferByID(_subDocTab.getBufferByIndex(i));
+			if (_mainDocTab.getIndexByBuffer(pBuf) != -1)
+			{
+				continue;  // clone was already searched in main; skip re-searching in sub
+			}
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
 			auto cp = _invisibleEditView.execute(SCI_GETCODEPAGE);
 			_invisibleEditView.execute(SCI_SETCODEPAGE, pBuf->getUnicodeMode() == uni8Bit ? cp : SC_CP_UTF8);


### PR DESCRIPTION
Fixes #6074 .

If adopted the suggested `change.log` entry is:
"Fix for Find-All-in-All-Opened-Documents searching a cloned document two times, and reporting same results two times."

----------------------

Note: I don't know why the github diff is showing my `continue` line as indented too many times. Perhaps it has to do with the intermixing of tabs and spaces in the code before I changed it?  

Here's what my change looks like in VS (boxed in red), note tab-indenting and space-indenting intermingled at top and bottom of screenshot (but **I** didn't do that):

![image](https://user-images.githubusercontent.com/30118311/63287141-96546e80-c287-11e9-8754-e265853a6a9f.png)
