### PR TITLE
Capitalized first character of 'wrap' in 'Word wrap'

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -224,7 +224,7 @@
                     <Item id="44010" name="Fold All"/>
                     <Item id="44019" name="Show All Characters"/>
                     <Item id="44020" name="Show Indent Guide"/>
-                    <Item id="44022" name="Word wrap"/>
+                    <Item id="44022" name="Word Wrap"/>
                     <Item id="44023" name="Zoom &amp;In (Ctrl+Mouse Wheel Up)"/>
                     <Item id="44024" name="Zoom &amp;Out (Ctrl+Mouse Wheel Down)"/>
                     <Item id="44025" name="Show White Space and TAB"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -220,7 +220,7 @@
                     <Item id="44010" name="Fold All"/>
                     <Item id="44019" name="Show All Characters"/>
                     <Item id="44020" name="Show Indent Guide"/>
-                    <Item id="44022" name="Word wrap"/>
+                    <Item id="44022" name="Word Wrap"/>
                     <Item id="44023" name="Zoom &amp;In (Ctrl+Mouse Wheel Up)"/>
                     <Item id="44024" name="Zoom &amp;Out (Ctrl+Mouse Wheel Down)"/>
                     <Item id="44025" name="Show White Space and TAB"/>

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -510,7 +510,7 @@ BEGIN
 			MENUITEM "Move Tab Forward",		IDM_VIEW_TAB_MOVEFORWARD
 			MENUITEM "Move Tab Backward",		IDM_VIEW_TAB_MOVEBACKWARD
 		END
-        MENUITEM "Word wrap",                   IDM_VIEW_WRAP
+        MENUITEM "Word Wrap",                   IDM_VIEW_WRAP
         MENUITEM "Focus on Another View",         IDM_VIEW_SWITCHTO_OTHER_VIEW
         MENUITEM "Hide Lines",                  IDM_VIEW_HIDELINES
         MENUITEM SEPARATOR


### PR DESCRIPTION
All of the items have uppercase characters excluding some cases like 'Folder as Workspace'. So I thought it would be better to change 'Word wrap' to 'Word Wrap' to unify things up a bit.
Before:
![Screenshot (67)](https://user-images.githubusercontent.com/41439841/67432820-9153c880-f604-11e9-81de-9290770362ee.png)
After:
![Screenshot (66)](https://user-images.githubusercontent.com/41439841/67432832-9d3f8a80-f604-11e9-8987-d8cf10014792.png)
