### PR TITLE
Fixed naming error, where "new 1" is followed up by "new 3"

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1103,7 +1103,7 @@ size_t FileManager::nextUntitledNewNumber() const
 	for (size_t i = 0; i < _buffers.size(); i++)
 	{
 		Buffer *buf = _buffers.at(i);
-		if (buf->isUntitled())
+		if (buf->isUntitled() && buf->isUtilityBuffer() == false) // Skip utility buffers (Find Results)
 		{
 			// if untitled document is invisible, then don't put its number into array (so its number is available to be used)
 			if ((buf->_referees[0])->isVisible())

--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -374,6 +374,9 @@ public:
 
 	void langHasBeenSetFromMenu() { _hasLangBeenSetFromMenu = true; };
 
+	void setUtilityBuffer(bool state) { _isUtilityBuffer = state; };
+	bool isUtilityBuffer() { return _isUtilityBuffer; };
+
 private:
 	int indexOfReference(const ScintillaEditView * identifier) const;
 
@@ -432,6 +435,8 @@ private:
 	bool _isMonitoringOn = false;
 
 	bool _hasLangBeenSetFromMenu = false;
+
+	bool _isUtilityBuffer = false; // Marks that DOC_UNNAMED is used for something else than a "real document". i.e. the Find Results -window.
 
 	MapPosition _mapPosition;
 

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2330,6 +2330,7 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		originalFinderProc = SetWindowLongPtr(_pFinder->_scintView.getHSelf(), GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(finderProc));
 
 		_pFinder->setFinderReadOnly(true);
+		_pFinder->_scintView.setUtilityView(true); // Mark the view as utility so it won't be considered as "new x"
 		_pFinder->_scintView.execute(SCI_SETCODEPAGE, SC_CP_UTF8);
 		_pFinder->_scintView.execute(SCI_USEPOPUP, FALSE);
 		_pFinder->_scintView.execute(SCI_SETUNDOCOLLECTION, false);	//dont store any undo information

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1806,6 +1806,8 @@ BufferID ScintillaEditView::attachDefaultDoc()
 
 	MainFileManager.addBufferReference(id, this);	//add a reference. Notepad only shows the buffer in tabbar
 
+	buf->setUtilityBuffer(true); // Mark the buffer as utility so it won't be considered as "new x"
+
 	_currentBufferID = id;
 	_currentBuffer = buf;
 	bufferUpdated(buf, BufferChangeMask);	//make sure everything is in sync with the buffer, since no reference exists

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -1806,8 +1806,6 @@ BufferID ScintillaEditView::attachDefaultDoc()
 
 	MainFileManager.addBufferReference(id, this);	//add a reference. Notepad only shows the buffer in tabbar
 
-	buf->setUtilityBuffer(true); // Mark the buffer as utility so it won't be considered as "new x"
-
 	_currentBufferID = id;
 	_currentBuffer = buf;
 	bufferUpdated(buf, BufferChangeMask);	//make sure everything is in sync with the buffer, since no reference exists
@@ -3713,5 +3711,14 @@ void ScintillaEditView::getFoldColor(COLORREF& fgColor, COLORREF& bgColor, COLOR
 	{
 		Style & style = stylers.getStyler(i);
 		activeFgColor = style._fgColor;
+	}
+}
+
+void ScintillaEditView::setUtilityView(bool status)
+{
+	// Currently this just sets utility state for its buffer. Add member for view separately if ever needed.
+	if (_currentBuffer != nullptr)
+	{
+		_currentBuffer->setUtilityBuffer(status);
 	}
 }

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -647,6 +647,8 @@ public:
 	void changeTextDirection(bool isRTL);
 	bool isTextDirectionRTL() const;
 
+	void setUtilityView(bool status); // Sets the view and buffer to be concidered as utility.
+
 protected:
 	static HINSTANCE _hLib;
 	static int _refCount;


### PR DESCRIPTION
Fixes #8677 


**The problem**
As described in the issue 8677, second unnamed document was named "new 3" instead of "new 2" when "Find Results" window was open.

**Reason**
I found out that Find Results window is an unnamed document (enumerated with state DOC_UNNAMED) to help writing lines to it, using same code that is used for writing any document. The document is then treated in the code as any other unnamed document whenever it is listed while trying to find the next number for a new document.

**Solution**
While this maybe could be fixed by adding new enumeration to the document types, the document types are used in so many places that I don't think I could make such a massive change. My solution was to add a new member, _isUtilityBuffer, to document buffers to indicate that it's not a normal document, but rather used for something else. So when Find Results -window is opened, it is marked as an utility buffer and will be ignored whenever deciding a name for new unnamed window.

