### PR TITLE
Allow user to start making a stream selection and then change to column block

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -323,6 +323,10 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.execute(SCI_SETMULTIPASTE, SC_MULTIPASTE_EACH);
 	_subEditView.execute(SCI_SETMULTIPASTE, SC_MULTIPASTE_EACH);
 
+	// allow user to start selecting as a stream block, then switch to a column block by adding Alt keypress
+	_mainEditView.execute(SCI_SETMOUSESELECTIONRECTANGULARSWITCH, true);
+	_subEditView.execute(SCI_SETMOUSESELECTIONRECTANGULARSWITCH, true);
+
 	// Let Scintilla deal with some of the folding functionality
 	_mainEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW);
 	_subEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW);

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2341,6 +2341,9 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		_pFinder->_scintView.execute(SCI_SETUSETABS, true);
 		_pFinder->_scintView.execute(SCI_SETTABWIDTH, 4);
 
+		// allow user to start selecting as a stream block, then switch to a column block by adding Alt keypress
+		_pFinder->_scintView.execute(SCI_SETMOUSESELECTIONRECTANGULARSWITCH, true);
+
 		// get the width of FindDlg
 		RECT findRect;
 		::GetWindowRect(_pFinder->getHSelf(), &findRect);
@@ -2445,6 +2448,9 @@ Finder * FindReplaceDlg::createFinder()
 
 	pFinder->_scintView.execute(SCI_SETUSETABS, true);
 	pFinder->_scintView.execute(SCI_SETTABWIDTH, 4);
+
+	// allow user to start selecting as a stream block, then switch to a column block by adding Alt keypress
+	pFinder->_scintView.execute(SCI_SETMOUSESELECTIONRECTANGULARSWITCH, true);
 
 	// get the width of FindDlg
 	RECT findRect;


### PR DESCRIPTION
Improves #8555 point 1, in editing views and also in _Find result_ and _Find in these found results_ windows.  My feeling is that if this PR is accepted, 8555 should be closed.

Test by starting to create a normal stream selection with the mouse, then in the middle of dragging to cover text add a press of the Alt key.  Note that the stream selection has now turned into a column block.

Behavior before this PR:  Once a stream selection is started, it couldn't be dynamically changed into a column block selection.

