### PR TITLE
Add ability to find-all in selected text of the current document

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1209,6 +1209,11 @@ Continue?"/>
 
 Find in all files except exe, obj &amp;&amp; log:
 *.* !*.exe !*.obj !*.log"/>
+            <inselection-checkbox-tip value = "Applies ONLY to:
+- Count
+- Find All in Curr Doc
+- Replace All
+- Mark / Clear"/>
             <find-status-top-reached value="Find: Found the 1st occurrence from the bottom. The beginning of the document has been reached."/>
             <find-status-end-reached value="Find: Found the 1st occurrence from the top. The end of the document has been reached."/>
             <find-status-replaceinfiles-1-replaced value="Replace in Files: 1 occurrence was replaced"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1209,6 +1209,11 @@ Continue?"/>
 
 Find in all files except exe, obj &amp;&amp; log:
 *.* !*.exe !*.obj !*.log"/>
+            <inselection-checkbox-tip value = "Applies ONLY to:
+- Count
+- Find All in Curr Doc
+- Replace All
+- Mark / Clear"/>
             <find-status-top-reached value="Find: Found the 1st occurrence from the bottom. The beginning of the document has been reached."/>
             <find-status-end-reached value="Find: Found the 1st occurrence from the top. The end of the document has been reached."/>
             <find-status-replaceinfiles-1-replaced value="Replace in Files: 1 occurrence was replaced"/>

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -248,6 +248,9 @@ FindReplaceDlg::~FindReplaceDlg()
 	if (_filterTip)
 		::DestroyWindow(_filterTip);
 
+	if (_inSelectionTip)
+		::DestroyWindow(_inSelectionTip);
+
 	if (_hMonospaceFont)
 		::DeleteObject(_hMonospaceFont);
 
@@ -892,7 +895,10 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 			 generic_string findInFilesFilterTip = pNativeSpeaker->getLocalizedStrFromID("find-in-files-filter-tip", TEXT("Find in cpp, cxx, h, hxx && hpp:\r*.cpp *.cxx *.h *.hxx *.hpp\r\rFind in all files except exe, obj && log:\r*.* !*.exe !*.obj !*.log"));
 			 _filterTip = CreateToolTip(IDD_FINDINFILES_FILTERS_STATIC, _hSelf, _hInst, const_cast<PTSTR>(findInFilesFilterTip.c_str()));
 
-			::SetWindowTextW(::GetDlgItem(_hSelf, IDC_FINDPREV), TEXT("▲"));
+			 generic_string inSelCheckboxTip = pNativeSpeaker->getLocalizedStrFromID("inselection-checkbox-tip", TEXT("Applies ONLY to:\r- Count\r- Find All in Curr Doc\r- Replace All\r- Mark / Clear"));
+			 _inSelectionTip = CreateToolTip(IDC_IN_SELECTION_CHECK, _hSelf, _hInst, const_cast<PTSTR>(inSelCheckboxTip.c_str()));
+			 
+			 ::SetWindowTextW(::GetDlgItem(_hSelf, IDC_FINDPREV), TEXT("▲"));
 			::SetWindowTextW(::GetDlgItem(_hSelf, IDC_FINDNEXT), TEXT("▼ Find Next"));
 			return TRUE;
 		}
@@ -1885,6 +1891,19 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 		startPosition = cr.cpMin;
 		endPosition = cr.cpMax;
 	}
+	else if (op == ProcessFindAll)
+	{
+		if (isEntire || !pOptions->_isInSelection)
+		{
+			startPosition = 0;
+			endPosition = docLength;
+		}
+		else
+		{
+			startPosition = cr.cpMin;
+			endPosition = cr.cpMax;
+		}
+	}
 	else if (pOptions->_isWrapAround || isEntire)	//entire document needs to be scanned
 	{
 		startPosition = 0;
@@ -2446,7 +2465,7 @@ void FindReplaceDlg::enableReplaceFunc(bool isEnable)
 	::ShowWindow(::GetDlgItem(_hSelf, IDREPLACEALL),hideOrShow);
 	::ShowWindow(::GetDlgItem(_hSelf, IDREPLACEINSEL),hideOrShow);
 	::ShowWindow(::GetDlgItem(_hSelf, IDC_REPLACE_OPENEDFILES),hideOrShow);
-	::ShowWindow(::GetDlgItem(_hSelf, IDC_REPLACEINSELECTION), SW_SHOW);
+	::ShowWindow(::GetDlgItem(_hSelf, IDC_REPLACEINSELECTION), hideOrShow);
 	::ShowWindow(::GetDlgItem(_hSelf, IDC_IN_SELECTION_CHECK), SW_SHOW);
 	::ShowWindow(::GetDlgItem(_hSelf, IDC_2_BUTTONS_MODE), SW_SHOW);
 	bool is2ButtonMode = isCheckedOrNot(IDC_2_BUTTONS_MODE);

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -363,6 +363,7 @@ private :
 	HWND _shiftTrickUpTip = nullptr;
 	HWND _2ButtonsTip = nullptr;
 	HWND _filterTip = nullptr;
+	HWND _inSelectionTip = nullptr;
 
 	bool _isRTL = false;
 


### PR DESCRIPTION
Implements #8113 

To conduct a search for all occurrences within a (single) selected range of text, tick the _In Selection_ checkbox before pressing the _Find All in Current Document_ button.  Results appear in the _Find result_ window.

Before this change, the only type of search in the _Find_ window/tab that respected _In Selection_ was a _Count_ search.  Thus _In Selection_ checkbox and the _Count_ button appeared boxed in with a "group box".  

Because the  _Find All in Current Document_ button is NOT adjacent to the _Count_ button so that the grouping box could simply be made larger to contain both buttons, it was decided to remove the grouping box on the _Find_ tab (conveniently also solving #7927 !).  

To make up for the now-missing UI cues about the feature, it was decided to add a tooltip to the _In Selection_ checkbox:

![image](https://user-images.githubusercontent.com/30118311/79704082-8ad59f00-827d-11ea-98a4-a76654cf91c0.png)
