### PR TITLE
Fixed Function list in C++ does not detect functions with parameter comments containing parantheses (reopen of #4899) #5522

### DIFF
--- a/PowerEditor/src/functionList.xml
+++ b/PowerEditor/src/functionList.xml
@@ -176,6 +176,94 @@
 							|	(?s:\x27(?:[^\x27\x5C]|\x5C.)*\x27)             # String Literal - Single Quoted
 							"
 			>
+				<classRange
+					mainExpr    ="^[\t\x20]*(class|struct)[\t\x20]+\w+\s*(final)?\s*(:\s*(AAAAAAAAAAAAAAAAAAAAAAAAAAAA99)\s+\w+\s*)?\{"
+					openSymbole ="\{"
+					closeSymbole="\}"
+				>
+					<function
+						mainExpr="(?x)                                              # Utilize inline comments (see `RegEx - Pattern Modifiers`)
+								(?:                                                 # Declaration specifiers
+									\b
+									(?:
+											(?-i:auto|register|static|extern|typedef)   # Storage class specifier
+									|	(?:                                         # Type specifier
+											(?-i:void|char|short|int|long|float|double|(?:un)?signed)
+										|	(?-i:struct|union|enum)
+											\s+
+											(?&amp;VALID_ID)                        # Struct, Union or Enum Specifier (simplified)
+										|	(?&amp;VALID_ID)                        # Type-definition name
+										)
+									|	(?'TYPE_QUALIFIER'(?-i:const|volatile))
+									)
+									\b
+									\s*
+								)*
+								(?'DECLARATOR'
+									(?'POINTER'
+										\*
+										\s*
+										(?:
+											\b(?&amp;TYPE_QUALIFIER)\b
+											\s*
+										)*
+										(?:(?&amp;POINTER))?                        # Boost::Regex 1.58-1.59 do not correctly handle quantifiers on subroutine calls
+									)?
+									(?:                                             # 'DIRECT_DECLARATOR'
+										\s*
+										(?'VALID_ID'                                # valid identifier, use as subroutine
+											\b(?!(?-i:
+												auto
+											|	break
+											|	c(?:ase|har|on(?:st|ntinue))
+											|	d(?:efault|o(?:uble)?)
+											|	e(?:lse|num|xtern)
+											|	f(?:loat|or)
+											|	goto
+											|	i(?:f|n(?:t|line))
+											|	long
+											|	while
+											|	re(?:gister|strict|turn)
+											|	s(?:hort|i(?:gned|zeof)|t(?:atic|ruct)|witch)
+											|	typedef
+											|	un(?:ion|signed)
+											|	vo(?:id|latile)
+											|	_(?:
+													A(?:lignas|lignof|tomic)
+												|	Bool
+												|	Complex
+												|	Generic
+												|	Imaginary
+												|	Noreturn
+												|	Static_assert
+												|	Thread_local
+												)
+											)\b)                                    # keywords, not to be used as identifier
+											[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*        # valid character combination for identifiers
+										)
+									|	\s*\(
+										(?&amp;DECLARATOR)
+										\)
+									|	\s*(?&amp;VALID_ID)
+										\s*\[
+										[^[\];{]*?
+										\]
+									|	\s*(?&amp;VALID_ID)
+										\s*\(
+										[^();{]*?
+										\)
+									)
+									\s*
+								)
+								(?=\{)                                              # start of function body
+							"
+					>
+						<functionName>
+							<nameExpr expr="(?!(if|while|for))\w+\s*\(" />
+							<nameExpr expr="(?!(if|while|for))\w+" />
+						</functionName>
+					</function>
+				</classRange>
 				<function
 					mainExpr="(?x)                                              # Utilize inline comments (see `RegEx - Pattern Modifiers`)
 							(?:                                                 # Declaration specifiers
@@ -254,14 +342,8 @@
 						"
 				>
 					<functionName>
-						<nameExpr expr="(?x)                                    # Utilize inline comments (see `RegEx - Pattern Modifiers`)
-								[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*
-								\s*\(                                           # start of parameters
-								(?s:.*?)                                        # whatever, until...
-								\)                                              # end   of parameters
-							" />
-						<!-- comment out the following node to display the method with its parameters -->
-<!--						<nameExpr expr="[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" /> -->
+						<nameExpr expr="(?!(if|while|for))\w+\s*\(" />
+						<nameExpr expr="(?!(if|while|for))\w+" />
 					</functionName>
 				</function>
 			</parser>


### PR DESCRIPTION
I added a class range to the C function definition due to the fact it wasn't capable of identifying a function with a comment within its parameters.  The class range just takes the preset function parameters and is pasted in a class range so it can more easily identify them.  The code also takes in only the function name and not the entire line before the parenthesis.