### PR TITLE
remove unnecessary delete fail msg

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1629,12 +1629,6 @@ bool Notepad_plus::fileDelete(BufferID id)
 
 		if (!MainFileManager.deleteFile(bufferID))
 		{
-			_nativeLangSpeaker.messageBox("DeleteFileFailed",
-				_pPublicInterface->getHSelf(),
-				TEXT("Delete File failed"),
-				TEXT("Delete File"),
-				MB_OK);
-
 			scnN.nmhdr.code = NPPN_FILEDELETEFAILED;
 			_pluginsManager.notify(&scnN);
 

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -739,7 +739,15 @@ bool FileManager::deleteFile(BufferID id)
 	fileOpStruct.hNameMappings         = NULL;
 	fileOpStruct.lpszProgressTitle     = NULL;
 
-	return SHFileOperation(&fileOpStruct) == 0;
+	try
+	{
+		return SHFileOperation(&fileOpStruct) == 0;
+	}
+	catch (...)
+	{
+		::MessageBox(NULL, TEXT("Move to Recycle Bin exception!"), TEXT(""), MB_OK);
+		return false;
+	}
 }
 
 


### PR DESCRIPTION
Resolves issue- "Delete Fail" dialog seems unnecessary if user selects 'no' #7499

Solution is to only show dialog in case of exception.
To reproduce the issue- See my detailed comment- https://github.com/notepad-plus-plus/notepad-plus-plus/issues/7499#issuecomment-551215145