### PR TITLE
Scintilla fix for hovered indicators

### DIFF
--- a/scintilla/src/EditView.cxx
+++ b/scintilla/src/EditView.cxx
@@ -1810,9 +1810,12 @@ void EditView::DrawForeground(Surface *surface, const EditModel &model, const Vi
 					const int indicatorValue = deco->ValueAt(ts.start + posLineStart);
 					if (indicatorValue) {
 						const Indicator &indicator = vsDraw.indicators[deco->Indicator()];
-						const bool hover = indicator.IsDynamic() &&
-							((model.hoverIndicatorPos >= ts.start + posLineStart) &&
-							(model.hoverIndicatorPos <= ts.end() + posLineStart));
+						bool hover = false;
+						if (indicator.IsDynamic()) {
+							const Sci::Position startPos = ts.start + posLineStart;
+							const Range rangeRun(deco->StartRun(startPos), deco->EndRun(startPos));
+							hover =	rangeRun.ContainsCharacter(model.hoverIndicatorPos);
+						}
 						if (hover) {
 							if ((indicator.sacHover.style == INDIC_TEXTFORE) || (indicator.sacHover.style == INDIC_EXPLORERLINK)) {
 								textFore = indicator.sacHover.fore;


### PR DESCRIPTION
To make the hovered blue underline links really shine, Scintilla needs another fix.

Without it, the URL becomes only partially hover-highlighted, if
- The hovered style is `INDIC_EXLORERLINK` or `INDIC_TEXTFORE`
AND
- There is a line break or a syntax highlighting change within the URL.
  (The line break is only possible with word wrapping on)

The problem was discovered by @Yaron10's thorough testing and is mentioned 1st in https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8634#issuecomment-678768659. 

I found out, that the detection, whether a character belonging to an indicator range, is currently hovered or not, didn't work in the text drawing part of the code (The part of the code, which is responsible for the decorations, like underlines or boxes, works).

I filed this as https://sourceforge.net/p/scintilla/bugs/2199/, and a fix for this has been integrated in the original Scintilla. 

What is now left to do, is to integrate the fix in the Notepad++ version of the `SciLexer.dll` too. Sorry for the trouble, but we are real indicator pioneers here.

