### PR TITLE
fix to remove extra confirm dialog

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1611,15 +1611,7 @@ bool Notepad_plus::fileDelete(BufferID id)
 	Buffer * buf = MainFileManager.getBufferByID(bufferID);
 	const TCHAR *fileNamePath = buf->getFullPathName();
 
-	winVer winVersion = (NppParameters::getInstance()).getWinVersion();
-	bool goAhead = true;
-	if (winVersion >= WV_WIN8 || winVersion == WV_UNKNOWN)
-	{
-		// Windows 8 (and version afer?) has no system alert, so we ask user's confirmation
-		goAhead = (doDeleteOrNot(fileNamePath) == IDYES);
-	}
-
-	if (goAhead)
+	if (doDeleteOrNot(fileNamePath) == IDYES)
 	{
 		SCNotification scnN;
 		scnN.nmhdr.code = NPPN_FILEBEFOREDELETE;

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -734,7 +734,7 @@ bool FileManager::deleteFile(BufferID id)
 	fileOpStruct.pFrom = fileNamePath.c_str();
 	fileOpStruct.pTo = NULL;
 	fileOpStruct.wFunc = FO_DELETE;
-	fileOpStruct.fFlags = FOF_ALLOWUNDO;
+	fileOpStruct.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMATION;
 	fileOpStruct.fAnyOperationsAborted = false;
 	fileOpStruct.hNameMappings         = NULL;
 	fileOpStruct.lpszProgressTitle     = NULL;


### PR DESCRIPTION
Resolves issue- "Delete Fail" dialog seems unnecessary if user selects 'no' #7499

**To reproduce the issue, See my detailed comment- https://github.com/notepad-plus-plus/notepad-plus-plus/issues/7499#issuecomment-551215145**

**Change1-** Adding _FOF_NOCONFIRMATION_
So that Windows confirm dialog never appears irrespective of recycle bin property- "Display delete confirmation dialog"
This makes NPP showing ONLY 1 confirm dialog(it's own) but not of windows.

**Change2-** Removing check for _if (winVersion >= WV_WIN8 || winVersion == WV_UNKNOWN)_
Comment here is wrong- https://github.com/notepad-plus-plus/notepad-plus-plus/blob/9bba1291d4cb7dd3c4255a368424de0d2df0b92b/PowerEditor/src/NppIO.cpp#L1618
Win8 or higher is no different than Win7 for this recycle bin property.
Whoever added this code must be having "Display delete confirmation dialog" property enabled in Win7 but after migrating system to >=Win8, property was disabled, leading to this faulty observation.

**Overall result of this PR-
Always show NPP's own confirm dialog(and nothing else) irrespective of recycle bin property "Display delete confirmation dialog" enabled or disabled.**
This will also fix the issue of "Delete Fail" dialog appearing on user selection "No" in case Windows confirm dialog appears. Now, "delete fail" dialog will appear only in case of exception.