### PR TITLE
Changes localization name back from "taiwaneseMandarin.xml"

### DIFF
--- a/PowerEditor/installer/nativeLang/chineseTraditional.xml
+++ b/PowerEditor/installer/nativeLang/chineseTraditional.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NotepadPlus>
-    <Native-Langue name="台灣繁體" filename="taiwaneseMandarin.xml" version="7.8.6">
+    <Native-Langue name="正體中文" filename="chineseTraditional.xml" version="7.8.6">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->

--- a/PowerEditor/installer/nsisInclude/langs4Installer.nsh
+++ b/PowerEditor/installer/nsisInclude/langs4Installer.nsh
@@ -98,7 +98,7 @@
 
 LangString langFileName ${LANG_ENGLISH} "english.xml"
 LangString langFileName ${LANG_FRENCH} "french.xml"
-LangString langFileName ${LANG_TRADCHINESE} "taiwaneseMandarin.xml"
+LangString langFileName ${LANG_TRADCHINESE} "chineseTraditional.xml"
 LangString langFileName ${LANG_SIMPCHINESE} "chineseSimplified.xml"
 LangString langFileName ${LANG_KOREAN} "korean.xml"
 LangString langFileName ${LANG_JAPANESE} "japanese.xml"

--- a/PowerEditor/installer/nsisInclude/langs4Npp.nsh
+++ b/PowerEditor/installer/nsisInclude/langs4Npp.nsh
@@ -70,8 +70,8 @@ SectionGroup "Localization" localization
 	${MementoUnselectedSection} "Catalan" catalan
 		CopyFiles "$PLUGINSDIR\nppLocalization\catalan.xml" "$INSTDIR\localization\catalan.xml"
 	${MementoSectionEnd}
-	${MementoUnselectedSection} "Taiwanese Mandarin" chineseTraditional
-		CopyFiles "$PLUGINSDIR\nppLocalization\taiwaneseMandarin.xml" "$INSTDIR\localization\taiwaneseMandarin.xml"
+	${MementoUnselectedSection} "Chinese (Traditional)" chineseTraditional
+		CopyFiles "$PLUGINSDIR\nppLocalization\chineseTraditional.xml" "$INSTDIR\localization\chineseTraditional.xml"
 	${MementoSectionEnd}
 	${MementoUnselectedSection} "Chinese (Simplified)" chineseSimplified
 		CopyFiles "$PLUGINSDIR\nppLocalization\chineseSimplified.xml" "$INSTDIR\localization\chineseSimplified.xml"
@@ -341,8 +341,7 @@ SectionGroup un.localization
 		Delete "$INSTDIR\localization\catalan.xml"
 	SectionEnd
 	Section un.chineseTraditional
-		Delete "$INSTDIR\localization\chinese.xml"
-		Delete "$INSTDIR\localization\taiwaneseMandarin.xml"
+		Delete "$INSTDIR\localization\chineseTraditional.xml"
 	SectionEnd
 	Section un.chineseSimplified
 		Delete "$INSTDIR\localization\chineseSimplified.xml"

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3794,7 +3794,7 @@ generic_string NppParameters::getLocPathFromStr(const generic_string & localizat
 	if (localizationCode == TEXT("ca"))
 		return TEXT("catalan.xml");
 	if (localizationCode == TEXT("zh-tw") || localizationCode == TEXT("zh-hk") || localizationCode == TEXT("zh-sg"))
-		return TEXT("taiwaneseMandarin.xml");
+		return TEXT("chineseTridational.xml");
 	if (localizationCode == TEXT("zh") || localizationCode == TEXT("zh-cn"))
 		return TEXT("chineseSimplified.xml");
 	if (localizationCode == TEXT("co") || localizationCode == TEXT("co-fr"))

--- a/PowerEditor/src/localizationString.h
+++ b/PowerEditor/src/localizationString.h
@@ -31,7 +31,7 @@ LocalizationSwitcher::LocalizationDefinition localizationDefs[] =
 	{TEXT("English"), TEXT("english.xml")},
 	{TEXT("English (customizable)"), TEXT("english_customizable.xml")},
 	{TEXT("Français"), TEXT("french.xml")},
-	{TEXT("台灣繁體"), TEXT("taiwaneseMandarin.xml")},
+	{TEXT("正體中文"), TEXT("chineseTridational.xml")},
 	{TEXT("中文简体"), TEXT("chineseSimplified.xml")},
 	{TEXT("한국어"), TEXT("korean.xml")},
 	{TEXT("日本語"), TEXT("japanese.xml")},


### PR DESCRIPTION
So, Hong Kong is using Chinese Traditional now, is HK a part of Taiwan?
Or have they need to use "台灣繁體" instead of "香港繁體"?

~~I'm a radical Honkongness, so I want to change this back.~~ :confused:

It's an attack for Chinese Mainland's dictatorship and legal discrimination against homosexuality, but it's also a __bad example for language/culture/region naming__.

I don't think it's "technical correct", just see below:

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/bf2cd8e05abf5ca6c93cdc8011e0023292aeedb8/PowerEditor/installer/nsisInclude/langs4Npp.nsh#L343-L349

If you think Taiwan is not a part of China, please do not break our culture into parts, thanks.

It's ridiculous to say that Traditional Chinese and Simplified Chinese are fundamentally different, just like `([''] != 0)` in JavaScript.
