### PR TITLE
Allow Rename (file) command to change file's drive

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -747,7 +747,7 @@ bool FileManager::moveFile(BufferID id, const TCHAR * newFileName)
 {
 	Buffer* buf = getBufferByID(id);
 	const TCHAR *fileNamePath = buf->getFullPathName();
-	if (::MoveFileEx(fileNamePath, newFileName, MOVEFILE_REPLACE_EXISTING) == 0)
+	if (::MoveFileEx(fileNamePath, newFileName, MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED) == 0)
 		return false;
 
 	buf->setFileName(newFileName);


### PR DESCRIPTION
Fixes #1978 .

Suggested `change.log` entry if this change is adopted:  "Fixed File-Rename failing when new name is on a different drive."