### PR TITLE
remove unnecessary delete fail msg

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1629,12 +1629,6 @@ bool Notepad_plus::fileDelete(BufferID id)
 
 		if (!MainFileManager.deleteFile(bufferID))
 		{
-			_nativeLangSpeaker.messageBox("DeleteFileFailed",
-				_pPublicInterface->getHSelf(),
-				TEXT("Delete File failed"),
-				TEXT("Delete File"),
-				MB_OK);
-
 			scnN.nmhdr.code = NPPN_FILEDELETEFAILED;
 			_pluginsManager.notify(&scnN);
 


### PR DESCRIPTION
Resolves issue- 'Move to Recycle Bin' > select 'No' -- "Delete Fail" dialog seems unnecessary #7499