### PR TITLE
Add SCI_SETCARETLINEBACKALPHA to the list of macroable commands in isMacroable function

### DIFF
--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -811,6 +811,7 @@ bool recordedMacroStep::isMacroable() const
 		case SCI_SCROLLTOSTART:
 		case SCI_SCROLLTOEND:
 		case SCI_SETVIRTUALSPACEOPTIONS:
+		case SCI_SETCARETLINEBACKALPHA:
 		{
 			if (_macroType == mtUseLParameter)
 				return true;


### PR DESCRIPTION
Fixes #8614, #5619