### PR TITLE
Fix horizontal scroll bar position

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1646,6 +1646,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case WM_ACTIVATE:
 		{
 			_pEditView->getFocus();
+			auto x = _pEditView->execute(SCI_GETXOFFSET);
+			_pEditView->execute(SCI_SETXOFFSET, x);
+			x = _pNonEditView->execute(SCI_GETXOFFSET);
+			_pNonEditView->execute(SCI_SETXOFFSET, x);
 			return TRUE;
 		}
 

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -221,13 +221,14 @@ public:
 	{
 		::DestroyWindow(_hSelf);
 		_hSelf = NULL;
+		_pScintillaFunc = NULL;
 	};
 
 	virtual void init(HINSTANCE hInst, HWND hPere);
 
 	LRESULT execute(UINT Msg, WPARAM wParam=0, LPARAM lParam=0) const {
 		try {
-			return _pScintillaFunc(_pScintillaPtr, Msg, wParam, lParam);
+			return (_pScintillaFunc) ? _pScintillaFunc(_pScintillaPtr, Msg, wParam, lParam) : -1;
 		}
 		catch (...)
 		{


### PR DESCRIPTION
Fixes #8466.

This effect does not only occur after restoring a minimized Npp, but also after starting Npp with a saved session. The lines included force Scintilla to update the horizontal scroll bar(s) without changing the current x-offset.