### PR TITLE
Prevent line number margin width user-noticeable glitch during boundary cross

### DIFF
--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2717,38 +2717,17 @@ void ScintillaEditView::updateLineNumberWidth()
 {
 	if (_lineNumbersShown)
 	{
-		auto linesVisible = execute(SCI_LINESONSCREEN);
-		if (linesVisible)
+		auto lineCount = execute(SCI_GETLINECOUNT);
+		int numDigits = 0;
+		while (lineCount)
 		{
-			auto firstVisibleLineVis = execute(SCI_GETFIRSTVISIBLELINE);
-			auto lastVisibleLineVis = linesVisible + firstVisibleLineVis + 1;
-
-			if (execute(SCI_GETWRAPMODE) != SC_WRAP_NONE)
-			{
-				auto numLinesDoc = execute(SCI_GETLINECOUNT);
-				auto prevLineDoc = execute(SCI_DOCLINEFROMVISIBLE, firstVisibleLineVis);
-				for (auto i = firstVisibleLineVis + 1; i <= lastVisibleLineVis; ++i)
-				{
-					auto lineDoc = execute(SCI_DOCLINEFROMVISIBLE, i);
-					if (lineDoc == numLinesDoc)
-						break;
-					if (lineDoc == prevLineDoc)
-						lastVisibleLineVis++;
-					prevLineDoc = lineDoc;
-				}
-			}
-
-			auto lastVisibleLineDoc = execute(SCI_DOCLINEFROMVISIBLE, lastVisibleLineVis);
-			int i = 0;
-
-			while (lastVisibleLineDoc)
-			{
-				lastVisibleLineDoc /= 10;
-				++i;
-			}
-
-			i = max(i, 3);
-			auto pixelWidth = 8 + i * execute(SCI_TEXTWIDTH, STYLE_LINENUMBER, reinterpret_cast<LPARAM>("8"));
+			lineCount /= 10;
+			++numDigits;
+		}
+		numDigits = max(numDigits, 3);
+		auto pixelWidth = 12 + numDigits * execute(SCI_TEXTWIDTH, STYLE_LINENUMBER, reinterpret_cast<LPARAM>("8"));
+		if (execute(SCI_GETMARGINWIDTHN, _SC_MARGE_LINENUMBER) != pixelWidth)
+		{
 			execute(SCI_SETMARGINWIDTHN, _SC_MARGE_LINENUMBER, pixelWidth);
 		}
 	}

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2726,10 +2726,7 @@ void ScintillaEditView::updateLineNumberWidth()
 		}
 		numDigits = max(numDigits, 3);
 		auto pixelWidth = 12 + numDigits * execute(SCI_TEXTWIDTH, STYLE_LINENUMBER, reinterpret_cast<LPARAM>("8"));
-		if (execute(SCI_GETMARGINWIDTHN, _SC_MARGE_LINENUMBER) != pixelWidth)
-		{
-			execute(SCI_SETMARGINWIDTHN, _SC_MARGE_LINENUMBER, pixelWidth);
-		}
+		execute(SCI_SETMARGINWIDTHN, _SC_MARGE_LINENUMBER, pixelWidth);
 	}
 }
 


### PR DESCRIPTION
Fixes #5670

As issue states, visual glitch occurs when scrolling through an area of the document where the line number changes from N digits to N+1 digits (first occurrence at line 999/1000, second occurrence at 9999/10000, etc.).

The existing code in `updateLineNumberWidth()` seems to do a bit much "thinking".
Is this really necessary?

Taking a cue from @xylographe 's https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5670#issuecomment-499312475 , this PR simplifies the logic by having a single-width line number margin for all lines in the document, corresponding to the size necessary for the largest line number in the document.  This has some advantages:

* solves the "glitching" issue
* faster execution for better performance (this code is called constantly as it is part of the PAINT process)
* simpler code

Tested with a document with several hundred million lines.

The disadvantage is that at small line numbers, the margin is wider than it truly needs to be.  In practice, even for the case of a doc with several hundred million lines, this (subjectively) is not really a big downside, except perhaps when one is evaluating a PR such as the current one. :-)

Note: PR also gives 4 more pixels to the width, by using an additive constant of 12 in the `pixelWidth` calculation (existing code uses a constant 8 pixels for this).