### PR TITLE
Disallow backward regex searches due to sometimes surprising results

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1022,23 +1022,31 @@ void Notepad_plus::command(int id)
 		case IDM_SEARCH_FINDNEXT :
 		case IDM_SEARCH_FINDPREV :
 		{
-			if (!_findReplaceDlg.isCreated())
-				return;
-
-			FindOption op = _findReplaceDlg.getCurrentOptions();
-			op._whichDirection = (id == IDM_SEARCH_FINDNEXT?DIR_DOWN:DIR_UP);
-			generic_string s = _findReplaceDlg.getText2search();
-			FindStatus status = FSNoMessage;
-			_findReplaceDlg.processFindNext(s.c_str(), &op, &status);
-			if (status == FSEndReached)
+			if (_findReplaceDlg.isCreated())
 			{
-				generic_string msg = _nativeLangSpeaker.getLocalizedStrFromID("find-status-end-reached", TEXT("Find: Found the 1st occurrence from the top. The end of the document has been reached."));
-				_findReplaceDlg.setStatusbarMessage(msg, FSEndReached);
-			}
-			else if (status == FSTopReached)
-			{
-				generic_string msg = _nativeLangSpeaker.getLocalizedStrFromID("find-status-top-reached", TEXT("Find: Found the 1st occurrence from the bottom. The beginning of the document has been reached."));
-				_findReplaceDlg.setStatusbarMessage(msg, FSTopReached);
+				FindOption op = _findReplaceDlg.getCurrentOptions();
+				if ((id == IDM_SEARCH_FINDPREV) && (op._searchType == FindRegex))
+				{
+					// regex upward search is disabled
+					// make this a no-action command
+				}
+				else
+				{
+					op._whichDirection = (id == IDM_SEARCH_FINDNEXT ? DIR_DOWN : DIR_UP);
+					generic_string s = _findReplaceDlg.getText2search();
+					FindStatus status = FSNoMessage;
+					_findReplaceDlg.processFindNext(s.c_str(), &op, &status);
+					if (status == FSEndReached)
+					{
+						generic_string msg = _nativeLangSpeaker.getLocalizedStrFromID("find-status-end-reached", TEXT("Find: Found the 1st occurrence from the top. The end of the document has been reached."));
+						_findReplaceDlg.setStatusbarMessage(msg, FSEndReached);
+					}
+					else if (status == FSTopReached)
+					{
+						generic_string msg = _nativeLangSpeaker.getLocalizedStrFromID("find-status-top-reached", TEXT("Find: Found the 1st occurrence from the bottom. The beginning of the document has been reached."));
+						_findReplaceDlg.setStatusbarMessage(msg, FSTopReached);
+					}
+				}
 			}
 		}
 		break;


### PR DESCRIPTION
Fixes #3640, although that is only part of the story. The full story, debated before, is that regular expression searching in a backward direction from the caret position causes matches that the user does not expect. The best thing that was decided to do (group decision) is to fully disable upward searching.

Note:  This is the corrected version of PR #8128 , which was hopelessly scrambled, or at least too messed up for me to figure out how to fix.  There was nothing wrong with the code in 8128, just the way the commit ended up due to a botched merge.

There aren't nearly as many lines of code changed as are shown below.  One more downside of github:  It's difference reports are poor.  BeyondCompare4 does a much better job at showing the real changes.
