### PR TITLE
Allow user to skip *.* when adding only excluding Filters for Find/Replace In Files

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1023,6 +1023,20 @@ bool matchInList(const TCHAR *fileName, const std::vector<generic_string> & patt
 	return is_matched;
 }
 
+bool allPatternsAreExclusion(const std::vector<generic_string> patterns)
+{
+	bool oneInclusionPatternFound = false;
+	for (size_t i = 0, len = patterns.size(); i < len; ++i)
+	{
+		if (patterns[i][0] != '!')
+		{
+			oneInclusionPatternFound = true;
+			break;
+		}
+	}
+	return not oneInclusionPatternFound;
+}
+
 generic_string GetLastErrorAsString(DWORD errorCode)
 {
 	generic_string errorMsg(_T(""));

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -92,6 +92,7 @@ std::string getFileContent(const TCHAR *file2read);
 generic_string relativeFilePathToFullFilePath(const TCHAR *relativeFilePath);
 void writeFileContent(const TCHAR *file2write, const char *content2write);
 bool matchInList(const TCHAR *fileName, const std::vector<generic_string> & patterns);
+bool allPatternsAreExclusion(const std::vector<generic_string> patterns);
 
 class WcharMbcsConvertor final
 {

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1532,6 +1532,11 @@ bool Notepad_plus::replaceInFiles()
 		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
 		_findReplaceDlg.getPatterns(patterns2Match);
 	}
+	else if (allPatternsAreExclusion(patterns2Match))
+	{
+		patterns2Match.insert(patterns2Match.begin(), TEXT("*.*"));
+	}
+
 	vector<generic_string> fileNames;
 
 	getMatchedFileNames(dir2Search, patterns2Match, fileNames, isRecursive, isInHiddenDir);
@@ -1619,14 +1624,6 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 	_pEditView = &_invisibleEditView;
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 
-	vector<generic_string> patterns2Match;
-	_findReplaceDlg.getPatterns(patterns2Match);
-	if (patterns2Match.size() == 0)
-	{
-		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
-		_findReplaceDlg.getPatterns(patterns2Match);
-	}
-
 	vector<generic_string> fileNames = findInFolderInfo->_pSourceFinder->getResultFilePaths();
 
 	findInFolderInfo->_pDestFinder->beginNewFilesSearch();
@@ -1710,6 +1707,10 @@ bool Notepad_plus::findInFiles()
 	{
 		_findReplaceDlg.setFindInFilesDirFilter(NULL, TEXT("*.*"));
 		_findReplaceDlg.getPatterns(patterns2Match);
+	}
+	else if (allPatternsAreExclusion(patterns2Match))
+	{
+		patterns2Match.insert(patterns2Match.begin(), TEXT("*.*"));
 	}
 
 	vector<generic_string> fileNames;


### PR DESCRIPTION
Implements #8169 

Note 1: `*.*` is not actually added to the user input box for `Filters:` (to avoid visual clutter), but is logically added when the search executes.

Note 2:  Code was removed in the "find in finder" execution path because patterns aren't used in that path to determine the fileset -- the fileset is predetermined from the earlier searching.  This code was noticed as unneeded during the effort for this PR.