### PR TITLE
Implements native Win32 API file access and uses it to write user files

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -34,6 +34,7 @@
 
 #include "StaticDialog.h"
 
+#include "FileInterface.h"
 #include "Common.h"
 #include "../Utf8.h"
 #include <Parameters.h>
@@ -124,20 +125,19 @@ generic_string relativeFilePathToFullFilePath(const TCHAR *relativeFilePath)
 
 void writeFileContent(const TCHAR *file2write, const char *content2write)
 {
-	FILE *f = generic_fopen(file2write, TEXT("w+"));
-	fwrite(content2write, sizeof(content2write[0]), strlen(content2write), f);
-	fflush(f);
-	fclose(f);
+	CFile file(file2write, CFile::Mode::WRITE);
+
+	if (file.IsOpened())
+		file.Write(content2write, static_cast<long>(strlen(content2write)));
 }
 
 
 void writeLog(const TCHAR *logFileName, const char *log2write)
 {
-	FILE *f = generic_fopen(logFileName, TEXT("a+"));
-	fwrite(log2write, sizeof(log2write[0]), strlen(log2write), f);
-	fputc('\n', f);
-	fflush(f);
-	fclose(f);
+	CFile file(logFileName, CFile::Mode::APPEND);
+
+	if (file.IsOpened())
+		file.Write(log2write, static_cast<long>(strlen(log2write)));
 }
 
 

--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -1,0 +1,153 @@
+// This file is part of Notepad++ project
+// Copyright (C)2019 Don HO <don.h@free.fr>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// Note that the GPL places important restrictions on "derived works", yet
+// it does not provide a detailed definition of that term.  To avoid
+// misunderstandings, we consider an application to constitute a
+// "derivative work" for the purpose of this license if it does any of the
+// following:
+// 1. Integrates source code from Notepad++.
+// 2. Integrates/includes/aggregates Notepad++ into a proprietary executable
+//    installer, such as those produced by InstallShield.
+// 3. Links to a library or executes a program that does any of the above.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+
+#include "FileInterface.h"
+
+
+CFile::CFile(const char *fname, Mode fmode) : _hMode(fmode)
+{
+	if (fname)
+	{
+		DWORD access, share, disp, attrib;
+		fillCreateParams(access, share, disp, attrib);
+
+		_hFile = ::CreateFileA(fname, access, share, NULL, disp, attrib, NULL);
+	}
+
+	if ((_hFile != INVALID_HANDLE_VALUE) && (_hMode == Mode::APPEND))
+	{
+		LARGE_INTEGER offset;
+		offset.QuadPart = 0;
+
+		::SetFilePointerEx(_hFile, offset, NULL, FILE_END);
+	}
+}
+
+
+CFile::CFile(const wchar_t *fname, Mode fmode) : _hMode(fmode)
+{
+	if (fname)
+	{
+		DWORD access, share, disp, attrib;
+		fillCreateParams(access, share, disp, attrib);
+
+		_hFile = ::CreateFileW(fname, access, share, NULL, disp, attrib, NULL);
+	}
+
+	if ((_hFile != INVALID_HANDLE_VALUE) && (_hMode == Mode::APPEND))
+	{
+		LARGE_INTEGER offset;
+		offset.QuadPart = 0;
+
+		::SetFilePointerEx(_hFile, offset, NULL, FILE_END);
+	}
+}
+
+
+void CFile::Close()
+{
+	if (IsOpened())
+	{
+		if (_written)
+		{
+			::SetEndOfFile(_hFile);
+			::FlushFileBuffers(_hFile);
+		}
+
+		::CloseHandle(_hFile);
+
+		_hFile = INVALID_HANDLE_VALUE;
+	}
+}
+
+
+int_fast64_t CFile::GetSize()
+{
+	LARGE_INTEGER r;
+	r.QuadPart = -1;
+
+	if (IsOpened())
+		::GetFileSizeEx(_hFile, &r);
+
+	return static_cast<int_fast64_t>(r.QuadPart);
+}
+
+
+long CFile::Read(void *rbuf, long buf_size)
+{
+	if (!IsOpened() || (rbuf == nullptr) || (buf_size <= 0))
+		return 0;
+
+	DWORD bytes_read = 0;
+
+	if (::ReadFile(_hFile, rbuf, static_cast<DWORD>(buf_size), &bytes_read, NULL) == FALSE)
+		return -1;
+
+	return static_cast<long>(bytes_read);
+}
+
+
+bool CFile::Write(const void *wbuf, long buf_size)
+{
+	if (!IsOpened() || (wbuf == nullptr) || (buf_size <= 0) || ((_hMode != Mode::WRITE) && (_hMode != Mode::APPEND)))
+		return false;
+
+	DWORD bytes_written = 0;
+
+	if (::WriteFile(_hFile, wbuf, static_cast<DWORD>(buf_size), &bytes_written, NULL) == FALSE)
+		return false;
+
+	if (!_written && (bytes_written != 0))
+		_written = true;
+
+	return (static_cast<long>(bytes_written) == buf_size);
+}
+
+
+// Helper function to auto-fill CreateFile params optimized for Notepad++ usage.
+void CFile::fillCreateParams(DWORD &access, DWORD &share, DWORD &disp, DWORD &attrib)
+{
+	access	= GENERIC_READ;
+	attrib	= FILE_ATTRIBUTE_NORMAL | FILE_FLAG_POSIX_SEMANTICS; // Distinguish between upper/lower case in name
+
+	if (_hMode == Mode::READ)
+	{
+		share	=	FILE_SHARE_READ;
+		disp	=	OPEN_EXISTING; // Open only if file exists and is not locked by other process
+
+		attrib	|=	FILE_FLAG_SEQUENTIAL_SCAN; // Optimize caching for sequential read
+	}
+	else
+	{
+		share	=	0;
+		disp	=	OPEN_ALWAYS; // Open existing file for writing without destroying it or create new
+
+		access	|=	GENERIC_WRITE;
+		attrib	|=	FILE_FLAG_WRITE_THROUGH; // Write cached data directly to disk (no lazy writer)
+	}
+}

--- a/PowerEditor/src/MISC/Common/FileInterface.h
+++ b/PowerEditor/src/MISC/Common/FileInterface.h
@@ -1,0 +1,76 @@
+// This file is part of Notepad++ project
+// Copyright (C)2019 Don HO <don.h@free.fr>
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// Note that the GPL places important restrictions on "derived works", yet
+// it does not provide a detailed definition of that term.  To avoid
+// misunderstandings, we consider an application to constitute a
+// "derivative work" for the purpose of this license if it does any of the
+// following:
+// 1. Integrates source code from Notepad++.
+// 2. Integrates/includes/aggregates Notepad++ into a proprietary executable
+//    installer, such as those produced by InstallShield.
+// 3. Links to a library or executes a program that does any of the above.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+
+#pragma once
+
+#include <windows.h>
+#include <tchar.h>
+#include <cstdint>
+
+
+class CFile
+{
+public:
+	enum class Mode
+	{
+		READ,
+		WRITE,
+		APPEND
+	};
+
+	CFile(const char *fname, Mode fmode = Mode::READ);
+	CFile(const wchar_t *fname, Mode fmode = Mode::READ);
+
+	~CFile()
+	{
+		Close();
+	}
+
+	bool IsOpened()
+	{
+		return (_hFile != INVALID_HANDLE_VALUE);
+	}
+
+	void Close();
+
+	int_fast64_t GetSize();
+
+	long Read(void *rbuf, long buf_size);
+	bool Write(const void *wbuf, long buf_size);
+
+
+private:
+	CFile(const CFile&) = delete;
+	CFile& operator=(const CFile&) = delete;
+
+	void fillCreateParams(DWORD &access, DWORD &share, DWORD &disp, DWORD &attrib);
+
+	HANDLE	_hFile		{INVALID_HANDLE_VALUE};
+	Mode	_hMode		{Mode::READ};
+	bool	_written	{false};
+};

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -212,7 +212,7 @@ public:
     void saveUserDefineLangs();
     void saveShortcuts();
 	void saveSession(const Session & session);
-	void saveCurrentSession();
+	void saveCurrentSession(bool postIt = false);
 	void saveFindHistory();
 
 	void getCurrentOpenedFiles(Session& session, bool includUntitledDoc = false);

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2125,7 +2125,10 @@ void Notepad_plus::saveSession(const Session & session)
 }
 
 
-void Notepad_plus::saveCurrentSession()
+void Notepad_plus::saveCurrentSession(bool postIt)
 {
-	::PostMessage(_pPublicInterface->getHSelf(), NPPM_INTERNAL_SAVECURRENTSESSION, 0, 0);
+	if (postIt)
+		::PostMessage(_pPublicInterface->getHSelf(), NPPM_INTERNAL_SAVECURRENTSESSION, 0, 0);
+	else
+		::SendMessage(_pPublicInterface->getHSelf(), NPPM_INTERNAL_SAVECURRENTSESSION, 0, 0);
 }

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -36,6 +36,7 @@
 #include "ScintillaEditView.h"
 #include "EncodingMapper.h"
 #include "uchardet.h"
+#include "FileInterface.h"
 
 static const int blockSize = 128 * 1024 + 4;
 static const int CR = 0x0D;
@@ -866,12 +867,11 @@ bool FileManager::backupCurrentBuffer()
 				::SetFileAttributes(fullpath, dwFileAttribs);
 			}
 
-			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wb"));
-			if (fp)
+			if (UnicodeConvertor.fopen(fullpath))
 			{
 				int lengthDoc = _pNotepadPlus->_pEditView->getCurrentDocLen();
 				char* buf = (char*)_pNotepadPlus->_pEditView->execute(SCI_GETCHARACTERPOINTER);	//to get characters directly from Scintilla buffer
-				size_t items_written = 0;
+				long items_written = 0;
 				if (encoding == -1) //no special encoding; can be handled directly by Utf8_16_Write
 				{
 					items_written = UnicodeConvertor.fwrite(buf, lengthDoc);
@@ -991,14 +991,13 @@ bool FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool isCopy, g
 
 	int encoding = buffer->getEncoding();
 
-	FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wb"));
-	if (fp)
+	if (UnicodeConvertor.fopen(fullpath))
 	{
 		_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, buffer->_doc);	//generate new document
 
 		int lengthDoc = _pscratchTilla->getCurrentDocLen();
 		char* buf = (char*)_pscratchTilla->execute(SCI_GETCHARACTERPOINTER);	//to get characters directly from Scintilla buffer
-		size_t items_written = 0;
+		long items_written = 0;
 		if (encoding == -1) //no special encoding; can be handled directly by Utf8_16_Write
 		{
 			items_written = UnicodeConvertor.fwrite(buf, lengthDoc);
@@ -1477,11 +1476,8 @@ BufferID FileManager::getBufferFromDocument(Document doc)
 
 bool FileManager::createEmptyFile(const TCHAR * path)
 {
-	FILE * file = generic_fopen(path, TEXT("wb"));
-	if (!file)
-		return false;
-	fclose(file);
-	return true;
+	CFile file(path, CFile::Mode::WRITE);
+	return file.IsOpened();
 }
 
 

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -31,6 +31,10 @@
 #pragma warning(disable: 4514) // nreferenced inline function has been removed
 #endif
 
+#include <memory>
+#include "FileInterface.h"
+
+
 class Utf8_16 {
 public:
 	typedef unsigned short utf16; // 16 bits
@@ -116,7 +120,6 @@ public:
 	size_t getNewSize() const { return m_nNewBufSize; }
 
 	UniMode getEncoding() const { return m_eEncoding; }
-	size_t calcCurPos(size_t pos);
     static UniMode determineEncoding(const unsigned char *buf, size_t bufLen);
 
 protected:
@@ -145,17 +148,16 @@ public:
 
 	void setEncoding(UniMode eType);
 
-	FILE * fopen(const TCHAR *_name, const TCHAR *_type);
-	size_t fwrite(const void* p, size_t _size);
-	void   fclose();
+	bool fopen(const TCHAR *name);
+	long fwrite(const void* p, long _size);
+	void fclose();
 
 	size_t convert(char* p, size_t _size);
 	char* getNewBuf() { return reinterpret_cast<char*>(m_pNewBuf); }
-	size_t calcCurPos(size_t pos);
 
 protected:
 	UniMode m_eEncoding;
-	FILE* m_pFile;
+	std::unique_ptr<CFile> m_pFile;
 	ubyte* m_pNewBuf;
 	size_t m_nBufSize;
 	bool m_bFirstWrite;

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -289,6 +289,7 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClCompile Include="..\src\WinControls\ColourPicker\ColourPopup.cpp" />
     <ClCompile Include="..\src\ScitillaComponent\columnEditor.cpp" />
     <ClCompile Include="..\src\MISC\Common\Common.cpp" />
+    <ClCompile Include="..\src\MISC\Common\FileInterface.cpp" />
     <ClCompile Include="..\src\WinControls\ContextMenu\ContextMenu.cpp" />
     <ClCompile Include="..\src\WinControls\PluginsAdmin\pluginsAdmin.cpp" />
     <ClCompile Include="..\src\WinControls\TabBar\ControlsTab.cpp" />
@@ -558,6 +559,7 @@ copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
     <ClInclude Include="..\src\WinControls\ColourPicker\ColourPopup.h" />
     <ClInclude Include="..\src\ScitillaComponent\columnEditor.h" />
     <ClInclude Include="..\src\MISC\Common\Common.h" />
+    <ClInclude Include="..\src\MISC\Common\FileInterface.h" />
     <ClInclude Include="..\src\WinControls\ContextMenu\ContextMenu.h" />
     <ClInclude Include="..\src\WinControls\PluginsAdmin\pluginsAdmin.h" />
     <ClInclude Include="..\src\WinControls\PluginsAdmin\pluginsAdminRes.h" />


### PR DESCRIPTION
Fixes #5664 and hopefully #6133 (config and session files are excluded because TinyXML lib still uses CRT file APIs)