### PR TITLE
Regression: Fixed command line parsing logic error

### DIFF
--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -299,8 +299,8 @@ PWSTR advanceCmdLine(PWSTR pCmdLine, const generic_string& string)
 		}
 	
 		// Match the substring only if it matched an entire substring		
-		if ( (ignoredString == pCmdLine || iswspace(*(ignoredString-1)) ) && // Check start
-			 (iswspace(*(ignoredString+len)) || *(ignoredString+len) == '\0') )
+		if ((ignoredString == pCmdLine || iswspace(*(ignoredString - 1))) && // Check start
+			(iswspace(*(ignoredString + len)) || *(ignoredString + len) == '\0' || *(ignoredString + len) == '"'))
 		{
 			ignoredString += len;
 


### PR DESCRIPTION
Fixed #6211 

## Root cause:
When you double click a file (where NPP has already replaced original Windows Notepad.exe) command like something like below is generated - 

`-notepadStyleCmdline -z "C:\WINDOWS\system32\NOTEPAD.EXE" F:\FakePath\PowerEditor\bin\change.log`

After processing this command line, final command line is left as `" F:\FakePath\PowerEditor\bin\change.log` while others are ignored. **Notice, quote `"` here just before the actual file path.**

Later on, MS PAI `::PathIsRelative` treats it as relative path because of quote `"` rather considering single file. It is expected too as per input to this API.

Now, notepad++ tries to open all the file from path `F:\FakePath\PowerEditor\bin\` (in above case) along with file `F:\FakePath\PowerEditor\bin\change.log`.