### PR TITLE
Avoid unnecessary notifications while deactivating window

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1645,11 +1645,14 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_ACTIVATE:
 		{
-			_pEditView->getFocus();
-			auto x = _pEditView->execute(SCI_GETXOFFSET);
-			_pEditView->execute(SCI_SETXOFFSET, x);
-			x = _pNonEditView->execute(SCI_GETXOFFSET);
-			_pNonEditView->execute(SCI_SETXOFFSET, x);
+			if (wParam != WA_INACTIVE)
+			{
+				_pEditView->getFocus();
+				auto x = _pEditView->execute(SCI_GETXOFFSET);
+				_pEditView->execute(SCI_SETXOFFSET, x);
+				x = _pNonEditView->execute(SCI_GETXOFFSET);
+				_pNonEditView->execute(SCI_SETXOFFSET, x);
+			}
 			return TRUE;
 		}
 


### PR DESCRIPTION
This is an enhancement of PR #8475 which fixed (and still fixes) #8466.

It takes into account, that `WM_ACTIVATE` is not called only, when the window is being activated, but also, when the window is being **de**activated. In the latter case it is not necessary to do the activation actions.

This was pointed out to me by @Predelnik, who had a problem with the additional `SCN_UPDATEUI/SC_UPDATE_H_SCROLL` notification occurring when the window is being deactivated, see https://github.com/Predelnik/DSpellCheck/issues/221#issuecomment-696652074 for details.