### PR TITLE
Appveyor CI Unittest for functionlist for #8762

### DIFF
--- a/PowerEditor/Test/FunctionList/unitTestLauncher.ps1
+++ b/PowerEditor/Test/FunctionList/unitTestLauncher.ps1
@@ -1,44 +1,48 @@
 $testRoot = ".\"
 
-Get-ChildItem $testRoot -Filter *.* | 
+Get-ChildItem -Path $testRoot -Attribute Directory | 
 Foreach-Object {
-    if ((Get-Item $testRoot$_) -is [System.IO.DirectoryInfo])
-    {
-        $dirName = (Get-Item $testRoot$_).Name
+
+		$dirName = (Get-Item $testRoot$_).Name
 		$langName = $dirName
-        $result = &.\unitTest.ps1 $dirName $langName
+		$sw = [Diagnostics.Stopwatch]::StartNew()
+		$result = &.\unitTest.ps1 $dirName $langName
+		$sw.Stop()
+		"Test: " + $sw.Elapsed.TotalMilliseconds + " ms"
+
 		
-        if ($result -eq 0)
+		if ($result -eq 0)
 		{
 			"$dirName ... OK"
 		}
-        elseif ($result -eq 1)
+		elseif ($result -eq 1)
 		{		
-			"$dirName ... unitTest file not found. Test skipt."
+			"$dirName ... unitTest file not found. Test skipped."
 		}
-        else
-        {
+		else
+		{
 			"$dirName ... KO"
 			""
 			"There are some problems in your functionList.xml"
-            exit -1
-        }
+			exit -1
+		}
 		
 		# Check all Sub-directories for other unit-tests
-		Get-ChildItem $testRoot$dirName -Filter *.* | 
+		Get-ChildItem -Path $testRoot\$dirName -Attribute Directory | 
 		Foreach-Object {
-		    if ((Get-Item $testRoot$dirName\$_) -is [System.IO.DirectoryInfo])
-			{
+
 				$subDirName = (Get-Item $testRoot$dirName\$_).Name
+				$sw = [Diagnostics.Stopwatch]::StartNew()
 				$subResult = &.\unitTest.ps1 $langName\$subDirName $langName
-				
+				$sw.Stop()
+				"Test:" + $sw.Elapsed.TotalMilliseconds + " ms"
 				if ($subResult -eq 0)
 				{
 					"$dirName-$subDirName ... OK"
 				}
 				elseif ($subResult -eq 1)
 				{		
-					"$dirName-$subDirName ... unitTest file not found. Test skipt."
+					"$dirName-$subDirName ... unitTest file not found. Test skipped."
 				}
 				else
 				{
@@ -47,9 +51,7 @@ Foreach-Object {
 					"There are some problems in your functionList.xml"
 					exit -1
 				}
-			}
 		}
-    }
 }
 ""
 "All tests are passed."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,8 @@ after_build:
     - ps: >-
         $nppFileName = "Notepad++.$env:PLATFORM_INPUT.$env:CONFIGURATION.exe"
 
+        Push-AppveyorArtifact "scintilla\bin\SciLexer.dll" -FileName "SciLexer.$env:PLATFORM.$env:CONFIGURATION.dll"
+
         if ($env:PLATFORM_INPUT -eq "x64" -and $env:CONFIGURATION -eq "Unicode Release") {
             Push-AppveyorArtifact "PowerEditor\bin64\Notepad++.exe" -FileName "$nppFileName"
         }
@@ -59,6 +61,22 @@ after_build:
 
         if ($env:PLATFORM_INPUT -eq "Win32" -and $env:CONFIGURATION -eq "Unicode Debug") {
             Push-AppveyorArtifact "PowerEditor\visual.net\Unicode Debug\Notepad++.exe" -FileName "$nppFileName"
+
+            Start-FileDownload 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.8.9/npp.7.8.9.bin.minimalist.7z'
+            7z x -y npp.7.8.9.bin.minimalist.7z | Out-Null
+            #take SciLexer.dll from downloaded version due to dependency of the functionlist tests on a version build with boost regex
+            #what is not the case for the dll build on appveyor CI (would either need a very time consuming boost build or usage of nuget packages)
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\SciLexer.dll" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\visual.net\Unicode Debug\Notepad++.exe" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\src\langs.model.xml" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\src\stylers.model.xml" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\src\shortcuts.xml" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\src\functionList.xml" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\src\contextMenu.xml" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            cd .\PowerEditor\Test\FunctionList\
+            .\unitTestLauncher.ps1
+            .\unitTestLauncher.ps1
+            #ATTENTION: current working dir is no longer at APPVEYOR_BUILD_FOLDER
         }
 
         if ($env:PLATFORM_INPUT -eq "mingw") {
@@ -66,4 +84,4 @@ after_build:
             Push-AppveyorArtifact "PowerEditor\bin\NotepadPP.exe_dynamic" -FileName "$nppFileName_dynamic"
         }
 
-        Push-AppveyorArtifact "scintilla\bin\SciLexer.dll" -FileName "SciLexer.$env:PLATFORM.$env:CONFIGURATION.dll"
+


### PR DESCRIPTION
- run unitTestLauncher.ps1 on win32 debug builds (release is not possible due to missing scintilla crypto signing)
- As workaround SciLexer.dll needs to be taken from an official build (7.8.9), because boost is required for functionlist to be functional. With this workaround it is also possible to run with the release build is required.
- slightly optimized test script, added timing traces
- Output see https://ci.appveyor.com/project/donho/notepad-plus-plus/build/job/xjn7iei8x50sgnj4