### PR TITLE
Remove unnecessary macro checks

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FunctionCallTip.h
+++ b/PowerEditor/src/ScitillaComponent/FunctionCallTip.h
@@ -28,9 +28,7 @@
 #ifndef FUNCTIONCALLTIP_H
 #define FUNCTIONCALLTIP_H
 
-#ifndef SCINTILLA_EDIT_VIEW_H
 #include "ScintillaEditView.h"
-#endif //SCINTILLA_EDIT_VIEW_H
 
 typedef std::vector<const TCHAR *> stringVec;
 

--- a/PowerEditor/src/ScitillaComponent/Printer.h
+++ b/PowerEditor/src/ScitillaComponent/Printer.h
@@ -29,9 +29,7 @@
 #ifndef PRINTER_H
 #define PRINTER_H
 
-#ifndef SCINTILLA_EDIT_VIEW_H
 #include "ScintillaEditView.h"
-#endif //SCINTILLA_EDIT_VIEW_H
 
 
 struct NPP_RangeToFormat {

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
@@ -33,9 +33,7 @@
 #include "findCharsInRange_rc.h"
 #endif //FINDCHARSINRANGE_RC_H
 
-#ifndef SCINTILLA_EDIT_VIEW_H
 #include "ScintillaEditView.h"
-#endif //SCINTILLA_EDIT_VIEW_H
 
 class FindCharsInRangeDlg : public StaticDialog
 {


### PR DESCRIPTION
The macro `SCINTILLA_EDIT_VIEW_H` is never defined and the header it's guarding already has a `#pragma once` inside it so there's no need to check for it before including the header.