### PR TITLE
Add count of files searched to 'Find result' output

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1680,7 +1680,7 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 	}
 	progress.close();
 
-	findInFolderInfo->_pDestFinder->finishFilesSearch(nbTotal, findInFolderInfo->_findOption._isMatchLineNumber);
+	findInFolderInfo->_pDestFinder->finishFilesSearch(nbTotal, int(filesCount), findInFolderInfo->_findOption._isMatchLineNumber);
 
 	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
 	_pEditView = pOldView;
@@ -1766,7 +1766,7 @@ bool Notepad_plus::findInFiles()
 
 	progress.close();
 
-	_findReplaceDlg.finishFilesSearch(nbTotal);
+	_findReplaceDlg.finishFilesSearch(nbTotal, int(filesCount));
 
 	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
 	_pEditView = pOldView;
@@ -1807,7 +1807,9 @@ bool Notepad_plus::findInOpenedFiles()
 	    }
     }
 
-    if (_mainWindowStatus & WindowSubActive)
+	size_t nbUniqueBuffers = _mainDocTab.nbItem();
+
+	if (_mainWindowStatus & WindowSubActive)
     {
 		for (size_t i = 0, len2 = _subDocTab.nbItem(); i < len2 ; ++i)
 	    {
@@ -1822,10 +1824,11 @@ bool Notepad_plus::findInOpenedFiles()
 			FindersInfo findersInfo;
 			findersInfo._pFileName = pBuf->getFullPathName();
 			nbTotal += _findReplaceDlg.processAll(ProcessFindAll, FindReplaceDlg::_env, isEntireDoc, &findersInfo);
+			++nbUniqueBuffers;
 	    }
     }
 
-	_findReplaceDlg.finishFilesSearch(nbTotal);
+	_findReplaceDlg.finishFilesSearch(nbTotal, int(nbUniqueBuffers));
 
 	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
 	_pEditView = pOldView;
@@ -1858,7 +1861,7 @@ bool Notepad_plus::findInCurrentFile()
 	findersInfo._pFileName = pBuf->getFullPathName();
 	nbTotal += _findReplaceDlg.processAll(ProcessFindAll, FindReplaceDlg::_env, isEntireDoc, &findersInfo);
 
-	_findReplaceDlg.finishFilesSearch(nbTotal);
+	_findReplaceDlg.finishFilesSearch(nbTotal, 1);
 
 	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, oldDoc);
 	_pEditView = pOldView;

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -3124,18 +3124,18 @@ void Finder::addFileHitCount(int count)
 	++_nbFoundFiles;
 }
 
-void Finder::addSearchHitCount(int count, bool isMatchLines)
+void Finder::addSearchHitCount(int count, int countSearched, bool isMatchLines)
 {
 	const TCHAR *moreInfo = isMatchLines ? TEXT(" - Line Filter Mode: only display the filtered results") :TEXT("");
 	TCHAR text[100];
 	if (count == 1 && _nbFoundFiles == 1)
-		wsprintf(text, TEXT(" (1 hit in 1 file%s)"), moreInfo);
+		wsprintf(text, TEXT(" (1 hit in 1 file of %i searched%s)"), countSearched, moreInfo);
 	else if (count == 1 && _nbFoundFiles != 1)
-		wsprintf(text, TEXT(" (1 hit in %i files%s)"), _nbFoundFiles, moreInfo);
+		wsprintf(text, TEXT(" (1 hit in %i files of %i searched%s)"), _nbFoundFiles, countSearched, moreInfo);
 	else if (count != 1 && _nbFoundFiles == 1)
-		wsprintf(text, TEXT(" (%i hits in 1 file%s)"), count, moreInfo);
+		wsprintf(text, TEXT(" (%i hits in 1 file of %i searched%s)"), count, countSearched, moreInfo);
 	else if (count != 1 && _nbFoundFiles != 1)
-		wsprintf(text, TEXT(" (%i hits in %i files%s)"), count, _nbFoundFiles, moreInfo);
+		wsprintf(text, TEXT(" (%i hits in %i files of %i searched%s)"), count, _nbFoundFiles, countSearched, moreInfo);
 	setFinderReadOnly(false);
 	_scintView.insertGenericTextFrom(_lastSearchHeaderPos, text);
 	setFinderReadOnly(true);
@@ -3270,7 +3270,7 @@ void Finder::beginNewFilesSearch()
 	_scintView.collapse(searchHeaderLevel - SC_FOLDLEVELBASE, fold_collapse);
 }
 
-void Finder::finishFilesSearch(int count, bool isMatchLines)
+void Finder::finishFilesSearch(int count, int searchedCount, bool isMatchLines)
 {
 	std::vector<FoundInfo>* _pOldFoundInfos;
 	std::vector<SearchResultMarking>* _pOldMarkings;
@@ -3288,7 +3288,7 @@ void Finder::finishFilesSearch(int count, bool isMatchLines)
 	if (_pMainMarkings->size() > 0)
 		_markingsStruct._markings = &((*_pMainMarkings)[0]);
 
-	addSearchHitCount(count, isMatchLines);
+	addSearchHitCount(count, searchedCount, isMatchLines);
 	_scintView.execute(SCI_SETSEL, 0, 0);
 
 	_scintView.execute(SCI_SETLEXER, SCLEX_SEARCHRESULT);

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -125,14 +125,14 @@ public:
 	void addSearchLine(const TCHAR *searchName);
 	void addFileNameTitle(const TCHAR * fileName);
 	void addFileHitCount(int count);
-	void addSearchHitCount(int count, bool isMatchLines = false);
+	void addSearchHitCount(int count, int countSearched, bool isMatchLines = false);
 	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline);
 	void setFinderStyle();
 	void removeAll();
 	void openAll();
 	void copy();
 	void beginNewFilesSearch();
-	void finishFilesSearch(int count, bool isMatchLines = false);
+	void finishFilesSearch(int count, int searchedCount, bool isMatchLines = false);
 	void gotoNextFoundResult(int direction);
 	void gotoFoundLine();
 	void deleteResult();
@@ -302,9 +302,9 @@ public :
 		_pFinder->addSearchLine(getText2search().c_str());
 	}
 
-	void finishFilesSearch(int count)
+	void finishFilesSearch(int count, int searchedCount)
 	{
-		_pFinder->finishFilesSearch(count);
+		_pFinder->finishFilesSearch(count, searchedCount);
 	}
 
 	void focusOnFinder() {


### PR DESCRIPTION
Implements #3980 for :

* _Find All_ on _Find in Files_ tab
* _Find All in All Opened Documents_ (sample'd below)
* _Find All in Current Document_ (the trivial case!, always `of 1 searched`)
* _Find in these Found Results_

Sample:

![image](https://user-images.githubusercontent.com/30118311/79907743-1b2ff300-83e8-11ea-9fea-967bcc4e3d4d.png)

**NOTE:**  Maybe this is a "tricky" sample, but observe that one of the 4 document tabs is actually a **cloned** document, thus there are only 3 files to search, leading to the output "...of 3 searched".