### PR TITLE
Enable and disable controls correctly for reg exp search mode in find-in-finder

### DIFF
--- a/PowerEditor/src/WinControls/StaticDialog/StaticDialog.h
+++ b/PowerEditor/src/WinControls/StaticDialog/StaticDialog.h
@@ -71,6 +71,11 @@ public :
 		return (BST_CHECKED == ::SendMessage(::GetDlgItem(_hSelf, checkControlID), BM_GETCHECK, 0, 0));
 	}
 
+	void setChecked(int checkControlID, bool checkOrNot = true) const
+	{
+		::SendDlgItemMessage(_hSelf, checkControlID, BM_SETCHECK, checkOrNot ? BST_CHECKED : BST_UNCHECKED, 0);
+	}
+
     virtual void destroy() override;
 
 protected:


### PR DESCRIPTION
Fixes #8768

-------------

@donho 

This change adds a new function `setChecked` into `StaticDialog.h` for use by the other code of this PR.

It simplifies an API call like this:

`::SendDlgItemMessage(_hSelf, IDC_MATCHLINENUM_CHECK_FIFOLDER, BM_SETCHECK, _options._isMatchLineNumber ? BST_CHECKED : BST_UNCHECKED, 0);
`

into something cleaner and easier to look at:

`setChecked(IDC_MATCHLINENUM_CHECK_FIFOLDER, _options._isMatchLineNumber);
`

I would probably not have added this function, but I noticed that `StaticDialog.h` already had the function `isCheckedOrNot` and I felt like if you have that function, why not create the companion function and call it `setChecked`?

This sets up a "refactoring" opportunity as there are about 200 other calls in the codebase that could be converted over to this cleaner/simpler style.  What do you think about doing that refactor?


