### PR TITLE
Fix URLs not underlined immediately after copy/paste

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -88,6 +88,10 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				prevWasEdit = false;
 			}
 
+			if (notification->modificationType & SC_MOD_CHANGEINDICATOR)
+			{
+				::InvalidateRect(notifyView->getHSelf(), NULL, FALSE);
+			}
 			break;
 		}
 


### PR DESCRIPTION
This PR fixes an effect brought up here: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8634#issuecomment-669503226. It can be seen as another step of the effort to put standard indicators into operation.

The effect can be reproduced as follows:
- New file
- URL underlining on
- Type four lines (the 4th line is empty):
				
		http://aaa
		http://bbb
		http://ccc

- Select them, copy them, paste them several times and watch.

The effect is, that the URLs are not underlined immediately after pasting. Only a cursor movement after the paste gets them underlined.

The reason for it is, that Notepad++ has no reaction to the `SC_MOD_CHANGEINDICATOR` notification implemented. So what happens is:
- The paste occurs
- After the paste, `addHotSpot` is called correctly
- `addHotSpot` marks the links using the indicator
- Scintilla notifies Notepad++ that indicators have been modified
Notepad++ should call `InvalidateRect(EditWindow)` now, what I suggest in this PR.
