### PR TITLE
Fix initialization of _monospacedFontFinfDlg parameter

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5077,8 +5077,8 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 				_nppGUI._backSlashIsEscapeCharacterForSql = false;
 
 			const TCHAR * optNameMonoFont = element->Attribute(TEXT("monospacedFontFinfDlg"));
-			if (optNameMonoFont && !lstrcmp(optNameMonoFont, TEXT("no")))
-				_nppGUI._monospacedFontFinfDlg = false;
+			if (optNameMonoFont)
+				_nppGUI._monospacedFontFinfDlg = (lstrcmp(optNameMonoFont, TEXT("yes")) == 0);
 
 			const TCHAR * optNameNewStyleSaveDlg = element->Attribute(TEXT("newStyleSaveDlg"));
 			if (optNameNewStyleSaveDlg)

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5076,9 +5076,9 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			if (optNameBackSlashEscape && !lstrcmp(optNameBackSlashEscape, TEXT("no")))
 				_nppGUI._backSlashIsEscapeCharacterForSql = false;
 
-			const TCHAR * optNameMonoFont = element->Attribute(TEXT("monospacedFontFinfDlg"));
+			const TCHAR * optNameMonoFont = element->Attribute(TEXT("monospacedFontFindDlg"));
 			if (optNameMonoFont)
-				_nppGUI._monospacedFontFinfDlg = (lstrcmp(optNameMonoFont, TEXT("yes")) == 0);
+				_nppGUI._monospacedFontFindDlg = (lstrcmp(optNameMonoFont, TEXT("yes")) == 0);
 
 			const TCHAR * optNameNewStyleSaveDlg = element->Attribute(TEXT("newStyleSaveDlg"));
 			if (optNameNewStyleSaveDlg)
@@ -5836,7 +5836,7 @@ void NppParameters::createXmlTreeFromGUIParams()
 
 		GUIConfigElement->SetAttribute(TEXT("fileSwitcherWithoutExtColumn"), _nppGUI._fileSwitcherWithoutExtColumn ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("backSlashIsEscapeCharacterForSql"), _nppGUI._backSlashIsEscapeCharacterForSql ? TEXT("yes") : TEXT("no"));
-		GUIConfigElement->SetAttribute(TEXT("monospacedFontFinfDlg"), _nppGUI._monospacedFontFinfDlg ? TEXT("yes") : TEXT("no"));
+		GUIConfigElement->SetAttribute(TEXT("monospacedFontFindDlg"), _nppGUI._monospacedFontFindDlg ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("newStyleSaveDlg"), _nppGUI._useNewStyleSaveDlg ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("isFolderDroppedOpenFiles"), _nppGUI._isFolderDroppedOpenFiles ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("docPeekOnTab"), _nppGUI._isDocPeekOnTab ? TEXT("yes") : TEXT("no"));

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -824,7 +824,7 @@ struct NppGUI final
 	char _rightmostDelimiter = ')';
 	bool _delimiterSelectionOnEntireDocument = false;
 	bool _backSlashIsEscapeCharacterForSql = true;
-	bool _monospacedFontFinfDlg = false;
+	bool _monospacedFontFindDlg = false;
 	bool _isWordCharDefault = true;
 	std::string _customWordChars;
 

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -794,7 +794,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 
 		case WM_INITDIALOG :
 		{
-			if ((NppParameters::getInstance()).getNppGUI()._monospacedFontFinfDlg)
+			if ((NppParameters::getInstance()).getNppGUI()._monospacedFontFindDlg)
 			{
 				HWND hFindCombo = ::GetDlgItem(_hSelf, IDFINDWHAT);
 				HWND hReplaceCombo = ::GetDlgItem(_hSelf, IDREPLACEWITH);

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -913,7 +913,7 @@ INT_PTR CALLBACK SettingsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 			::SendDlgItemMessage(_hSelf, IDC_CHECK_MIN2SYSTRAY, BM_SETCHECK, nppGUI._isMinimizedToTray, 0);
 			::SendDlgItemMessage(_hSelf, IDC_CHECK_DETECTENCODING, BM_SETCHECK, nppGUI._detectEncoding, 0);
             ::SendDlgItemMessage(_hSelf, IDC_CHECK_AUTOUPDATE, BM_SETCHECK, nppGUI._autoUpdateOpt._doAutoUpdate, 0);
-			::SendDlgItemMessage(_hSelf, IDC_CHECK_MONOSPACEDFONT_FINDDLG, BM_SETCHECK, nppGUI._monospacedFontFinfDlg, 0);
+			::SendDlgItemMessage(_hSelf, IDC_CHECK_MONOSPACEDFONT_FINDDLG, BM_SETCHECK, nppGUI._monospacedFontFindDlg, 0);
 			::SendDlgItemMessage(_hSelf, IDC_CHECK_ENABLEDOCPEEKER, BM_SETCHECK, nppGUI._isDocPeekOnTab ? BST_CHECKED : BST_UNCHECKED, 0);
 			::SendDlgItemMessage(_hSelf, IDC_CHECK_ENABLEDOCPEEKONMAP, BM_SETCHECK, nppGUI._isDocPeekOnMap ? BST_CHECKED : BST_UNCHECKED, 0);
 
@@ -1074,7 +1074,7 @@ INT_PTR CALLBACK SettingsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 
 				case IDC_CHECK_MONOSPACEDFONT_FINDDLG:
 				{
-					nppGUI._monospacedFontFinfDlg = isCheckedOrNot(IDC_CHECK_MONOSPACEDFONT_FINDDLG);
+					nppGUI._monospacedFontFindDlg = isCheckedOrNot(IDC_CHECK_MONOSPACEDFONT_FINDDLG);
 					return TRUE;
 				}
 


### PR DESCRIPTION
Fixes the initialization of the _monospacedFontFinfDlg parameter, which was always set to false.

Also fixes typo **`FinfDlg`** ==> **`FindDlg`** (in a separate commit for convenience of review).
