### PR TITLE
Remove association check before enabling 'View Current File In' menu items

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2005,10 +2005,10 @@ void Notepad_plus::checkDocState()
 
 	enableCommand(IDM_FILE_OPEN_DEFAULT_VIEWER, isAssoCommandExisting(curBuf->getFullPathName()), MENU);
 
-	enableCommand(IDM_VIEW_IN_FIREFOX, isAssoCommandExisting(curBuf->getFullPathName()), MENU);
-	enableCommand(IDM_VIEW_IN_CHROME, isAssoCommandExisting(curBuf->getFullPathName()), MENU);
-	enableCommand(IDM_VIEW_IN_IE, isAssoCommandExisting(curBuf->getFullPathName()), MENU);
-	enableCommand(IDM_VIEW_IN_EDGE, isAssoCommandExisting(curBuf->getFullPathName()), MENU);
+	enableCommand(IDM_VIEW_IN_FIREFOX, isFileExisting, MENU);
+	enableCommand(IDM_VIEW_IN_CHROME, isFileExisting, MENU);
+	enableCommand(IDM_VIEW_IN_IE, isFileExisting, MENU);
+	enableCommand(IDM_VIEW_IN_EDGE, isFileExisting, MENU);
 
 	enableConvertMenuItems(curBuf->getEolFormat());
 	checkUnicodeMenuItems();


### PR DESCRIPTION
Fixes #5903 .

Suggested `change.log` entry if adopted:  "Remove restriction that file types must be known before enabling the 'View Current File In...' menu items; all (saved) files are now viewable in the browsers."