### PR TITLE
Fix Clickable Links in wrapped windows effect

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2262,15 +2262,12 @@ void ScintillaEditView::replaceSelWith(const char * replaceText)
 void ScintillaEditView::getVisibleStartAndEndPosition(int * startPos, int * endPos)
 {
 	assert(startPos != NULL && endPos != NULL);
+	// Get the position of the 1st and last showing chars from the edit view
+	RECT rcEditView;
+	getClientRect(rcEditView);
+	*startPos = static_cast<int32_t>(execute(SCI_POSITIONFROMPOINT, 0, 0));
+	*endPos = static_cast<int32_t>(execute(SCI_POSITIONFROMPOINT, rcEditView.right - rcEditView.left, rcEditView.bottom - rcEditView.top));
 
-	auto firstVisibleLine = execute(SCI_GETFIRSTVISIBLELINE);
-	*startPos = static_cast<int32_t>(execute(SCI_POSITIONFROMLINE, execute(SCI_DOCLINEFROMVISIBLE, firstVisibleLine)));
-	auto linesOnScreen = execute(SCI_LINESONSCREEN);
-	auto lineCount = execute(SCI_GETLINECOUNT);
-	auto visibleLine = execute(SCI_DOCLINEFROMVISIBLE, firstVisibleLine + min(linesOnScreen, lineCount));
-	*endPos = static_cast<int32_t>(execute(SCI_POSITIONFROMLINE, visibleLine));
-	if (*endPos == -1) 
-		*endPos = static_cast<int32_t>(execute(SCI_GETLENGTH));
 }
 
 char * ScintillaEditView::getWordFromRange(char * txt, int size, int pos1, int pos2)


### PR DESCRIPTION
Fixes #5503.

This one is hard to reproduce, especially in the current unreleased version. It can be verified in the 7.8.7 release, and it is hidden now after PR #8409. It can be made visible again by commenting out the `addHotSpot` calls in the `WM_SIZE` case of Big Switch. But it has not been fixed by this lines.

There is another occasion, when this effect occurs. You have to make an edit window, wrap on, and assure, that all lines in it are wrapped one ore more times. Then, in the last line of this edit window, insert an URL. It will not be recognized. Looks like this:
![LinkWrap](https://user-images.githubusercontent.com/40629737/85633133-e7d44380-b678-11ea-87da-9c53fdfdb8e6.png)

The deeper reason of it is, that the function `ScintillaEditView::getVisibleStartAndEndPosition` does not work for wrapped windows. It returns a smaller range than necessary for wrapped windows, so that the last few links in the edit window are not recognized. So my suggestion is to modify it. Since it is used in `addHotSpot` only, I expect no side effects.
