### PR TITLE
Fixed #7508 (kind of regression)

### DIFF
--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -306,7 +306,11 @@ void DebugInfoDlg::doDialog()
 
 void DoSaveOrNotBox::doDialog(bool isRTL)
 {
-	
+	if (::IsIconic(_hParent))
+	{
+		::ShowWindow(_hParent, SW_RESTORE);
+	}
+
 	if (isRTL)
 	{
 		DLGTEMPLATE *pMyDlgTemplate = NULL;


### PR DESCRIPTION
Fixed issue #7508.
This issue was introduced in commit 3f7956dc1bd16445f031a38bca8aa9e72806a408

**Root cause:** 
When main windows is minimized and user tries to close it from taskbar, then save confirmation dialog does not come front. Why? Reason is still unknown, but it seems either there is some problem in constructing modal dialog using `DialogBoxParam` or may be problem with Style/styleEX used in rc of `IDD_DOSAVEORNOTBOX` dialog.

But bringing main windows front (if minimized) and then showing save confirmation, resolves the reported issue. I have verified on Win10 x64.
