### PR TITLE
Scroll visible area horizontally so a FindNext match is fully viewable

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -223,6 +223,9 @@ void Searching::displaySectionCentered(int posStart, int posEnd, ScintillaEditVi
 	pEditView->execute(SCI_GOTOPOS, isDownwards ? posEnd : posStart);
 	pEditView->execute(SCI_SETYCARETPOLICY, CARET_EVEN);
 
+	// Adjust so that we see the entire match; primarily horizontally
+	pEditView->execute(SCI_SCROLLRANGE, posStart, posEnd);
+
 	// Move cursor to end of result and select result
 	pEditView->execute(SCI_GOTOPOS, posEnd);
 	pEditView->execute(SCI_SETANCHOR, posStart);


### PR DESCRIPTION
Fixes #8804