### PR TITLE
Fix open file command line with scroll option (-n/-l)

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5462,7 +5462,7 @@ std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * co
                 auto pos = _pEditView->execute(SCI_FINDCOLUMN, ln-1, cn-1);
                 _pEditView->execute(SCI_GOTOPOS, pos);
             }
-
+			_pEditView->setPositionRestoreNeeded(false);
 			_pEditView->scrollPosToCenter(_pEditView->execute(SCI_GETCURRENTPOS));
 
 			switchEditViewTo(iView);	//restore view

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -635,6 +635,7 @@ public:
     void setTabSettings(Lang *lang);
 	bool isWrapRestoreNeeded() const {return _wrapRestoreNeeded;};
 	void setWrapRestoreNeeded(bool isWrapRestoredNeeded) {_wrapRestoreNeeded = isWrapRestoredNeeded;};
+	void setPositionRestoreNeeded(bool isPositionRestoredNeeded) { _positionRestoreNeeded = isPositionRestoredNeeded;};
 
 	bool isCJK() const {
 		return ((_codepage == CP_CHINESE_TRADITIONAL) || (_codepage == CP_CHINESE_SIMPLIFIED) ||


### PR DESCRIPTION
Fixes #8476
The scroll action was canceled by the "restore position"  mechanism. I add an accessor to disable the "restore position" mechanism in case of scroll action passed by command line argument.