### PR TITLE
Fix position restoration of a found result if Word-Wrap is on

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -512,6 +512,7 @@ void Finder::gotoFoundLine()
 
 	// Switch to another document
 	::SendMessage(::GetParent(_hParent), WM_DOOPEN, 0, reinterpret_cast<LPARAM>(fInfo._fullPath.c_str()));
+	(*_ppEditView)->_positionRestoreNeeded = false;
 	Searching::displaySectionCentered(fInfo._start, fInfo._end, *_ppEditView);
 
 	// Then we colourise the double clicked line


### PR DESCRIPTION
Fixes #7865

In case Word-Wrap is on, on buffer activation, the last active position was restored instead the position of the found result.