### PR TITLE
Fix UDL folding breaking with delimiters

### DIFF
--- a/scintilla/lexers/LexUser.cxx
+++ b/scintilla/lexers/LexUser.cxx
@@ -1713,6 +1713,8 @@ static void ColouriseUserDoc(Sci_PositionU startPos, Sci_Position length, int in
                             sc.Forward(iter->length());
                         if (sc.atLineStart)
                             checkEOL = EOL_FORCE_CHECK;
+                        else if (sc.atLineEnd)
+                            checkEOL = EOL_SKIP_CHECK;
 
                         // paint end of delimiter sequence
                         sc.SetState(newState);


### PR DESCRIPTION
This fixes a bug where UDL folding breaks if 1) the file uses
non-Windows line endings and 2) delimiters are defined.