### PR TITLE
Fix loadFileData() does not detect error properly issue

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1351,6 +1351,11 @@ bool FileManager::loadFileData(Document doc, const TCHAR * filename, char* data,
 		do
 		{
 			lenFile = fread(data+incompleteMultibyteChar, 1, blockSize-incompleteMultibyteChar, fp) + incompleteMultibyteChar;
+			if (ferror(fp) != 0)
+			{
+				success = false;
+				break;
+			}
 			if (lenFile == 0) break;
 
             if (isFirstTime)


### PR DESCRIPTION
show error if read file fails:
![image](https://user-images.githubusercontent.com/1271541/81955445-c52f2380-9612-11ea-8b73-95c64b6c159f.png)

Fix #3381