### PR TITLE
Change focus to edit window after activating function in function list

### DIFF
--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -557,6 +557,7 @@ void FunctionListPanel::notified(LPNMHDR notification)
 			case NM_DBLCLK:
 			{
 				openSelection(treeView);
+				PostMessage(_hParent, WM_COMMAND, SCEN_SETFOCUS << 16, reinterpret_cast<LPARAM>((*_ppEditView)->getHSelf()));
 			}
 			break;
 
@@ -570,7 +571,9 @@ void FunctionListPanel::notified(LPNMHDR notification)
 					{
 						HTREEITEM hItem = treeView.getSelection();
 						treeView.toggleExpandCollapse(hItem);
+						break;
 					}
+					PostMessage(_hParent, WM_COMMAND, SCEN_SETFOCUS << 16, reinterpret_cast<LPARAM>((*_ppEditView)->getHSelf()));
 				}
 			}
 			break;


### PR DESCRIPTION
Fixes #4356.

Makes function list behave like "Project Panel" and "Folder As Workspace" with almost zero effort: If a function is choosen with return key or double click, then the focus switches to the edit window.

