### PR TITLE
Fix mistyped Item id in slovenian.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/slovenian.xml
+++ b/PowerEditor/installer/nativeLang/slovenian.xml
@@ -585,7 +585,7 @@
                     <Item id="21424" name="Odpri:"/>
                     <Item id="21425" name="Sredina:"/>
                     <Item id="21426" name="Zapri:"/>
-                    <Item id="21127" name="Slogovnik"/>				
+                    <Item id="21427" name="Slogovnik"/>
                 </Folder>
 				   <Keywords title="Seznam ključnih besed">
 						<Item id="22101" name="1. skupina"/>


### PR DESCRIPTION
If anyone who understands Slovenian would like to add the three missing items below, feel free to include this correction in your own PR.
```
<Item id="46300" name="Open User Defined Language folder..."/>

<Item subMenuId="language-userDefinedLanguage" name="User Defined Language"/>

<find-in-files-filter-tip value="Find in cpp, cxx, h, hxx &amp;&amp; hpp:
*.cpp *.cxx *.h *.hxx *.hpp

Find in all files except exe, obj &amp;&amp; log:
*.* !*.exe !*.obj !*.log"/>
```
