### PR TITLE
Wrong characters shown when reloading a file that changed its encoding. #5997

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1381,6 +1381,7 @@ bool FileManager::loadFileData(Document doc, const TCHAR * filename, char* data,
 			{
 				if (fileFormat._encoding == SC_CP_UTF8)
 				{
+					_pscratchTilla->execute(SCI_SETCODEPAGE, SC_CP_UTF8);
 					// Pass through UTF-8 (this does not check validity of characters, thus inserting a multi-byte character in two halfs is working)
 					_pscratchTilla->execute(SCI_APPENDTEXT, lenFile, reinterpret_cast<LPARAM>(data));
 				}


### PR DESCRIPTION
Wrong characters shown when reloading a file that changed its encoding. #5997