### PR TITLE
Fix wrong Project panel at start issue

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -388,6 +388,8 @@ private:
                                               // then WM_ENDSESSION is send with wParam == FALSE
                                               // in this case this boolean is set true, so Notepad++ will quit and its current session will be saved 
 
+    bool _isWorkspaceFileLoadedFromCommandLine = false;
+
 	ScintillaCtrls _scintillaCtrls4Plugins;
 
 	std::vector<std::pair<int, int> > _hideLinesMarks;

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -245,6 +245,10 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	{
 		_notepad_plus_plus_core.launchFileBrowser(fns, true);
 	}
+	else if (_notepad_plus_plus_core._isWorkspaceFileLoadedFromCommandLine)
+	{
+		::SendMessage(_hSelf, WM_COMMAND, IDM_VIEW_PROJECT_PANEL_1, 0);
+	}
 
 	// Notify plugins that Notepad++ is ready
 	SCNotification scnN;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -211,7 +211,8 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
 	if (isFileWorkspace(longFileName) && PathFileExists(longFileName))
 	{
 		nppParam.setWorkSpaceFilePath(0, longFileName);
-		command(IDM_VIEW_PROJECT_PANEL_1);
+		_isWorkspaceFileLoadedFromCommandLine = true;
+//		command(IDM_VIEW_PROJECT_PANEL_1);
 		return BUFFER_INVALID;
 	}
 


### PR DESCRIPTION
Fixes #8126

I do not say, that this is the right way to fix it.

I only say, the `IDM_VIEW_PROJECT_PANEL_1` command works in **Notepad_plus_Window.cpp**, but not in **NppIo.cpp**. 

What I did is the most none-invasive solution, I kept the checks where they were and shifted the `IDM_VIEW_PROJECT_PANEL_1` command to a later point in the startup process, where it works. 