### PR TITLE
Fix block selection cursor position after tab.

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2456,8 +2456,10 @@ void Notepad_plus::addHotSpot(ScintillaEditView* view)
 
 	int urlAction = (NppParameters::getInstance()).getNppGUI()._styleURL;
 	LPARAM indicStyle = (urlAction == 2) ? INDIC_PLAIN : INDIC_HIDDEN;
-	pView->execute(SCI_INDICSETSTYLE, URL_INDIC, indicStyle);
-	pView->execute(SCI_INDICSETHOVERSTYLE, URL_INDIC, INDIC_FULLBOX);
+
+	LPARAM indicStyleCur = pView->execute(SCI_INDICGETSTYLE, URL_INDIC);
+	if (indicStyleCur != indicStyle)
+		pView->execute(SCI_INDICSETSTYLE, URL_INDIC, indicStyle);
 
 	int startPos = 0;
 	int endPos = -1;

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -329,6 +329,8 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT4, true);
 	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT5, true);
 
+    execute(SCI_INDICSETHOVERSTYLE, URL_INDIC, INDIC_FULLBOX);
+
 	_codepage = ::GetACP();
 
 	::SetWindowLongPtr(_hSelf, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));


### PR DESCRIPTION
Fixes #8400 

Sorry for the unexpected side effect, I didn't see it coming. But I still believe, that using indicators for the URLs is the better solution over the long run.

Moved the hover style setting to the initialization of Scintilla edit view. The normal style setting must remain in `addHotSpot` to allow live preview while changing preferences.

