### PR TITLE
Add right-click context menu to bookmark margin

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -603,6 +603,31 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			break;
 		}
 
+		case SCN_MARGINRIGHTCLICK:
+		{
+			if (notification->nmhdr.hwndFrom == _mainEditView.getHSelf())
+				switchEditViewTo(MAIN_VIEW);
+			else if (notification->nmhdr.hwndFrom == _subEditView.getHSelf())
+				switchEditViewTo(SUB_VIEW);
+
+			if ((notification->margin == ScintillaEditView::_SC_MARGE_SYBOLE) && !notification->modifiers)
+			{
+				POINT p;
+				::GetCursorPos(&p);
+				MenuPosition& menuPos = getMenuPosition("search-bookmark");
+				HMENU hSearchMenu = ::GetSubMenu(_mainMenuHandle, menuPos._x);
+				if (hSearchMenu)
+				{
+					HMENU hBookmarkMenu = ::GetSubMenu(hSearchMenu, menuPos._y);
+					if (hBookmarkMenu)
+					{
+						TrackPopupMenu(hBookmarkMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
+					}
+				}
+			}
+			break;
+		}
+
 		case SCN_FOLDINGSTATECHANGED :
 		{
 			if ((notification->nmhdr.hwndFrom == _mainEditView.getHSelf()) || (notification->nmhdr.hwndFrom == _subEditView.getHSelf()))


### PR DESCRIPTION
Implements #8319 

Example UI:  

![image](https://user-images.githubusercontent.com/30118311/82963610-61e9ad80-9f91-11ea-9d4b-f3b69b0c92e4.png)

Credits:
Thanks to @Ekopalypse for email discussion of grabbing an existing menu and popping it up.  It was a fun discussion but in the end I searched N++ source for `TrackPopupMenu` and found the easy solution via copy/paste/change. :-)