### PR TITLE
Fix URL detection in first line of document.

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2260,9 +2260,12 @@ void ScintillaEditView::getVisibleStartAndEndPosition(int * startPos, int * endP
 	// Get the position of the 1st and last showing chars from the edit view
 	RECT rcEditView;
 	getClientRect(rcEditView);
-	*startPos = static_cast<int32_t>(execute(SCI_POSITIONFROMPOINT, 0, 0));
-	*endPos = static_cast<int32_t>(execute(SCI_POSITIONFROMPOINT, rcEditView.right - rcEditView.left, rcEditView.bottom - rcEditView.top));
-
+	LRESULT pos = execute(SCI_POSITIONFROMPOINT, 0, 0);
+	LRESULT line = execute(SCI_LINEFROMPOSITION, pos);
+	*startPos = static_cast<int32_t>(execute(SCI_POSITIONFROMLINE, line));
+	pos = execute(SCI_POSITIONFROMPOINT, rcEditView.right - rcEditView.left, rcEditView.bottom - rcEditView.top);
+	line = execute(SCI_LINEFROMPOSITION, pos);
+	*endPos = static_cast<int32_t>(execute(SCI_GETLINEENDPOSITION, line));
 }
 
 char * ScintillaEditView::getWordFromRange(char * txt, int size, int pos1, int pos2)


### PR DESCRIPTION
Fixes #8668. 

The function `ScintillaEditView::getVisibleStartAndEndPosition` is used to detect the text range processed by `Notepad_plus::addHotSpot`. It is not used for any other purposes.

The start of the range detected with `SCI_POSITIONFROMPOINT` does not include the beginning of the line, if it is invisible due to horizontal scrolling.

The end of the range, detected with `SCI_POSITIONFROMPOINT` too, contains the end of the last visible line only, if word wrap is turned off. With word wrap, the end of the current line may not be included if it's not visible.

Now, the function returns the range from the beginning of the first line partially visible to the end of the last line partially visible, and this whether wrapped or not. Sorry for disregarding this in my PR #8467.