### PR TITLE
Change autocomplete to not use regex mode replacement

### DIFF
--- a/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScitillaComponent/AutoCompletion.cpp
@@ -378,7 +378,7 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 
 	if (wordArray.size() == 1 && autoInsert)
 	{
-		int replacedLength = _pEditView->replaceTargetRegExMode(wordArray[0].c_str(), startPos, curPos);
+		int replacedLength = _pEditView->replaceTarget(wordArray[0].c_str(), startPos, curPos);
 		_pEditView->execute(SCI_GOTOPOS, startPos + replacedLength);
 		return true;
 	}


### PR DESCRIPTION
Fixes #8397

I'm not sure why regular expression mode replacement was ever used here.
If anyone reading this can provide a reason, I'm sure we'll abort this and look for another fix.