### PR TITLE
Add word-count in selected text to document Summary output

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1339,6 +1339,7 @@ Find in all files except exe, obj &amp;&amp; log:
             <summary-filemodifytime value="Modified: "/>
             <summary-nbchar value="Characters (without line endings): "/>
             <summary-nbword value="Words: "/>
+            <summary-nbwordinsel value="Words (in 1 selection): "/>
             <summary-nbline value="Lines: "/>
             <summary-nbbyte value="Document length: "/>
             <summary-nbsel1 value=" selected characters ("/>

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3224,11 +3224,12 @@ size_t Notepad_plus::getSelectedBytes()
 	return result;
 }
 
-int Notepad_plus::wordCount()
+int Notepad_plus::wordCount(bool isEntireDoc)
 {
     FindOption env;
     env._str2Search = TEXT("[^ 	\\\\.,;:!?()+\\r\\n\\-\\*/=\\]\\[{}&~\"'`|@$%<>\\^]+");
     env._searchType = FindRegex;
+	if (!isEntireDoc) env._isInSelection = true;
     return _findReplaceDlg.processAll(ProcessCountAll, &env, true);
 }
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -594,7 +594,7 @@ private:
 	bool noOpenedDoc() const;
 	bool goToPreviousIndicator(int indicID2Search, bool isWrap = true) const;
 	bool goToNextIndicator(int indicID2Search, bool isWrap = true) const;
-	int wordCount();
+	int wordCount(bool isEntireDoc);
 
 	void wsTabConvert(spaceTab whichWay);
 	void doTrim(trimOp whichPart);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2141,6 +2141,7 @@ void Notepad_plus::command(int id)
 				}
 				generic_string nbCharLabel = pNativeSpeaker->getLocalizedStrFromID("summary-nbchar", TEXT("Characters (without line endings): "));
 				generic_string nbWordLabel = pNativeSpeaker->getLocalizedStrFromID("summary-nbword", TEXT("Words: "));
+				generic_string nbWordInSelLabel = pNativeSpeaker->getLocalizedStrFromID("summary-nbwordinsel", TEXT("Words (in 1 selection): "));
 				generic_string nbLineLabel = pNativeSpeaker->getLocalizedStrFromID("summary-nbline", TEXT("Lines: "));
 				generic_string nbByteLabel = pNativeSpeaker->getLocalizedStrFromID("summary-nbbyte", TEXT("Document length: "));
 				generic_string nbSelLabel1 = pNativeSpeaker->getLocalizedStrFromID("summary-nbsel1", TEXT(" selected characters ("));
@@ -2149,7 +2150,8 @@ void Notepad_plus::command(int id)
 
 				UniMode um = _pEditView->getCurrentBuffer()->getUnicodeMode();
 				auto nbChar = getCurrentDocCharCount(um);
-				int nbWord = wordCount();
+				int nbWord = wordCount(true);
+				int nbWordInSel = wordCount(false);
 				auto nbLine = _pEditView->execute(SCI_GETLINECOUNT);
 				auto nbByte = _pEditView->execute(SCI_GETLENGTH);
 				auto nbSel = getSelectedCharNumber(um);
@@ -2163,6 +2165,13 @@ void Notepad_plus::command(int id)
 				characterNumber += nbWordLabel;
 				characterNumber += commafyInt(nbWord).c_str();
 				characterNumber += TEXT("\r");
+
+				if (_pEditView->execute(SCI_GETSELECTIONS) == 1)
+				{
+					characterNumber += nbWordInSelLabel;
+					characterNumber += commafyInt(nbWordInSel).c_str();
+					characterNumber += TEXT("\r");
+				}
 
 				characterNumber += nbLineLabel;
 				characterNumber += commafyInt(static_cast<int>(nbLine)).c_str();


### PR DESCRIPTION
Implements #8790

Example:

![image](https://user-images.githubusercontent.com/30118311/92032926-d96d6c80-ed38-11ea-9e22-1b61063a6c71.png)

No attempt is made to handle multiple or column-block selections.

If invoked with no selection, will show output of `0` ; this serves as a prompt to the user that the feature is available to count words in a single selection.