### PR TITLE
Fix incorrect use of std::remove_if().

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -462,7 +462,8 @@ void Notepad_plus::command(int id)
 			if (nppGui._searchEngineChoice == nppGui.se_custom)
 			{
 				url = nppGui._searchEngineCustom;
-				remove_if(url.begin(), url.end(), _istspace);
+				auto newEnd = remove_if(url.begin(), url.end(), [](TCHAR c){ return _istspace(c); });
+				url.erase(newEnd, url.end());
 
 				auto httpPos = url.find(TEXT("http://"));
 				auto httpsPos = url.find(TEXT("https://"));


### PR DESCRIPTION
std::remove_if() will not erase elements from the underlying container, and since what remains outside of the new valid range is implementation defined we should be erasing those elements otherwise we are left with unspecified characters at the end of the URL.