### PR TITLE
Use Scintilla built-in Markdown lexer

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -43,7 +43,7 @@ enum LangType {L_TEXT, L_PHP , L_C, L_CPP, L_CS, L_OBJC, L_JAVA, L_RC,\
 			   L_ASN1, L_AVS, L_BLITZBASIC, L_PUREBASIC, L_FREEBASIC, \
 			   L_CSOUND, L_ERLANG, L_ESCRIPT, L_FORTH, L_LATEX, \
 			   L_MMIXAL, L_NIMROD, L_NNCRONTAB, L_OSCRIPT, L_REBOL, \
-			   L_REGISTRY, L_RUST, L_SPICE, L_TXT2TAGS, L_VISUALPROLOG,\
+			   L_REGISTRY, L_RUST, L_SPICE, L_TXT2TAGS, L_VISUALPROLOG, L_MARKDOWN,\
 			   // Don't use L_JS, use L_JAVASCRIPT instead
 			   // The end of enumated language type, so it should be always at the end
 			   L_EXTERNAL};

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2993,6 +2993,8 @@ LangType Notepad_plus::menuID2LangType(int cmdID)
             return L_TXT2TAGS;
         case IDM_LANG_VISUALPROLOG:
             return L_VISUALPROLOG;
+        case IDM_LANG_MARKDOWN:
+            return L_MARKDOWN;
 		case IDM_LANG_USER :
             return L_USER;
 		default: {

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -736,6 +736,7 @@ BEGIN
         MENUITEM "LaTeX",                   IDM_LANG_LATEX
         MENUITEM "Lua",                     IDM_LANG_LUA
         MENUITEM "Makefile",                IDM_LANG_MAKEFILE
+        MENUITEM "Markdown",                IDM_LANG_MARKDOWN
         MENUITEM "Matlab",                  IDM_LANG_MATLAB
         MENUITEM "MMIXAL",                  IDM_LANG_MMIXAL
         MENUITEM "MS-DOS Style",            IDM_LANG_ASCII
@@ -858,6 +859,7 @@ BEGIN
      POPUP "M"
     BEGIN
         MENUITEM "Makefile",              IDM_LANG_MAKEFILE
+        MENUITEM "Markdown",              IDM_LANG_MARKDOWN
         MENUITEM "Matlab",                IDM_LANG_MATLAB
         MENUITEM "MMIXAL",                IDM_LANG_MMIXAL
         MENUITEM "MS-DOS Style",          IDM_LANG_ASCII

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3040,6 +3040,7 @@ void Notepad_plus::command(int id)
         case IDM_LANG_SPICE :
         case IDM_LANG_TXT2TAGS :
         case IDM_LANG_VISUALPROLOG:
+        case IDM_LANG_MARKDOWN:
 		case IDM_LANG_USER :
 		{
             setLanguage(menuID2LangType(id));

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -6346,6 +6346,9 @@ int NppParameters::langTypeToCommandID(LangType lt) const
 		case L_VISUALPROLOG:
 			id = IDM_LANG_VISUALPROLOG; break;
 
+		case L_MARKDOWN:
+			id = IDM_LANG_MARKDOWN; break;
+
 		case L_SEARCHRESULT :
 			id = -1;	break;
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -166,6 +166,7 @@ LanguageName ScintillaEditView::langNames[L_EXTERNAL+1] = {
 {TEXT("spice"),			TEXT("Spice"),				TEXT("spice file"),										L_SPICE,		SCLEX_SPICE},
 {TEXT("txt2tags"),		TEXT("txt2tags"),			TEXT("txt2tags file"),									L_TXT2TAGS,		SCLEX_TXT2TAGS},
 {TEXT("visualprolog"),	TEXT("Visual Prolog"),		TEXT("Visual Prolog file"),								L_VISUALPROLOG,	SCLEX_VISUALPROLOG},
+{TEXT("markdown"),		TEXT("Markdown"),			TEXT("Markdown file"),									L_MARKDOWN,		SCLEX_MARKDOWN},
 {TEXT("ext"),			TEXT("External"),			TEXT("External"),										L_EXTERNAL,		SCLEX_NULL}
 };
 
@@ -1720,6 +1721,9 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 
 		case L_VISUALPROLOG:
 			setVisualPrologLexer(); break;
+
+		case L_MARKDOWN:
+			setMarkdownLexer(); break;
 
 		case L_TEXT :
 		default :

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -986,6 +986,9 @@ protected:
 		setLexer(SCLEX_VISUALPROLOG, L_VISUALPROLOG, LIST_0 | LIST_1 | LIST_2 | LIST_3);
 	}
 
+	void setMarkdownLexer() {
+		setLexer(SCLEX_MARKDOWN, L_MARKDOWN, LIST_NONE);
+	}
     //--------------------
 
 	void setSearchResultLexer() {

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -515,6 +515,7 @@
     #define    IDM_LANG_SPICE              (IDM_LANG + 81)
     #define    IDM_LANG_TXT2TAGS           (IDM_LANG + 82)
     #define    IDM_LANG_VISUALPROLOG       (IDM_LANG + 83)
+    #define    IDM_LANG_MARKDOWN           (IDM_LANG + 84)
 
     #define    IDM_LANG_EXTERNAL           (IDM_LANG + 165)
     #define    IDM_LANG_EXTERNAL_LIMIT     (IDM_LANG + 179)

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -707,6 +707,31 @@
             <WordsStyle name="TARGET" styleID="5" fgColor="FF0000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="IDEOL" styleID="9" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="2" fontSize="" />
         </LexerType>
+        <LexerType name="markdown" desc="Markdown" ext="md">
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LINE_BEGIN" styleID="1" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRONG1" styleID="2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="STRONG2" styleID="3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="EM1" styleID="4" fgColor="400000" bgColor="FFFFFF" fontName="" fontStyle="3" fontSize="" />
+            <WordsStyle name="EM2" styleID="5" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEADER1" styleID="6" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="HEADER2" styleID="7" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="HEADER3" styleID="8" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="HEADER4" styleID="9" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="HEADER5" styleID="10" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="HEADER6" styleID="11" fgColor="FF8040" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="PRECHAR" styleID="12" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ULIST_ITEM" styleID="13" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="OLIST_ITEM" styleID="14" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCKQUOTE" styleID="15" fgColor="008000" bgColor="C0C0C0" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRIKEOUT" styleID="16" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HRULE" styleID="17" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="LINK" styleID="18" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CODE" styleID="19" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="CODE2" styleID="20" fgColor="808040" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CODEBK" styleID="21" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
+
+        </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />


### PR DESCRIPTION
This PR has intention to integrate Scintilla built-in Markdown lexer.
After some tests with https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md ,
it seems the lexer is still buggy and not ready, and the including ULD markdown with package is far more superior.

You're welcome to test and submit your result/suggestion/thought by commenting here.

For testing, you have to remove "userDefinedLang-markdown.default.modern.xml", "stylers.xml" and "langs.xml".