### PR TITLE
Fixed code error (may be typo)

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6543,7 +6543,7 @@ DWORD WINAPI Notepad_plus::threadTextPlayer(void *params)
 	const wchar_t* quoter = qParams->_quoter;
 	wstring quoter_str = quoter;
 	size_t pos = quoter_str.find(TEXT("Anonymous"));
-	if (pos == string::npos)
+	if (pos == wstring::npos)
 	{
 		::SendMessage(curScintilla, SCI_APPENDTEXT, 3, reinterpret_cast<LPARAM>("\n- "));
 		::SendMessage(curScintilla, SCI_GOTOPOS, ::SendMessage(curScintilla, SCI_GETLENGTH, 0, 0), 0);

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3348,25 +3348,25 @@ void NppParameters::feedUserKeywordList(TiXmlNode *node)
 			{
 				kwl = (valueNode)?valueNode->Value():TEXT("");
 				//int len = _tcslen(kwl);
-				basic_string<TCHAR> temp{TEXT(" ")};
+				generic_string temp{TEXT(" ")};
 
 				temp += kwl;
 				size_t pos = 0;
 
 				pos = temp.find(TEXT(" 0"));
-				while (pos != string::npos)
+				while (pos != generic_string::npos)
 				{
 					temp.replace(pos, 2, TEXT(" 00"));
 					pos = temp.find(TEXT(" 0"), pos+1);
 				}
 				pos = temp.find(TEXT(" 1"));
-				while (pos != string::npos)
+				while (pos != generic_string::npos)
 				{
 					temp.replace(pos, 2, TEXT(" 03"));
 					pos = temp.find(TEXT(" 1"));
 				}
 				pos = temp.find(TEXT(" 2"));
-				while (pos != string::npos)
+				while (pos != generic_string::npos)
 				{
 					temp.replace(pos, 2, TEXT(" 04"));
 					pos = temp.find(TEXT(" 2"));


### PR DESCRIPTION
Fixing some code error that seems to be typo.

- Notepad_plus.cpp: 
Performing find operation on `wstring` should compare with `wstring::npos` instead of `string::npos`. Mind `w' here.

- Parameters.cpp
`basic_string<TCHAR>` is typedef as `generic_string`. So replace `basic_string<TCHAR>` by `generic_string`. 
Also use `::npos` from `generic_string` instead from `string::npos`.

