### PR TITLE
Fix auto scroll to last line after update not working

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3866,10 +3866,12 @@ void Notepad_plus::performPostReload(int whichOne)
 	if (whichOne == MAIN_VIEW)
 	{
 		_mainEditView.execute(SCI_GOTOLINE, _mainEditView.execute(SCI_GETLINECOUNT) -1);
+		_mainEditView.saveCurrentPos();
 	}
 	else
 	{
 		_subEditView.execute(SCI_GOTOLINE, _subEditView.execute(SCI_GETLINECOUNT) -1);
+		_subEditView.saveCurrentPos();
 	}
 }
 


### PR DESCRIPTION
When using the "Scroll to the last line after update" setting with Word wrap, the screen was not scrolling down to the last line. It would simply flicker down to the end, and come back to the previous scroll location.

Before version 7.8.2 (including), it would scroll to what would be the last line if Word Wrap weren't active (example: 50 lines, with 1 added line from word wrap, would result in a scroll to line 49).

This pull request fixes the issue by saving the location after the scroll to the end is done, which prevents further operations from restoring a previous position.

Fixes #8477 and fixes #8214 