### PR TITLE
Fix regular expression has an unescaped '.' (dot) characters

### DIFF
--- a/scintilla/scripts/LexGen.py
+++ b/scintilla/scripts/LexGen.py
@@ -37,7 +37,7 @@ def UpdateVersionNumbers(sci, root):
     UpdateLineInFile(root + "doc/ScintillaDownload.html", "       Release",
         "       Release " + sci.versionDotted)
     ReplaceREInFile(root + "doc/ScintillaDownload.html",
-        r"/www.scintilla.org/([a-zA-Z]+)\d\d\d",
+        r"/www\.scintilla\.org/([a-zA-Z]+)\d\d\d",
         r"/www.scintilla.org/\g<1>" +  sci.version)
     UpdateLineInFile(root + "doc/index.html",
         '          <font color="#FFCC99" size="3"> Release version',


### PR DESCRIPTION
### Description

Escaped  `.` character before-and-after `scintilla`

Escape all meta-characters appropriately when constructing regular expressions for security checks, pay special attention to the `.` meta-character.
If a regular expression implements such a check, it is easy to accidentally make the check too permissive by not escaping the . meta-characters appropriately. Even if the check is not used in a security-critical context, the incomplete check may still cause undesirable behaviors when it accidentally succeeds.