### PR TITLE
Retain local config option during update installation

### DIFF
--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -102,6 +102,9 @@ Function ExtraOptions
 	Pop $NoUserDataCheckboxHandle
 	${NSD_OnClick} $NoUserDataCheckboxHandle OnChange_NoUserDataCheckBox
 	
+	IfFileExists $INSTDIR\doLocalConf.xml 0 +2
+	${NSD_Check} $NoUserDataCheckboxHandle
+		
 	StrLen $0 $PROGRAMFILES
 	StrCpy $1 $InstDir $0
 


### PR DESCRIPTION
Check for the existence of the doLocalConfig.xml file in the installer so that during installation of Notepad++ we don't have to manually recheck the "Don't use %APPDATA%" checkbox.
This is even more valuable when doing silent updates so it retains the existing configuration.