### PR TITLE
Fix column key sort with col block starting in col1 bug

### DIFF
--- a/PowerEditor/src/MISC/Common/Sorters.h
+++ b/PowerEditor/src/MISC/Common/Sorters.h
@@ -50,9 +50,9 @@ protected:
 	{
 		if (isSortingSpecificColumns())
 		{
-			// prevent an std::out_of_range exception
 			if (input.length() < _fromColumn)
 			{
+				// prevent an std::out_of_range exception
 				return TEXT("");
 			}
 			else if (_fromColumn == _toColumn)
@@ -74,7 +74,7 @@ protected:
 
 	bool isSortingSpecificColumns()
 	{
-		return _fromColumn != 0 || _toColumn != 0;
+		return _toColumn != 0;
 	}
 
 public:

--- a/PowerEditor/src/MISC/Common/Sorters.h
+++ b/PowerEditor/src/MISC/Common/Sorters.h
@@ -74,7 +74,7 @@ protected:
 
 	bool isSortingSpecificColumns()
 	{
-		return _fromColumn != 0 && _toColumn != 0;
+		return _fromColumn != 0 || _toColumn != 0;
 	}
 
 public:


### PR DESCRIPTION
Fixes #8716

Note that when a column block begins in (user) column 1, `_fromColumn` is zero; in the original code this would cause `isSortingSpecificColumns()` to return `false`.