### PR TITLE
Add "commandLineInterpreter" setting in config.xml

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -89,7 +89,7 @@ void Notepad_plus::command(int id)
 
 		case IDM_FILE_OPEN_CMD:
 		{
-			Command cmd(TEXT("cmd"));
+			Command cmd(NppParameters::getInstance().getNppGUI()._commandLineInterpreter.c_str());
 			cmd.run(_pPublicInterface->getHSelf(), TEXT("$(CURRENT_DIRECTORY)"));
 		}
 		break;

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2076,7 +2076,6 @@ bool NppParameters::getSessionFromXmlTree(TiXmlDocument *pSessionDoc, Session *p
 					(childNode->ToElement())->Attribute(TEXT("endPos"), &position._endPos);
 					(childNode->ToElement())->Attribute(TEXT("selMode"), &position._selMode);
 					(childNode->ToElement())->Attribute(TEXT("scrollWidth"), &position._scrollWidth);
-
 					MapPosition mapPosition;
 					int32_t mapPosVal;
 					const TCHAR *mapPosStr = (childNode->ToElement())->Attribute(TEXT("mapFirstVisibleDisplayLine"), &mapPosVal);
@@ -5096,7 +5095,16 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			const TCHAR * optDocPeekOnMap = element->Attribute(TEXT("docPeekOnMap"));
 			if (optDocPeekOnMap)
 				_nppGUI._isDocPeekOnMap = (lstrcmp(optDocPeekOnMap, TEXT("yes")) == 0);
-
+		}
+		else if (!lstrcmp(nm, TEXT("commandLineInterpreter")))
+		{
+			TiXmlNode *node = childNode->FirstChild();
+			if (node)
+			{
+				const TCHAR *cli = node->Value();
+				if (cli && cli[0])
+					_nppGUI._commandLineInterpreter.assign(cli);
+			}
 		}
 	}
 }
@@ -5859,6 +5867,14 @@ void NppParameters::createXmlTreeFromGUIParams()
 		GUIConfigElement->SetAttribute(TEXT("wholeWordOnly"), _nppGUI._smartHiliteWordOnly ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("useFindSettings"), _nppGUI._smartHiliteUseFindSettings ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("onAnotherView"), _nppGUI._smartHiliteOnAnotherView ? TEXT("yes") : TEXT("no"));
+	}
+
+	// <GUIConfig name="commandLineInterpreter">powershell</GUIConfig>
+	if (_nppGUI._commandLineInterpreter.compare(TEXT("cmd")))
+	{
+		TiXmlElement *GUIConfigElement = (newGUIRoot->InsertEndChild(TiXmlElement(TEXT("GUIConfig"))))->ToElement();
+		GUIConfigElement->SetAttribute(TEXT("name"), TEXT("commandLineInterpreter"));
+		GUIConfigElement->InsertEndChild(TiXmlText(_nppGUI._commandLineInterpreter.c_str()));
 	}
 
 	// <GUIConfig name="ScintillaPrimaryView" lineNumberMargin="show" bookMarkMargin="show" indentGuideLine="show" folderMarkStyle="box" lineWrapMethod="aligned" currentLineHilitingShow="show" scrollBeyondLastLine="no" disableAdvancedScrolling="no" wrapSymbolShow="hide" Wrap="no" borderEdge="yes" edge="no" edgeNbColumn="80" zoom="0" zoom2="0" whiteSpaceShow="hide" eolShow="hide" borderWidth="2" smoothFont="no" />

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -857,6 +857,8 @@ struct NppGUI final
 	generic_string _definedSessionExt;
 	generic_string _definedWorkspaceExt;
 
+	generic_string _commandLineInterpreter = TEXT("cmd");
+
 	struct AutoUpdateOptions
 	{
 		bool _doAutoUpdate = true;

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -779,9 +779,7 @@ void FileBrowser::popupMenuCmd(int cmdID)
 			generic_string path = getNodePath(selectedNode);
 			if (::PathFileExists(path.c_str()))
 			{
-				TCHAR cmdStr[1024];
-				wsprintf(cmdStr, TEXT("cmd"));
-				Command cmd(cmdStr);
+				Command cmd(NppParameters::getInstance().getNppGUI()._commandLineInterpreter.c_str());
 				cmd.run(nullptr, path.c_str());
 			}
 		}


### PR DESCRIPTION
Sets cli used to "Open Containing Folder in cmd".

Implements #7737

Allows user to set the command line interpreter that is invoked when “Open Containing Folder in cmd” (or “CMD here”) is selected. This setting is intentionally not accessible in the **Preferences** dialogue,
because changing this from _cmd_ (the default value) to something else will most likely require some preparation, like adjusting PATH in the Registry, or creating a hard link in a suitable directory, or even writing a small utility acting as a bridge between NPP and the targeted shell. Hence, I believe, it is wiser to treat this setting like the _dlgAlwaysVisible_ setting: documented in the user manual, but not available in **Preferences**.
