### PR TITLE
Make MinGW gcc build work again

### DIFF
--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -26,6 +26,7 @@
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 
+#include <memory>
 #include <algorithm>
 #include <array>
 #include "shortcut.h"


### PR DESCRIPTION
EDIT: Fixes [this MinGW build error](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/53452d96e0bf17f9f5eaaeec9c6beb2424f6d8cd#r36430299).
