### PR TITLE
Avoid using "using namespace std;", rather use "std::"

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -33,8 +33,6 @@
 #include "PluginsManager.h"
 #include "resource.h"
 
-using namespace std;
-
 const TCHAR * USERMSG = TEXT(" is not compatible with the current version of Notepad++.\n\n\
 Do you want to remove this plugin from the plugins directory to prevent this message from the next launch?");
 
@@ -296,7 +294,7 @@ bool PluginsManager::loadPluginsV2(const TCHAR* dir)
 	if (_isDisabled)
 		return false;
 
-	vector<generic_string> dllNames;
+	std::vector<generic_string> dllNames;
 
 	NppParameters& nppParams = NppParameters::getInstance();
 	generic_string nppPath = nppParams.getNppPath();
@@ -389,7 +387,7 @@ bool PluginsManager::getShortcutByCmdID(int cmdID, ShortcutKey *sk)
 	if (cmdID == 0 || !sk)
 		return false;
 
-	const vector<PluginCmdShortcut> & pluginCmdSCList = (NppParameters::getInstance()).getPluginCommandList();
+	const std::vector<PluginCmdShortcut> & pluginCmdSCList = (NppParameters::getInstance()).getPluginCommandList();
 
 	for (size_t i = 0, len = pluginCmdSCList.size(); i < len ; ++i)
 	{
@@ -415,7 +413,7 @@ bool PluginsManager::removeShortcutByCmdID(int cmdID)
 	if (cmdID == 0) { return false; }
 
 	NppParameters& nppParam = NppParameters::getInstance();
-	vector<PluginCmdShortcut> & pluginCmdSCList = nppParam.getPluginCommandList();
+	std::vector<PluginCmdShortcut> & pluginCmdSCList = nppParam.getPluginCommandList();
 
 	for (size_t i = 0, len = pluginCmdSCList.size(); i < len; ++i)
 	{
@@ -437,7 +435,7 @@ bool PluginsManager::removeShortcutByCmdID(int cmdID)
 
 void PluginsManager::addInMenuFromPMIndex(int i)
 {
-    vector<PluginCmdShortcut> & pluginCmdSCList = (NppParameters::getInstance()).getPluginCommandList();
+    std::vector<PluginCmdShortcut> & pluginCmdSCList = (NppParameters::getInstance()).getPluginCommandList();
 	::InsertMenu(_hPluginsMenu, i, MF_BYPOSITION | MF_POPUP, (UINT_PTR)_pluginInfos[i]->_pluginMenu, _pluginInfos[i]->_funcName.c_str());
 
     unsigned short j = 0;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -50,7 +50,6 @@
 #include "fileBrowser.h"
 #include "Common.h"
 
-using namespace std;
 
 enum tb_stat {tb_saved, tb_unsaved, tb_ro};
 #define DIR_LEFT true
@@ -537,7 +536,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_windowsMenu.init(_pPublicInterface->getHinst(), _mainMenuHandle, windowTrans.c_str());
 
 	// Update context menu strings (translated)
-	vector<MenuItemUnit> & tmp = nppParam.getContextMenuItems();
+	std::vector<MenuItemUnit> & tmp = nppParam.getContextMenuItems();
 	size_t len = tmp.size();
 	TCHAR menuName[64];
 	for (size_t i = 0 ; i < len ; ++i)
@@ -551,7 +550,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 
 	//Input all the menu item names into shortcut list
 	//This will automatically do all translations, since menu translation has been done already
-	vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
+	std::vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
 	len = shortcuts.size();
 
 	for (size_t i = 0; i < len; ++i)
@@ -582,7 +581,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	nppParam.setAccelerator(&_accelerator);
 
 	// Scintilla key accelerator
-	vector<HWND> scints;
+	std::vector<HWND> scints;
 	scints.push_back(_mainEditView.getHSelf());
 	scints.push_back(_subEditView.getHSelf());
 	_scintaccelerator.init(&scints, _mainMenuHandle, hwnd);
@@ -818,7 +817,7 @@ bool Notepad_plus::saveFileBrowserParam()
 {
 	if (_pFileBrowser)
 	{
-		vector<generic_string> rootPaths = _pFileBrowser->getRoots();
+		std::vector<generic_string> rootPaths = _pFileBrowser->getRoots();
 		generic_string selectedItemPath = _pFileBrowser->getSelectedItemPath();
 		return (NppParameters::getInstance()).writeFileBrowserSettings(rootPaths, selectedItemPath);
 	}
@@ -839,16 +838,16 @@ void Notepad_plus::saveDockingParams()
 	nppGUI._dockingData._containerTabInfo.clear();
 
 	// create a vector to save the current information
-	vector<PluginDlgDockingInfo>	vPluginDockInfo;
-	vector<FloatingWindowInfo>		vFloatingWindowInfo;
+	std::vector<PluginDlgDockingInfo>	vPluginDockInfo;
+	std::vector<FloatingWindowInfo>		vFloatingWindowInfo;
 
 	// save every container
-	vector<DockingCont*> vCont = _dockingManager.getContainerInfo();
+	std::vector<DockingCont*> vCont = _dockingManager.getContainerInfo();
 
 	for (size_t i = 0, len = vCont.size(); i < len ; ++i)
 	{
 		// save at first the visible Tb's
-		vector<tTbData *>	vDataVis	= vCont[i]->getDataOfVisTb();
+		std::vector<tTbData *>	vDataVis	= vCont[i]->getDataOfVisTb();
 
 		for (size_t j = 0, len2 = vDataVis.size(); j < len2 ; ++j)
 		{
@@ -860,7 +859,7 @@ void Notepad_plus::saveDockingParams()
 		}
 
 		// save the hidden Tb's
-		vector<tTbData *>	vDataAll	= vCont[i]->getDataOfAllTb();
+		std::vector<tTbData *>	vDataAll	= vCont[i]->getDataOfAllTb();
 
 		for (size_t j = 0, len3 = vDataAll.size(); j < len3 ; ++j)
 		{
@@ -1158,8 +1157,8 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
     int newCurrentPos = 0;
 	int tabStop = static_cast<int32_t>(tabWidth - 1);   // remember, counting from zero !
     bool onlyLeading = false;
-    vector<int> bookmarks;
-    vector<int> folding;
+    std::vector<int> bookmarks;
+    std::vector<int> folding;
 
     for (int i=0; i<lastLine; ++i)
     {
@@ -1425,7 +1424,7 @@ void Notepad_plus::removeDuplicateLines()
 	_findReplaceDlg.processAll(ProcessReplaceAll, &env, true);
 }
 
-void Notepad_plus::getMatchedFileNames(const TCHAR *dir, const vector<generic_string> & patterns, vector<generic_string> & fileNames, bool isRecursive, bool isInHiddenDir)
+void Notepad_plus::getMatchedFileNames(const TCHAR *dir, const std::vector<generic_string> & patterns, std::vector<generic_string> & fileNames, bool isRecursive, bool isInHiddenDir)
 {
 	generic_string dirFilter(dir);
 	dirFilter += TEXT("*.*");
@@ -1516,14 +1515,14 @@ bool Notepad_plus::replaceInFiles()
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 	Buffer * oldBuf = _invisibleEditView.getCurrentBuffer();	//for manually setting the buffer, so notifications can be handled properly
 
-	vector<generic_string> patterns2Match;
+	std::vector<generic_string> patterns2Match;
 	_findReplaceDlg.getPatterns(patterns2Match);
 	if (patterns2Match.size() == 0)
 	{
 		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
 		_findReplaceDlg.getPatterns(patterns2Match);
 	}
-	vector<generic_string> fileNames;
+	std::vector<generic_string> fileNames;
 
 	getMatchedFileNames(dir2Search, patterns2Match, fileNames, isRecursive, isInHiddenDir);
 
@@ -1610,7 +1609,7 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 	_pEditView = &_invisibleEditView;
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 
-	vector<generic_string> patterns2Match;
+	std::vector<generic_string> patterns2Match;
 	_findReplaceDlg.getPatterns(patterns2Match);
 	if (patterns2Match.size() == 0)
 	{
@@ -1618,7 +1617,7 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 		_findReplaceDlg.getPatterns(patterns2Match);
 	}
 
-	vector<generic_string> fileNames = findInFolderInfo->_pSourceFinder->getResultFilePaths();
+	std::vector<generic_string> fileNames = findInFolderInfo->_pSourceFinder->getResultFilePaths();
 
 	findInFolderInfo->_pDestFinder->beginNewFilesSearch();
 	findInFolderInfo->_pDestFinder->addSearchLine(findInFolderInfo->_findOption._str2Search.c_str());
@@ -1695,7 +1694,7 @@ bool Notepad_plus::findInFiles()
 	_pEditView = &_invisibleEditView;
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 
-	vector<generic_string> patterns2Match;
+	std::vector<generic_string> patterns2Match;
 	_findReplaceDlg.getPatterns(patterns2Match);
 	if (patterns2Match.size() == 0)
 	{
@@ -1703,7 +1702,7 @@ bool Notepad_plus::findInFiles()
 		_findReplaceDlg.getPatterns(patterns2Match);
 	}
 
-	vector<generic_string> fileNames;
+	std::vector<generic_string> fileNames;
 	getMatchedFileNames(dir2Search, patterns2Match, fileNames, isRecursive, isInHiddenDir);
 
 	_findReplaceDlg.beginNewFilesSearch();
@@ -3259,8 +3258,8 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 
 		int filesDropped = ::DragQueryFile(hdrop, 0xffffffff, NULL, 0);
 
-		vector<generic_string> folderPaths;
-		vector<generic_string> filePaths;
+		std::vector<generic_string> folderPaths;
+		std::vector<generic_string> filePaths;
 		for (int i = 0; i < filesDropped; ++i)
 		{
 			TCHAR pathDropped[MAX_PATH];
@@ -3649,9 +3648,9 @@ void Notepad_plus::docOpenInNewInstance(FileTransferMode mode, int x, int y)
 	command += TEXT(" -l");
 	command += ScintillaEditView::langNames[buf->getLangType()].lexerName;
 	command += TEXT(" -n");
-	command += to_wstring(_pEditView->getCurrentLineNumber() + 1);
+	command += std::to_wstring(_pEditView->getCurrentLineNumber() + 1);
 	command += TEXT(" -c");
-	command += to_wstring(_pEditView->getCurrentColumnNumber() + 1);
+	command += std::to_wstring(_pEditView->getCurrentColumnNumber() + 1);
 
 	Command cmd(command);
 	cmd.run(_pPublicInterface->getHSelf());
@@ -4417,7 +4416,7 @@ void Notepad_plus::saveScintillasZoom()
 bool Notepad_plus::addCurrentMacro()
 {
 	NppParameters& nppParams = NppParameters::getInstance();
-	vector<MacroShortcut> & theMacros = nppParams.getMacroList();
+	std::vector<MacroShortcut> & theMacros = nppParams.getMacroList();
 
 	int nbMacro = static_cast<int32_t>(theMacros.size());
 
@@ -4985,7 +4984,7 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includUntitledD
 			BufferID bufID = docTab[k]->getBufferByIndex(i);
 			ScintillaEditView *editView = k == 0?&_mainEditView:&_subEditView;
 			size_t activeIndex = k == 0 ? session._activeMainIndex : session._activeSubIndex;
-			vector<sessionFileInfo> *viewFiles = (vector<sessionFileInfo> *)(k == 0?&(session._mainViewFiles):&(session._subViewFiles));
+			std::vector<sessionFileInfo>* viewFiles = (std::vector<sessionFileInfo>*)(k == 0 ? &(session._mainViewFiles) : &(session._subViewFiles));
 
 			Buffer * buf = MainFileManager.getBufferByID(bufID);
 
@@ -5461,7 +5460,7 @@ void Notepad_plus::setFindReplaceFolderFilter(const TCHAR *dir, const TCHAR *fil
 		if (ext && ext[0])
 		{
 			fltr = TEXT("");
-			vector<generic_string> vStr;
+			std::vector<generic_string> vStr;
 			cutString(ext, vStr);
 			for (size_t i = 0 ,len = vStr.size(); i < len; ++i)
 			{
@@ -5478,12 +5477,12 @@ void Notepad_plus::setFindReplaceFolderFilter(const TCHAR *dir, const TCHAR *fil
 	_findReplaceDlg.setFindInFilesDirFilter(dir, filter);
 }
 
-vector<generic_string> Notepad_plus::addNppComponents(const TCHAR *destDir, const TCHAR *extFilterName, const TCHAR *extFilter)
+std::vector<generic_string> Notepad_plus::addNppComponents(const TCHAR *destDir, const TCHAR *extFilterName, const TCHAR *extFilter)
 {
 	FileDialog fDlg(_pPublicInterface->getHSelf(), _pPublicInterface->getHinst());
     fDlg.setExtFilter(extFilterName, extFilter, NULL);
 
-    vector<generic_string> copiedFiles;
+	std::vector<generic_string> copiedFiles;
 
     if (stringVector *pfns = fDlg.doOpenMultiFilesDlg())
     {
@@ -5514,12 +5513,12 @@ vector<generic_string> Notepad_plus::addNppComponents(const TCHAR *destDir, cons
     return copiedFiles;
 }
 
-vector<generic_string> Notepad_plus::addNppPlugins(const TCHAR *extFilterName, const TCHAR *extFilter)
+std::vector<generic_string> Notepad_plus::addNppPlugins(const TCHAR *extFilterName, const TCHAR *extFilter)
 {
 	FileDialog fDlg(_pPublicInterface->getHSelf(), _pPublicInterface->getHinst());
     fDlg.setExtFilter(extFilterName, extFilter, NULL);
 
-    vector<generic_string> copiedFiles;
+	std::vector<generic_string> copiedFiles;
 
     if (stringVector *pfns = fDlg.doOpenMultiFilesDlg())
     {
@@ -5689,7 +5688,7 @@ bool Notepad_plus::reloadLang()
 		::ModifyMenu(_mainMenuHandle, IDM_WINDOW_WINDOWS, MF_BYCOMMAND, IDM_WINDOW_WINDOWS, windowTrans.c_str());
 	}
 	// Update scintilla context menu strings
-	vector<MenuItemUnit> & tmp = nppParam.getContextMenuItems();
+	std::vector<MenuItemUnit> & tmp = nppParam.getContextMenuItems();
 	size_t len = tmp.size();
 	TCHAR menuName[64];
 	for (size_t i = 0 ; i < len ; ++i)
@@ -5701,7 +5700,7 @@ bool Notepad_plus::reloadLang()
 		}
 	}
 
-	vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
+	std::vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
 	len = shortcuts.size();
 
 	for (size_t i = 0; i < len; ++i)
@@ -5938,7 +5937,7 @@ void Notepad_plus::launchAnsiCharPanel()
 	_pAnsiCharPanel->display();
 }
 
-void Notepad_plus::launchFileBrowser(const vector<generic_string> & folders, bool fromScratch)
+void Notepad_plus::launchFileBrowser(const std::vector<generic_string> & folders, bool fromScratch)
 {
 	if (!_pFileBrowser)
 	{
@@ -6410,7 +6409,7 @@ int Notepad_plus::getRandomAction(int ranNum)
 }
 
 
-bool isInList(int elem, vector<int> elemList)
+bool isInList(int elem, const std::vector<int>& elemList)
 {
 	for (size_t i = 0, len = elemList.size(); i < len; ++i)
 	{
@@ -6472,7 +6471,7 @@ DWORD WINAPI Notepad_plus::threadTextPlayer(void *params)
     HWND curScintilla = pCurrentView->getHSelf();
 	const int nbMaxTrolling = 1;
 	int nbTrolling = 0;
-	vector<int> generatedRans;
+	std::vector<int> generatedRans;
 	wchar_t previousChar = '\0';
 
 	for (size_t i = 0, len = lstrlen(text2display); i < len ; ++i)
@@ -6541,9 +6540,9 @@ DWORD WINAPI Notepad_plus::threadTextPlayer(void *params)
 
 	//writeLog(TEXT("c:\\tmp\\log.txt"), "\n\n\n\n");
 	const wchar_t* quoter = qParams->_quoter;
-	wstring quoter_str = quoter;
+	std::wstring quoter_str = quoter;
 	size_t pos = quoter_str.find(TEXT("Anonymous"));
-	if (pos == string::npos)
+	if (pos == std::wstring::npos)
 	{
 		::SendMessage(curScintilla, SCI_APPENDTEXT, 3, reinterpret_cast<LPARAM>("\n- "));
 		::SendMessage(curScintilla, SCI_GOTOPOS, ::SendMessage(curScintilla, SCI_GETLENGTH, 0, 0), 0);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -41,7 +41,6 @@
 #include "md5.h"
 #include "sha-256.h"
 
-using namespace std;
 
 std::mutex command_mutex;
 
@@ -131,7 +130,7 @@ void Notepad_plus::command(int id)
 			{
 				if (_pFileBrowser == nullptr) // first launch, check in params to open folders
 				{
-					vector<generic_string> dummy;
+					std::vector<generic_string> dummy;
 					launchFileBrowser(dummy);
 					if (_pFileBrowser != nullptr)
 					{
@@ -165,7 +164,7 @@ void Notepad_plus::command(int id)
 		case IDM_FILESWITCHER_FILESCLOSEOTHERS:
 			if (_pFileSwitcherPanel)
 			{
-				vector<SwitcherFileInfo> files = _pFileSwitcherPanel->getSelectedFiles(id == IDM_FILESWITCHER_FILESCLOSEOTHERS);
+				std::vector<SwitcherFileInfo> files = _pFileSwitcherPanel->getSelectedFiles(id == IDM_FILESWITCHER_FILESCLOSEOTHERS);
 				for (size_t i = 0, len = files.size(); i < len; ++i)
 				{
 					fileClose((BufferID)files[i]._bufID, files[i]._iView);
@@ -585,7 +584,7 @@ void Notepad_plus::command(int id)
 				hasLineSelection = selStart != selEnd;
 				if (hasLineSelection)
 				{
-					pair<int, int> lineRange = _pEditView->getSelectionLinesRange();
+					std::pair<int, int> lineRange = _pEditView->getSelectionLinesRange();
 					// One single line selection is not allowed.
 					if (lineRange.first == lineRange.second)
 					{
@@ -723,7 +722,7 @@ void Notepad_plus::command(int id)
 				}
 				else
 				{
-					vector<generic_string> dummy;
+					std::vector<generic_string> dummy;
 					launchFileBrowser(dummy);
 					checkMenuItem(IDM_VIEW_FILEBROWSER, true);
 					_toolBar.setCheck(IDM_VIEW_FILEBROWSER, true);
@@ -2520,7 +2519,7 @@ void Notepad_plus::command(int id)
 			// Copy plugins to Plugins Home
             const TCHAR *extFilterName = TEXT("Notepad++ plugin");
             const TCHAR *extFilter = TEXT(".dll");
-            vector<generic_string> copiedFiles = addNppPlugins(extFilterName, extFilter);
+			std::vector<generic_string> copiedFiles = addNppPlugins(extFilterName, extFilter);
 
             // Tell users to restart Notepad++ to load plugin
 			if (copiedFiles.size())
@@ -2546,7 +2545,7 @@ void Notepad_plus::command(int id)
             NppParameters& nppParams = NppParameters::getInstance();
             ThemeSwitcher & themeSwitcher = nppParams.getThemeSwitcher();
 
-            vector<generic_string> copiedFiles = addNppComponents(destDir, extFilterName, extFilter);
+			std::vector<generic_string> copiedFiles = addNppComponents(destDir, extFilterName, extFilter);
             for (size_t i = 0, len = copiedFiles.size(); i < len ; ++i)
             {
                 generic_string themeName(themeSwitcher.getThemeFromXmlFileName(copiedFiles[i].c_str()));
@@ -3320,13 +3319,13 @@ void Notepad_plus::command(int id)
 			else if ((id >= ID_MACRO) && (id < ID_MACRO_LIMIT))
 			{
 				int i = id - ID_MACRO;
-				vector<MacroShortcut> & theMacros = (NppParameters::getInstance()).getMacroList();
+				std::vector<MacroShortcut> & theMacros = (NppParameters::getInstance()).getMacroList();
 				macroPlayback(theMacros[i].getMacro());
 			}
 			else if ((id >= ID_USER_CMD) && (id < ID_USER_CMD_LIMIT))
 			{
 				int i = id - ID_USER_CMD;
-				vector<UserCommand> & theUserCommands = (NppParameters::getInstance()).getUserCommandList();
+				std::vector<UserCommand> & theUserCommands = (NppParameters::getInstance()).getUserCommandList();
 				UserCommand ucmd = theUserCommands[i];
 
 				Command cmd(ucmd.getCmd());

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -37,7 +37,6 @@
 #include "ReadDirectoryChanges.h"
 #include <tchar.h>
 
-using namespace std;
 
 DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 {
@@ -349,8 +348,8 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
     {
         if (globbing || ::PathIsDirectory(fileName.c_str()))
         {
-            vector<generic_string> fileNames;
-            vector<generic_string> patterns;
+            std::vector<generic_string> fileNames;
+            std::vector<generic_string> patterns;
             if (globbing)
             {
                 const TCHAR * substring = wcsrchr(fileName.c_str(), TCHAR('\\'));
@@ -1767,7 +1766,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 
 		if (isFileSession(pFn) || isFileWorkspace(pFn))
 		{
-			vector<sessionFileInfo>::iterator posIt = session._mainViewFiles.begin() + i;
+			std::vector<sessionFileInfo>::iterator posIt = session._mainViewFiles.begin() + i;
 			session._mainViewFiles.erase(posIt);
 			continue;	//skip session files, not supporting recursive sessions or embedded workspace files
 		}
@@ -1846,7 +1845,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 		}
 		else
 		{
-			vector<sessionFileInfo>::iterator posIt = session._mainViewFiles.begin() + i;
+			std::vector<sessionFileInfo>::iterator posIt = session._mainViewFiles.begin() + i;
 			session._mainViewFiles.erase(posIt);
 			allSessionFilesLoaded = false;
 		}
@@ -1868,7 +1867,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 		const TCHAR *pFn = session._subViewFiles[k]._fileName.c_str();
 
 		if (isFileSession(pFn) || isFileWorkspace(pFn)) {
-			vector<sessionFileInfo>::iterator posIt = session._subViewFiles.begin() + k;
+			std::vector<sessionFileInfo>::iterator posIt = session._subViewFiles.begin() + k;
 			session._subViewFiles.erase(posIt);
 			continue;	//skip session files, not supporting recursive sessions or embedded workspace files
 		}
@@ -1962,7 +1961,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode)
 		}
 		else
 		{
-			vector<sessionFileInfo>::iterator posIt = session._subViewFiles.begin() + k;
+			std::vector<sessionFileInfo>::iterator posIt = session._subViewFiles.begin() + k;
 			session._subViewFiles.erase(posIt);
 			allSessionFilesLoaded = false;
 		}

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -36,8 +36,6 @@
 #include "Common.h"
 #include <stack>
 
-using namespace std;
-
 // Only for 2 main Scintilla editors
 BOOL Notepad_plus::notify(SCNotification *notification)
 {
@@ -255,7 +253,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					{
 						TCHAR goToView[32] = TEXT("Move to other view");
 						TCHAR cloneToView[32] = TEXT("Clone to other View");
-						vector<MenuItemUnit> itemUnitArray;
+						std::vector<MenuItemUnit> itemUnitArray;
 						itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_GOTO_ANOTHER_VIEW, goToView));
 						itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_CLONE_TO_ANOTHER_VIEW, cloneToView));
 						_tabPopupDropMenu.create(_pPublicInterface->getHSelf(), itemUnitArray, _mainMenuHandle);
@@ -494,7 +492,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				{
 					if (!_fileSwitcherMultiFilePopupMenu.isCreated())
 					{
-						vector<MenuItemUnit> itemUnitArray;
+						std::vector<MenuItemUnit> itemUnitArray;
 						itemUnitArray.push_back(MenuItemUnit(IDM_FILESWITCHER_FILESCLOSE, TEXT("Close Selected files")));
 						itemUnitArray.push_back(MenuItemUnit(IDM_FILESWITCHER_FILESCLOSEOTHERS, TEXT("Close others files")));
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -38,8 +38,6 @@
 
 #pragma warning(disable : 4996) // for GetVersionEx()
 
-using namespace std;
-
 
 namespace // anonymous namespace
 {
@@ -648,7 +646,7 @@ int base64ToAscii(char *dest, const char *base64Str)
 } // anonymous namespace
 
 
-void cutString(const TCHAR* str2cut, vector<generic_string>& patternVect)
+void cutString(const TCHAR* str2cut, std::vector<generic_string>& patternVect)
 {
 	if (str2cut == nullptr) return;
 
@@ -698,10 +696,10 @@ std::wstring LocalizationSwitcher::getXmlFilePathFromLangName(const wchar_t *lan
 bool LocalizationSwitcher::addLanguageFromXml(const std::wstring& xmlFullPath)
 {
 	wchar_t * fn = ::PathFindFileNameW(xmlFullPath.c_str());
-	wstring foundLang = getLangFromXmlFileName(fn);
+	std::wstring foundLang = getLangFromXmlFileName(fn);
 	if (not foundLang.empty())
 	{
-		_localizationList.push_back(pair<wstring, wstring>(foundLang, xmlFullPath));
+		_localizationList.push_back(std::pair<std::wstring, std::wstring>(foundLang, xmlFullPath));
 		return true;
 	}
 	return false;
@@ -710,7 +708,7 @@ bool LocalizationSwitcher::addLanguageFromXml(const std::wstring& xmlFullPath)
 
 bool LocalizationSwitcher::switchToLang(const wchar_t *lang2switch) const
 {
-	wstring langPath = getXmlFilePathFromLangName(lang2switch);
+	std::wstring langPath = getXmlFilePathFromLangName(lang2switch);
 	if (langPath.empty())
 		return false;
 
@@ -1833,7 +1831,7 @@ int NppParameters::getCmdIdFromMenuEntryItemName(HMENU mainMenuHadle, const gene
 		::GetMenuString(mainMenuHadle, i, menuEntryString, 64, MF_BYPOSITION);
 		if (generic_stricmp(menuEntryName.c_str(), purgeMenuItemString(menuEntryString).c_str()) == 0)
 		{
-			vector< pair<HMENU, int> > parentMenuPos;
+			std::vector< std::pair<HMENU, int> > parentMenuPos;
 			HMENU topMenu = ::GetSubMenu(mainMenuHadle, i);
 			int maxTopMenuPos = ::GetMenuItemCount(topMenu);
 			HMENU currMenu = topMenu;
@@ -1846,7 +1844,7 @@ int NppParameters::getCmdIdFromMenuEntryItemName(HMENU mainMenuHadle, const gene
 				if (::GetSubMenu(currMenu, currMenuPos))
 				{
 					//  Go into sub menu
-					parentMenuPos.push_back(::make_pair(currMenu, currMenuPos));
+					parentMenuPos.push_back(std::make_pair(currMenu, currMenuPos));
 					currMenu = ::GetSubMenu(currMenu, currMenuPos);
 					currMenuPos = 0;
 					currMaxMenuPos = ::GetMenuItemCount(currMenu);
@@ -2671,7 +2669,7 @@ std::pair<unsigned char, unsigned char> NppParameters::feedUserLang(TiXmlNode *n
 		}
 	}
 	int iEnd = _nbUserLang;
-	return pair<unsigned char, unsigned char>(static_cast<unsigned char>(iBegin), static_cast<unsigned char>(iEnd));
+	return std::pair<unsigned char, unsigned char>(static_cast<unsigned char>(iBegin), static_cast<unsigned char>(iEnd));
 }
 
 bool NppParameters::importUDLFromFile(const generic_string& sourceFile)
@@ -3092,22 +3090,22 @@ void NppParameters::writeSession(const Session & session, const TCHAR *fileName)
 
 		struct ViewElem {
 			TiXmlNode *viewNode;
-			vector<sessionFileInfo> *viewFiles;
+			std::vector<sessionFileInfo> *viewFiles;
 			size_t activeIndex;
 		};
 		const int nbElem = 2;
 		ViewElem viewElems[nbElem];
 		viewElems[0].viewNode = sessionNode->InsertEndChild(TiXmlElement(TEXT("mainView")));
 		viewElems[1].viewNode = sessionNode->InsertEndChild(TiXmlElement(TEXT("subView")));
-		viewElems[0].viewFiles = (vector<sessionFileInfo> *)(&(session._mainViewFiles));
-		viewElems[1].viewFiles = (vector<sessionFileInfo> *)(&(session._subViewFiles));
+		viewElems[0].viewFiles = (std::vector<sessionFileInfo> *)(&(session._mainViewFiles));
+		viewElems[1].viewFiles = (std::vector<sessionFileInfo> *)(&(session._subViewFiles));
 		viewElems[0].activeIndex = session._activeMainIndex;
 		viewElems[1].activeIndex = session._activeSubIndex;
 
 		for (size_t k = 0; k < nbElem ; ++k)
 		{
 			(viewElems[k].viewNode->ToElement())->SetAttribute(TEXT("activeIndex"), static_cast<int32_t>(viewElems[k].activeIndex));
-			vector<sessionFileInfo> & viewSessionFiles = *(viewElems[k].viewFiles);
+			std::vector<sessionFileInfo> & viewSessionFiles = *(viewElems[k].viewFiles);
 
 			for (size_t i = 0, len = viewElems[k].viewFiles->size(); i < len ; ++i)
 			{
@@ -3243,7 +3241,7 @@ int NppParameters::addUserLangToEnd(const UserLangContainer & userLang, const TC
 	++_nbUserLang;
 	unsigned char iEnd = _nbUserLang;
 
-	_pXmlUserLangsDoc.push_back(UdlXmlFileState(nullptr, true, make_pair(iBegin, iEnd)));
+	_pXmlUserLangsDoc.push_back(UdlXmlFileState(nullptr, true, std::make_pair(iBegin, iEnd)));
 
 	// imported UDL from xml file will be added into default udl, so we should make default udl dirty
 	setUdlXmlDirtyFromXmlDoc(_pXmlUserLangDoc);
@@ -3331,7 +3329,7 @@ void NppParameters::feedUserKeywordList(TiXmlNode *node)
 			const TCHAR *kwl = nullptr;
 			if (!lstrcmp(udlVersion, TEXT("")) && !lstrcmp(keywordsName, TEXT("Delimiters")))	// support for old style (pre 2.0)
 			{
-				basic_string<TCHAR> temp;
+				generic_string temp;
 				kwl = (valueNode)?valueNode->Value():TEXT("000000");
 
 				temp += TEXT("00");	 if (kwl[0] != '0') temp += kwl[0];	 temp += TEXT(" 01");
@@ -3348,25 +3346,25 @@ void NppParameters::feedUserKeywordList(TiXmlNode *node)
 			{
 				kwl = (valueNode)?valueNode->Value():TEXT("");
 				//int len = _tcslen(kwl);
-				basic_string<TCHAR> temp{TEXT(" ")};
+				generic_string temp{TEXT(" ")};
 
 				temp += kwl;
 				size_t pos = 0;
 
 				pos = temp.find(TEXT(" 0"));
-				while (pos != string::npos)
+				while (pos != generic_string::npos)
 				{
 					temp.replace(pos, 2, TEXT(" 00"));
 					pos = temp.find(TEXT(" 0"), pos+1);
 				}
 				pos = temp.find(TEXT(" 1"));
-				while (pos != string::npos)
+				while (pos != generic_string::npos)
 				{
 					temp.replace(pos, 2, TEXT(" 03"));
 					pos = temp.find(TEXT(" 1"));
 				}
 				pos = temp.find(TEXT(" 2"));
-				while (pos != string::npos)
+				while (pos != generic_string::npos)
 				{
 					temp.replace(pos, 2, TEXT(" 04"));
 					pos = temp.find(TEXT(" 2"));
@@ -3656,7 +3654,7 @@ bool NppParameters::writeProjectPanelsSettings() const
 	return true;
 }
 
-bool NppParameters::writeFileBrowserSettings(const vector<generic_string> & rootPaths, const generic_string & latestSelectedItemPath) const
+bool NppParameters::writeFileBrowserSettings(const std::vector<generic_string> & rootPaths, const generic_string & latestSelectedItemPath) const
 {
 	if (!_pXmlUserDoc) return false;
 
@@ -4931,7 +4929,7 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 					close = closeVal;
 
 				if (open != -1 && close != -1)
-					_nppGUI._matchedPairConf._matchedPairsInit.push_back(pair<char, char>(char(open), char(close)));
+					_nppGUI._matchedPairConf._matchedPairsInit.push_back(std::pair<char, char>(char(open), char(close)));
 			}
 		}
 		else if (!lstrcmp(nm, TEXT("sessionExt")))

--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -31,9 +31,8 @@
 #include "AutoCompletion.h"
 #include "Notepad_plus_msgs.h"
 
-using namespace std;
 
-static bool isInList(const generic_string& word, const vector<generic_string> & wordArray)
+static bool isInList(const generic_string& word, const std::vector<generic_string> & wordArray)
 {
 	for (size_t i = 0, len = wordArray.size(); i < len; ++i)
 		if (wordArray[i] == word)
@@ -91,7 +90,7 @@ bool AutoCompletion::showApiAndWordComplete()
 		return false;
 
 	// Get word array
-	vector<generic_string> wordArray;
+	std::vector<generic_string> wordArray;
 	_pEditView->getGenericText(beginChars, bufSize, startPos, curPos);
 
 	getWordArray(wordArray, beginChars);
@@ -111,7 +110,7 @@ bool AutoCompletion::showApiAndWordComplete()
 		}
 	}
 
-	sort(wordArray.begin(), wordArray.end());
+	std::sort(wordArray.begin(), wordArray.end());
 
 	// Get word list
 	generic_string words;
@@ -130,7 +129,7 @@ bool AutoCompletion::showApiAndWordComplete()
 }
 
 
-void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beginChars)
+void AutoCompletion::getWordArray(std::vector<generic_string> & wordArray, TCHAR *beginChars)
 {
 	const size_t bufSize = 256;
 	const NppGUI & nppGUI = NppParameters::getInstance().getNppGUI();
@@ -197,7 +196,7 @@ static bool isFile(const generic_string& path)
 
 static bool isAllowedBeforeDriveLetter(TCHAR c)
 {
-	locale loc;
+	std::locale loc;
 	return c == '\'' || c == '"' || c == '(' || std::isspace(c, loc);
 }
 
@@ -207,7 +206,7 @@ static bool getRawPath(const generic_string& input, generic_string &rawPath_out)
 	// Algorithm: look for a colon. The colon must be preceded by an alphabetic character.
 	// The alphabetic character must, in turn, be preceded by nothing, or by whitespace, or by
 	// a quotation mark.
-	locale loc;
+	std::locale loc;
 	size_t lastOccurrence = input.rfind(L":");
 	if (lastOccurrence == std::string::npos) // No match.
 		return false;
@@ -338,7 +337,7 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 		return false;
 
 	// Get word array
-	vector<generic_string> wordArray;
+	std::vector<generic_string> wordArray;
 	_pEditView->getGenericText(beginChars, bufSize, startPos, curPos);
 
 	getWordArray(wordArray, beginChars);
@@ -352,7 +351,7 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 		return true;
 	}
 
-	sort(wordArray.begin(), wordArray.end());
+	std::sort(wordArray.begin(), wordArray.end());
 
 	// Get word list
 	generic_string words(TEXT(""));
@@ -545,7 +544,7 @@ int InsertedMatchedChars::search(char startChar, char endChar, int posToDetect)
 
 void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & matchedPairConf)
 {
-	const vector< pair<char, char> > & matchedPairs = matchedPairConf._matchedPairs;
+	const std::vector< std::pair<char, char> >& matchedPairs = matchedPairConf._matchedPairs;
 	int caretPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
 	const char *matchedChars = NULL;
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -34,7 +34,6 @@
 #include "tchar.h"
 #include "verifySignedFile.h"
 
-using namespace std;
 
 // initialize the static variable
 
@@ -56,7 +55,10 @@ const int ScintillaEditView::_SC_MARGE_SYBOLE = 1;
 const int ScintillaEditView::_SC_MARGE_FOLDER = 2;
 
 WNDPROC ScintillaEditView::_scintillaDefaultProc = NULL;
-string ScintillaEditView::_defaultCharList = "";
+std::string ScintillaEditView::_defaultCharList = "";
+
+using basic_stringA = std::basic_string<char>;
+using basic_stringW = std::basic_string<wchar_t>;
 
 /*
 SC_MARKNUM_*     | Arrow               Plus/minus           Circle tree                 Box tree
@@ -677,10 +679,10 @@ void ScintillaEditView::setEmbeddedJSLexer()
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 	makeStyle(L_JS, pKwArray);
 
-	basic_string<char> keywordList("");
+	basic_stringA keywordList("");
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
@@ -698,10 +700,10 @@ void ScintillaEditView::setJsonLexer()
 
 	makeStyle(L_JSON, pKwArray);
 
-	basic_string<char> keywordList("");
+	basic_stringA keywordList("");
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
@@ -719,10 +721,10 @@ void ScintillaEditView::setEmbeddedPhpLexer()
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 	makeStyle(L_PHP, pKwArray);
 
-	basic_string<char> keywordList("");
+	basic_stringA keywordList("");
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
@@ -737,10 +739,10 @@ void ScintillaEditView::setEmbeddedAspLexer()
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 	makeStyle(L_ASP, pKwArray);
 
-	basic_string<char> keywordList("");
+	basic_stringA keywordList("");
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 		keywordList = wstring2string(kwlW, CP_ACP);
 	}
 
@@ -902,7 +904,7 @@ void ScintillaEditView::setExternalLexer(LangType typeDoc)
 
 			if (style._keywordClass >= 0 && style._keywordClass <= KEYWORDSET_MAX)
 			{
-				basic_string<char> keywordList("");
+				basic_stringA keywordList("");
 				if (style._keywords)
 				{
 					keywordList = wstring2string(*(style._keywords), CP_ACP);
@@ -934,18 +936,18 @@ void ScintillaEditView::setCppLexer(LangType langType)
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 	makeStyle(langType, pKwArray);
 
-	basic_string<char> keywordListInstruction("");
-	basic_string<char> keywordListType("");
+	basic_stringA keywordListInstruction("");
+	basic_stringA keywordListType("");
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 		keywordListInstruction = wstring2string(kwlW, CP_ACP);
 	}
 	cppInstrs = getCompleteKeywordList(keywordListInstruction, langType, LANG_INDEX_INSTR);
 
 	if (pKwArray[LANG_INDEX_TYPE])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_TYPE];
 		keywordListType = wstring2string(kwlW, CP_ACP);
 	}
 	cppTypes = getCompleteKeywordList(keywordListType, langType, LANG_INDEX_TYPE);
@@ -989,27 +991,27 @@ void ScintillaEditView::setJsLexer()
 			setStyle(style);
 		}
 
-		basic_string<char> keywordListInstruction("");
-		basic_string<char> keywordListType("");
-		basic_string<char> keywordListInstruction2("");
+		basic_stringA keywordListInstruction("");
+		basic_stringA keywordListType("");
+		basic_stringA keywordListInstruction2("");
 
 		if (pKwArray[LANG_INDEX_INSTR])
 		{
-			basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+			basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 			keywordListInstruction = wstring2string(kwlW, CP_ACP);
 		}
 		const char *jsInstrs = getCompleteKeywordList(keywordListInstruction, L_JAVASCRIPT, LANG_INDEX_INSTR);
 
 		if (pKwArray[LANG_INDEX_TYPE])
 		{
-			basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE];
+			basic_stringW kwlW = pKwArray[LANG_INDEX_TYPE];
 			keywordListType = wstring2string(kwlW, CP_ACP);
 		}
 		const char *jsTypes = getCompleteKeywordList(keywordListType, L_JAVASCRIPT, LANG_INDEX_TYPE);
 
 		if (pKwArray[LANG_INDEX_INSTR2])
 		{
-			basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR2];
+			basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR2];
 			keywordListInstruction2 = wstring2string(kwlW, CP_ACP);
 		}
 		const char *jsInstrs2 = getCompleteKeywordList(keywordListInstruction2, L_JAVASCRIPT, LANG_INDEX_INSTR2);
@@ -1055,10 +1057,10 @@ void ScintillaEditView::setJsLexer()
 
 		makeStyle(L_JS, pKwArray);
 
-		basic_string<char> keywordListInstruction("");
+		basic_stringA keywordListInstruction("");
 		if (pKwArray[LANG_INDEX_INSTR])
 		{
-			basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+			basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 			keywordListInstruction = wstring2string(kwlW, CP_ACP);
 		}
 		const char *jsEmbeddedInstrs = getCompleteKeywordList(keywordListInstruction, L_JS, LANG_INDEX_INSTR);
@@ -1088,18 +1090,18 @@ void ScintillaEditView::setTclLexer()
 	const TCHAR *pKwArray[10] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 	makeStyle(L_TCL, pKwArray);
 
-	basic_string<char> keywordListInstruction("");
-	basic_string<char> keywordListType("");
+	basic_stringA keywordListInstruction("");
+	basic_stringA keywordListType("");
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_INSTR];
 		keywordListInstruction = wstring2string(kwlW, CP_ACP);
 	}
 	tclInstrs = getCompleteKeywordList(keywordListInstruction, L_TCL, LANG_INDEX_INSTR);
 
 	if (pKwArray[LANG_INDEX_TYPE])
 	{
-		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE];
+		basic_stringW kwlW = pKwArray[LANG_INDEX_TYPE];
 		keywordListType = wstring2string(kwlW, CP_ACP);
 	}
 	tclTypes = getCompleteKeywordList(keywordListType, L_TCL, LANG_INDEX_TYPE);
@@ -1116,21 +1118,21 @@ void ScintillaEditView::setObjCLexer(LangType langType)
 
 	makeStyle(langType, pKwArray);
 
-	basic_string<char> objcInstr1Kwl("");
+	basic_stringA objcInstr1Kwl("");
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
 		objcInstr1Kwl = wstring2string(pKwArray[LANG_INDEX_INSTR], CP_ACP);
 	}
 	const char *objcInstrs = getCompleteKeywordList(objcInstr1Kwl, langType, LANG_INDEX_INSTR);
 
-	basic_string<char> objcInstr2Kwl("");
+	basic_stringA objcInstr2Kwl("");
 	if (pKwArray[LANG_INDEX_INSTR2])
 	{
 		objcInstr2Kwl = wstring2string(pKwArray[LANG_INDEX_INSTR2], CP_ACP);
 	}
 	const char *objCDirective = getCompleteKeywordList(objcInstr2Kwl, langType, LANG_INDEX_INSTR2);
 
-	basic_string<char> objcTypeKwl("");
+	basic_stringA objcTypeKwl("");
 	if (pKwArray[LANG_INDEX_TYPE])
 	{
 		objcTypeKwl = wstring2string(pKwArray[LANG_INDEX_TYPE], CP_ACP);
@@ -1138,7 +1140,7 @@ void ScintillaEditView::setObjCLexer(LangType langType)
 	const char *objcTypes = getCompleteKeywordList(objcTypeKwl, langType, LANG_INDEX_TYPE);
 
 
-	basic_string<char> objcType2Kwl("");
+	basic_stringA objcType2Kwl("");
 	if (pKwArray[LANG_INDEX_TYPE2])
 	{
 		objcType2Kwl = wstring2string(pKwArray[LANG_INDEX_TYPE2], CP_ACP);
@@ -1147,7 +1149,7 @@ void ScintillaEditView::setObjCLexer(LangType langType)
 
 
 
-	basic_string<char> doxygenKeyWordsString("");
+	basic_stringA doxygenKeyWordsString("");
 	const TCHAR *doxygenKeyWordsW = NppParameters::getInstance().getWordList(L_CPP, LANG_INDEX_TYPE2);
 	if (doxygenKeyWordsW)
 	{
@@ -1289,7 +1291,7 @@ void ScintillaEditView::addCustomWordChars()
 	if (nppGUI._customWordChars.empty())
 		return;
 
-	string chars2addStr;
+	std::string chars2addStr;
 	for (size_t i = 0; i < nppGUI._customWordChars.length(); ++i)
 	{
 		bool found = false;
@@ -1311,7 +1313,7 @@ void ScintillaEditView::addCustomWordChars()
 
 	if (not chars2addStr.empty())
 	{
-		string newCharList = _defaultCharList;
+		std::string newCharList = _defaultCharList;
 		newCharList += chars2addStr;
 		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>(newCharList.c_str()));
 	}
@@ -2217,7 +2219,7 @@ char * ScintillaEditView::getWordOnCaretPos(char * txt, int size)
     if (!size)
 		return NULL;
 
-    pair<int,int> range = getWordRange();
+    std::pair<int,int> range = getWordRange();
     return getWordFromRange(txt, size, range.first, range.second);
 }
 
@@ -2668,9 +2670,9 @@ void ScintillaEditView::setMultiSelections(const ColumnModeInfos & cmi)
 
 // Get selection range : (fromLine, toLine)
 // return (-1, -1) if multi-selection
-pair<int, int> ScintillaEditView::getSelectionLinesRange() const
+std::pair<int, int> ScintillaEditView::getSelectionLinesRange() const
 {
-    pair<int, int> range(-1, -1);
+    std::pair<int, int> range(-1, -1);
     if (execute(SCI_GETSELECTIONS) > 1) // multi-selection
         return range;
 	int32_t start = static_cast<int32_t>(execute(SCI_GETSELECTIONSTART));
@@ -2888,17 +2890,17 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 
 
 
-pair<int, int> ScintillaEditView::getWordRange()
+std::pair<int, int> ScintillaEditView::getWordRange()
 {
     auto caretPos = execute(SCI_GETCURRENTPOS, 0, 0);
 	int startPos = static_cast<int>(execute(SCI_WORDSTARTPOSITION, caretPos, true));
 	int endPos = static_cast<int>(execute(SCI_WORDENDPOSITION, caretPos, true));
-    return pair<int, int>(startPos, endPos);
+    return std::pair<int, int>(startPos, endPos);
 }
 
 bool ScintillaEditView::expandWordSelection()
 {
-    pair<int, int> wordRange = 	getWordRange();
+    std::pair<int, int> wordRange = 	getWordRange();
     if (wordRange.first != wordRange.second) {
         execute(SCI_SETSELECTIONSTART, wordRange.first);
         execute(SCI_SETSELECTIONEND, wordRange.second);

--- a/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -34,11 +34,10 @@
 #include "xmlMatchedTagsHighlighter.h"
 #include "ScintillaEditView.h"
 
-using namespace std;
 
-vector< pair<int, int> > XmlMatchedTagsHighlighter::getAttributesPos(int start, int end)
+std::vector< std::pair<int, int> > XmlMatchedTagsHighlighter::getAttributesPos(int start, int end)
 {
-	vector< pair<int, int> > attributes;
+	std::vector< std::pair<int, int> > attributes;
 
 	int bufLen = end - start + 1;
 	char *buf = new char[bufLen+1];
@@ -115,12 +114,12 @@ vector< pair<int, int> > XmlMatchedTagsHighlighter::getAttributesPos(int start, 
 
 		if (state == attr_valid)
 		{
-			attributes.push_back(pair<int, int>(start+startPos, start+i+oneMoreChar));
+			attributes.push_back(std::pair<int, int>(start+startPos, start+i+oneMoreChar));
 			state = attr_invalid;
 		}
 	}
 	if (state == attr_value)
-		attributes.push_back(pair<int, int>(start+startPos, start+i-1));
+		attributes.push_back(std::pair<int, int>(start+startPos, start+i-1));
 
 	delete [] buf;
 	return attributes;
@@ -638,7 +637,7 @@ void XmlMatchedTagsHighlighter::tagMatch(bool doHiliteAttr)
         // Colouising its attributs
         if (doHiliteAttr)
 		{
-			vector< pair<int, int> > attributes = getAttributesPos(xmlTags.tagNameEnd, xmlTags.tagOpenEnd - openTagTailLen);
+			std::vector< std::pair<int, int> > attributes = getAttributesPos(xmlTags.tagNameEnd, xmlTags.tagOpenEnd - openTagTailLen);
 			_pEditView->execute(SCI_SETINDICATORCURRENT,  SCE_UNIVERSAL_TAGATTR);
 			for (size_t i = 0, len = attributes.size(); i < len ; ++i)
 			{

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
@@ -32,7 +32,6 @@
 #include "Parameters.h"
 #include "localization.h"
 
-using namespace std;
 
 void ListView::init(HINSTANCE hInst, HWND parent)
 {
@@ -93,7 +92,7 @@ void ListView::destroy()
 	_hSelf = NULL;
 }
 
-void ListView::addLine(const vector<generic_string> & values2Add, LPARAM lParam, int pos2insert)
+void ListView::addLine(const std::vector<generic_string> & values2Add, LPARAM lParam, int pos2insert)
 {
 	if (not values2Add.size())
 		return;
@@ -164,7 +163,7 @@ LPARAM ListView::getLParamFromIndex(int itemIndex) const
 
 std::vector<size_t> ListView::getCheckedIndexes() const
 {
-	vector<size_t> checkedIndexes;
+	std::vector<size_t> checkedIndexes;
 	size_t nbItem = ListView_GetItemCount(_hSelf);
 	for (size_t i = 0; i < nbItem; ++i)
 	{

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -32,7 +32,6 @@
 #include "WordStyleDlg.h"
 #include "ScintillaEditView.h"
 
-using namespace std;
 
 LRESULT CALLBACK ColourStaticTextHooker::colourStaticProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
@@ -108,7 +107,7 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 			ThemeSwitcher & themeSwitcher = nppParamInst.getThemeSwitcher();
 			for (size_t i = 0 ; i < themeSwitcher.size() ; ++i)
 			{
-				pair<generic_string, generic_string> & themeInfo = themeSwitcher.getElementFromIndex(i);
+				std::pair<generic_string, generic_string> & themeInfo = themeSwitcher.getElementFromIndex(i);
 				int j = static_cast<int32_t>(::SendMessage(_hSwitch2ThemeCombo, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(themeInfo.first.c_str())));
 				if (! themeInfo.second.compare( nppParamInst.getNppGUI()._themeName ) )
 				{
@@ -637,7 +636,7 @@ void WordStyleDlg::switchToTheme()
 
 	NppParameters& nppParamInst = NppParameters::getInstance();
 	ThemeSwitcher & themeSwitcher = nppParamInst.getThemeSwitcher();
-	pair<generic_string, generic_string> & themeInfo = themeSwitcher.getElementFromIndex(iSel);
+	std::pair<generic_string, generic_string> & themeInfo = themeSwitcher.getElementFromIndex(iSel);
 	_themeName = themeInfo.second;
 
 	if (_isThemeDirty)

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -32,7 +32,6 @@
 #include "ToolTip.h"
 #include "Parameters.h"
 
-using namespace std;
 
 #ifndef WH_MOUSE_LL
 #define WH_MOUSE_LL 14
@@ -172,7 +171,7 @@ void DockingCont::removeToolbar(tTbData TbData)
 
 			// free resources
 			delete _vTbData[iTb];
-			vector<tTbData*>::iterator itr = _vTbData.begin() + iTb;
+			std::vector<tTbData*>::iterator itr = _vTbData.begin() + iTb;
 			_vTbData.erase(itr);
 		}
 	}
@@ -245,9 +244,9 @@ tTbData* DockingCont::getDataOfActiveTb()
 	return pTbData;
 }
 
-vector<tTbData*> DockingCont::getDataOfVisTb()
+std::vector<tTbData*> DockingCont::getDataOfVisTb()
 {
-	vector<tTbData*> vTbData;
+	std::vector<tTbData*> vTbData;
 	TCITEM tcItem = {0};
 	int iItemCnt = static_cast<int32_t>(::SendMessage(_hContTab, TCM_GETITEMCOUNT, 0, 0));
 

--- a/PowerEditor/src/WinControls/DockingWnd/DockingManager.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingManager.cpp
@@ -34,7 +34,6 @@
 #include "Gripper.h"
 #include "Parameters.h"
 
-using namespace std;
 
 BOOL DockingManager::_isRegistered = FALSE;
 
@@ -52,7 +51,7 @@ LRESULT CALLBACK focusWndProc(int nCode, WPARAM wParam, LPARAM lParam)
 		DockingManager *pDockingManager = (DockingManager *)::GetWindowLongPtr(hWndServer, GWLP_USERDATA);
 		if (pDockingManager)
 		{
-			vector<DockingCont*> & vcontainer = pDockingManager->getContainerInfo();
+			std::vector<DockingCont*> & vcontainer = pDockingManager->getContainerInfo();
 			CWPSTRUCT * pCwp = (CWPSTRUCT*)lParam;
 			if (pCwp->message == WM_KILLFOCUS)
 			{
@@ -805,7 +804,7 @@ DockingCont* DockingManager::toggleActiveTb(DockingCont* pContSrc, UINT message,
 
 DockingCont* DockingManager::toggleVisTb(DockingCont* pContSrc, UINT message, LPRECT prcFloat)
 {
-	vector<tTbData*>	vTbData		= pContSrc->getDataOfVisTb();
+	std::vector<tTbData*>	vTbData		= pContSrc->getDataOfVisTb();
 	tTbData*			pTbData		= pContSrc->getDataOfActiveTb();
 
 	int					iContSrc	= GetContainer(pContSrc);
@@ -871,7 +870,7 @@ void DockingManager::toggleActiveTb(DockingCont* pContSrc, DockingCont* pContTgt
 
 void DockingManager::toggleVisTb(DockingCont* pContSrc, DockingCont* pContTgt)
 {
-	vector<tTbData*>	vTbData		= pContSrc->getDataOfVisTb();
+	std::vector<tTbData*>	vTbData		= pContSrc->getDataOfVisTb();
 	tTbData*			pTbData		= pContSrc->getDataOfActiveTb();
 
 	// at first hide container and resize
@@ -955,7 +954,7 @@ int DockingManager::FindEmptyContainer()
     // search for used floated containers
     for (size_t iCont = 0; iCont < DOCKCONT_MAX; ++iCont)
     {
-        vector<tTbData*>    vTbData = _vContainer[iCont]->getDataOfAllTb();
+		std::vector<tTbData*>    vTbData = _vContainer[iCont]->getDataOfAllTb();
 
         for (size_t iTb = 0, len = vTbData.size(); iTb < len; ++iTb)
         {

--- a/PowerEditor/src/WinControls/DockingWnd/Gripper.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/Gripper.cpp
@@ -34,8 +34,6 @@
 #include "DockingManager.h"
 #include "Parameters.h"
 
-using namespace std;
-
 #ifndef WH_KEYBOARD_LL
 #define WH_KEYBOARD_LL 13
 #endif
@@ -411,7 +409,7 @@ void Gripper::onButtonUp()
 
 void Gripper::doTabReordering(POINT pt)
 {
-	vector<DockingCont*>	vCont		= _pDockMgr->getContainerInfo();
+	std::vector<DockingCont*>	vCont		= _pDockMgr->getContainerInfo();
 	BOOL					inTab		= FALSE;
 	HWND					hTab		= NULL;
 	HWND					hTabOld		= _hTab;
@@ -728,7 +726,7 @@ void Gripper::getMovingRect(POINT pt, RECT *rc)
 
 DockingCont* Gripper::contHitTest(POINT pt)
 {
-	vector<DockingCont*>	vCont	= _pDockMgr->getContainerInfo();
+	std::vector<DockingCont*>	vCont	= _pDockMgr->getContainerInfo();
 	HWND					hWnd	= ::WindowFromPoint(pt);
 
 	for (size_t iCont = 0, len = vCont.size(); iCont < len; ++iCont)
@@ -782,7 +780,7 @@ DockingCont* Gripper::contHitTest(POINT pt)
 DockingCont* Gripper::workHitTest(POINT pt, RECT *rc)
 {
 	RECT					rcCont	= {0};
-	vector<DockingCont*>	vCont	= _pDockMgr->getContainerInfo();
+	std::vector<DockingCont*>	vCont	= _pDockMgr->getContainerInfo();
 
 	/* at first test if cursor points into a visible container */
 	for (size_t iCont = 0, len = vCont.size(); iCont < len; ++iCont)

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -63,9 +63,9 @@ FileBrowser::~FileBrowser()
 	}
 }
 
-vector<generic_string> split(const generic_string & string2split, TCHAR sep)
+std::vector<generic_string> split(const generic_string & string2split, TCHAR sep)
 {
-	vector<generic_string> splitedStrings;
+	std::vector<generic_string> splitedStrings;
 	size_t len = string2split.length();
 	size_t beginPos = 0;
 	for (size_t i = 0; i < len + 1; ++i)
@@ -167,7 +167,7 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			generic_string pathSuffix = file2Change[0].substr(sepPos + separator.length(), file2Change[0].length() - 1);
 
 			// remove prefix of file/folder in changeInfo, splite the remained path
-			vector<generic_string> linarPathArray = split(pathSuffix, '\\');
+			std::vector<generic_string> linarPathArray = split(pathSuffix, '\\');
 
 			generic_string rootPath = file2Change[0].substr(0, sepPos);
 			generic_string path = rootPath;
@@ -194,7 +194,7 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			generic_string pathSuffix = file2Change[0].substr(sepPos + separator.length(), file2Change[0].length() - 1);
 
 			// remove prefix of file/folder in changeInfo, splite the remained path
-			vector<generic_string> linarPathArray = split(pathSuffix, '\\');
+			std::vector<generic_string> linarPathArray = split(pathSuffix, '\\');
 
 			generic_string rootPath = file2Change[0].substr(0, sepPos);
 			// search recursively and modify the tree structure
@@ -219,7 +219,7 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			generic_string pathSuffix = file2Change[0].substr(sepPos + separator.length(), file2Change[0].length() - 1);
 
 			// remove prefix of file/folder in changeInfo, splite the remained path
-			vector<generic_string> linarPathArray = split(pathSuffix, '\\');
+			std::vector<generic_string> linarPathArray = split(pathSuffix, '\\');
 
 			generic_string rootPath = file2Change[0].substr(0, sepPos);
 
@@ -228,7 +228,7 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 				return false;
 
 			generic_string pathSuffix2 = file2Change[1].substr(sepPos2 + separator.length(), file2Change[1].length() - 1);
-			vector<generic_string> linarPathArray2 = split(pathSuffix2, '\\');
+			std::vector<generic_string> linarPathArray2 = split(pathSuffix2, '\\');
 
 			bool isRenamed = renameInTree(rootPath, nullptr, linarPathArray, linarPathArray2[linarPathArray2.size() - 1]);
 			if (not isRenamed)
@@ -354,7 +354,7 @@ generic_string FileBrowser::getNodePath(HTREEITEM node) const
 {
 	if (not node) return TEXT("");
 
-	vector<generic_string> fullPathArray;
+	std::vector<generic_string> fullPathArray;
 	generic_string fullPath;
 
 	// go up until to root, then get the full path
@@ -866,8 +866,8 @@ bool isRelatedRootFolder(const generic_string & relatedRoot, const generic_strin
 	if (pos != 0) // pos == 0 is the necessary condition, but not enough
 		return false;
 
-	vector<generic_string> relatedRootArray = split(relatedRoot, '\\');
-	vector<generic_string> subFolderArray = split(subFolder, '\\');
+	std::vector<generic_string> relatedRootArray = split(relatedRoot, '\\');
+	std::vector<generic_string> subFolderArray = split(subFolder, '\\');
 
 	size_t index2Compare = relatedRootArray.size() - 1;
 
@@ -900,7 +900,7 @@ void FileBrowser::addRootFolder(generic_string rootFolderPath)
 				//do nothing, go down to select the dir
 				generic_string rootPath = _folderUpdaters[i]->_rootFolder._rootPath;
 				generic_string pathSuffix = rootFolderPath.substr(rootPath.size() + 1, rootFolderPath.size() - rootPath.size());
-				vector<generic_string> linarPathArray = split(pathSuffix, '\\');
+				std::vector<generic_string> linarPathArray = split(pathSuffix, '\\');
 				
 				HTREEITEM foundItem = findInTree(rootPath, nullptr, linarPathArray);
 				if (foundItem)
@@ -1014,9 +1014,9 @@ HTREEITEM FileBrowser::findChildNodeFromName(HTREEITEM parent, const generic_str
 	return childNodeFound;
 }
 
-vector<generic_string> FileBrowser::getRoots() const
+std::vector<generic_string> FileBrowser::getRoots() const
 {
-	vector<generic_string> roots;
+	std::vector<generic_string> roots;
 
 	for (HTREEITEM hItemNode = _treeView.getRoot();
 		hItemNode != nullptr;
@@ -1044,7 +1044,7 @@ generic_string FileBrowser::getSelectedItemPath() const
 	return itemPath;
 }
 
-bool FileBrowser::addInTree(const generic_string& rootPath, const generic_string& addItemFullPath, HTREEITEM node, vector<generic_string> linarPathArray)
+bool FileBrowser::addInTree(const generic_string& rootPath, const generic_string& addItemFullPath, HTREEITEM node, std::vector<generic_string> linarPathArray)
 {
 	if (node == nullptr) // it's a root. Search the right root with rootPath
 	{

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -32,7 +32,6 @@
 #include <fstream>
 
 using nlohmann::json;
-using namespace std;
 
 #define CX_BITMAP         16
 #define CY_BITMAP         16

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -30,8 +30,6 @@
 #include "functionParser.h"
 #include "BoostRegexSearch.h"
 
-using namespace std;
-
 FunctionParsersManager::~FunctionParsersManager()
 {
 	for (size_t i = 0, len = _parsers.size(); i < len; ++i)
@@ -499,7 +497,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 	return targetEnd;
 }
 
-void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair<int, int> > &scannedZones, const std::vector< std::pair<int, int> > & commentZones, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
+void FunctionZoneParser::classParse(std::vector<foundInfo>& foundInfos, std::vector< std::pair<int, int> >& scannedZones, const std::vector< std::pair<int, int> >& commentZones, size_t begin, size_t end, ScintillaEditView** ppEditView, generic_string classStructName)
 {
 	if (begin >= end)
 		return;
@@ -528,7 +526,7 @@ void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair
 		if (targetEnd > int(end)) //we found a result but outside our range, therefore do not process it
 			break;
 		
-		scannedZones.push_back(pair<int, int>(targetStart, targetEnd));
+		scannedZones.push_back(std::pair<int, int>(targetStart, targetEnd));
 
 		int foundTextLen = targetEnd - targetStart;
 		if (targetStart + foundTextLen == int(end))
@@ -546,7 +544,7 @@ void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair
 }
 
 
-void FunctionParser::getCommentZones(vector< pair<int, int> > & commentZone, size_t begin, size_t end, ScintillaEditView **ppEditView)
+void FunctionParser::getCommentZones(std::vector< std::pair<int, int> >& commentZone, size_t begin, size_t end, ScintillaEditView** ppEditView)
 {
 	if ((begin >= end) || (_commentExpr.empty()))
 		return;
@@ -564,7 +562,7 @@ void FunctionParser::getCommentZones(vector< pair<int, int> > & commentZone, siz
 		if (targetEnd > int(end)) //we found a result but outside our range, therefore do not process it
 			break;
 
-		commentZone.push_back(pair<int, int>(targetStart, targetEnd));
+		commentZone.push_back(std::pair<int, int>(targetStart, targetEnd));
 
 		int foundTextLen = targetEnd - targetStart;
 		if (targetStart + foundTextLen == int(end))
@@ -587,18 +585,18 @@ bool FunctionParser::isInZones(int pos2Test, const std::vector< std::pair<int, i
 }
 
 
-void FunctionParser::getInvertZones(vector< pair<int, int> > &  destZones, vector< pair<int, int> > &  sourceZones, size_t begin, size_t end)
+void FunctionParser::getInvertZones(std::vector< std::pair<int, int> >& destZones, std::vector< std::pair<int, int> >& sourceZones, size_t begin, size_t end)
 {
 	if (sourceZones.size() == 0)
 	{
-		destZones.push_back(pair<int, int>(static_cast<int>(begin), static_cast<int>(end)));
+		destZones.push_back(std::pair<int, int>(static_cast<int>(begin), static_cast<int>(end)));
 	}
 	else
 	{
 		// check the begin
 		if (int(begin) < sourceZones[0].first)
 		{
-			destZones.push_back(pair<int, int>(static_cast<int>(begin), sourceZones[0].first - 1));
+			destZones.push_back(std::pair<int, int>(static_cast<int>(begin), sourceZones[0].first - 1));
 		}
 
 		size_t i = 0;
@@ -607,18 +605,18 @@ void FunctionParser::getInvertZones(vector< pair<int, int> > &  destZones, vecto
 			int newBegin = sourceZones[i].second + 1;
 			int newEnd = sourceZones[i+1].first - 1;
 			if (newBegin < newEnd)
-				destZones.push_back(pair<int, int>(newBegin, newEnd));
+				destZones.push_back(std::pair<int, int>(newBegin, newEnd));
 		}
 		int lastBegin = sourceZones[i].second + 1;
 		if (lastBegin < int(end))
-			destZones.push_back(pair<int, int>(lastBegin, static_cast<int>(end)));
+			destZones.push_back(std::pair<int, int>(lastBegin, static_cast<int>(end)));
 	}
 }
 
 
 void FunctionZoneParser::parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
 {
-	vector< pair<int, int> > classZones, commentZones, nonCommentZones;
+	std::vector< std::pair<int, int> > classZones, commentZones, nonCommentZones;
 	getCommentZones(commentZones, begin, end, ppEditView);
 	getInvertZones(nonCommentZones, commentZones, begin, end);
 	for (size_t i = 0, len = nonCommentZones.size(); i < len; ++i)
@@ -629,7 +627,7 @@ void FunctionZoneParser::parse(std::vector<foundInfo> & foundInfos, size_t begin
 
 void FunctionUnitParser::parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
 {
-	vector< pair<int, int> > commentZones, nonCommentZones;
+	std::vector< std::pair<int, int> > commentZones, nonCommentZones;
 	getCommentZones(commentZones, begin, end, ppEditView);
 	getInvertZones(nonCommentZones, commentZones, begin, end);
 	for (size_t i = 0, len = nonCommentZones.size(); i < len; ++i)
@@ -643,7 +641,7 @@ void FunctionUnitParser::parse(std::vector<foundInfo> & foundInfos, size_t begin
 // sort in _selLpos : increased order
 struct SortZones final
 {
-	bool operator() (pair<int, int> & l, pair<int, int> & r)
+	bool operator() (std::pair<int, int> & l, std::pair<int, int> & r)
 	{
 		return (l.first < r.first);
 	}
@@ -651,7 +649,7 @@ struct SortZones final
 
 void FunctionMixParser::parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
 {
-	vector< pair<int, int> > commentZones, scannedZones, nonScannedZones;
+	std::vector< std::pair<int, int> > commentZones, scannedZones, nonScannedZones;
 	getCommentZones(commentZones, begin, end, ppEditView);
 
 	classParse(foundInfos, scannedZones, commentZones, begin, end, ppEditView, classStructName);
@@ -659,7 +657,7 @@ void FunctionMixParser::parse(std::vector<foundInfo> & foundInfos, size_t begin,
 	// the second level
 	for (size_t i = 0, len = scannedZones.size(); i < len; ++i)
 	{
-		vector< pair<int, int> > temp;
+		std::vector< std::pair<int, int> > temp;
 		classParse(foundInfos, temp, commentZones, scannedZones[i].first, scannedZones[i].second, ppEditView, classStructName);
 	}
 	// invert scannedZones

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -30,8 +30,6 @@
 #include "Notepad_plus.h"
 
 
-using namespace std;
-
 void ShortcutMapper::initTabs()
 {
 	HWND hTab = _hTabCtrl = ::GetDlgItem(_hSelf, IDC_BABYGRID_TABBAR);
@@ -246,7 +244,7 @@ void ShortcutMapper::fillOutBabyGrid()
 	{
 		case STATE_MENU:
 		{
-			vector<CommandShortcut> & cshortcuts = nppParam.getUserShortcuts();
+			std::vector<CommandShortcut> & cshortcuts = nppParam.getUserShortcuts();
 			cs_index = 1;
 			for (size_t i = 0; i < nbItems; ++i)
 			{
@@ -274,7 +272,7 @@ void ShortcutMapper::fillOutBabyGrid()
 
 		case STATE_MACRO:
 		{
-			vector<MacroShortcut> & cshortcuts = nppParam.getMacroList();
+			std::vector<MacroShortcut> & cshortcuts = nppParam.getMacroList();
 			cs_index = 1;
 			for (size_t i = 0; i < nbItems; ++i)
 			{
@@ -303,7 +301,7 @@ void ShortcutMapper::fillOutBabyGrid()
 
 		case STATE_USER:
 		{
-			vector<UserCommand> & cshortcuts = nppParam.getUserCommandList();
+			std::vector<UserCommand> & cshortcuts = nppParam.getUserCommandList();
 			cs_index = 1;
 			for (size_t i = 0; i < nbItems; ++i)
 			{
@@ -333,7 +331,7 @@ void ShortcutMapper::fillOutBabyGrid()
 
 		case STATE_PLUGIN:
 		{
-			vector<PluginCmdShortcut> & cshortcuts = nppParam.getPluginCommandList();
+			std::vector<PluginCmdShortcut> & cshortcuts = nppParam.getPluginCommandList();
 			cs_index = 1;
 			for (size_t i = 0; i < nbItems; ++i)
 			{
@@ -363,7 +361,7 @@ void ShortcutMapper::fillOutBabyGrid()
 
 		case STATE_SCINTILLA:
 		{
-			vector<ScintillaKeyMap> & cshortcuts = nppParam.getScintillaKeyList();
+			std::vector<ScintillaKeyMap> & cshortcuts = nppParam.getScintillaKeyList();
 			cs_index=1;
 			for (size_t i = 0; i < nbItems; ++i)
 			{
@@ -591,7 +589,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_MENU:
 						{
 							//Get CommandShortcut corresponding to row
-							vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
+							std::vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
 							CommandShortcut csc = shortcuts[shortcutIndex];
 							csc.clear();
 							shortcuts[shortcutIndex] = csc;
@@ -614,7 +612,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_MACRO: 
 						{
 							//Get MacroShortcut corresponding to row
-							vector<MacroShortcut> & shortcuts = nppParam.getMacroList();
+							std::vector<MacroShortcut> & shortcuts = nppParam.getMacroList();
 							MacroShortcut msc = shortcuts[shortcutIndex];
 							msc.clear();
 							shortcuts[shortcutIndex] = msc;
@@ -634,7 +632,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_USER: 
 						{
 							//Get UserCommand corresponding to row
-							vector<UserCommand> & shortcuts = nppParam.getUserCommandList();
+							std::vector<UserCommand> & shortcuts = nppParam.getUserCommandList();
 							UserCommand ucmd = shortcuts[shortcutIndex];
 							ucmd.clear();
 
@@ -657,7 +655,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_PLUGIN: 
 						{
 							//Get PluginCmdShortcut corresponding to row
-							vector<PluginCmdShortcut> & shortcuts = nppParam.getPluginCommandList();
+							std::vector<PluginCmdShortcut> & shortcuts = nppParam.getPluginCommandList();
 							PluginCmdShortcut pcsc = shortcuts[shortcutIndex];
 							pcsc.clear();
 							//shortcut was altered
@@ -714,7 +712,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_MENU:
 						{
 							//Get CommandShortcut corresponding to row
-							vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
+							std::vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
 							CommandShortcut csc = shortcuts[shortcutIndex], prevcsc = shortcuts[shortcutIndex];
 							csc.init(_hInst, _hSelf);
 							if (csc.doDialog() != -1 && prevcsc != csc)
@@ -740,7 +738,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_MACRO: 
 						{
 							//Get MacroShortcut corresponding to row
-							vector<MacroShortcut> & shortcuts = nppParam.getMacroList();
+							std::vector<MacroShortcut> & shortcuts = nppParam.getMacroList();
 							MacroShortcut msc = shortcuts[shortcutIndex], prevmsc = shortcuts[shortcutIndex];
 							msc.init(_hInst, _hSelf);
 							if (msc.doDialog() != -1 && prevmsc != msc)
@@ -765,7 +763,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_USER: 
 						{
 							//Get UserCommand corresponding to row
-							vector<UserCommand> & shortcuts = nppParam.getUserCommandList();
+							std::vector<UserCommand> & shortcuts = nppParam.getUserCommandList();
 							UserCommand ucmd = shortcuts[shortcutIndex];
 							ucmd.init(_hInst, _hSelf);
 							UserCommand prevucmd = ucmd;
@@ -791,7 +789,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_PLUGIN:
 						{
 							//Get PluginCmdShortcut corresponding to row
-							vector<PluginCmdShortcut> & shortcuts = nppParam.getPluginCommandList();
+							std::vector<PluginCmdShortcut> & shortcuts = nppParam.getPluginCommandList();
 							PluginCmdShortcut pcsc = shortcuts[shortcutIndex];
 							pcsc.init(_hInst, _hSelf);
 							PluginCmdShortcut prevpcsc = pcsc;
@@ -826,7 +824,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						case STATE_SCINTILLA:
 						{
 							//Get ScintillaKeyMap corresponding to row
-							vector<ScintillaKeyMap> & shortcuts = nppParam.getScintillaKeyList();
+							std::vector<ScintillaKeyMap> & shortcuts = nppParam.getScintillaKeyList();
 							ScintillaKeyMap skm = shortcuts[shortcutIndex], prevskm = shortcuts[shortcutIndex];
 							skm.init(_hInst, _hSelf);
 							if (skm.doDialog() != -1 && prevskm != skm)
@@ -891,8 +889,8 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 
 							case STATE_MACRO: 
 							{
-								vector<MacroShortcut> & theMacros = nppParam.getMacroList();
-								vector<MacroShortcut>::iterator it = theMacros.begin();
+								std::vector<MacroShortcut> & theMacros = nppParam.getMacroList();
+								std::vector<MacroShortcut>::iterator it = theMacros.begin();
 								cmdID = theMacros[shortcutIndex].getID();
 								theMacros.erase(it + shortcutIndex);
 
@@ -925,8 +923,8 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 
 							case STATE_USER: 
 							{
-								vector<UserCommand> & theUserCmds = nppParam.getUserCommandList();
-								vector<UserCommand>::iterator it = theUserCmds.begin();
+								std::vector<UserCommand> & theUserCmds = nppParam.getUserCommandList();
+								std::vector<UserCommand>::iterator it = theUserCmds.begin();
 								cmdID = theUserCmds[shortcutIndex].getID();
 								theUserCmds.erase(it + shortcutIndex);
 
@@ -992,7 +990,7 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 							::GetCursorPos(&p);
 							if (!_rightClickMenu.isCreated())
 							{
-								vector<MenuItemUnit> itemUnitArray;
+								std::vector<MenuItemUnit> itemUnitArray;
 								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_MODIFY, TEXT("Modify")));
 								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_DELETE, TEXT("Delete")));
 								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_CLEAR, TEXT("Clear")));
@@ -1061,35 +1059,35 @@ INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 							{
 								case STATE_MENU:
 								{
-									vector<CommandShortcut> & vShortcuts = nppParam.getUserShortcuts();
+									std::vector<CommandShortcut> & vShortcuts = nppParam.getUserShortcuts();
 									findKeyConflicts(&conflictInfo, vShortcuts[currentIndex].getKeyCombo(), currentIndex);
 								}
 								break;
 
 								case STATE_MACRO:
 								{
-									vector<MacroShortcut> & vShortcuts = nppParam.getMacroList();
+									std::vector<MacroShortcut> & vShortcuts = nppParam.getMacroList();
 									findKeyConflicts(&conflictInfo, vShortcuts[currentIndex].getKeyCombo(), currentIndex);
 								}
 								break;
 
 								case STATE_USER:
 								{
-									vector<UserCommand> & vShortcuts = nppParam.getUserCommandList();
+									std::vector<UserCommand> & vShortcuts = nppParam.getUserCommandList();
 									findKeyConflicts(&conflictInfo, vShortcuts[currentIndex].getKeyCombo(), currentIndex);
 								}
 								break;
 
 								case STATE_PLUGIN:
 								{
-									vector<PluginCmdShortcut> & vShortcuts = nppParam.getPluginCommandList();
+									std::vector<PluginCmdShortcut> & vShortcuts = nppParam.getPluginCommandList();
 									findKeyConflicts(&conflictInfo, vShortcuts[currentIndex].getKeyCombo(), currentIndex);
 								}
 								break;
 
 								case STATE_SCINTILLA:
 								{
-									vector<ScintillaKeyMap> & vShortcuts = nppParam.getScintillaKeyList();
+									std::vector<ScintillaKeyMap> & vShortcuts = nppParam.getScintillaKeyList();
 									size_t sciCombos = vShortcuts[currentIndex].getSize();
 									for (size_t sciIndex = 0; sciIndex < sciCombos; ++sciIndex)
 										findKeyConflicts(&conflictInfo, vShortcuts[currentIndex].getKeyComboByIndex(sciIndex), currentIndex);
@@ -1140,7 +1138,7 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 		{
 			case STATE_MENU:
 			{
-				vector<CommandShortcut> & vShortcuts = nppParam.getUserShortcuts();
+				std::vector<CommandShortcut> & vShortcuts = nppParam.getUserShortcuts();
 				size_t nbItems = vShortcuts.size();
 				for (size_t itemIndex = 0; itemIndex < nbItems; ++itemIndex)
 				{
@@ -1174,7 +1172,7 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 			} //case STATE_MENU
 			case STATE_MACRO:
 			{
-				vector<MacroShortcut> & vShortcuts = nppParam.getMacroList();
+				std::vector<MacroShortcut> & vShortcuts = nppParam.getMacroList();
 				size_t nbItems = vShortcuts.size();
 				for (size_t itemIndex = 0; itemIndex < nbItems; ++itemIndex)
 				{
@@ -1208,7 +1206,7 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 			} //case STATE_MACRO
 			case STATE_USER:
 			{
-				vector<UserCommand> & vShortcuts = nppParam.getUserCommandList();
+				std::vector<UserCommand> & vShortcuts = nppParam.getUserCommandList();
 				size_t nbItems = vShortcuts.size();
 				for (size_t itemIndex = 0; itemIndex < nbItems; ++itemIndex)
 				{
@@ -1242,7 +1240,7 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 			} //case STATE_USER
 			case STATE_PLUGIN:
 			{
-				vector<PluginCmdShortcut> & vShortcuts = nppParam.getPluginCommandList();
+				std::vector<PluginCmdShortcut> & vShortcuts = nppParam.getPluginCommandList();
 				size_t nbItems = vShortcuts.size();
 				for (size_t itemIndex = 0; itemIndex < nbItems; ++itemIndex)
 				{
@@ -1276,7 +1274,7 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 			} //case STATE_PLUGIN
 			case STATE_SCINTILLA:
 			{
-				vector<ScintillaKeyMap> & vShortcuts = nppParam.getScintillaKeyList();
+				std::vector<ScintillaKeyMap> & vShortcuts = nppParam.getScintillaKeyList();
 				size_t nbItems = vShortcuts.size();
 				for (size_t itemIndex = 0; itemIndex < nbItems; ++itemIndex)
 				{

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -44,7 +44,6 @@
 #define TEXTFILE        256
 #define IDR_PLUGINLISTJSONFILE  101
 
-using namespace std;
 using nlohmann::json;
 
 Version::Version(const generic_string& versionStr)
@@ -56,7 +55,7 @@ Version::Version(const generic_string& versionStr)
 			throw generic_string(TEXT("The string to parse is not a valid version format. Let's make it default value in catch block."));
 		
 		int i = 0;
-		vector<unsigned long*> v = {&_major, &_minor, &_patch, &_build};
+		std::vector<unsigned long*> v = {&_major, &_minor, &_patch, &_build};
 		for (const auto& s : ss)
 		{
 			if (!isNumber(s))
@@ -404,7 +403,7 @@ void PluginsAdminDlg::collectNppCurrentStatusInfos()
 
 }
 
-vector<PluginUpdateInfo*> PluginViewList::fromUiIndexesToPluginInfos(const std::vector<size_t>& uiIndexes) const
+std::vector<PluginUpdateInfo*> PluginViewList::fromUiIndexesToPluginInfos(const std::vector<size_t>& uiIndexes) const
 {
 	std::vector<PluginUpdateInfo*> r;
 	size_t nb = _ui.nbItem();
@@ -439,7 +438,7 @@ PluginsAdminDlg::PluginsAdminDlg()
 #endif
 }
 
-bool PluginsAdminDlg::exitToInstallRemovePlugins(Operation op, const vector<PluginUpdateInfo*>& puis)
+bool PluginsAdminDlg::exitToInstallRemovePlugins(Operation op, const std::vector<PluginUpdateInfo*>& puis)
 {
 	generic_string opStr;
 	if (op == pa_install)
@@ -536,8 +535,8 @@ bool PluginsAdminDlg::installPlugins()
 {
 	// Need to exit Notepad++
 
-	vector<size_t> indexes = _availableList.getCheckedIndexes();
-	vector<PluginUpdateInfo*> puis = _availableList.fromUiIndexesToPluginInfos(indexes);
+	std::vector<size_t> indexes = _availableList.getCheckedIndexes();
+	std::vector<PluginUpdateInfo*> puis = _availableList.fromUiIndexesToPluginInfos(indexes);
 
 	return exitToInstallRemovePlugins(pa_install, puis);
 }
@@ -546,8 +545,8 @@ bool PluginsAdminDlg::updatePlugins()
 {
 	// Need to exit Notepad++
 
-	vector<size_t> indexes = _updateList.getCheckedIndexes();
-	vector<PluginUpdateInfo*> puis = _updateList.fromUiIndexesToPluginInfos(indexes);
+	std::vector<size_t> indexes = _updateList.getCheckedIndexes();
+	std::vector<PluginUpdateInfo*> puis = _updateList.fromUiIndexesToPluginInfos(indexes);
 
 	return exitToInstallRemovePlugins(pa_update, puis);
 }
@@ -556,8 +555,8 @@ bool PluginsAdminDlg::removePlugins()
 {
 	// Need to exit Notepad++
 
-	vector<size_t> indexes = _installedList.getCheckedIndexes();
-	vector<PluginUpdateInfo*> puis = _installedList.fromUiIndexesToPluginInfos(indexes);
+	std::vector<size_t> indexes = _installedList.getCheckedIndexes();
+	std::vector<PluginUpdateInfo*> puis = _installedList.fromUiIndexesToPluginInfos(indexes);
 
 	return exitToInstallRemovePlugins(pa_remove, puis);
 }
@@ -614,7 +613,7 @@ void PluginViewList::pushBack(PluginUpdateInfo* pi)
 {
 	_list.push_back(pi);
 
-	vector<generic_string> values2Add;
+	std::vector<generic_string> values2Add;
 	values2Add.push_back(pi->_displayName);
 	Version v = pi->_version;
 	values2Add.push_back(v.toString());
@@ -642,7 +641,7 @@ bool loadFromJson(PluginViewList & pl, const json& j)
 			//std::unique_ptr<PluginUpdateInfo*> pi = make_unique<PluginUpdateInfo*>();
 			PluginUpdateInfo* pi = new PluginUpdateInfo();
 
-			string valStr = i.at("folder-name").get<std::string>();
+			std::string valStr = i.at("folder-name").get<std::string>();
 			pi->_folderName = wmc.char2wchar(valStr.c_str(), CP_ACP);
 
 			valStr = i.at("display-name").get<std::string>();
@@ -748,7 +747,7 @@ bool PluginsAdminDlg::updateListAndLoadFromJson()
 #ifdef DEBUG // if not debug, then it's release
 
 		// load from nppPluginList.json instead of nppPluginList.dll
-		ifstream nppPluginListJson(_pluginListFullPath);
+		std::ifstream nppPluginListJson(_pluginListFullPath);
 		nppPluginListJson >> j;
 
 #else //RELEASE
@@ -959,7 +958,7 @@ bool PluginViewList::restore(const generic_string& folderName)
 	{
 		if (i->_folderName == folderName)
 		{
-			vector<generic_string> values2Add;
+			std::vector<generic_string> values2Add;
 			values2Add.push_back(i->_displayName);
 			Version v = i->_version;
 			values2Add.push_back(v.toString());
@@ -1078,7 +1077,7 @@ void PluginsAdminDlg::switchDialog(int indexToSwitch)
 	::ShowWindow(hInstallButton, showAvailable ? SW_SHOW : SW_HIDE);
 	if (showAvailable)
 	{
-		vector<size_t> checkedArray = _availableList.getCheckedIndexes();
+		std::vector<size_t> checkedArray = _availableList.getCheckedIndexes();
 		showAvailable = checkedArray.size() > 0;
 	}
 	::EnableWindow(hInstallButton, showAvailable);
@@ -1086,7 +1085,7 @@ void PluginsAdminDlg::switchDialog(int indexToSwitch)
 	::ShowWindow(hUpdateButton, showUpdate ? SW_SHOW : SW_HIDE);
 	if (showUpdate)
 	{
-		vector<size_t> checkedArray = _updateList.getCheckedIndexes();
+		std::vector<size_t> checkedArray = _updateList.getCheckedIndexes();
 		showUpdate = checkedArray.size() > 0;
 	}
 	::EnableWindow(hUpdateButton, showUpdate);
@@ -1094,7 +1093,7 @@ void PluginsAdminDlg::switchDialog(int indexToSwitch)
 	::ShowWindow(hRemoveButton, showInstalled ? SW_SHOW : SW_HIDE);
 	if (showInstalled)
 	{
-		vector<size_t> checkedArray = _installedList.getCheckedIndexes();
+		std::vector<size_t> checkedArray = _installedList.getCheckedIndexes();
 		showInstalled = checkedArray.size() > 0;
 	}
 	::EnableWindow(hRemoveButton, showInstalled);
@@ -1199,7 +1198,7 @@ INT_PTR CALLBACK PluginsAdminDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 							(pnmv->uNewState & LVIS_STATEIMAGEMASK) == INDEXTOSTATEIMAGEMASK(1))   // unchecked
 						{
 							HWND hButton = ::GetDlgItem(_hSelf, buttonID);
-							vector<size_t> checkedArray = pViewList->getCheckedIndexes();
+							std::vector<size_t> checkedArray = pViewList->getCheckedIndexes();
 							bool showButton = checkedArray.size() > 0;
 
 							::EnableWindow(hButton, showButton);

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -35,8 +35,6 @@
 
 #define MyGetGValue(rgb)      (LOBYTE((rgb)>>8))
 
-using namespace std;
-
 const int BLINKRATE_FASTEST = 50;
 const int BLINKRATE_SLOWEST = 2500;
 const int BLINKRATE_INTERVAL = 50;
@@ -399,14 +397,14 @@ INT_PTR CALLBACK BarsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 
 			for (size_t i = 0, len = localizationSwitcher.size(); i < len ; ++i)
 			{
-				pair<wstring, wstring> localizationInfo = localizationSwitcher.getElementFromIndex(i);
+				std::pair<std::wstring, std::wstring> localizationInfo = localizationSwitcher.getElementFromIndex(i);
 				::SendDlgItemMessage(_hSelf, IDC_COMBO_LOCALIZATION, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(localizationInfo.first.c_str()));
 			}
-			wstring lang = TEXT("English"); // Set default language as Englishs
+			std::wstring lang = TEXT("English"); // Set default language as Englishs
 			if (nppParam.getNativeLangA()) // if nativeLangA is not NULL, then we can be sure the default language (English) is not used
 			{
-				string fn = localizationSwitcher.getFileName();
-				wstring fnW = s2ws(fn);
+				std::string fn = localizationSwitcher.getFileName();
+				std::wstring fnW = s2ws(fn);
 				lang = localizationSwitcher.getLangFromXmlFileName(fnW.c_str());
 			}
 			auto index = ::SendDlgItemMessage(_hSelf, IDC_COMBO_LOCALIZATION, CB_FINDSTRINGEXACT, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(lang.c_str()));
@@ -1772,7 +1770,7 @@ INT_PTR CALLBACK LangMenuDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 				case IDC_BUTTON_REMOVE :
 				{
 					int list2Remove, list2Add, idButton2Enable, idButton2Disable;
-					vector<LangMenuItem> *pSrcLst, *pDestLst;
+					std::vector<LangMenuItem> *pSrcLst, *pDestLst;
 
 					if (LOWORD(wParam)==IDC_BUTTON_REMOVE)
 					{
@@ -1805,7 +1803,7 @@ INT_PTR CALLBACK LangMenuDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 					::SendDlgItemMessage(_hSelf, list2Remove, LB_GETTEXT, iRemove, reinterpret_cast<LPARAM>(s));
 
 					LangMenuItem lmi = pSrcLst->at(iRemove);
-					vector<LangMenuItem>::iterator lang2Remove = pSrcLst->begin() + iRemove;
+					std::vector<LangMenuItem>::iterator lang2Remove = pSrcLst->begin() + iRemove;
 					pSrcLst->erase(lang2Remove);
 
 					auto iAdd = ::SendDlgItemMessage(_hSelf, list2Add, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(s));
@@ -2776,17 +2774,17 @@ INT_PTR CALLBACK AutoCompletionDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 						::SendDlgItemMessage(_hSelf, IDC_MACHEDPAIROPEN_EDIT1, WM_GETTEXT, MAX_PATH, reinterpret_cast<LPARAM>(opener));
 						::SendDlgItemMessage(_hSelf, IDC_MACHEDPAIRCLOSE_EDIT1, WM_GETTEXT, MAX_PATH, reinterpret_cast<LPARAM>(closer));
 						if (opener[0] < 0x80 && opener[0] != '\0' && closer[0] < 0x80 && closer[0] != '\0')
-							nppGUI._matchedPairConf._matchedPairs.push_back(pair<char, char>(static_cast<char>(opener[0]), static_cast<char>(closer[0])));
+							nppGUI._matchedPairConf._matchedPairs.push_back(std::pair<char, char>(static_cast<char>(opener[0]), static_cast<char>(closer[0])));
 
 						::SendDlgItemMessage(_hSelf, IDC_MACHEDPAIROPEN_EDIT2, WM_GETTEXT, MAX_PATH, reinterpret_cast<LPARAM>(opener));
 						::SendDlgItemMessage(_hSelf, IDC_MACHEDPAIRCLOSE_EDIT2, WM_GETTEXT, MAX_PATH, reinterpret_cast<LPARAM>(closer));
 						if (opener[0] < 0x80 && opener[0] != '\0' && closer[0] < 0x80 && closer[0] != '\0')
-							nppGUI._matchedPairConf._matchedPairs.push_back(pair<char, char>(static_cast<char>(opener[0]), static_cast<char>(closer[0])));
+							nppGUI._matchedPairConf._matchedPairs.push_back(std::pair<char, char>(static_cast<char>(opener[0]), static_cast<char>(closer[0])));
 
 						::SendDlgItemMessage(_hSelf, IDC_MACHEDPAIROPEN_EDIT3, WM_GETTEXT, MAX_PATH, reinterpret_cast<LPARAM>(opener));
 						::SendDlgItemMessage(_hSelf, IDC_MACHEDPAIRCLOSE_EDIT3, WM_GETTEXT, MAX_PATH, reinterpret_cast<LPARAM>(closer));
 						if (opener[0] < 0x80 && opener[0] != '\0' && closer[0] < 0x80 && closer[0] != '\0')
-							nppGUI._matchedPairConf._matchedPairs.push_back(pair<char, char>(static_cast<char>(opener[0]), static_cast<char>(closer[0])));
+							nppGUI._matchedPairConf._matchedPairs.push_back(std::pair<char, char>(static_cast<char>(opener[0]), static_cast<char>(closer[0])));
 						 
 						return TRUE;
 					}

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
@@ -42,12 +42,11 @@
 #include <windows.h>
 #include <vector>
 #include <list>
-
-using namespace std;
+#include <string>
 
 #include "ThreadSafeQueue.h"
 
-typedef pair<DWORD, std::wstring> TDirectoryChangeNotification;
+typedef std::pair<DWORD, std::wstring> TDirectoryChangeNotification;
 
 namespace ReadDirectoryChangesPrivate
 {

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
@@ -88,11 +88,11 @@ protected:
 	// Data buffer for the request.
 	// Since the memory is allocated by malloc, it will always
 	// be aligned as required by ReadDirectoryChangesW().
-	vector<BYTE> m_Buffer;
+	std::vector<BYTE> m_Buffer;
 
 	// Double buffer strategy so that we can issue a new read
 	// request before we process the current buffer.
-	vector<BYTE> m_BackupBuffer;
+	std::vector<BYTE> m_BackupBuffer;
 };
 
 ///////////////////////////////////////////////////////////////////////////
@@ -169,7 +169,7 @@ protected:
 		m_pBlocks.clear();
 	}
 
-	vector<CReadChangesRequest*> m_pBlocks;
+	std::vector<CReadChangesRequest*> m_pBlocks;
 
 	bool m_bTerminate;
 };

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -35,8 +35,6 @@
 #include "Notepad_plus_Window.h"
 #include "keys.h"
 
-using namespace std;
-
 const int KEY_STR_LEN = 16;
 
 struct KeyIDNAME {
@@ -303,19 +301,19 @@ void getNameStrFromCmd(DWORD cmd, generic_string & str)
 {
 	if ((cmd >= ID_MACRO) && (cmd < ID_MACRO_LIMIT))
 	{
-		vector<MacroShortcut> & theMacros = (NppParameters::getInstance()).getMacroList();
+		std::vector<MacroShortcut> & theMacros = (NppParameters::getInstance()).getMacroList();
 		int i = cmd - ID_MACRO;
 		str = theMacros[i].getName();
 	}
 	else if ((cmd >= ID_USER_CMD) && (cmd < ID_USER_CMD_LIMIT))
 	{
-		vector<UserCommand> & userCommands = (NppParameters::getInstance()).getUserCommandList();
+		std::vector<UserCommand> & userCommands = (NppParameters::getInstance()).getUserCommandList();
 		int i = cmd - ID_USER_CMD;
 		str = userCommands[i].getName();
 	}
 	else if ((cmd >= ID_PLUGINS_CMD) && (cmd < ID_PLUGINS_CMD_LIMIT))
 	{
-		vector<PluginCmdShortcut> & pluginCmds = (NppParameters::getInstance()).getPluginCommandList();
+		std::vector<PluginCmdShortcut> & pluginCmds = (NppParameters::getInstance()).getPluginCommandList();
 		size_t i = 0;
 		for (size_t j = 0, len = pluginCmds.size(); j < len ; ++j)
 		{
@@ -488,14 +486,14 @@ INT_PTR CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 // return true if one of CommandShortcuts is deleted. Otherwise false.
 void Accelerator::updateShortcuts() 
 {
-	const array<unsigned long, 3> incrFindAccIds = { IDM_SEARCH_FINDNEXT, IDM_SEARCH_FINDPREV, IDM_SEARCH_FINDINCREMENT };
+	const std::array<unsigned long, 3> incrFindAccIds = { IDM_SEARCH_FINDNEXT, IDM_SEARCH_FINDPREV, IDM_SEARCH_FINDINCREMENT };
 
 	NppParameters& nppParam = NppParameters::getInstance();
 
-	vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
-	vector<MacroShortcut> & macros  = nppParam.getMacroList();
-	vector<UserCommand> & userCommands = nppParam.getUserCommandList();
-	vector<PluginCmdShortcut> & pluginCommands = nppParam.getPluginCommandList();
+	std::vector<CommandShortcut> & shortcuts = nppParam.getUserShortcuts();
+	std::vector<MacroShortcut> & macros  = nppParam.getMacroList();
+	std::vector<UserCommand> & userCommands = nppParam.getUserCommandList();
+	std::vector<PluginCmdShortcut> & pluginCommands = nppParam.getPluginCommandList();
 
 	size_t nbMenu = shortcuts.size();
 	size_t nbMacro = macros.size();
@@ -504,7 +502,7 @@ void Accelerator::updateShortcuts()
 
 	delete [] _pAccelArray;
 	_pAccelArray = new ACCEL[nbMenu+nbMacro+nbUserCmd+nbPluginCmd];
-	vector<ACCEL> incrFindAcc;
+	std::vector<ACCEL> incrFindAcc;
 
 	ACCEL *pSearchFindAccel = nullptr;
 	int offset = 0;
@@ -603,25 +601,25 @@ void Accelerator::updateShortcuts()
 void Accelerator::updateFullMenu()
 {
 	NppParameters& nppParam = NppParameters::getInstance();
-	vector<CommandShortcut> commands = nppParam.getUserShortcuts();
+	std::vector<CommandShortcut> commands = nppParam.getUserShortcuts();
 	for (size_t i = 0; i < commands.size(); ++i)
 	{
 		updateMenuItemByCommand(commands[i]);
 	}
 
-	vector<MacroShortcut> mcommands = nppParam.getMacroList();
+	std::vector<MacroShortcut> mcommands = nppParam.getMacroList();
 	for (size_t i = 0; i < mcommands.size(); ++i)
 	{
 		updateMenuItemByCommand(mcommands[i]);
 	}
 
-	vector<UserCommand> ucommands = nppParam.getUserCommandList();
+	std::vector<UserCommand> ucommands = nppParam.getUserCommandList();
 	for (size_t i = 0; i < ucommands.size(); ++i)
 	{
 		updateMenuItemByCommand(ucommands[i]);
 	}
 
-	vector<PluginCmdShortcut> pcommands = nppParam.getPluginCommandList();
+	std::vector<PluginCmdShortcut> pcommands = nppParam.getPluginCommandList();
 	for (size_t i = 0; i < pcommands.size(); ++i)
 	{
 		updateMenuItemByCommand(pcommands[i]);
@@ -867,7 +865,7 @@ void recordedMacroStep::PlayBack(Window* pNotepad, ScintillaEditView *pEditView)
 	}
 }
 
-void ScintillaAccelerator::init(vector<HWND> * vScintillas, HMENU hMenu, HWND menuParent)
+void ScintillaAccelerator::init(std::vector<HWND> * vScintillas, HMENU hMenu, HWND menuParent)
 {
 	_hAccelMenu = hMenu;
 	_hMenuParent = menuParent;
@@ -881,7 +879,7 @@ void ScintillaAccelerator::init(vector<HWND> * vScintillas, HMENU hMenu, HWND me
 void ScintillaAccelerator::updateKeys() 
 {
 	NppParameters& nppParam = NppParameters::getInstance();
-	vector<ScintillaKeyMap> & map = nppParam.getScintillaKeyList();
+	std::vector<ScintillaKeyMap> & map = nppParam.getScintillaKeyList();
 	size_t mapSize = map.size();
 	size_t index;
 	size_t nb = nbScintillas();

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -31,8 +31,6 @@
 #include "EncodingMapper.h"
 #include "localization.h"
 
-using namespace std;
-
 
 
 MenuPosition menuPos[] = {
@@ -729,25 +727,25 @@ void NativeLangSpeaker::changeFindReplaceDlgLang(FindReplaceDlg & findReplaceDlg
 
 				if (titre1 && titre1[0])
 				{
-					basic_string<wchar_t> nameW = wmc.char2wchar(titre1, _nativeLangEncoding);
+					std::basic_string<wchar_t> nameW = wmc.char2wchar(titre1, _nativeLangEncoding);
 					nppParam.getFindDlgTabTitiles()._find = nameW;
 					findReplaceDlg.changeTabName(FIND_DLG, nppParam.getFindDlgTabTitiles()._find.c_str());
 				}
 				if (titre2  && titre2[0])
 				{
-					basic_string<wchar_t> nameW = wmc.char2wchar(titre2, _nativeLangEncoding);
+					std::basic_string<wchar_t> nameW = wmc.char2wchar(titre2, _nativeLangEncoding);
 					nppParam.getFindDlgTabTitiles()._replace = nameW;
 					findReplaceDlg.changeTabName(REPLACE_DLG, nppParam.getFindDlgTabTitiles()._replace.c_str());
 				}
 				if (titre3 && titre3[0])
 				{
-					basic_string<wchar_t> nameW = wmc.char2wchar(titre3, _nativeLangEncoding);
+					std::basic_string<wchar_t> nameW = wmc.char2wchar(titre3, _nativeLangEncoding);
 					nppParam.getFindDlgTabTitiles()._findInFiles = nameW;
 					findReplaceDlg.changeTabName(FINDINFILES_DLG, nppParam.getFindDlgTabTitiles()._findInFiles.c_str());
 				}
 				if (titre4 && titre4[0])
 				{
-					basic_string<wchar_t> nameW = wmc.char2wchar(titre4, _nativeLangEncoding);
+					std::basic_string<wchar_t> nameW = wmc.char2wchar(titre4, _nativeLangEncoding);
 					nppParam.getFindDlgTabTitiles()._mark = nameW;
 					findReplaceDlg.changeTabName(MARK_DLG, nppParam.getFindDlgTabTitiles()._mark.c_str());
 				}
@@ -775,7 +773,7 @@ void NativeLangSpeaker::changePluginsAdminDlgLang(PluginsAdminDlg & pluginsAdmin
 					const char *name = (ColumnPluginNode->ToElement())->Attribute("name");
 					if (name && name[0])
 					{
-						basic_string<wchar_t> nameW = wmc.char2wchar(name, _nativeLangEncoding);
+						std::basic_string<wchar_t> nameW = wmc.char2wchar(name, _nativeLangEncoding);
 						pluginsAdminDlg.changeColumnName(COLUMN_PLUGIN, nameW.c_str());
 					}
 				}
@@ -786,7 +784,7 @@ void NativeLangSpeaker::changePluginsAdminDlgLang(PluginsAdminDlg & pluginsAdmin
 					const char *name = (ColumnVersionNode->ToElement())->Attribute("name");
 					if (name && name[0])
 					{
-						basic_string<wchar_t> nameW = wmc.char2wchar(name, _nativeLangEncoding);
+						std::basic_string<wchar_t> nameW = wmc.char2wchar(name, _nativeLangEncoding);
 						pluginsAdminDlg.changeColumnName(COLUMN_VERSION, nameW.c_str());
 					}
 				}
@@ -797,17 +795,17 @@ void NativeLangSpeaker::changePluginsAdminDlgLang(PluginsAdminDlg & pluginsAdmin
 
 				if (titre1 && titre1[0])
 				{
-					basic_string<wchar_t> nameW = wmc.char2wchar(titre1, _nativeLangEncoding);
+					std::basic_string<wchar_t> nameW = wmc.char2wchar(titre1, _nativeLangEncoding);
 					pluginsAdminDlg.changeTabName(AVAILABLE_LIST, nameW.c_str());
 				}
 				if (titre2  && titre2[0])
 				{
-					basic_string<wchar_t> nameW = wmc.char2wchar(titre2, _nativeLangEncoding);
+					std::basic_string<wchar_t> nameW = wmc.char2wchar(titre2, _nativeLangEncoding);
 					pluginsAdminDlg.changeTabName(UPDATES_LIST, nameW.c_str());
 				}
 				if (titre3 && titre3[0])
 				{
-					basic_string<wchar_t> nameW = wmc.char2wchar(titre3, _nativeLangEncoding);
+					std::basic_string<wchar_t> nameW = wmc.char2wchar(titre3, _nativeLangEncoding);
 					pluginsAdminDlg.changeTabName(INSTALLED_LIST, nameW.c_str());
 				}
 			}
@@ -942,8 +940,8 @@ void NativeLangSpeaker::changeShortcutLang()
 	if (!_nativeLangA) return;
 
 	NppParameters& nppParam = NppParameters::getInstance();
-	vector<CommandShortcut> & mainshortcuts = nppParam.getUserShortcuts();
-	vector<ScintillaKeyMap> & scinshortcuts = nppParam.getScintillaKeyList();
+	std::vector<CommandShortcut> & mainshortcuts = nppParam.getUserShortcuts();
+	std::vector<ScintillaKeyMap> & scinshortcuts = nppParam.getScintillaKeyList();
 
 	TiXmlNodeA *shortcuts = _nativeLangA->FirstChild("Shortcuts");
 	if (!shortcuts) return;


### PR DESCRIPTION
Avoid using `using namespace std;` rather use `std::`. Using `using namespace std;` is considered bad practice.

Some links which advise not to use `using namespace std;`
https://isocpp.org/wiki/faq/coding-standards#using-namespace-std
https://akrzemi1.wordpress.com/2019/03/14/not-using-namespace-std/
https://stackoverflow.com/questions/1452721/why-is-using-namespace-std-considered-bad-practice