### PR TITLE
Fix URL hovered style with no underline

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2498,8 +2498,15 @@ void Notepad_plus::addHotSpot(ScintillaEditView* view)
 	LPARAM indicStyle = (urlAction == 2) ? INDIC_PLAIN : INDIC_HIDDEN;
 
 	LPARAM indicStyleCur = pView->execute(SCI_INDICGETSTYLE, URL_INDIC);
-	if (indicStyleCur != indicStyle)
+	LPARAM indicHoverStyleCur = pView->execute(SCI_INDICGETHOVERSTYLE, URL_INDIC);
+
+	if ((indicStyleCur != indicStyle) || (indicHoverStyleCur != INDIC_FULLBOX))
+	{
 		pView->execute(SCI_INDICSETSTYLE, URL_INDIC, indicStyle);
+		pView->execute(SCI_INDICSETHOVERSTYLE, URL_INDIC, INDIC_FULLBOX);
+		pView->execute(SCI_INDICSETALPHA, URL_INDIC, 70);
+		pView->execute(SCI_INDICSETFLAGS, URL_INDIC, SC_INDICFLAG_VALUEFORE);
+	}
 
 	int startPos = 0;
 	int endPos = -1;

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -329,11 +329,6 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT4, true);
 	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT5, true);
 
-	execute(SCI_INDICSETHOVERSTYLE, URL_INDIC, INDIC_FULLBOX);
-	execute(SCI_INDICSETALPHA, URL_INDIC, 70);
-	execute(SCI_INDICSETFLAGS, URL_INDIC, SC_INDICFLAG_VALUEFORE);
-
-
 	if ((NppParameters::getInstance()).getNppGUI()._writeTechnologyEngine == directWriteTechnology)
 		execute(SCI_SETTECHNOLOGY, SC_TECHNOLOGY_DIRECTWRITE);
 	// If useDirectWrite is turned off, leave the technology setting untouched,


### PR DESCRIPTION
Fixes #8493.

The reason is, that the `SCI_INDICSETSTYLE` command unfortunately resets the indicator hover style too, so that it has to be set again after calling `SCI_INDICSETSTYLE`. 

The desired functionality, for what this trouble began, was to make the change of the _No Underline_ option visible immediately. The first solution was, to set it every time in `addHotSpot`, until it was realized, that the cursor position was reset while block selection. The solution for this was to call the `SCI_INDICSETSTYLE` command only, if the _No Underline_ option changed. _Edit:_ This was the occasion, when the new bug crawled in (660284011776830a4f483ceeadf244dd5522d7f9). I moved `SCI_INDICSETHOVERSTYLE` to the init function of Scintilla Edit view, because I thought, this never changes, it needs to be set only once.

Now, the `SCI_INDICSETHOVERSTYLE` is called after every `SCI_INDICSETSTYLE` too, the PRO for this is, that all indicator style setting commands are at the same place again.  As before, the indicator style setting commands are only applied if the style has been changed, so that the problem with the block selection remains absent.

Successfully tested with this PR:
- Cursor position while inserting chars in block selection (Issue #8400)
- Underline color in dark themes (Issue #8405)

Sorry for the trouble.