### PR TITLE
Fix scintilla restoring wrapped buffer issue

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -946,6 +946,17 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			if (not notifyView)
 				return FALSE;
 
+			// Check if a restore position is needed. 
+			// Restoring a position must done after SCN_PAINTED notification so that it works in every circumstances (including wrapped large file)
+			if (_mainEditView.isPositionRestoreNeeded())
+			{
+				_mainEditView.restoreCurrentPosAfterPainted();
+			}
+			if (_subEditView.isPositionRestoreNeeded())
+			{
+				_subEditView.restoreCurrentPosAfterPainted();
+			}
+
 			// ViewMoveAtWrappingDisableFix: Disable wrapping messes up visible lines.
 			// Therefore save view position before in IDM_VIEW_WRAP and restore after SCN_PAINTED, as doc. says
 			if (_mainEditView.isWrapRestoreNeeded())

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2076,6 +2076,7 @@ bool NppParameters::getSessionFromXmlTree(TiXmlDocument *pSessionDoc, Session *p
 					(childNode->ToElement())->Attribute(TEXT("endPos"), &position._endPos);
 					(childNode->ToElement())->Attribute(TEXT("selMode"), &position._selMode);
 					(childNode->ToElement())->Attribute(TEXT("scrollWidth"), &position._scrollWidth);
+					(childNode->ToElement())->Attribute(TEXT("offset"), &position._offset);
 					MapPosition mapPosition;
 					int32_t mapPosVal;
 					const TCHAR *mapPosStr = (childNode->ToElement())->Attribute(TEXT("mapFirstVisibleDisplayLine"), &mapPosVal);
@@ -3120,6 +3121,7 @@ void NppParameters::writeSession(const Session & session, const TCHAR *fileName)
 				(fileNameNode->ToElement())->SetAttribute(TEXT("startPos"), viewSessionFiles[i]._startPos);
 				(fileNameNode->ToElement())->SetAttribute(TEXT("endPos"), viewSessionFiles[i]._endPos);
 				(fileNameNode->ToElement())->SetAttribute(TEXT("selMode"), viewSessionFiles[i]._selMode);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("offset"), viewSessionFiles[i]._offset);
 				(fileNameNode->ToElement())->SetAttribute(TEXT("lang"), viewSessionFiles[i]._langName.c_str());
 				(fileNameNode->ToElement())->SetAttribute(TEXT("encoding"), viewSessionFiles[i]._encoding);
 				(fileNameNode->ToElement())->SetAttribute(TEXT("userReadOnly"), (viewSessionFiles[i]._isUserReadOnly && !viewSessionFiles[i]._isMonitoring) ? TEXT("yes") : TEXT("no"));

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -136,6 +136,7 @@ struct Position
 	int _xOffset = 0;
 	int _selMode = 0;
 	int _scrollWidth = 1;
+	int _offset = 0;
 };
 
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -274,6 +274,7 @@ public:
 
 	void saveCurrentPos();
 	void restoreCurrentPos();
+	void restoreCurrentPosAfterPainted();
 
 	void beginOrEndSelect();
 	bool beginEndSelectedIsStarted() const {
@@ -632,6 +633,8 @@ public:
     void setTabSettings(Lang *lang);
 	bool isWrapRestoreNeeded() const {return _wrapRestoreNeeded;};
 	void setWrapRestoreNeeded(bool isWrapRestoredNeeded) {_wrapRestoreNeeded = isWrapRestoredNeeded;};
+	bool isPositionRestoreNeeded() const {return _positionRestoreNeeded;};
+
 
 	bool isCJK() const {
 		return ((_codepage == CP_CHINESE_TRADITIONAL) || (_codepage == CP_CHINESE_SIMPLIFIED) ||
@@ -668,6 +671,7 @@ protected:
 	int _codepage = CP_ACP;
 	bool _lineNumbersShown = false;
 	bool _wrapRestoreNeeded = false;
+	bool _positionRestoreNeeded = false;
 
 	typedef std::unordered_map<int, Style> StyleMap;
 	typedef std::unordered_map<BufferID, StyleMap*> BufferStyleMap;


### PR DESCRIPTION
Fix scintilla restoring wrapped buffer issue: If you switch between tabs, text jump to another lines.
It's an old bug, fixed in v7.5.9, but it had performance regression so it was reverted in v6.0.0.

It's been one year, and I'm back.
This works whatever the size of the file.
There isn't any performance regression because we don't use SCI_ENSUREVISIBLE scintilla command.

In case wrap option on, The restore position function is done in **twice** steps.

- First step: set selection, set anchor, set xoffset...
- Second step: once Scintilla has send the notification SCN_PAINTED, we can scroll several lines to set the first visible line to the correct wrapped line.

Keep in mind that Line wrapping is a background activity that takes time, specially for huge file.

Fixes #2078, #2576, #3570, #4825, #4881

Here is a video of the test https://youtu.be/LPcjKSV6GT4 

`