### PR TITLE
Fix input focus not in edit window after double click

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -513,15 +513,15 @@ void FileBrowser::openSelectFile()
 	HTREEITEM selectedNode = _treeView.getSelection();
 	if (!selectedNode) return;
 
-	generic_string fullPath = getNodePath(selectedNode);
+	_selectedNodeFullPath = getNodePath(selectedNode);
 
 	// test the path - if it's a file, open it, otherwise just fold or unfold it
-	if (!::PathFileExists(fullPath.c_str()))
+	if (!::PathFileExists(_selectedNodeFullPath.c_str()))
 		return;
-	if (::PathIsDirectory(fullPath.c_str()))
+	if (::PathIsDirectory(_selectedNodeFullPath.c_str()))
 		return;
 
-	::SendMessage(_hParent, NPPM_DOOPEN, 0, reinterpret_cast<LPARAM>(fullPath.c_str()));
+	::PostMessage(_hParent, NPPM_DOOPEN, 0, reinterpret_cast<LPARAM>(_selectedNodeFullPath.c_str()));
 }
 
 

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -176,6 +176,8 @@ protected:
 	HMENU _hFileMenu = NULL;
 	std::vector<FolderUpdater *> _folderUpdaters;
 
+	generic_string _selectedNodeFullPath; // this member is used only for PostMessage call
+
 	std::vector<SortingData4lParam*> sortingDataArray;
 
 	void initPopupMenus();

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -579,7 +579,7 @@ void ProjectPanel::openSelectFile()
 		tvItem.mask = TVIF_IMAGE | TVIF_SELECTEDIMAGE;
 		if (::PathFileExists(fn->c_str()))
 		{
-			::SendMessage(_hParent, NPPM_DOOPEN, 0, reinterpret_cast<LPARAM>(fn->c_str()));
+			::PostMessage(_hParent, NPPM_DOOPEN, 0, reinterpret_cast<LPARAM>(fn->c_str()));
 			tvItem.iImage = INDEX_LEAF;
 			tvItem.iSelectedImage = INDEX_LEAF;
 		}


### PR DESCRIPTION
Fixes #4656 and #8361 

This one bothers me too.

Replace `SendMessage` with `PostMessage`, and it works.

As always with `PostMessage`, the life time of the parameters is important.

In the `ProjectPanel` class, the filename parameter already lives long enough in `fullPathStrs`.

In the `FileBrowser` class, I had to add a new member `_fullPath` instead of leaving the filename at the stack.