### PR TITLE
Improve Document Map precision

### DIFF
--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.h
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.h
@@ -144,7 +144,7 @@ private:
 	ScintillaEditView **_ppEditView = nullptr;
 	ScintillaEditView *_pMapView = nullptr;
 	ViewZoneDlg _vzDlg;
-
+	HWND _hwndScintilla;
 	bool _isTemporarilyShowing = false;
 
 	// for needToRecomputeWith function


### PR DESCRIPTION
Improves #8294

To solve the 2-pixel offset problem, we have to use the actual Scintilla window for position calculation, because it has a `WS_EX_CLIENTEDGE` style attached to it, which shifts it contents. The new way to calculate the position is implemented in `DocumentMap::doMove()`.

The calculation of the current visible range is now based on the document positions in the corners of the edit window, and map scrolling is done by Scintilla itself now.

In non-wrapped views, the hight of the orange window is calculcated now on the basis of the height of the edit window: If there is only a half line visible at the bottom, than the orange window covers only a half line in the Document Map.

In wrapped views, the number of lines visible in the edit window can differ from the number of lines in the Document Map view for the same range of text, because wrapping can be different. Hence the size of the orange window can change in wrapped views, although the height of the edit window remains constant. This is tricky, and the wrapped view does not work as good as the non-wrapped view, but a little better than before.
