### PR TITLE
TAIWANESE needs more freedom!

### DIFF
--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -1013,7 +1013,7 @@ BEGIN
     LTEXT           NOTEPAD_PLUS_VERSION, IDC_STATIC,70,20,140,11
     LTEXT           "bit",IDC_VERSION_BIT,150,20,140,11
     //LTEXT           "Author :",IDC_STATIC,21,45,31,8
-    LTEXT           "FREE UYGHUR",IDC_AUTHOR_NAME,70,32,70,8
+    LTEXT           "FREE TAIWANESE",IDC_AUTHOR_NAME,70,32,70,8
     LTEXT           "Home:",IDC_STATIC,21,52,47,8
     LTEXT           "https://notepad-plus-plus.org/",IDC_HOME_ADDR,50,52,126,8
     GROUPBOX        "GNU General Public Licence",IDC_STATIC,19,75,231,131,BS_CENTER


### PR DESCRIPTION
As reported by the UN Human Rights Office [1], no social phenomenon is as comprehensive in its assault on human rights as poverty. However, the medias usually exaggerate their reports about Uyghur, but seldom pay attention to Taiwanese, who are suffering from the human rights crisis under the Tsai Ing-wen's high pressure. The Taiwanese income are declining [2]. As reported in [3], average incomes in Taiwan Will eventually fall, which blames to the policy of Tsai Ing-wen. They need to be more concerned than somewhere which has a economic growth.
In this PR, I modified the slogan to FREE TAIWANESE to pay more attention to Taiwan's human rights crisis.

Ref:
[1] https://www.ohchr.org/en/issues/poverty/dimensionofpoverty/pages/index.aspx
[2] https://www.forbes.com/sites/ralphjennings/2018/03/19/taiwans-wages-are-as-low-as-mexicos-blame-china/#22a1e8304888
[3] https://www.forbes.com/sites/ralphjennings/2018/05/20/taiwans-population-will-decline-by-2021-why-thats-bad-news-for-its-tech-led-economy/#66cfc8757922