### PR TITLE
Update catalan translation to 7.8.7

### DIFF
--- a/PowerEditor/installer/nativeLang/catalan.xml
+++ b/PowerEditor/installer/nativeLang/catalan.xml
@@ -5,9 +5,10 @@ Updated 07.12.2019, v7.8.2
 By Hiro5 <groccat at gmail>
 -->
 <NotepadPlus>
-	<Native-Langue name="Català" filename="catalan.xml" version="7.8.2">
+	<Native-Langue name="Català" filename="catalan.xml" version="7.8.7">
 		<Menu>
 			<Main>
+				<!-- Entrades del menú principal -->
 				<Entries>
 					<Item menuId="file" name="&amp;Fitxer"/>
 					<Item menuId="edit" name="&amp;Edita"/>
@@ -22,9 +23,10 @@ By Hiro5 <groccat at gmail>
 					<Item idName="Plugins" name="C&amp;omplements"/>
 					<Item idName="Window" name="Fine&amp;stres"/>
 				</Entries>
+				<!-- Entrades del sub-menú -->
 				<SubEntries>
 					<Item subMenuId="file-openFolder" name="Obre la carpeta contenidora"/>
-					<Item subMenuId="file-closeMore" name = "&amp;Més tancaments"/>
+					<Item subMenuId="file-closeMore" name="&amp;Més tancaments"/>
 					<Item subMenuId="file-recentFiles" name="&amp;Fitxers recents"/>
 					<Item subMenuId="edit-copyToClipboard" name="Copia al porta&amp;-retalls"/>
 					<Item subMenuId="edit-indent" name="Tab&amp;ulació"/>
@@ -45,7 +47,7 @@ By Hiro5 <groccat at gmail>
 					<Item subMenuId="view-showSymbol" name="Mostra sím&amp;bol"/>
 					<Item subMenuId="view-zoom" name="&amp;Zoom"/>
 					<Item subMenuId="view-moveCloneDocument" name="M&amp;ou/clona el document actual"/>
-					<Item subMenuId="view-tab" name = "Pestanyes"/>
+					<Item subMenuId="view-tab" name="Pestanyes"/>
 					<Item subMenuId="view-collapseLevel" name="P&amp;lega el nivell..."/>
 					<Item subMenuId="view-uncollapseLevel" name="De&amp;splega el nivell..."/>
 					<Item subMenuId="view-project" name="Pro&amp;jectes"/>
@@ -71,47 +73,58 @@ By Hiro5 <groccat at gmail>
 					<Item subMenuId="tools-md5" name="MD5"/>
 					<Item subMenuId="tools-sha256" name="SHA-256"/>
 				</SubEntries>
+
+				<!-- Tots els ítems del menú -->
 				<Commands>
 					<Item id="41001" name="&amp;Nou"/>
 					<Item id="41002" name="&amp;Obre..."/>
 					<Item id="41019" name="Explorador de Windows"/>
 					<Item id="41020" name="Indicador d'ordres"/>
-					<Item id="41023" name="Obre amb el visualitzador per defecte"/>
-					<Item id="41022" name="Obre carpeta de treball"/>
-					<Item id="41014" name="&amp;Recarrega des del disc"/>
-					<Item id="41006" name="&amp;Desa"/>
-					<Item id="41008" name="&amp;Anomena i desa..."/>
-					<Item id="41015" name="Anomena &amp;còpia i desa..."/>
-					<Item id="41007" name="D&amp;esa'ls tots"/>
-					<Item id="41017" name="Can&amp;via el nom..."/>
 					<Item id="41003" name="&amp;Tanca"/>
 					<Item id="41004" name="Tanca'&amp;ls tots"/>
 					<Item id="41005" name="Tanca'ls tots &amp;menys l'actiu"/>
 					<Item id="41009" name="Tanca tots els de l'&amp;esquerra"/>
 					<Item id="41018" name="Tanca tots els de la &amp;dreta"/>
 					<Item id="41024" name="Tanca tots els no canviats"/>
-					<Item id="41016" name="Es&amp;borra del disc"/>
-					<Item id="41012" name="Carre&amp;ga Sessió..."/>
-					<Item id="41013" name="Desa &amp;Sessió..."/>
+					<Item id="41006" name="&amp;Desa"/>
+					<Item id="41007" name="D&amp;esa'ls tots"/>
+					<Item id="41008" name="&amp;Anomena i desa..."/>
 					<Item id="41010" name="&amp;Imprimeix..."/>
 					<Item id="1001"  name="Im&amp;primeix ara!"/>
-					<Item id="41021" name="Restaura el darrer fitxer tancat"/>
-					<Item id="42040" name="Obre tots els fit&amp;xers recents"/>
-					<Item id="42041" name="Nete&amp;ja llista de fitxers recents"/>
 					<Item id="41011" name="S&amp;urt"/>
-					<Item id="42003" name="&amp;Desfés"/>
-					<Item id="42004" name="Re&amp;fés"/>
+					<Item id="41012" name="Carre&amp;ga Sessió..."/>
+					<Item id="41013" name="Desa &amp;Sessió..."/>
+					<Item id="41014" name="&amp;Recarrega des del disc"/>
+					<Item id="41015" name="Anomena &amp;còpia i desa..."/>
+					<Item id="41016" name="Es&amp;borra del disc"/>
+					<Item id="41017" name="Can&amp;via el nom..."/>
+					<Item id="41021" name="Restaura el darrer fitxer tancat"/>
+					<Item id="41022" name="Obre carpeta de treball"/>
+					<Item id="41023" name="Obre amb el visualitzador per defecte"/>
 					<Item id="42001" name="Re&amp;talla"/>
 					<Item id="42002" name="&amp;Copia"/>
+					<Item id="42003" name="&amp;Desfés"/>
+					<Item id="42004" name="Re&amp;fés"/>
 					<Item id="42005" name="En&amp;ganxa"/>
 					<Item id="42006" name="Es&amp;borra"/>
 					<Item id="42007" name="&amp;Selecciona-ho tot"/>
 					<Item id="42020" name="Comença/acaba la selecció"/>
-					<Item id="42029" name="Copia el camí sencer del fitxe&amp;r"/>
-					<Item id="42030" name="Copia el &amp;nom del fitxer"/>
-					<Item id="42031" name="Copia el camí del &amp;directori on és el fitxer"/>
 					<Item id="42008" name="&amp;Insereix tabulació"/>
 					<Item id="42009" name="&amp;Esborra tabulació"/>
+					<Item id="42010" name="&amp;Duplica línia actual"/>
+					<Item id="42077" name="Esborra línies duplicades consecutives"/>
+					<Item id="42012" name="&amp;Talla línies"/>
+					<Item id="42013" name="&amp;Uneix línies"/>
+					<Item id="42014" name="Mou a&amp;munt aquesta línia"/>
+					<Item id="42015" name="Mou a&amp;vall aquesta línia"/>
+					<Item id="42059" name="Ordena línies ascendentment"/>
+					<Item id="42060" name="Ordena línies descendentment"/>
+					<Item id="42061" name="Ordena línies d'enters ascendentment"/>
+					<Item id="42062" name="Ordena línies d'enters descendentment"/>
+					<Item id="42063" name="Ordena línies de decimals amb coma ascendentment"/>
+					<Item id="42064" name="Ordena línies de decimals amb coma descendentment"/>
+					<Item id="42065" name="Ordena línies de decimals amb punt ascendentment"/>
+					<Item id="42066" name="Ordena línies de decimals amb punt descendentment"/>
 					<Item id="42016" name="Converteix a M&amp;AJÚSCULES"/>
 					<Item id="42017" name="Converteix a m&amp;inúscules"/>
 					<Item id="42067" name="Maj. Inicial Per Paraula"/>
@@ -120,39 +133,16 @@ By Hiro5 <groccat at gmail>
 					<Item id="42070" name="Maj. inicial per frase (barrejat)"/>
 					<Item id="42071" name="iNVERTEIX mAJ./mIN."/>
 					<Item id="42072" name="MaJ./mIn. ALeATori"/>
-					<Item id="42010" name="&amp;Duplica línia actual"/>
-					<Item id="42077" name="Esborra línies duplicades consecutives"/>
-					<Item id="42012" name="&amp;Talla línies"/>
-					<Item id="42013" name="&amp;Uneix línies"/>
-					<Item id="42059" name="Ordena línies ascendentment"/>
-					<Item id="42061" name="Ordena línies d'enters ascendentment"/>
-					<Item id="42063" name="Ordena línies de decimals amb coma ascendentment"/>
-					<Item id="42065" name="Ordena línies de decimals amb punt ascendentment"/>
-					<Item id="42060" name="Ordena línies descendentment"/>
-					<Item id="42062" name="Ordena línies d'enters descendentment"/>
-					<Item id="42064" name="Ordena línies de decimals amb coma descendentment"/>
-					<Item id="42066" name="Ordena línies de decimals amb punt descendentment"/>
-					<Item id="42014" name="Mou a&amp;munt aquesta línia"/>
-					<Item id="42015" name="Mou a&amp;vall aquesta línia"/>
-					<Item id="42055" name="&amp;Esborra línies buides"/>
-					<Item id="42056" name="Esborra línies &amp;buides o amb espais en blanc"/>
-					<Item id="42057" name="Afegeix línia en blanc a sobre"/>
-					<Item id="42058" name="Afegeix línia en blanc a sota"/>
+					<Item id="42073" name="Obre fitxer"/>
+					<Item id="42074" name="Obre carpeta contenidora en l'Explorador"/>
+					<Item id="42075" name="Cerca a Internet"/>
+					<Item id="42076" name="Canvia el motor de cerca…"/>
+					<Item id="42018" name="&amp;Comença l'enregistrament"/>
+					<Item id="42019" name="&amp;Atura l'enregistrament"/>
+					<Item id="42021" name="&amp;Reprodueix"/>
 					<Item id="42022" name="Afegeix/Treu símbol de comentari de &amp;línia/es"/>
-					<Item id="42035" name="&amp;Afegeix símbol de comentari de línia/es"/>
-					<Item id="42036" name="&amp;Treu símbol de comentari de línia/es"/>
 					<Item id="42023" name="Afegeix símbol de comentari de &amp;selecció"/>
 					<Item id="42047" name="Treu símbol de comentari de s&amp;elecció"/>
-					<Item id="50000" name="Autocompleta &amp;funcions"/>
-					<Item id="50001" name="Autocompleta &amp;paraules"/>
-					<Item id="50002" name="&amp;Suggeriments de paràmetres de funcions"/>
-					<Item id="50003" name="Canvia al document anterior"/>
-					<Item id="50004" name="Canvia al document següent"/>
-					<Item id="50005" name="Comença/atura l'enregistrament de macro"/>
-					<Item id="50006" name="Compleció de camí"/>
-					<Item id="45001" name="Converteix a format &amp;Windows"/>
-					<Item id="45002" name="Converteix a format &amp;UNIX"/>
-					<Item id="45003" name="Converteix a format &amp;MAC"/>
 					<Item id="42024" name="Treu espais de &amp;finals de línia"/>
 					<Item id="42042" name="Treu espais d'&amp;inicis de línia"/>
 					<Item id="42043" name="Treu espais d'inicis i finals de &amp;línia"/>
@@ -166,44 +156,56 @@ By Hiro5 <groccat at gmail>
 					<Item id="42048" name="&amp;Copia contingut binari"/>
 					<Item id="42049" name="&amp;Talla contingut binari"/>
 					<Item id="42050" name="&amp;Enganxa contingut binari"/>
-					<Item id="42073" name="Obre fitxer"/>
-					<Item id="42074" name="Obre carpeta contenidora en l'Explorador"/>
-					<Item id="42075" name="Cerca a Internet"/>
-					<Item id="42076" name="Canvia el motor de cerca…"/>
 					<Item id="42037" name="Consell del &amp;mode de columna..."/>
 					<Item id="42034" name="&amp;Insereix en columna..."/>
 					<Item id="42051" name="P&amp;anell d'inserció de caràcters"/>
 					<Item id="42052" name="&amp;Historial del porta-retalls"/>
+					<Item id="42025" name="&amp;Desa la macro actual..."/>
+					<Item id="42026" name="Text de &amp;dreta a esquerra"/>
+					<Item id="42027" name="Text d'&amp;esquerra a dreta"/>
 					<Item id="42028" name="M&amp;ode de Només-Lectura"/>
+					<Item id="42029" name="Copia el camí sencer del fitxe&amp;r"/>
+					<Item id="42030" name="Copia el &amp;nom del fitxer"/>
+					<Item id="42031" name="Copia el camí del &amp;directori on és el fitxer"/>
+					<Item id="42032" name="&amp;Executa una macro diverses vegades..."/>
 					<Item id="42033" name="T&amp;reu marca de Només-Lectura"/>
+					<Item id="42035" name="&amp;Afegeix símbol de comentari de línia/es"/>
+					<Item id="42036" name="&amp;Treu símbol de comentari de línia/es"/>
+					<Item id="42055" name="&amp;Esborra línies buides"/>
+					<Item id="42056" name="Esborra línies &amp;buides o amb espais en blanc"/>
+					<Item id="42057" name="Afegeix línia en blanc a sobre"/>
+					<Item id="42058" name="Afegeix línia en blanc a sota"/>
 					<Item id="43001" name="&amp;Cerca..."/>
-					<Item id="43013" name="Cerca als &amp;fitxers..."/>
 					<Item id="43002" name="Cerca &amp;següent"/>
+					<Item id="43003" name="&amp;Reemplaça..."/>
+					<Item id="43004" name="Vés a la línia o &amp;posició..."/>
+					<Item id="43005" name="Activa/desactiva &amp;marca de línia"/>
+					<Item id="43006" name="Cerca marca de línia &amp;següent"/>
+					<Item id="43007" name="Cerca marca de línia &amp;anterior"/>
+					<Item id="43008" name="&amp;Neteja totes les marques de línia"/>
+					<Item id="43018" name="&amp;Retalla les línies marcades"/>
+					<Item id="43019" name="&amp;Copia les línies marcades"/>
+					<Item id="43020" name="En&amp;ganxa a les línies marcades (canviar)"/>
+					<Item id="43021" name="Es&amp;borra les línies marcades"/>
+					<Item id="43051" name="&amp;Esborra línies sense marcar"/>
+					<Item id="43050" name="&amp;Inverteix línies marcades"/>
+					<Item id="43052" name="Cerca interva&amp;l de caràcters..."/>
+					<Item id="43053" name="Selecciona el bloc"/>
+					<Item id="43009" name="Vés a l'altre extrem del &amp;bloc"/>
 					<Item id="43010" name="Cerca &amp;anterior"/>
-					<Item id="43048" name="S&amp;elecciona i cerca següent"/>
-					<Item id="43049" name="Seleccio&amp;na i cerca anterior"/>
+					<Item id="43011" name="Cerca &amp;incremental..."/>
+					<Item id="43013" name="Cerca als &amp;fitxers..."/>
 					<Item id="43014" name="Cerca &amp;volàtil següent"/>
 					<Item id="43015" name="Cerca v&amp;olàtil anterior"/>
-					<Item id="43003" name="&amp;Reemplaça..."/>
-					<Item id="43011" name="Cerca &amp;incremental..."/>
-					<Item id="43045" name="Finestra &amp;de resultats de cerca"/>
-					<Item id="43046" name="Res&amp;ultat de cerca següent"/>
-					<Item id="43047" name="Resul&amp;tat de cerca anterior"/>
-					<Item id="43004" name="Vés a la línia o &amp;posició..."/>
-					<Item id="43009" name="Vés a l'altre extrem del &amp;bloc"/>
-					<Item id="43053" name="Selecciona el bloc"/>
-					<Item id="43054" name="Marca..."/>
-					<Item id="43016" name="Marca&amp;-ho tot"/>
 					<Item id="43022" name="Utilitza &amp;1r. estil"/>
-					<Item id="43024" name="Utilitza &amp;2n. estil"/>
-					<Item id="43026" name="Utilitza &amp;3r. estil"/>
-					<Item id="43028" name="Utilitza &amp;4t. estil"/>
-					<Item id="43030" name="Utilitza &amp;5è. estil"/>
-					<Item id="43017" name="Desmarca-&amp;ho tot"/>
 					<Item id="43023" name="Neteja &amp;1r. estil"/>
+					<Item id="43024" name="Utilitza &amp;2n. estil"/>
 					<Item id="43025" name="Neteja &amp;2n. estil"/>
+					<Item id="43026" name="Utilitza &amp;3r. estil"/>
 					<Item id="43027" name="Neteja &amp;3r. estil"/>
+					<Item id="43028" name="Utilitza &amp;4t. estil"/>
 					<Item id="43029" name="Neteja &amp;4t. estil"/>
+					<Item id="43030" name="Utilitza &amp;5è. estil"/>
 					<Item id="43031" name="Neteja &amp;5è. estil"/>
 					<Item id="43032" name="Neteja &amp;tots els estils"/>
 					<Item id="43033" name="&amp;1r. estil"/>
@@ -218,32 +220,28 @@ By Hiro5 <groccat at gmail>
 					<Item id="43042" name="&amp;4t. estil"/>
 					<Item id="43043" name="&amp;5è. estil"/>
 					<Item id="43044" name="&amp;Cerca estil"/>
-					<Item id="43005" name="Activa/desactiva &amp;marca de línia"/>
-					<Item id="43006" name="Cerca marca de línia &amp;següent"/>
-					<Item id="43007" name="Cerca marca de línia &amp;anterior"/>
-					<Item id="43008" name="&amp;Neteja totes les marques de línia"/>
-					<Item id="43018" name="&amp;Retalla les línies marcades"/>
-					<Item id="43019" name="&amp;Copia les línies marcades"/>
-					<Item id="43020" name="En&amp;ganxa a les línies marcades (canviar)"/>
-					<Item id="43021" name="Es&amp;borra les línies marcades"/>
-					<Item id="43051" name="&amp;Esborra línies sense marcar"/>
-					<Item id="43050" name="&amp;Inverteix línies marcades"/>
-					<Item id="43052" name="Cerca interva&amp;l de caràcters..."/>
-					<Item id="44034" name="Se&amp;mpre per damunt"/>
-					<Item id="44032" name="Mode a pantalla &amp;completa"/>
+					<Item id="43045" name="Finestra &amp;de resultats de cerca"/>
+					<Item id="43046" name="Res&amp;ultat de cerca següent"/>
+					<Item id="43047" name="Resul&amp;tat de cerca anterior"/>
+					<Item id="43048" name="S&amp;elecciona i cerca següent"/>
+					<Item id="43049" name="Seleccio&amp;na i cerca anterior"/>
+					<Item id="43054" name="Marca..."/>
 					<Item id="44009" name="Mode fi&amp;x"/>
-					<Item id="44025" name="Mostra els &amp;espais en blanc i els tabuladors"/>
-					<Item id="44026" name="Mostra el &amp;salt de línia"/>
+					<Item id="44010" name="&amp;Plega-ho tot"/>
 					<Item id="44019" name="Mostra tots els &amp;caràcters"/>
 					<Item id="44020" name="Mostra la &amp;guia del sagnat"/>
-					<Item id="44041" name="Mostra símbol de &amp;tall"/>
+					<Item id="44022" name="Ajusta el &amp;text"/>
 					<Item id="44023" name="&amp;Amplia (Ctrl+Roda del ratolí amunt)"/>
 					<Item id="44024" name="&amp;Redueix (Ctrl+Roda del ratolí avall)"/>
-					<Item id="44033" name="R&amp;ecupera la posició d'apropament"/>
-					<Item id="10001" name="Mou a una altra &amp;vista"/>
-					<Item id="10002" name="&amp;Clona a una altra vista"/>
-					<Item id="10003" name="Mou a una nova fine&amp;stra"/>
-					<Item id="10004" name="Cl&amp;ona a una nova finestra"/>
+					<Item id="44025" name="Mostra els &amp;espais en blanc i els tabuladors"/>
+					<Item id="44026" name="Mostra el &amp;salt de línia"/>
+					<Item id="44029" name="Desplega&amp;-ho tot"/>
+					<Item id="44030" name="Plega el &amp;nivell actual"/>
+					<Item id="44031" name="Desplega el n&amp;ivell actual"/>
+					<Item id="44049" name="Sumari&amp;..."/>
+					<Item id="44080" name="M&amp;apa del document"/>
+					<Item id="44084" name="Llista de funcions"/>
+					<Item id="44085" name="Carpetes de treball"/>
 					<Item id="44086" name="1a. pestanya"/>
 					<Item id="44087" name="2a. pestanya"/>
 					<Item id="44088" name="3a. pestanya"/>
@@ -255,88 +253,86 @@ By Hiro5 <groccat at gmail>
 					<Item id="44094" name="9a. pestanya"/>
 					<Item id="44095" name="Pestanya següent"/>
 					<Item id="44096" name="Pestanya anterior"/>
+					<Item id="44097" name="Monitora canvis del fitxer"/>
 					<Item id="44098" name="Mou pestanya endavant"/>
 					<Item id="44099" name="Mou pestanya enrere"/>
-					<Item id="44022" name="Ajusta el &amp;text"/>
-					<Item id="44072" name="Activa la vista p&amp;rincipal"/>
-					<Item id="44042" name="Ama&amp;ga les línies"/>
-					<Item id="44010" name="&amp;Plega-ho tot"/>
-					<Item id="44029" name="Desplega&amp;-ho tot"/>
-					<Item id="44030" name="Plega el &amp;nivell actual"/>
-					<Item id="44031" name="Desplega el n&amp;ivell actual"/>
-					<Item id="44049" name="Sumari&amp;..."/>
-					<Item id="44085" name="Carpetes de treball"/>
-					<Item id="44080" name="M&amp;apa del document"/>
-					<Item id="44084" name="Llista de funcions"/>
+					<Item id="44032" name="Mode a pantalla &amp;completa"/>
+					<Item id="44033" name="R&amp;ecupera la posició d'apropament"/>
+					<Item id="44034" name="Se&amp;mpre per damunt"/>
 					<Item id="44035" name="Sincronitza el desplaçament &amp;vertical"/>
 					<Item id="44036" name="Sincronitza el desplaçament &amp;horitzontal"/>
-					<Item id="42026" name="Text de &amp;dreta a esquerra"/>
-					<Item id="42027" name="Text d'&amp;esquerra a dreta"/>
-					<Item id="44097" name="Monitora canvis del fitxer"/>
+					<Item id="44041" name="Mostra símbol de &amp;tall"/>
+					<Item id="44072" name="Activa la vista p&amp;rincipal"/>
 					<Item id="44081" name="Panell de projecte &amp;1"/>
 					<Item id="44082" name="Panell de projecte &amp;2"/>
 					<Item id="44083" name="Panell de projecte &amp;3"/>
-					<Item id="44012" name="Amaga el marge de número de línia"/>
-					<Item id="44013" name="Amaga el marge de marca de línia"/>
-					<Item id="44014" name="Amaga el marge d'agrupació"/>
+					<Item id="45001" name="Converteix a format &amp;Windows"/>
+					<Item id="45002" name="Converteix a format &amp;UNIX"/>
+					<Item id="45003" name="Converteix a format &amp;MAC"/>
 					<Item id="45004" name="Codifica com A&amp;NSI"/>
-					<Item id="45008" name="Codifica com UT&amp;F-8"/>
 					<Item id="45005" name="Codifica com UTF-&amp;8 amb BOM"/>
 					<Item id="45006" name="Cod&amp;ifica com UCS-2 Big Endian amb BOM"/>
 					<Item id="45007" name="Co&amp;difica com UCS-2 Little Endian amb BOM"/>
-					<Item id="45060" name="Big5 (Tradicional)"/>
-					<Item id="45061" name="GB2312 (Simplificat)"/>
-					<Item id="45054" name="OEM 861: Islandès"/>
-					<Item id="45057" name="OEM 865: Nòrdic"/>
-					<Item id="45048" name="OEM 850: DOS Llatí 1"/>
-					<Item id="45053" name="OEM 860: Portuguès"/>
-					<Item id="45056" name="OEM 863: Francès"/>
+					<Item id="45008" name="Codifica com UT&amp;F-8"/>
 					<Item id="45009" name="Converteix a &amp;ANSI"/>
 					<Item id="45010" name="Converteix a &amp;UTF-8"/>
 					<Item id="45011" name="Converteix a U&amp;TF-8 amb BOM"/>
 					<Item id="45012" name="Converteix a UCS-2 &amp;Big Endian amb BOM"/>
 					<Item id="45013" name="Converteix a UCS-2 &amp;Little Endian amb BOM"/>
-					<Item id="46033" name="Assemblador"/>
-					<Item id="46019" name="MS INI (fitxer)"/>
-					<Item id="46015" name="MS-DOS (estil)"/>
-					<Item id="46016" name="Normal (document de text)"/>
-					<Item id="46017" name="RC (fitxer de recursos)"/>
-					<Item id="46180" name="D&amp;efinit per l'usuari"/>
+					<Item id="45060" name="Big5 (Tradicional)"/>
+					<Item id="45061" name="GB2312 (Simplificat)"/>
+					<Item id="45054" name="OEM 861: Islandès"/>
+					<Item id="45057" name="OEM 865: Nòrdic"/>
+					<Item id="45053" name="OEM 860: Portuguès"/>
+					<Item id="45056" name="OEM 863: Francès"/>
+
+					<Item id="10001" name="Mou a una altra &amp;vista"/>
+					<Item id="10002" name="&amp;Clona a una altra vista"/>
+					<Item id="10003" name="Mou a una nova fine&amp;stra"/>
+					<Item id="10004" name="Cl&amp;ona a una nova finestra"/>
+
+					<Item id="46001" name="&amp;Configuració d'estil..."/>
 					<Item id="46250" name="Definiu el llenguatge..."/>
 					<Item id="46300" name="Obre la carpeta del Llenguatge definit per l'usuari..."/>
-					<Item id="48011" name="&amp;Preferències..."/>
-					<Item id="48014" name="Obre la carpeta dels complements"/>
-					<Item id="46001" name="&amp;Configuració d'estil..."/>
-					<Item id="48009" name="&amp;Editor de tecles de dreceres..."/>
-					<Item id="48005" name="Importa &amp;complements ..."/>
-					<Item id="48006" name="Importa &amp;temes d'estil..."/>
-					<Item id="48018" name="Edita el menú contextual emergent"/>
-					<Item id="48501" name="Genera..."/>
-					<Item id="48502" name="Genera dels fitxers..."/>
-					<Item id="48503" name="Genera de la selecció al porta-retalls"/>
-					<Item id="48504" name="Genera..."/>
-					<Item id="48505" name="Genera dels fitxers..."/>
-					<Item id="48506" name="Genera de la selecció al porta-retalls"/>
-					<Item id="42018" name="&amp;Comença l'enregistrament"/>
-					<Item id="42019" name="&amp;Atura l'enregistrament"/>
-					<Item id="42021" name="&amp;Reprodueix"/>
-					<Item id="42025" name="&amp;Desa la macro actual..."/>
-					<Item id="42032" name="&amp;Executa una macro diverses vegades..."/>
-					<Item id="48016" name="&amp;Modifica tecla de drecera/Esborra macro..."/>
-					<Item id="49000" name="&amp;Executa..."/>
-					<Item id="48017" name="&amp;Modifica tecla de drecera/Esborra ordre..."/>
-					<Item id="48015" name="Administració de complements..."/>
+					<Item id="46180" name="D&amp;efinit per l'usuari"/>
+					<Item id="47000" name="&amp;Quant a Notepad++"/>
 					<Item id="47010" name="Ús en &amp;línia d'ordres..."/>
 					<Item id="47001" name="Web de &amp;Notepad++"/>
 					<Item id="47002" name="Pàgina del &amp;projecte Notepad++"/>
 					<Item id="47003" name="Documentació en línia"/>
 					<Item id="47004" name="&amp;Fòrum de Notepad++"/>
 					<Item id="47011" name="&amp;Suport en línia"/>
+					<Item id="47012" name="Informació de depuració..."/>
 					<Item id="47005" name="Aconsegueix més &amp;complements"/>
 					<Item id="47006" name="Ac&amp;tualitza Notepad++"/>
 					<Item id="47009" name="Confi&amp;gura l'intermediari d'actualització"/>
-					<Item id="47012" name="Informació de depuració..."/>
-					<Item id="47000" name="&amp;Quant a Notepad++"/>
+					<Item id="48005" name="Importa &amp;complements ..."/>
+					<Item id="48006" name="Importa &amp;temes d'estil..."/>
+					<Item id="48018" name="Edita el menú contextual emergent"/>
+					<Item id="48009" name="&amp;Editor de tecles de dreceres..."/>
+					<Item id="48011" name="&amp;Preferències..."/>
+					<Item id="48014" name="Obre la carpeta dels complements"/>
+					<Item id="48015" name="Administració de complements..."/>
+					<Item id="48501" name="Genera..."/>
+					<Item id="48502" name="Genera dels fitxers..."/>
+					<Item id="48503" name="Genera de la selecció al porta-retalls"/>
+					<Item id="48504" name="Genera..."/>
+					<Item id="48505" name="Genera dels fitxers..."/>
+					<Item id="48506" name="Genera de la selecció al porta-retalls"/>
+					<Item id="49000" name="&amp;Executa..."/>
+
+					<Item id="50000" name="Autocompleta &amp;funcions"/>
+					<Item id="50001" name="Autocompleta &amp;paraules"/>
+					<Item id="50002" name="&amp;Suggeriments de paràmetres de funcions"/>
+					<Item id="50003" name="Canvia al document anterior"/>
+					<Item id="50004" name="Canvia al document següent"/>
+					<Item id="50005" name="Comença/atura l'enregistrament de macro"/>
+					<Item id="50006" name="Compleció de camí"/>
+					<Item id="44042" name="Ama&amp;ga les línies"/>
+					<Item id="42040" name="Obre tots els fit&amp;xers recents"/>
+					<Item id="42041" name="Nete&amp;ja llista de fitxers recents"/>
+					<Item id="48016" name="&amp;Modifica tecla de drecera/Esborra macro..."/>
+					<Item id="48017" name="&amp;Modifica tecla de drecera/Esborra ordre..."/>
 				</Commands>
 			</Main>
 			<Splitter>
@@ -344,117 +340,123 @@ By Hiro5 <groccat at gmail>
 			<TabBar>
 				<Item CMID="0"  name="&amp;Tanca"/>
 				<Item CMID="1"  name="Tanca'ls tots m&amp;enys aquest"/>
-				<Item CMID="17" name="Tanca tots els de l'esquerra"/>
-				<Item CMID="18" name="Tanca tots els de la dreta"/>
-				<Item CMID="22" name="Tanca tots els no canviats"/>
 				<Item CMID="2"  name="&amp;Desa"/>
 				<Item CMID="3"  name="Desa &amp;com a..."/>
-				<Item CMID="10" name="Canvia el &amp;nom..."/>
-				<Item CMID="11" name="Su&amp;primeix"/>
-				<Item CMID="16" name="Recarre&amp;ga"/>
 				<Item CMID="4"  name="&amp;Imprimeix..."/>
-				<Item CMID="19" name="Obre la carpeta contenidora amb l'Explorador"/>
-				<Item CMID="20" name="Obre la carpeta contenidora amb l'Indicador d'ordres"/>
-				<Item CMID="21" name="Obre amb el visualitzador per defecte"/>
-				<Item CMID="12" name="&amp;Mode de Només-Lectura"/>
-				<Item CMID="13" name="Treu m&amp;arca de Només-Lectura"/>
+				<Item CMID="5"  name="Mou a una altra &amp;vista"/>
+				<Item CMID="6"  name="Clona a una altra vi&amp;sta"/>
 				<Item CMID="7"  name="Copia el camí sence&amp;r d'aquest fitxer"/>
 				<Item CMID="8"  name="C&amp;opia el nom d'aquest fitxer"/>
 				<Item CMID="9"  name="Copia el camí del di&amp;rectori d'aquest fitxer"/>
-				<Item CMID="5"  name="Mou a una altra &amp;vista"/>
-				<Item CMID="6"  name="Clona a una altra vi&amp;sta"/>
+				<Item CMID="10" name="Canvia el &amp;nom..."/>
+				<Item CMID="11" name="Su&amp;primeix"/>
+				<Item CMID="12" name="&amp;Mode de Només-Lectura"/>
+				<Item CMID="13" name="Treu m&amp;arca de Només-Lectura"/>
 				<Item CMID="14" name="Mou a una nova &amp;finestra"/>
 				<Item CMID="15" name="C&amp;lona a una nova finestra"/>
+				<Item CMID="16" name="Recarre&amp;ga"/>
+				<Item CMID="17" name="Tanca tots els de l'esquerra"/>
+				<Item CMID="18" name="Tanca tots els de la dreta"/>
+				<Item CMID="19" name="Obre la carpeta contenidora amb l'Explorador"/>
+				<Item CMID="20" name="Obre la carpeta contenidora amb l'Indicador d'ordres"/>
+				<Item CMID="21" name="Obre amb el visualitzador per defecte"/>
+				<Item CMID="22" name="Tanca tots els no canviats"/>
 			</TabBar>
 		</Menu>
+
 		<Dialog>
 			<Find title="" titleFind="Cerca" titleReplace="Reemplaça" titleFindInFiles="Cerca als fitxers" titleMark="Marca">
-				<Item id="1617" name="Estil de símbol trobat"/>
-				<Item id="1637" name="Cerca als fitxers"/>
 				<Item id="1"    name="Cerca següent"/>
 				<Item id="1722" name="Inverteix direcció"/>
-				<Item id="1614" name="Compta coincidències"/>
-				<Item id="1636" name="Cerca-ho tot als documents oberts"/>
-				<Item id="1641" name="Cerca-ho tot en el document actual"/>
-				<Item id="1608" name="&amp;Reemplaça"/>
-				<Item id="1609" name="Reemplaça-ho &amp;tot"/>
-				<Item id="1635" name="Reemplaça-ho tot als documents oberts"/>
-				<Item id="1656" name="Cerca'ls tots"/>
-				<Item id="1660" name="Reemplaça-ho als fitxers"/>
 				<Item id="2"    name="Tanca"/>
 				<Item id="1620" name="Què voleu trobar?:"/>
-				<Item id="1611" name="Re&amp;emplaça amb:"/>
-				<Item id="1654" name="Filtres:"/>
-				<Item id="1655" name="Directori:"/>
-				<Item id="1616" name="Marca la línia"/>
-				<Item id="1618" name="Neteja a cada recerca"/>
-				<Item id="1615" name="Marca'ls tots"/>
-				<Item id="1632" name="A la selecció"/>
-				<Item id="1633" name="Neteja"/>
-				<Item id="1661" name="Segueix fitxer actual"/>
-				<Item id="1658" name="Inclou subdirectoris"/>
-				<Item id="1659" name="Inclou carpetes ocultes"/>
 				<Item id="1603" name="Només la paraula sencera"/>
 				<Item id="1604" name="Diferencia majúscules i minúscules"/>
+				<Item id="1605" name="Expressió regular"/>
 				<Item id="1606" name="Dóna la volta"/>
+				<Item id="1614" name="Compta coincidències"/>
+				<Item id="1615" name="Marca'ls tots"/>
+				<Item id="1616" name="Marca la línia"/>
+				<Item id="1618" name="Neteja a cada recerca"/>
+				<Item id="1611" name="Re&amp;emplaça amb:"/>
+				<Item id="1608" name="&amp;Reemplaça"/>
+				<Item id="1609" name="Reemplaça-ho &amp;tot"/>
+				<Item id="1687" name="En perdre el focus"/>
+				<Item id="1688" name="Sempre"/>
+				<Item id="1632" name="A la selecció"/>
+				<Item id="1633" name="Neteja"/>
+				<Item id="1635" name="Reemplaça-ho tot als documents oberts"/>
+				<Item id="1636" name="Cerca-ho tot als documents oberts"/>
+				<Item id="1654" name="Filtres:"/>
+				<Item id="1655" name="Directori:"/>
+				<Item id="1656" name="Cerca'ls tots"/>
+				<Item id="1658" name="Inclou subdirectoris"/>
+				<Item id="1659" name="Inclou carpetes ocultes"/>
 				<Item id="1624" name="Mode de cerca"/>
 				<Item id="1625" name="Normal"/>
 				<Item id="1626" name="Estès (\n, \r, \t, \0, \x...)"/>
-				<Item id="1605" name="Expressió regular"/>
-				<Item id="1703" name="&amp;. cerca nova línia"/>
-				<Item id="1623" name=" "/>
+				<Item id="1660" name="Reemplaça-ho als fitxers"/>
+				<Item id="1661" name="Segueix fitxer actual"/>
+				<Item id="1641" name="Cerca-ho tot en el document actual"/>
 				<Item id="1686" name="Transparència"/>
-				<Item id="1687" name="En perdre el focus"/>
-				<Item id="1688" name="Sempre"/>
+				<Item id="1703" name="&amp;. cerca nova línia"/>
 				<Item id="1721" name="▲"/>
 				<Item id="1723" name="▼ Cerca següent"/>
 			</Find>
-			<FindCharsInRange title = "Cerca interval de caràcters...">
-				<Item id="2910" name="Cerca"/>
+
+			<FindCharsInRange title="Cerca interval de caràcters...">
 				<Item id="2" name="Tanca"/>
 				<Item id="2901" name="Caràcters no-ASCII (128-255)"/>
-				<Item id="2902" name="Caràcters ASCII (0 - 127)"/>
+				<Item id="2902" name="Caràcters ASCII (0-127)"/>
 				<Item id="2903" name="Aquest interval:"/>
 				<Item id="2906" name="Amunt"/>
 				<Item id="2907" name="Avall"/>
 				<Item id="2908" name="Direcció"/>
 				<Item id="2909" name="Dóna la volta"/>
+				<Item id="2910" name="Cerca"/>
 			</FindCharsInRange>
+
 			<GoToLine title="Vés a la línia o posició...">
 				<Item id="2007" name="Línia"/>
 				<Item id="2008" name="Posició (en bytes)"/>
+				<Item id="1"    name="&amp;Vés-hi!"/>
+				<Item id="2"    name="No vaig enlloc!"/>
 				<Item id="2004" name="Sou aquí:"/>
 				<Item id="2005" name="Voleu anar a:"/>
 				<Item id="2006" name="No podeu anar més enllà de:"/>
-				<Item id="1"    name="&amp;Vés-hi!"/>
-				<Item id="2"    name="No vaig enlloc!"/>
 			</GoToLine>
+
 			<Run title="Executa...">
 				<Item id="1903" name="Trieu el programa que voleu executar aquí"/>
 				<Item id="1"    name="Executa"/>
-				<Item id="1904" name="Desa..."/>
 				<Item id="2"    name="Atura"/>
+				<Item id="1904" name="Desa..."/>
 			</Run>
+
 			<MD5FromFilesDlg title="Genera resums MD5 dels fitxers">
 				<Item id="1922" name="Trieu els fitxers per generar els MD5..."/>
 				<Item id="1924" name="Copia al porta-retalls"/>
 				<Item id="2"    name="Tanca"/>
 			</MD5FromFilesDlg>
+
 			<MD5FromTextDlg title="Genera resums MD5">
 				<Item id="1932" name="Tracta cada línia com un text per separat"/>
 				<Item id="1934" name="Copia al porta-retalls"/>
 				<Item id="2"    name="Tanca"/>
 			</MD5FromTextDlg>
+
 			<SHA256FromFilesDlg title="Genera resums SHA-256 de fitxers">
 				<Item id="1922" name="Tria els fitxers per generar els SHA-256..."/>
 				<Item id="1924" name="Copia al porta-retalls"/>
 				<Item id="2"    name="Tanca"/>
 			</SHA256FromFilesDlg>
+
 			<SHA256FromTextDlg title="Genera resums SHA-256">
 				<Item id="1932" name="Tracta cada línia com un text per separat"/>
 				<Item id="1934" name="Copia al porta-retalls"/>
 				<Item id="2"    name="Tanca"/>
 			</SHA256FromTextDlg>
+
 			<PluginsAdminDlg title="Administrador de complements" titleAvailable = "Disponibles" titleUpdates = "Actualitzacions" titleInstalled = "Instal·lats">
 				<ColumnPlugin   name="Complement"/>
 				<ColumnVersion  name="Versió"/>
@@ -465,27 +467,28 @@ By Hiro5 <groccat at gmail>
 				<Item id="5508" name="Següent"/>
 				<Item id="2"    name="Tanca"/>
 			</PluginsAdminDlg>
+
 			<StyleConfig title="Configuració d'estil">
-				<Item id="2" name="Cancel·la"/>
+				<Item id="2"    name="Cancel·la"/>
 				<Item id="2301" name="Desa &amp;i tanca"/>
 				<Item id="2303" name="Transparència"/>
 				<Item id="2306" name="Selecciona tema:"/>
 				<SubDialog>
-					<Item id="2225" name="Llenguatge:"/>
-					<Item id="2211" name="Configuració d'estil:"/>
-					<Item id="2212" name="Estil dels colors"/>
-					<Item id="2206" name="Col. en primer pla"/>
-					<Item id="2207" name="Color de fons"/>
-					<Item id="2213" name="Estil de lletra"/>
-					<Item id="2208" name="Tipus de lletra:"/>
-					<Item id="2209" name="Mida de lletra:"/>
 					<Item id="2204" name="Negreta"/>
 					<Item id="2205" name="Cursiva"/>
-					<Item id="2218" name="Subratlla"/>
+					<Item id="2206" name="Col. en primer pla"/>
+					<Item id="2207" name="Color de fons"/>
+					<Item id="2208" name="Tipus de lletra:"/>
+					<Item id="2209" name="Mida de lletra:"/>
+					<Item id="2211" name="Configuració d'estil:"/>
+					<Item id="2212" name="Estil dels colors"/>
+					<Item id="2213" name="Estil de lletra"/>
 					<Item id="2214" name="Ext. per defecte:"/>
 					<Item id="2216" name="Ext. de l'usuari/a:"/>
+					<Item id="2218" name="Subratlla"/>
 					<Item id="2219" name="Paraules clau per defecte"/>
 					<Item id="2221" name="Definició de paraules clau de l'usuari/a"/>
+					<Item id="2225" name="Llenguatge:"/>
 					<Item id="2226" name="Habilita color en primer pla global"/>
 					<Item id="2227" name="Habilita color de fons global"/>
 					<Item id="2228" name="Habilita tipus de lletra global"/>
@@ -495,6 +498,7 @@ By Hiro5 <groccat at gmail>
 					<Item id="2232" name="Habilita estil subratllat global"/>
 				</SubDialog>
 			</StyleConfig>
+
 			<ShortcutMapper title="Dreceres de teclat">
 				<Item id="2602" name="Modifica"/>
 				<Item id="2603" name="Suprimeix"/>
@@ -525,26 +529,25 @@ By Hiro5 <groccat at gmail>
 			</ShortcutMapperSubDialg>
 			<UserDefine title="Llenguatge definit per l'usuari">
 				<Item id="20001" name="Acobla"/>
-				<Item id="20007" name="Lleng. d'usuari:"/>
+				<Item id="20002" name="Canvia el nom"/>
 				<Item id="20003" name="Crea nou..."/>
+				<Item id="20004" name="Esborra"/>
 				<Item id="20005" name="Anomena i desa.."/>
+				<Item id="20007" name="Lleng. d'usuari:"/>
+				<Item id="20009" name="Ext.:"/>
+				<Item id="20012" name="Ignora majúscules"/>
+				<Item id="20011" name="Transparència"/>
 				<Item id="20015" name="Importa..."/>
 				<Item id="20016" name="Exporta..."/>
-				<Item id="20011" name="Transparència"/>
-				<Item id="20012" name="Ignora majúscules"/>
-				<Item id="20009" name="Ext.:"/>
-				<Item id="20002" name="Canvia el nom"/>
-				<Item id="20004" name="Esborra"/>
-				<Item id="24001" name="Activa caràcter d'escapada:"/>
 				<StylerDialog title="Diàleg d'estil">
 					<Item id="25030" name="Opcions de lletra:"/>
+					<Item id="25006" name="Color de primer pla"/>
+					<Item id="25007" name="Color de fons"/>
 					<Item id="25031" name="Nom:"/>
 					<Item id="25032" name="Mida:"/>
 					<Item id="25001" name="Negreta"/>
 					<Item id="25002" name="Cursiva"/>
 					<Item id="25003" name="Subratllat"/>
-					<Item id="25006" name="Color de primer pla"/>
-					<Item id="25007" name="Color de fons"/>
 					<Item id="25029" name="Incrustació:"/>
 					<Item id="25008" name="Delimitador 1"/>
 					<Item id="25009" name="Delimitador 2"/>
@@ -571,26 +574,26 @@ By Hiro5 <groccat at gmail>
 					<Item id="2" name="&amp;Cancel·la"/>
 				</StylerDialog>
 				<Folder title="Per defecte i Bloc de codi">
-					<Item id="21105" name="Documentació:"/>
-					<Item id="21104" name="Web de documentació temporal:"/>
 					<Item id="21101" name="Per defecte"/>
 					<Item id="21102" name="Estil"/>
+					<Item id="21105" name="Documentació:"/>
+					<Item id="21104" name="Web de documentació temporal:"/>
 					<Item id="21106" name="Plegament &amp;compacte (plega línies buides)"/>
-					<Item id="21420" name="Plegat de comentari: "/>
-					<Item id="21427" name="Estil"/>
-					<Item id="21424" name="Obertura:"/>
-					<Item id="21425" name="Mig:"/>
-					<Item id="21426" name="Tancament:"/>
 					<Item id="21220" name="Plegat de codi 1: "/>
-					<Item id="21227" name="Estil"/>
 					<Item id="21224" name="Obertura:"/>
 					<Item id="21225" name="Mig:"/>
 					<Item id="21226" name="Tancament:"/>
+					<Item id="21227" name="Estil"/>
 					<Item id="21320" name="Plegat de codi 2 (necessita separadors):"/>
-					<Item id="21327" name="Estil"/>
 					<Item id="21324" name="Obertura:"/>
 					<Item id="21325" name="Mig:"/>
 					<Item id="21326" name="Tancament:"/>
+					<Item id="21327" name="Estil"/>
+					<Item id="21420" name="Plegat de comentari: "/>
+					<Item id="21424" name="Obertura:"/>
+					<Item id="21425" name="Mig:"/>
+					<Item id="21426" name="Tancament:"/>
+					<Item id="21427" name="Estil"/>
 				</Folder>
 				<Keywords title="Llista de paraules clau">
 					<Item id="22101" name="1r. Grup"/>
@@ -601,14 +604,6 @@ By Hiro5 <groccat at gmail>
 					<Item id="22501" name="6è. Grup"/>
 					<Item id="22551" name="7è. Grup"/>
 					<Item id="22601" name="8è. Grup"/>
-					<Item id="22122" name="Estil"/>
-					<Item id="22222" name="Estil"/>
-					<Item id="22322" name="Estil"/>
-					<Item id="22422" name="Estil"/>
-					<Item id="22472" name="Estil"/>
-					<Item id="22522" name="Estil"/>
-					<Item id="22572" name="Estil"/>
-					<Item id="22622" name="Estil"/>
 					<Item id="22121" name="Mode prefix"/>
 					<Item id="22221" name="Mode prefix"/>
 					<Item id="22321" name="Mode prefix"/>
@@ -617,6 +612,14 @@ By Hiro5 <groccat at gmail>
 					<Item id="22521" name="Mode prefix"/>
 					<Item id="22571" name="Mode prefix"/>
 					<Item id="22621" name="Mode prefix"/>
+					<Item id="22122" name="Estil"/>
+					<Item id="22222" name="Estil"/>
+					<Item id="22322" name="Estil"/>
+					<Item id="22422" name="Estil"/>
+					<Item id="22472" name="Estil"/>
+					<Item id="22522" name="Estil"/>
+					<Item id="22572" name="Estil"/>
+					<Item id="22622" name="Estil"/>
 				</Keywords>
 				<Comment title="Comentaris i números">
 					<Item id="23003" name="Posició de comentari de línia"/>
@@ -624,15 +627,15 @@ By Hiro5 <groccat at gmail>
 					<Item id="23005" name="Força al principi de línia"/>
 					<Item id="23006" name="Permet espaiat inicial"/>
 					<Item id="23001" name="Permet plegat de comentaris"/>
-					<Item id="23301" name="Comentaris de línia"/>
 					<Item id="23326" name="Estil"/>
 					<Item id="23323" name="Obertura"/>
 					<Item id="23324" name="Caràcter de continuació"/>
 					<Item id="23325" name="Tancament"/>
-					<Item id="23101" name="Comentaris de bloc"/>
+					<Item id="23301" name="Comentaris de línia"/>
 					<Item id="23124" name="Estil"/>
 					<Item id="23122" name="Obertura"/>
 					<Item id="23123" name="Tancament"/>
+					<Item id="23101" name="Comentaris de bloc"/>
 					<Item id="23201" name="Número"/>
 					<Item id="23220" name="Estil"/>
 					<Item id="23230" name="Prefix 1:"/>
@@ -641,7 +644,7 @@ By Hiro5 <groccat at gmail>
 					<Item id="23236" name="Extres 2:"/>
 					<Item id="23238" name="Sufix 1:"/>
 					<Item id="23240" name="Sufix 2:"/>
-					<Item id="23242" name="Rang : "/>
+					<Item id="23242" name="Rang: "/>
 					<Item id="23244" name="Separador decimal"/>
 					<Item id="23245" name="Punt"/>
 					<Item id="23246" name="Coma"/>
@@ -653,72 +656,76 @@ By Hiro5 <groccat at gmail>
 					<Item id="24116" name="Operadors 1"/>
 					<Item id="24117" name="Operadors 2 (necessita separadors)"/>
 					<Item id="24201" name="Delimitador 1"/>
-					<Item id="24223" name="Estil"/>
 					<Item id="24220" name="Obertura: "/>
 					<Item id="24221" name="Escapament: "/>
 					<Item id="24222" name="Tancament: "/>
+					<Item id="24223" name="Estil"/>
 					<Item id="24301" name="Delimitador 2"/>
-					<Item id="24323" name="Estil"/>
 					<Item id="24320" name="Obertura: "/>
 					<Item id="24321" name="Escapament: "/>
 					<Item id="24322" name="Tancament: "/>
+					<Item id="24323" name="Estil"/>
 					<Item id="24401" name="Delimitador 3"/>
-					<Item id="24423" name="Estil"/>
 					<Item id="24420" name="Obertura: "/>
 					<Item id="24421" name="Escapament: "/>
 					<Item id="24422" name="Tancament: "/>
+					<Item id="24423" name="Estil"/>
 					<Item id="24451" name="Delimitador 4"/>
-					<Item id="24473" name="Estil"/>
 					<Item id="24470" name="Obertura: "/>
 					<Item id="24471" name="Escapament: "/>
 					<Item id="24472" name="Tancament: "/>
+					<Item id="24473" name="Estil"/>
 					<Item id="24501" name="Delimitador 5"/>
-					<Item id="24523" name="Estil"/>
 					<Item id="24520" name="Obertura: "/>
 					<Item id="24521" name="Escapament: "/>
 					<Item id="24522" name="Tancament: "/>
+					<Item id="24523" name="Estil"/>
 					<Item id="24551" name="Delimitador 6"/>
-					<Item id="24573" name="Estil"/>
 					<Item id="24570" name="Obertura: "/>
 					<Item id="24571" name="Escapament: "/>
 					<Item id="24572" name="Tancament: "/>
+					<Item id="24573" name="Estil"/>
 					<Item id="24601" name="Delimitador 7"/>
-					<Item id="24623" name="Estil"/>
 					<Item id="24620" name="Obertura: "/>
 					<Item id="24621" name="Escapament: "/>
 					<Item id="24622" name="Tancament: "/>
+					<Item id="24623" name="Estil"/>
 					<Item id="24651" name="Delimitador 8"/>
-					<Item id="24673" name="Estil"/>
 					<Item id="24670" name="Obertura: "/>
 					<Item id="24671" name="Escapament: "/>
 					<Item id="24672" name="Tancament: "/>
+					<Item id="24673" name="Estil"/>
 				</Operator>
 			</UserDefine>
 			<Preference title="Preferències">
 				<Item id="6001" name="Tanca"/>
 				<Global title="Global">
-					<Item id="6123" name="Idioma"/>
 					<Item id="6101" name="Barra d'eines"/>
 					<Item id="6102" name="Amaga la barra d'eines"/>
 					<Item id="6103" name="Icones petites"/>
 					<Item id="6104" name="Icones grans"/>
 					<Item id="6105" name="Icones estàndard"/>
-					<Item id="6125" name="Panell de documents"/>
-					<Item id="6126" name="Mostra"/>
-					<Item id="6127" name="Desactiva la columna d'extensions"/>
-					<Item id="6111" name="Mostra barra d'estat"/>
+
 					<Item id="6106" name="Barra de pestanyes"/>
-					<Item id="6118" name="Amaga la barra de pestanyes"/>
-					<Item id="6119" name="Multilínia"/>
-					<Item id="6120" name="Vertical"/>
 					<Item id="6107" name="Redueix"/>
 					<Item id="6108" name="Bloqueja (no es podrà arrossegar)"/>
 					<Item id="6109" name="Enfosqueix pestanyes inactives"/>
 					<Item id="6110" name="Marca superior a la pestanya activa"/>
+
+					<Item id="6111" name="Mostra barra d'estat"/>
 					<Item id="6112" name="Botó de tancar a cada pestanya"/>
 					<Item id="6113" name="Doble clic per tancar el document"/>
+					<Item id="6118" name="Amaga la barra de pestanyes"/>
+					<Item id="6119" name="Multilínia"/>
+					<Item id="6120" name="Vertical"/>
 					<Item id="6121" name="Surt en tancar l'última pestanya"/>
+
 					<Item id="6122" name="Amaga la barra de menú (prem Alt o F10 per accedir)"/>
+					<Item id="6123" name="Idioma"/>
+
+					<Item id="6125" name="Panell de documents"/>
+					<Item id="6126" name="Mostra"/>
+					<Item id="6127" name="Desactiva la columna d'extensions"/>
 				</Global>
 				<Scintillas title="Opcions visuals">
 					<Item id="6216" name="Configuració del cursor"/>
@@ -734,26 +741,28 @@ By Hiro5 <groccat at gmail>
 					<Item id="6204" name="Arbre en cercle"/>
 					<Item id="6205" name="Arbre en caixa"/>
 					<Item id="6226" name="Cap"/>
-					<Item id="6211" name="Configuració de la vora vertical"/>
-					<Item id="6208" name="Mostra la vora vertical"/>
-					<Item id="6212" name="Mode de línia"/>
-					<Item id="6213" name="Mode de color de fons"/>
-					<Item id="6209" name="Número de columna:"/>
-					<Item id="6231" name="Mida del marge"/>
-					<Item id="6235" name="Sense vores"/>
+
 					<Item id="6227" name="Ajustament de línia"/>
 					<Item id="6228" name="Per defecte"/>
 					<Item id="6229" name="Alineat"/>
 					<Item id="6230" name="Sagnat"/>
+
 					<Item id="6206" name="Mostra el número de línia al marge"/>
 					<Item id="6207" name="Mostra les marques de línia al marge"/>
+					<Item id="6208" name="Mostra la vora vertical"/>
+					<Item id="6234" name="Desactiva el desplaçament avançat&#xD;(si teniu problemes amb el touchpad)"/>
+					<Item id="6211" name="Configuració de la vora vertical"/>
+					<Item id="6213" name="Mode de color de fons"/>
+					<Item id="6237" name="Afegiu el marcador de columna indicant la seva posició amb un número decimal.
+Podeu definir diversos marcadors de columnes mitjançant un espai en blanc per separar els diferents números."/>
 					<Item id="6214" name="Activa el realçament de la línia actual"/>
 					<Item id="6215" name="Activa suavitzat de lletra"/>
+					<Item id="6231" name="Mida del marge"/>
+					<Item id="6235" name="Sense vores"/>
 					<Item id="6236" name="Permet desplaç. després de l'última línia"/>
-					<Item id="6234" name="Desactiva el desplaçament avançat&#xD;(si teniu problemes amb el touchpad)"/>
 				</Scintillas>
+
 				<NewDoc title="Document nou">
-					<Item id="6419" name="Document nou"/>
 					<Item id="6401" name="Salt de línia"/>
 					<Item id="6402" name="Windows"/>
 					<Item id="6403" name="Unix"/>
@@ -761,12 +770,14 @@ By Hiro5 <groccat at gmail>
 					<Item id="6405" name="Codificació"/>
 					<Item id="6406" name="ANSI"/>
 					<Item id="6407" name="UTF-8"/>
-					<Item id="6420" name="Aplica als fitxers ANSI oberts"/>
 					<Item id="6408" name="UTF-8 amb BOM"/>
 					<Item id="6409" name="UCS2 Big Endian amb BOM"/>
 					<Item id="6410" name="UCS2 Little Endian amb BOM"/>
 					<Item id="6411" name="Llenguatge inicial:"/>
+					<Item id="6419" name="Document nou"/>
+					<Item id="6420" name="Aplica als fitxers ANSI oberts"/>
 				</NewDoc>
+
 				<DefaultDir title="Directoris">
 					<Item id="6413" name="Directori d'obertura/emmagatzematge"/>
 					<Item id="6414" name="Segons el document actual"/>
@@ -774,31 +785,24 @@ By Hiro5 <groccat at gmail>
 					<Item id="6430" name="Diàleg de desament sense extensions de fitxer"/>
 					<Item id="6431" name="Obre els fitxers d'una carpeta arrossegada en comptes d'obrir a Carpetes de treball"/>
 				</DefaultDir>
-				<RecentFilesHistory title="Historial de fitxers recents">
-					<Item id="6304" name="Historial de fitxers recents"/>
-					<Item id="6305" name="No comprovis els fitxers en iniciar"/>
-					<Item id="6306" name="Límit de fitxers a l'historial:"/>
-					<Item id="6429" name="Mostra l'historial"/>
-					<Item id="6424" name="Al submenú"/>
-					<Item id="6425" name="Només el nom del fitxer"/>
-					<Item id="6426" name="Camí complet del fitxer"/>
-					<Item id="6427" name="Camí amb límit de caràcters:"/>
-				</RecentFilesHistory>
+
 				<FileAssoc title="Associació de fitxers">
+					<Item id="4008" name="Si us plau, sortiu del Notepad++ i reinicieu Notepad++ en mode administrador per utilitzar aquesta funció."/>
 					<Item id="4009" name="Extensions suportades:"/>
 					<Item id="4010" name="Ext. registrades:"/>
 				</FileAssoc>
 				<Language title="Llenguatge">
-					<Item id="6508" name="Menú Llenguatge"/>
-					<Item id="6507" name="Compacta el menú Llenguatge"/>
 					<Item id="6505" name="Ítems disponibles"/>
 					<Item id="6506" name="Ítems no disponibles"/>
+					<Item id="6507" name="Compacta el menú Llenguatge"/>
+					<Item id="6508" name="Menú Llenguatge"/>
 					<Item id="6301" name="Configuració de tabulació"/>
-					<Item id="6510" name="Utilitza el predeterminat"/>
-					<Item id="6303" name="Mida de tabulació:"/>
 					<Item id="6302" name="Reemplaça per espais"/>
+					<Item id="6303" name="Mida de tabulació:"/>
+					<Item id="6510" name="Utilitza el predeterminat"/>
 					<Item id="6335" name="Tracta \ com a caràcter d'escapada per l'SQL"/>
 				</Language>
+
 				<Highlighting title="Ressaltat">
 					<Item id="6333" name="Ressaltat intel·ligent"/>
 					<Item id="6326" name="Activa el ressaltat intel·ligent"/>
@@ -811,6 +815,7 @@ By Hiro5 <groccat at gmail>
 					<Item id="6328" name="Destaca els atributs de par. clau"/>
 					<Item id="6330" name="Destaca la zona php/asp/comentari"/>
 				</Highlighting>
+
 				<Print title="Impressió">
 					<Item id="6601" name="Imprimeix número de línia"/>
 					<Item id="6602" name="Opcions de color"/>
@@ -819,34 +824,46 @@ By Hiro5 <groccat at gmail>
 					<Item id="6605" name="Blanc i negre"/>
 					<Item id="6606" name="Sense color de fons"/>
 					<Item id="6607" name="Marges de pàgina (Unitat:mm)"/>
-					<Item id="6613" name="Superior"/>
 					<Item id="6612" name="Esquerra"/>
+					<Item id="6613" name="Superior"/>
 					<Item id="6614" name="Dreta"/>
 					<Item id="6615" name="Inferior"/>
-					<Item id="6728" name="Capçalera i peu de pàgina"/>
-					<Item id="6725" name="Variable:"/>
-					<Item id="6723" name="Afegeix"/>
+					<Item id="6706" name="Negreta"/>
+					<Item id="6707" name="Cursiva"/>
 					<Item id="6708" name="Capçalera"/>
 					<Item id="6709" name="A l'esquerra"/>
 					<Item id="6710" name="Al mig"/>
 					<Item id="6711" name="A la dreta"/>
-					<Item id="6706" name="Negreta"/>
-					<Item id="6707" name="Cursiva"/>
+					<Item id="6717" name="Negreta"/>
+					<Item id="6718" name="Cursiva"/>
 					<Item id="6719" name="Peu"/>
 					<Item id="6720" name="A l'esquerra"/>
 					<Item id="6721" name="Al mig"/>
 					<Item id="6722" name="A la dreta"/>
-					<Item id="6717" name="Negreta"/>
-					<Item id="6718" name="Cursiva"/>
+					<Item id="6723" name="Afegeix"/>
+					<Item id="6725" name="Variable:"/>
 					<Item id="6727" name=" "/>
+					<Item id="6728" name="Capçalera i peu de pàgina"/>
 				</Print>
+
+				<RecentFilesHistory title="Historial de fitxers recents">
+					<Item id="6304" name="Historial de fitxers recents"/>
+					<Item id="6306" name="Límit de fitxers a l'historial:"/>
+					<Item id="6305" name="No comprovis els fitxers en iniciar"/>
+					<Item id="6429" name="Mostra l'historial"/>
+					<Item id="6424" name="Al submenú"/>
+					<Item id="6425" name="Només el nom del fitxer"/>
+					<Item id="6426" name="Camí complet del fitxer"/>
+					<Item id="6427" name="Camí amb límit de caràcters:"/>
+				</RecentFilesHistory>
+
 				<Backup title="Còpia de seguretat">
 					<Item id="6817" name="Captura de sessió i còpia periòdica"/>
-					<Item id="6309" name="Recorda la sessió actual per la propera execució"/>
 					<Item id="6818" name="Activa la captura de sessió i còpia periòdica"/>
 					<Item id="6819" name="Copia cada"/>
 					<Item id="6821" name="segons"/>
 					<Item id="6822" name="Directori:"/>
+					<Item id="6309" name="Recorda la sessió actual per la propera execució"/>
 					<Item id="6801" name="Còpia de seguretat en desar"/>
 					<Item id="6315" name="Cap còpia"/>
 					<Item id="6316" name="Còpia simple"/>
@@ -854,25 +871,28 @@ By Hiro5 <groccat at gmail>
 					<Item id="6804" name="Directori de còpia personalitzat"/>
 					<Item id="6803" name="Directori:"/>
 				</Backup>
+
 				<AutoCompletion title="Autocompleció">
+					<Item id="6115" name="Autotabulació"/>
 					<Item id="6807" name="Autocompleció"/>
 					<Item id="6808" name="Permetre Autocompleció a cada entrada"/>
 					<Item id="6809" name="Autocompleta funcions"/>
 					<Item id="6810" name="Autocompleta paraules"/>
 					<Item id="6816" name="Autocompleta funcions i paraules"/>
 					<Item id="6824" name="Ignora els números"/>
-					<Item id="6815" name="Suggeriments en crear paràm. de funció"/>
 					<Item id="6811" name="De"/>
 					<Item id="6813" name="caràcters ordinals anglesos"/>
 					<Item id="6814" name="Valors vàlids: 1 - 9"/>
+					<Item id="6815" name="Suggeriments en crear paràm. de funció"/>
 					<Item id="6851" name="Autoinserció"/>
-					<Item id="6857" name="tanca-etiq. html/xml"/>
+					<Item id="6857" name="Tanca-etiq. html/xml"/>
 					<Item id="6858" name="Obre"/>
 					<Item id="6859" name="Tanca"/>
 					<Item id="6860" name="Parella 1:"/>
 					<Item id="6863" name="Parella 2:"/>
 					<Item id="6866" name="Parella 3:"/>
 				</AutoCompletion>
+
 				<MultiInstance title="Múltiples instàncies">
 					<Item id="6151" name="Opcions de múltiples instàncies"/>
 					<Item id="6152" name="Obre sessió en nova instància de Notepad++"/>
@@ -880,48 +900,23 @@ By Hiro5 <groccat at gmail>
 					<Item id="6154" name="Per defecte (una instància)"/>
 					<Item id="6155" name="La modificació d'aquest paràmetre requereix reiniciar Notepad++"/>
 				</MultiInstance>
+
 				<Delimiter title="Delimitació">
-					<Item id="6161" name="Llista de caràcters de paraula"/>
-					<Item id="6162" name="Utilitza la llista de caràcters de paraula tal qual"/>
-					<Item id="6163" name="Afegeix caràcters com a part de paraula&#xD;(desactiveu si no sabeu què feu)"/>
 					<Item id="6251" name="Opcions de selecció de delimitació (Control + doble clic del ratolí)"/>
 					<Item id="6252" name="Obre"/>
 					<Item id="6255" name="Tanca"/>
 					<Item id="6256" name="Permet en diverses línies"/>
+					<Item id="6161" name="Llista de caràcters de paraula"/>
+					<Item id="6162" name="Utilitza la llista de caràcters de paraula tal qual"/>
+					<Item id="6163" name="Afegeix caràcters com a part de paraula&#xD;(desactiveu si no sabeu què feu)"/>
 				</Delimiter>
+
 				<Cloud title="Núvol">
 					<Item id="6262" name="Paràmetres al núvol"/>
 					<Item id="6263" name="Sense núvol"/>
 					<Item id="6267" name="Indiqueu el directori del núvol aquí:"/>
 				</Cloud>
-				<MISC title="Miscel·lània">
-					<ComboBox id="6347">
-						<Element name="Activa"/>
-						<Element name="Activa per a tot fitxer obert"/>
-						<Element name="Desactiva"/>
-					</ComboBox>
-					<Item id="6324" name="Canvi de document (Ctrl+Tab)"/>
-					<Item id="6114" name="Habilita"/>
-					<Item id="6117" name="Ordena per l'editat més recent"/>
-					<Item id="6344" name="Previsualització del document"/>
-					<Item id="6345" name="Previsualitza en la pestanya"/>
-					<Item id="6346" name="Previsualitza en el mapa del document"/>
-					<Item id="6334" name="Autodetecta codificació de caràcters"/>
-					<Item id="6314" name="Empra lletra monoespai al diàleg de cerca (demana reiniciar Notepad++)"/>
-					<Item id="6115" name="Sagnat automàtic"/>
-					<Item id="6308" name="Minimitza a la safata del sistema"/>
-					<Item id="6331" name="Mostra només el nom de fitxer a la barra de títol"/>
-					<Item id="6323" name="Actualitza Notepad++ automàticament"/>
-					<Item id="6318" name="Configuració dels enllaços clicables"/>
-					<Item id="6319" name="Habilita"/>
-					<Item id="6320" name="No subratllis"/>
-					<Item id="6312" name="Autodetecció d'estat del fitxer"/>
-					<Item id="6307" name="Habilita"/>
-					<Item id="6313" name="Actualitza en silenci"/>
-					<Item id="6325" name="Vés a l'última línia després d'actualitzar"/>
-					<Item id="6322" name="Ext. del fitxer de sessió:"/>
-					<Item id="6337" name="Ext. del fitxer d'espai de treball:"/>
-				</MISC>
+
 				<SearchEngine title="Motor de cerca">
 					<Item id="6271" name="Motor de cerca (per l'ordre “Cerca a Internet”)"/>
 					<Item id="6272" name="DuckDuckGo"/>
@@ -929,38 +924,67 @@ By Hiro5 <groccat at gmail>
 					<Item id="6274" name="Bing"/>
 					<Item id="6275" name="Yahoo!"/>
 					<Item id="6276" name="Establiu un motor de cerca aquí:"/>
+					<!-- No canvieu res de la URL -->
 					<Item id="6278" name="Exemple: https://www.google.com/search?q=$(CURRENT_WORD)"/>
 				</SearchEngine>
+
+				<MISC title="Miscel·lània">
+					<ComboBox id="6347">
+						<Element name="Activa"/>
+						<Element name="Activa per a tot fitxer obert"/>
+						<Element name="Desactiva"/>
+					</ComboBox>
+					<Item id="6308" name="Minimitza a la safata del sistema"/>
+					<Item id="6312" name="Autodetecció d'estat del fitxer"/>
+					<Item id="6313" name="Actualitza en silenci"/>
+					<Item id="6318" name="Configuració dels enllaços clicables"/>
+					<Item id="6325" name="Vés a l'última línia després d'actualitzar"/>
+					<Item id="6319" name="Habilita"/>
+					<Item id="6320" name="No subratllis"/>
+					<Item id="6322" name="Ext. del fitxer de sessió:"/>
+					<Item id="6323" name="Actualitza Notepad++ automàticament"/>
+					<Item id="6324" name="Canvi de document (Ctrl+Tab)"/>
+					<Item id="6331" name="Mostra només el nom de fitxer a la barra de títol"/>
+					<Item id="6334" name="Autodetecta codificació de caràcters"/>
+					<Item id="6314" name="Empra lletra monoespai al diàleg de cerca (demana reiniciar Notepad++)"/>
+					<Item id="6337" name="Ext. del fitxer d'espai de treball:"/>
+					<Item id="6114" name="Habilita"/>
+					<Item id="6117" name="Ordena per l'editat més recent"/>
+					<Item id="6344" name="Previsualització del document"/>
+					<Item id="6345" name="Previsualitza en la pestanya"/>
+					<Item id="6346" name="Previsualitza en el mapa del document"/>
+					<Item id="6348" name="No ompliu el camp de cerca al diàleg de cerca amb la paraula seleccionada"/>
+				</MISC>
 			</Preference>
 			<MultiMacro title="Executa una macro diverses vegades">
+				<Item id="1" name="Executa"/>
+				<Item id="2" name="Cancel·la"/>
 				<Item id="8006" name="Macro a executar:"/>
 				<Item id="8001" name="Executa"/>
 				<Item id="8005" name="vegades"/>
 				<Item id="8002" name="Executa fins al final del fitxer"/>
-				<Item id="1" name="Executa"/>
-				<Item id="2" name="Cancel·la"/>
 			</MultiMacro>
 			<Window title="Finestres...">
 				<Item id="1" name="Activa"/>
+				<Item id="2" name="Accepta"/>
 				<Item id="7002" name="Desa"/>
 				<Item id="7003" name="Tanca finestr."/>
 				<Item id="7004" name="Ordena pestany."/>
-				<Item id="2" name="Accepta"/>
 			</Window>
 			<ColumnEditor title="Inserció en columna...">
-				<Item id="1" name="D'acord"/>
-				<Item id="2" name="Cancel·la"/>
 				<Item id="2023" name="Text a inserir"/>
 				<Item id="2033" name="Números a inserir"/>
 				<Item id="2030" name="Número inicial:"/>
 				<Item id="2031" name="Incrementat en:"/>
-				<Item id="2036" name="Repeteix:"/>
 				<Item id="2035" name="Omple amb zeros"/>
+				<Item id="2036" name="Repeteix:"/>
 				<Item id="2032" name="Format"/>
 				<Item id="2024" name="Decimal"/>
 				<Item id="2025" name="Octal"/>
 				<Item id="2026" name="Hexadecimal"/>
 				<Item id="2027" name="Binari"/>
+				<Item id="1" name="D'acord"/>
+				<Item id="2" name="Cancel·la"/>
 			</ColumnEditor>
 			<FindInFinder title="Cerca al cercador">
 				<Item id="1"    name="Cerca-ho tot"/>
@@ -984,7 +1008,7 @@ By Hiro5 <groccat at gmail>
 				<Item id="5" name="N&amp;o a tot"/>
 			</DoSaveOrNot>
 		</Dialog>
-		<MessageBox>
+		<MessageBox> <!-- $INT_REPLACE$ és un marcador, no el tradueixis -->
 			<ContextMenuXmlEditWarning title="Editant contextMenu" message="Podeu modificar el menú contextual emergent de Notepad++ editant el fitxer contextMenu.xml.&#xD;Reinicieu Notepad++ després de modificar contextMenu.xml perquè faci efecte."/>
 			<NppHelpAbsentWarning title="No existeix el fitxer" message="&#xD;no existeix. El podeu baixar de la web de Notepad++."/>
 			<SaveCurrentModifWarning title="Desa la modificació actual" message="Hauríeu de desar la modificació actual.&#xD;Totes les modificacions desades no es podran desfer.&#xD;&#xD;Voleu continuar?"/>
@@ -994,6 +1018,7 @@ By Hiro5 <groccat at gmail>
 			<FileLockedWarning title="No s'ha pogut desar" message="Comproveu si aquest fitxer està obert amb un altre programa"/>
 			<FileAlreadyOpenedInNpp title="" message="El fitxer ja està obert amb Notepad++."/>
 			<DeleteFileFailed title="Esborra fitxer" message="No s'ha pogut esborrar el fitxer"/>
+
 			<NbFileToOpenImportantWarning title="Massa fitxers per obrir" message="Esteu a punt d'obrir $INT_REPLACE$ fitxers.&#xD;Segur que voleu obrir-los?"/>
 			<SettingsOnCloudError title="Opcions al núvol" message="Sembla que el directori indicat a les opcions del núvol es troba en una unitat de només lectura,&#xD;o en una carpeta que demana drets d'accés d'escriptura.&#xD;Els vostres paràmetres del núvol es cancel·laran. Reinicieu a un valor coherent a través del diàleg de Preferències."/>
 			<FilePathNotFoundWarning title="Obre fitxer" message="El fitxer que intenteu obrir no existeix."/>
@@ -1009,6 +1034,7 @@ By Hiro5 <groccat at gmail>
 			<DoReloadOrNotAndLooseChange title="Recarrega" message="&quot;$STR_REPLACE$&quot;&#xD;&#xD;Aquest fitxer s'ha modificat amb un altre programa.&#xD;El voleu recarregar i perdre els canvis que s'han fet amb Notepad++?"/>
 			<PrehistoricSystemDetected title="Sistema prehistòric detectat" message="Sembla que encara utilitzeu un sistema prehistòric, lamentablement aquesta característica només funciona en un sistema més modern."/>
 			<XpUpdaterProblem title="Actualitzador de Notepad++" message="L'actualitzador de Notepad++ no és compatible amb XP per una capa de seguretat obsoleta sota XP.&#xD;Voleu anar a la web de Notepad++ per baixar l'última versió?"/>
+			<GUpProxyConfNeedAdminMode title="Configuració del servidor intermediari" message="Si us plau, reinicieu el Notepad++ en mode d'administrador per configurar el servidor intermediari."/>
 			<DocTooDirtyToMonitor title="Problema de monitoratge" message="El document està en brut. Deseu la modificació abans de monitorar-lo."/>
 			<DocNoExistToMonitor title="Problema de monitoratge" message="El fitxer hauria d'existir per monitorar-lo."/>
 			<FileTooBigToOpen title="Problema amb mida de fitxer" message="El fitxer és massa gran per obrir-lo amb Notepad++"/>
@@ -1020,6 +1046,7 @@ By Hiro5 <groccat at gmail>
 			<LoadLangsFailed title="Configurador" message="Ha fallat la càrrega de langs.xml!&#xD;Voleu recuperar el vostre langs.xml?"/>
 			<LoadLangsFailedFinal title="Configurador" message="Ha fallat la càrrega de langs.xml!"/>
 			<FolderAsWorspaceSubfolderExists title="Problema d'afegir carpeta en Carpeta de treball" message="Existeix una subcarpeta de la carpeta que voleu afegir.&#xD;Esborreu la seva arrel del panell abans d'afegir la carpeta &quot;$STR_REPLACE$&quot;."/>
+
 			<ProjectPanelChanged title="$STR_REPLACE$" message="L'espai de treball s'ha modificat. Voleu desar-lo?"/>
 			<ProjectPanelChangedSaveError title="$STR_REPLACE$" message="L'espai de treball no s'ha desat."/>
 			<ProjectPanelOpenDoSaveDirtyWsOrNot title="Obre espai de treball" message="L'espai de treball actual s'ha modificat. Voleu desar el projecte actual?"/>
@@ -1052,9 +1079,10 @@ By Hiro5 <groccat at gmail>
 			<ColumnName name="Nom"/>
 			<ColumnPath name="Camí"/>
 			<ColumnType name="Tipus"/>
+			<ColumnSize name="Mida"/>
 		</WindowsDlg>
 		<AsciiInsertion>
-			<PanelTitle name="Panell d'inserció ASCII"/>
+			<PanelTitle name="Panell d'inserció de codis ASCII"/>
 			<ColumnVal name="Valor"/>
 			<ColumnHex name="Hex"/>
 			<ColumnChar name="Caràcter"/>
@@ -1085,6 +1113,7 @@ By Hiro5 <groccat at gmail>
 				<Item id="3520" name="Copia el nom del fitxer"/>
 			</Menus>
 		</FolderAsWorkspace>
+		<!-- TODO: Can the following section be removed? It doesn't exists in other lenguages -->
 		<FileBrowser>
 			<PanelTitle name="Carpetes de treball"/>
 		</FileBrowser>
@@ -1135,6 +1164,7 @@ By Hiro5 <groccat at gmail>
 			</Menus>
 		</ProjectManager>
 		<MiscStrings>
+			<!-- $INT_REPLACE$ i $STR_REPLACE$ són marcadors, no els tradueixis -->
 			<word-chars-list-tip value="Això permet afegir caràcters de paraula als predeterminats per quan es fa una selecció amb doble clic, o quan es cerca amb l'opció «Només la paraula sencera»."/>
 			<word-chars-list-warning-begin value="Vigileu: "/>
 			<word-chars-list-space-warning value="$INT_REPLACE$ espai(s)"/>
@@ -1202,6 +1232,14 @@ By Hiro5 <groccat at gmail>
 			<summary-nbsel1 value=" selecció ("/>
 			<summary-nbsel2 value=" bytes) en "/>
 			<summary-nbrange value=" rang(s)"/>
+			<replace-in-files-confirm-title value="Esteu segur?"/>
+			<replace-in-files-confirm-directory value="Esteu segur que voleu substituir totes els resultats a :"/>
+			<replace-in-files-confirm-filetype value="Per tipus de fitxer :"/>
+			<find-result-caption value="Cerca el resultat"/>
+			<find-result-title value="Cerca"/>
+			<find-result-title-info value="($INT_REPLACE1$ resultats en $INT_REPLACE2$ fitxers de $INT_REPLACE3$ cercats)"/>
+			<find-result-title-info-extra value=" - Mode de filtre de línia: només mostra els resultats filtrats"/>
+			<find-result-hits value="($INT_REPLACE$ resultats)"/>
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -439,7 +439,7 @@
                 <Item id="1934" name="Copy to Clipboard"/>
                 <Item id="2"    name="Close"/>
             </MD5FromTextDlg>
-            
+
             <SHA256FromFilesDlg title="Generate SHA-256 digest from files">
                 <Item id="1922" name="Choose files to generate SHA-256..."/>
                 <Item id="1924" name="Copy to Clipboard"/>
@@ -451,7 +451,7 @@
                 <Item id="1934" name="Copy to Clipboard"/>
                 <Item id="2"    name="Close"/>
             </SHA256FromTextDlg>
-            
+
             <PluginsAdminDlg title="Plugins Admin" titleAvailable = "Available" titleUpdates = "Updates" titleInstalled = "Installed">
                 <ColumnPlugin   name="Plugin"/>
                 <ColumnVersion  name="Version"/>


### PR DESCRIPTION
- Sort catalan.xml file like english.xml file to track changes easier.
- Removed ids: 24001, 6209, 6212, 6115, 6307
- Updated ids: 23242, 6857, 2902
- Added ids: 6237, 4008, 6115, 6348, GUpProxyConfNeedAdminMode, ColumnSize, AsciiInsertion/PanelTitle, replace-in-files-confirm-title, replace-in-files-confirm-directory, replace-in-files-confirm-filetype, find-result-caption, find-result-title, find-result-title-info, find-result-title-info-extra, find-result-hits.
- Remove empty spaces from english.xml.