### PR TITLE
Fix a autoCompletion close tag bug #6078

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -582,34 +582,24 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 		case int('('):
 			if (matchedPairConf._doParentheses)
 			{
-				if (isCharNextBlank || isInSandwich)
-
-				{
-					matchedChars = ")";
-					_insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
-				}
+				matchedChars = ")";
+				_insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
 			}
 		break;
 
 		case int('['):
 			if (matchedPairConf._doBrackets)
 			{
-				if (isCharNextBlank || isInSandwich)
-				{
-					matchedChars = "]";
-					_insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
-				}
+				matchedChars = "]";
+				_insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
 			}
 		break;
 
 		case int('{'):
 			if (matchedPairConf._doCurlyBrackets)
 			{
-				if (isCharNextBlank || isInSandwich)
-				{
-					matchedChars = "}";
-					_insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
-				}
+				matchedChars = "}";
+				_insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
 			}
 		break;
 


### PR DESCRIPTION
Improvement #7733 

In issue #6078 , the problem is that when insert '(', '[', '{' with letters in '()', '[]', '{}', they are not autocomplete despite setting auto-input.
([]), (()) {()}... this is not problem.
I want to write `void function(int arr[])`, but that is written as 'void function(int arr[ )'.
I have to write ']' manually.

(closetag switch caluse in function 'insertMatchedChars' of 'AutoCompletion.cpp')
```
case int('('):
if (matchedPairConf._doParentheses)
{
    if (isCharNextBlank || isInSandwich)
    {
	    matchedChars = ")";
	    _insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
    }
}
```
I wondered if I needed an `if (isCharNextBlank || isInSandwich)` clause.
So I comment out only `if (isCharNextBlank || isInSandwich)` for each switch case ( '(', '[', '{' ).

```
case int('('):
if (matchedPairConf._doParentheses)
{
    matchedChars = ")";
    _insertedMatchedChars.add(MatchedCharInserted(static_cast<char>(character), caretPos - 1));
}
```