### PR TITLE
Add menu item to hide search results window

### DIFF
--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -395,7 +395,8 @@ BEGIN
         MENUITEM "Find (Volatile) Previous",    IDM_SEARCH_VOLATILE_FINDPREV
         MENUITEM "&Replace...",                 IDM_SEARCH_REPLACE
         MENUITEM "&Incremental Search",         IDM_SEARCH_FINDINCREMENT
-        MENUITEM "Search Results Window",       IDM_FOCUS_ON_FOUND_RESULTS
+        MENUITEM "Show Search Results Window",  IDM_FOCUS_ON_FOUND_RESULTS
+        MENUITEM "Hide Search Results Window",  IDM_HIDE_FOUND_RESULTS
         MENUITEM "Next Search Result",          IDM_SEARCH_GOTONEXTFOUND
         MENUITEM "Previous Search Result",      IDM_SEARCH_GOTOPREVFOUND
         MENUITEM "&Go to...",                   IDM_SEARCH_GOTOLINE

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1099,6 +1099,12 @@ void Notepad_plus::command(int id)
 		}
 		break;
 
+		case IDM_HIDE_FOUND_RESULTS:
+		{
+			_findReplaceDlg.hideFinder();
+		}
+		break;
+
 		case IDM_SEARCH_VOLATILE_FINDNEXT :
 		case IDM_SEARCH_VOLATILE_FINDPREV :
 		{

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -190,6 +190,7 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{ VK_H,       IDM_SEARCH_REPLACE,                           true,  false, false, nullptr },
 	{ VK_I,       IDM_SEARCH_FINDINCREMENT,                     true,  true,  false, nullptr },
 	{ VK_F7,      IDM_FOCUS_ON_FOUND_RESULTS,                   false, false, false, nullptr },
+	{ VK_F7,      IDM_HIDE_FOUND_RESULTS,		                true,  false, false, nullptr },
 	{ VK_F4,      IDM_SEARCH_GOTOPREVFOUND,                     false, false, true,  nullptr },
 	{ VK_F4,      IDM_SEARCH_GOTONEXTFOUND,                     false, false, false, nullptr },
 	{ VK_G,       IDM_SEARCH_GOTOLINE,                          true,  false, false, nullptr },

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -317,6 +317,18 @@ public :
 		}
 	};
 
+	void hideFinder() 
+	{
+		if (_pFinder)
+		{
+			//When already visible, hide finder
+			if (_pFinder->_scintView.isVisible())
+			{
+				::SendMessage(_hParent, NPPM_DMMHIDE, 0, reinterpret_cast<LPARAM>(_pFinder->getHSelf()));
+			}
+		}
+	};
+
 	HWND getHFindResults() {
 		if (_pFinder)
 			return _pFinder->_scintView.getHSelf();

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -247,6 +247,7 @@
 	#define    IDM_SEARCH_FINDCHARINRANGE      (IDM_SEARCH + 52)
 	#define    IDM_SEARCH_SELECTMATCHINGBRACES (IDM_SEARCH + 53)
 	#define    IDM_SEARCH_MARK                 (IDM_SEARCH + 54)
+    #define    IDM_HIDE_FOUND_RESULTS          (IDM_SEARCH + 55)
 	
 #define    IDM_MISC    (IDM + 3500)
 	#define    IDM_FILESWITCHER_FILESCLOSE            (IDM_MISC + 1)


### PR DESCRIPTION
Resolves issue #2946 
Adds a new menu item to "Hide Search Results Window". Has a corresponding keyboard shortcut mapping. 
Renamed menu item "Search Results Window" to "Show Search Results Window" to clarify purpose and fit in with new menu item. 