### PR TITLE
Remove some unnecessary string constructions

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -201,7 +201,7 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 
 	_notepad_plus_plus_core.getMatchedFileNames(localizationDir.c_str(), patterns, fileNames, false, false);
 	for (size_t i = 0, len = fileNames.size(); i < len; ++i)
-		localizationSwitcher.addLanguageFromXml(fileNames[i].c_str());
+		localizationSwitcher.addLanguageFromXml(fileNames[i]);
 
 	fileNames.clear();
 	ThemeSwitcher & themeSwitcher = nppParams.getThemeSwitcher();
@@ -217,7 +217,7 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	    _notepad_plus_plus_core.getMatchedFileNames(themeDir.c_str(), patterns, fileNames, false, false);
 	    for (size_t i = 0, len = fileNames.size() ; i < len ; ++i)
 	    {
-		    themeSwitcher.addThemeFromXml(fileNames[i].c_str());
+		    themeSwitcher.addThemeFromXml(fileNames[i]);
 	    }
     }
 
@@ -231,7 +231,7 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 		generic_string themeName( themeSwitcher.getThemeFromXmlFileName(fileNames[i].c_str()) );
 		if (! themeSwitcher.themeNameExists(themeName.c_str()) )
 		{
-			themeSwitcher.addThemeFromXml(fileNames[i].c_str());
+			themeSwitcher.addThemeFromXml(fileNames[i]);
 		}
 	}
 


### PR DESCRIPTION
The callees already take the parameters by reference so there's no need to construct temporaries in the caller.