### PR TITLE
Fix to tab clicks under multi-line mode

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -586,6 +586,9 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 
 		case WM_LBUTTONDOWN :
 		{
+			_dragRefPoint.x = LOWORD(lParam);
+			_dragRefPoint.y = HIWORD(lParam);
+
 			if (_drawTabCloseButton)
 			{
 				int xPos = LOWORD(lParam);
@@ -633,15 +636,18 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 
 		case WM_MOUSEMOVE :
 		{
+			POINT p;
+			p.x = LOWORD(lParam);
+			p.y = HIWORD(lParam);
+
 			if (_mightBeDragging && !_isDragging)
 			{
 				// Grrr! Who has stolen focus and eaten the WM_LBUTTONUP?!
 				if (GetKeyState(VK_LBUTTON) >= 0)
 				{
 					_mightBeDragging = false;
-					_dragCount = 0;
 				}
-				else if (++_dragCount > 2)
+				else if (_dragRefPoint.x != p.x || _dragRefPoint.y != p.y)
 				{
 					int tabFocused = static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURFOCUS, 0, 0));
 					int tabSelected = static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0));
@@ -663,10 +669,6 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 					}
 				}
 			}
-
-			POINT p;
-			p.x = LOWORD(lParam);
-			p.y = HIWORD(lParam);
 
 			if (_isDragging)
 			{
@@ -771,7 +773,6 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 		case WM_LBUTTONUP :
 		{
 			_mightBeDragging = false;
-			_dragCount = 0;
 
 			int xPos = LOWORD(lParam);
 			int yPos = HIWORD(lParam);

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -224,7 +224,7 @@ protected:
     static bool _doDragNDrop;
 	// drag N drop members
 	bool _mightBeDragging = false;
-	int _dragCount = 0;
+	POINT _dragRefPoint = {LONG_MAX, LONG_MAX};
 	bool _isDragging = false;
 	bool _isDraggingInside = false;
     int _nSrcTab = -1;


### PR DESCRIPTION
MOUSEMOVE message could be sent continuously while a mouse button is held down, even if the mouse isn't moving, so using _dragCount is to determine whether we are dragging is unsafe.

This addresses at least some of the issues mentioned here: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/4339

Previously, merely clicking (without dragging) a tab could cause unexpected tab switching, sometimes corruption (tab becoming blank/inaccessible), and eventually crashing.