### PR TITLE
Add confirmation prompt to Replace-all-in-all-opened-docs command

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1268,6 +1268,8 @@ Find in all files except exe, obj &amp;&amp; log:
             <replace-in-files-confirm-title value="Are you sure?"/>
             <replace-in-files-confirm-directory value="Are you sure you want to replace all occurrences in :"/>
             <replace-in-files-confirm-filetype value="For file type :"/>
+            <replace-in-open-docs-confirm-title value="Are you sure?"/>
+            <replace-in-open-docs-confirm-message value="Are you sure you want to replace all occurrences in all open documents?"/>
             <find-result-caption value="Find result"/>
             <find-result-title value="Search"/>
             <find-result-title-info value="($INT_REPLACE1$ hits in $INT_REPLACE2$ files of $INT_REPLACE3$ searched)"/>

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -417,6 +417,7 @@ private :
 	void saveInMacro(size_t cmd, int cmdType);
 	void drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct);
 	bool replaceInFilesConfirmCheck(generic_string directory, generic_string fileTypes);
+	bool replaceInOpenDocsConfirmCheck(void);
 };
 
 //FindIncrementDlg: incremental search dialog, docked in rebar


### PR DESCRIPTION
Implements #5253
Probably implements the implied request in #8432 ??
Implements point 3 in #2855

Also implements desires expressed here:
* https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8213#issuecomment-624167936
* https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8213#issuecomment-632230473

So this was easy enough to implement.
Although, personally, I did not mind the existing behavior as I've never (in 5 years of using N++) pressed _Replace All in All Opened Documents_ by mistake.

My feeling is that I don't care one bit if this gets accepted or rejected.
If it gets rejected, that will stand as the final decision on this feature, and any future issues opened of this nature will be quickly closed without debate.