### PR TITLE
Fix for multi-line tabBar click activation #6274

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -599,8 +599,20 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 				}
 			}
 
-            ::CallWindowProc(_tabBarDefaultProc, hwnd, Message, wParam, lParam);
-			int currentTabOn = static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0));
+			if (::GetWindowLongPtr(_hSelf, GWL_STYLE) & TCS_BUTTONS)
+			{
+				int nTab = getTabIndexAt(LOWORD(lParam), HIWORD(lParam));
+				if (nTab != -1 && nTab != static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0)))
+				{
+					setActiveTab(nTab); // executes when Multi-line TabBar is enabled
+				}
+			}
+			else
+			{
+				int currentTabOn = static_cast<int32_t>(::SendMessage(_hSelf, TCM_GETCURSEL, 0, 0));
+				notify(NM_CLICK, currentTabOn);
+			}
+			::CallWindowProc(_tabBarDefaultProc, hwnd, Message, wParam, lParam);
 
 			if (wParam == 2)
 				return TRUE;
@@ -610,9 +622,7 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 				_mightBeDragging = true;
             }
 
-			notify(NM_CLICK, currentTabOn);
-
-            return TRUE;
+			return TRUE;
 		}
 
 		case WM_RBUTTONDOWN :	//rightclick selects tab aswell


### PR DESCRIPTION
If Multi-line TabBar is enabled, mouse right click for tab selection still works fine without any change-
```
case WM_RBUTTONDOWN :	//rightclick selects tab aswell
        setActiveTab(nTab);
```
**Regarding Issue:**
I can repro. this issue very easily, I hope you too. If not, freely ask for help.
**Regarding PR:**
This is a quick fix kinda. I debugged a lot but couldn't find the root cause.
```
-> TabBar.cpp Line-602
-> Under case WM_LBUTTONDOWN :
-> ::CallWindowProc(_tabBarDefaultProc, hwnd, Message, wParam, lParam);
```
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/a156bf10529dad33714a73d825529d3ce5ff5a28/PowerEditor/src/WinControls/TabBar/TabBar.cpp#L602
This statement immediately switches tab, but only in single line tab mode, not multiline. Weird!

I added additional code snippet, which will be executed ONLY if end-user performs LDOWN while Multi-line is enabled. Not changing any previous functionality(LDOWN on Multi-line disabled still works same)
I have done rigorous testing from my side. It will be good if someone does the final testing.
Or, if someone has a better solution(especially after finding the root cause of problem), will be happy to know the correct approach and solution. :)