### PR TITLE
Add ability to do a find-all in a selection

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1209,6 +1209,12 @@ Continue?"/>
 
 Find in all files except exe, obj &amp;&amp; log:
 *.* !*.exe !*.obj !*.log"/>
+            <inselection-checkbox-tip value = "Applies ONLY to:
+- Count
+- Find All in Current Document
+- Replace All
+- Mark All
+- Clear all marks"/>
             <find-status-top-reached value="Find: Found the 1st occurrence from the bottom. The beginning of the document has been reached."/>
             <find-status-end-reached value="Find: Found the 1st occurrence from the top. The end of the document has been reached."/>
             <find-status-replaceinfiles-1-replaced value="Replace in Files: 1 occurrence was replaced"/>

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -569,7 +569,7 @@ private:
 	//void changeStyleCtrlsLang(HWND hDlg, int *idArray, const char **translatedText);
 	bool replaceInOpenedFiles();
 	bool findInOpenedFiles();
-	bool findInCurrentFile();
+	bool findInCurrentFile(bool restrictSearchToSelectedText);
 
 	void getMatchedFileNames(const TCHAR *dir, const std::vector<generic_string> & patterns, std::vector<generic_string> & fileNames, bool isRecursive, bool isInHiddenDir);
 	void doSynScorll(HWND hW);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -219,7 +219,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_FINDALL_INCURRENTDOC:
 		{
-			return findInCurrentFile();
+			bool searchScopeIsSelectedText = (wParam == 0) ? false : true;
+			return findInCurrentFile(searchScopeIsSelectedText);
 		}
 
 		case WM_FINDINFILES:

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -46,7 +46,7 @@ enum DIALOG_TYPE {FIND_DLG, REPLACE_DLG, FINDINFILES_DLG, MARK_DLG};
 
 //#define FIND_REPLACE_STR_MAX 256
 
-enum InWhat{ALL_OPEN_DOCS, FILES_IN_DIR, CURRENT_DOC};
+enum InWhat{ALL_OPEN_DOCS, FILES_IN_DIR, CURRENT_DOC, CURR_DOC_SELECTION};
 
 struct FoundInfo {
 	FoundInfo(int start, int end, size_t lineNumber, const TCHAR *fullPath)
@@ -125,14 +125,14 @@ public:
 	void addSearchLine(const TCHAR *searchName);
 	void addFileNameTitle(const TCHAR * fileName);
 	void addFileHitCount(int count);
-	void addSearchHitCount(int count, int countSearched, bool isMatchLines = false);
+	void addSearchHitCount(int count, int countSearched, bool isMatchLines, bool isSelectionSearched);
 	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline);
 	void setFinderStyle();
 	void removeAll();
 	void openAll();
 	void copy();
 	void beginNewFilesSearch();
-	void finishFilesSearch(int count, int searchedCount, bool isMatchLines = false);
+	void finishFilesSearch(int count, int searchedCount, bool isMatchLines, bool isSelectionSearched);
 	void gotoNextFoundResult(int direction);
 	void gotoFoundLine();
 	void deleteResult();
@@ -302,9 +302,9 @@ public :
 		_pFinder->addSearchLine(getText2search().c_str());
 	}
 
-	void finishFilesSearch(int count, int searchedCount)
+	void finishFilesSearch(int count, int searchedCount, bool isSelectionSearched)
 	{
-		_pFinder->finishFilesSearch(count, searchedCount);
+		_pFinder->finishFilesSearch(count, searchedCount, false, isSelectionSearched);
 	}
 
 	void focusOnFinder() {
@@ -363,6 +363,7 @@ private :
 	HWND _shiftTrickUpTip = nullptr;
 	HWND _2ButtonsTip = nullptr;
 	HWND _filterTip = nullptr;
+	HWND _inSelectionTip = nullptr;
 
 	bool _isRTL = false;
 


### PR DESCRIPTION
Implements #8133 

To conduct a search for all occurrences within a (single) selected range of text, tick the **_In Selection_** checkbox before pressing the **_Find All in Current Document_** button. Results appear in the **_Find result_** window.

Before this change, the only type of search in the **_Find_** window/tab that respected **_In Selection_** was a **_Count_** search. Thus **_In Selection_** checkbox and the **_Count_** button appeared boxed in with a "group box".

Because the **_Find All in Current Document_** button is NOT adjacent to the **_Count_** button so that the grouping box could simply be made larger to contain both buttons, it was decided to remove the grouping box on the **_Find_** tab (conveniently also solving #7927 !).

The alternative of swapping positions of **_Find All in Current Document_** button and the **_Find All in All Open Documents_** button was discarded for another reason as well:  possibly too disruptive to users used to the current placement.

To make up for the now-missing UI cues about the feature, it was decided to add a tooltip for the In Selection checkbox; text very similar to the following:

![image](https://user-images.githubusercontent.com/30118311/80929175-ce4d0480-8d77-11ea-98ca-64b6afe6cabe.png)

When a In Selection find-all is conducted the output in the Find result window will reflect it by using the verbage "selection" instead of "file"; example:

![image](https://user-images.githubusercontent.com/30118311/80929363-554eac80-8d79-11ea-8490-fb7fb11f763c.png)
