### PR TITLE
Retain find history if config file value set too large

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2243,6 +2243,10 @@ void NppParameters::feedFindHistoryParameters(TiXmlNode *node)
 	if (!findHistoryRoot) return;
 
 	(findHistoryRoot->ToElement())->Attribute(TEXT("nbMaxFindHistoryPath"), &_findHistory._nbMaxFindHistoryPath);
+	if (_findHistory._nbMaxFindHistoryPath > NB_MAX_FINDHISTORY_PATH)
+	{
+		_findHistory._nbMaxFindHistoryPath = NB_MAX_FINDHISTORY_PATH;
+	}
 	if ((_findHistory._nbMaxFindHistoryPath > 0) && (_findHistory._nbMaxFindHistoryPath <= NB_MAX_FINDHISTORY_PATH))
 	{
 		for (TiXmlNode *childNode = findHistoryRoot->FirstChildElement(TEXT("Path"));
@@ -2258,6 +2262,10 @@ void NppParameters::feedFindHistoryParameters(TiXmlNode *node)
 	}
 
 	(findHistoryRoot->ToElement())->Attribute(TEXT("nbMaxFindHistoryFilter"), &_findHistory._nbMaxFindHistoryFilter);
+	if (_findHistory._nbMaxFindHistoryFilter > NB_MAX_FINDHISTORY_FILTER)
+	{
+		_findHistory._nbMaxFindHistoryFilter = NB_MAX_FINDHISTORY_FILTER;
+	}
 	if ((_findHistory._nbMaxFindHistoryFilter > 0) && (_findHistory._nbMaxFindHistoryFilter <= NB_MAX_FINDHISTORY_FILTER))
 	{
 		for (TiXmlNode *childNode = findHistoryRoot->FirstChildElement(TEXT("Filter"));
@@ -2273,6 +2281,10 @@ void NppParameters::feedFindHistoryParameters(TiXmlNode *node)
 	}
 
 	(findHistoryRoot->ToElement())->Attribute(TEXT("nbMaxFindHistoryFind"), &_findHistory._nbMaxFindHistoryFind);
+	if (_findHistory._nbMaxFindHistoryFind > NB_MAX_FINDHISTORY_FIND)
+	{
+		_findHistory._nbMaxFindHistoryFind = NB_MAX_FINDHISTORY_FIND;
+	}
 	if ((_findHistory._nbMaxFindHistoryFind > 0) && (_findHistory._nbMaxFindHistoryFind <= NB_MAX_FINDHISTORY_FIND))
 	{
 		for (TiXmlNode *childNode = findHistoryRoot->FirstChildElement(TEXT("Find"));
@@ -2288,6 +2300,10 @@ void NppParameters::feedFindHistoryParameters(TiXmlNode *node)
 	}
 
 	(findHistoryRoot->ToElement())->Attribute(TEXT("nbMaxFindHistoryReplace"), &_findHistory._nbMaxFindHistoryReplace);
+	if (_findHistory._nbMaxFindHistoryReplace > NB_MAX_FINDHISTORY_REPLACE)
+	{
+		_findHistory._nbMaxFindHistoryReplace = NB_MAX_FINDHISTORY_REPLACE;
+	}
 	if ((_findHistory._nbMaxFindHistoryReplace > 0) && (_findHistory._nbMaxFindHistoryReplace <= NB_MAX_FINDHISTORY_REPLACE))
 	{
 		for (TiXmlNode *childNode = findHistoryRoot->FirstChildElement(TEXT("Replace"));


### PR DESCRIPTION
Fixes #323

Side effect:  Overwrites any too-large history-count values in the `config.xml` file to the top-end allowable values.  This is judged to be acceptable.