### PR TITLE
Fix Load project file by dragging doesn't work

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5999,10 +5999,9 @@ void Notepad_plus::launchFileBrowser(const vector<generic_string> & folders, boo
 
 void Notepad_plus::launchProjectPanel(int cmdID, ProjectPanel ** pProjPanel, int panelID)
 {
+	NppParameters& nppParam = NppParameters::getInstance();
 	if (!(*pProjPanel))
 	{
-		NppParameters& nppParam = NppParameters::getInstance();
-
 		(*pProjPanel) = new ProjectPanel;
 		(*pProjPanel)->init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf());
 		(*pProjPanel)->setWorkSpaceFilePath(nppParam.getWorkSpaceFilePath(panelID));
@@ -6039,6 +6038,11 @@ void Notepad_plus::launchProjectPanel(int cmdID, ProjectPanel ** pProjPanel, int
 
 		(*pProjPanel)->setBackgroundColor(bgColor);
 		(*pProjPanel)->setForegroundColor(fgColor);
+	}
+	else
+	{
+		if ((*pProjPanel)->saveWorkspaceRequest())
+			(*pProjPanel)->openWorkSpace(nppParam.getWorkSpaceFilePath(panelID));
 	}
 	(*pProjPanel)->display();
 }

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -388,8 +388,9 @@ private:
                                               // then WM_ENDSESSION is send with wParam == FALSE
                                               // in this case this boolean is set true, so Notepad++ will quit and its current session will be saved 
 
-    bool _isWorkspaceFileLoadedFromCommandLine = false;
-
+    bool _isWorkspaceFileLoadedFromCommandLine = false; // Set during Notepad_plus::doOpen if workspace file is opened.
+                                                        // But it is only evaluated during startup, when doOpen
+                                                        // has been called while command line interpretation.
 	ScintillaCtrls _scintillaCtrls4Plugins;
 
 	std::vector<std::pair<int, int> > _hideLinesMarks;

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -247,6 +247,10 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	}
 	else if (_notepad_plus_plus_core._isWorkspaceFileLoadedFromCommandLine)
 	{
+		// Switch back to Project Panel 1, when a workspace file has been specified in the command line.
+		// This code is executed only once in lifetime of the process, at the first initialization. It is necessary, because
+		// the Project Panels are not loaded by Notepad_plus::doOpen only, but also by the Plugin Manager restoring the state
+		// of the last session from config.xml.
 		::SendMessage(_hSelf, WM_COMMAND, IDM_VIEW_PROJECT_PANEL_1, 0);
 	}
 

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -212,7 +212,9 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
 	{
 		nppParam.setWorkSpaceFilePath(0, longFileName);
 		_isWorkspaceFileLoadedFromCommandLine = true;
-//		command(IDM_VIEW_PROJECT_PANEL_1);
+		// This line switches to Project Panel 1 while starting up Npp
+		// and after dragging a workspace file to Npp:
+		command(IDM_VIEW_PROJECT_PANEL_1);
 		return BUFFER_INVALID;
 	}
 

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -863,6 +863,35 @@ HTREEITEM ProjectPanel::addFolder(HTREEITEM hTreeItem, const TCHAR *folderName)
 	return addedItem;
 }
 
+bool ProjectPanel::saveWorkspaceRequest()
+{ // returns true for continue and false for break
+	if (_isDirty)
+	{
+		NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
+		int res = pNativeSpeaker->messageBox("ProjectPanelOpenDoSaveDirtyWsOrNot",
+					_hSelf,
+					TEXT("The current workspace was modified. Do you want to save the current project?"),
+					TEXT("Open Workspace"),
+					MB_YESNOCANCEL | MB_ICONQUESTION | MB_APPLMODAL);
+				
+		if (res == IDYES)
+		{
+			if (!saveWorkSpace())
+				return false;
+		}
+		else if (res == IDNO)
+		{
+			// Don't save so do nothing here
+		}
+		else if (res == IDCANCEL) 
+		{
+			// User cancels action "New Workspace" so we interrupt here
+			return false;
+		}
+	}
+	return true;
+}
+
 void ProjectPanel::popupMenuCmd(int cmdID)
 {
 	// get selected item handle
@@ -989,31 +1018,8 @@ void ProjectPanel::popupMenuCmd(int cmdID)
 
 		case IDM_PROJECT_OPENWS:
 		{
-			NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
-			if (_isDirty)
-			{
-				
-				int res = pNativeSpeaker->messageBox("ProjectPanelOpenDoSaveDirtyWsOrNot",
-					_hSelf,
-					TEXT("The current workspace was modified. Do you want to save the current project?"),
-					TEXT("Open Workspace"),
-					MB_YESNOCANCEL | MB_ICONQUESTION | MB_APPLMODAL);
-				
-				if (res == IDYES)
-				{
-					if (!saveWorkSpace())
-						return;
-				}
-				else if (res == IDNO)
-				{
-					// Don't save so do nothing here
-				}
-				else if (res == IDCANCEL) 
-				{
-					// User cancels action "New Workspace" so we interrupt here
-					return;
-				}
-			}
+			if (!saveWorkspaceRequest())
+				break;
 
 			FileDialog fDlg(_hSelf, ::GetModuleHandle(NULL));
 			setFileExtFilter(fDlg);
@@ -1021,6 +1027,7 @@ void ProjectPanel::popupMenuCmd(int cmdID)
 			{
 				if (!openWorkSpace(fn))
 				{
+					NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 					pNativeSpeaker->messageBox("ProjectPanelOpenFailed",
 						_hSelf,
 						TEXT("The workspace could not be opened.\rIt seems the file to open is not a valid project file."),

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
@@ -83,6 +83,7 @@ public:
     };
 
 	void newWorkSpace();
+	bool saveWorkspaceRequest();
 	bool openWorkSpace(const TCHAR *projectFileName);
 	bool saveWorkSpace();
 	bool saveWorkSpaceAs(bool saveCopyAs);


### PR DESCRIPTION
Fixes #8324 

To say it clearly, this never worked even before my PR #8161.

The only exception was: If no Project Panel was stored in `config.xml` before starting Npp, then it worked exactly one time. My PR #8161 wrecked even this. So I felt obligated to fix the drag and drop issue too.

The drag and drop operation as well as the command line use Project Panel 1 as target. I extended the safety question which occurs when a modified workspace file is being replaced by another workspace file to the drag and drop operation. This made it necessary to transfer this safety request into a new function.