### PR TITLE
Balance unbalanced GlobalLock/Unlock() pairs

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -377,7 +377,7 @@ void Notepad_plus::command(int id)
 								_pEditView->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
 								_pEditView->execute(SCI_ADDTEXT, *lpLen, reinterpret_cast<LPARAM>(lpchar));
 
-								GlobalUnlock(hglb);
+								GlobalUnlock(hglbLen);
 							}
 						}
 					}

--- a/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
+++ b/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
@@ -76,7 +76,8 @@ ClipboardData ClipboardHistoryPanel::getClipboadData()
 					clipboardData.push_back(static_cast<unsigned char>(lpchar[i]));
 				}
 			}
-			GlobalUnlock(hglb); 
+			GlobalUnlock(hglb);
+			GlobalUnlock(hglb);
 		}
 	}
 	CloseClipboard();

--- a/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
+++ b/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
@@ -64,7 +64,7 @@ ClipboardData ClipboardHistoryPanel::getClipboadData()
 						{
 							clipboardData.push_back(static_cast<unsigned char>(lpchar[i]));
 						}
-						GlobalUnlock(hglb); 
+						GlobalUnlock(hglbLen);
 					}
 				}
 			}


### PR DESCRIPTION
The commit messages explain the reason for both, but as mentioned in the title the `GlobalLock()`/`GlobalUnlock()` pairs needed balancing to avoid leaks.

Note that the double call to `GlobalUnlock()` was chosen over casting the result of `GlobalLock()` to two separate types to avoid a strict-aliasing violation.