### PR TITLE
Update dead Link.

### DIFF
--- a/PowerEditor/src/contextMenu.xml
+++ b/PowerEditor/src/contextMenu.xml
@@ -4,7 +4,7 @@ By modifying this file, you can customize your context menu popuped as right cli
 It may be more convinient to access to your frequent used commands via context menu than via the top menu.
 
 Please check "How to Customize the Context Menu" on:
-http://docs.notepad-plus-plus.org/index.php/Context_Menu
+https://npp-user-manual.org/docs/config-files/#the-context-menu-contextmenu-xml
 -->
 <NotepadPlus>
     <ScintillaContextMenu>


### PR DESCRIPTION
"http://docs.notepad-plus-plus.org/index.php/Context_Menu" Is 404d.
Update to new documentation location:
"https://npp-user-manual.org/docs/config-files/#the-context-menu-contextmenu-xml"