### PR TITLE
[Fixed issue]: Open Explorer with Correct path in Folder as workspace

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -675,8 +675,11 @@ void FileBrowser::popupMenuCmd(int cmdID)
 			generic_string path = getNodePath(selectedNode);
 			if (::PathFileExists(path.c_str()))
 			{
-				TCHAR cmdStr[1024];
-				wsprintf(cmdStr, TEXT("explorer /select,\"%s\""), path.c_str());
+				TCHAR cmdStr[1024] = {};
+				if (getNodeType(selectedNode) == browserNodeType_file)
+					wsprintf(cmdStr, TEXT("explorer /select,\"%s\""), path.c_str());
+				else
+					wsprintf(cmdStr, TEXT("explorer \"%s\""), path.c_str());
 				Command cmd(cmdStr);
 				cmd.run(nullptr);
 			}


### PR DESCRIPTION
Fixed defect #5981.

### Current Behavior if selected node is
1. Folder path `/project/path/to/dir` :
    - **CMD here**: open `cmd` at **/project/path/to/dir**
    - **Explorer here**: open directory at **/project/path/to** and highlights folder **dir**

2. File path `/project/path/to/dir/sample.txt` :
     - **CMD here**: open `cmd` at **/project/path/to/dir**
     - **Explorer here**: open directory at **/project/path/to/dir** and highlights file **sample.txt**
## 
### New Behavior if selected node is
1. Folder path `/project/path/to/dir` :
    - **CMD here**: open `cmd` at **/project/path/to/dir**
    - **Explorer here**: open directory at **/project/path/to/dir**. (**This is the only change in behavior.**)

2. File path `/project/path/to/dir/sample.txt` :
     - **CMD here**: open `cmd` at **/project/path/to/dir**
     - **Explorer here**: open directory at **/project/path/to/dir** and highlights file **sample.txt**


Now similar to `**CMD here**, **Explorer here** will navigate to full path instead of parent folder.