### PR TITLE
Escape key in Funtion List treeview switches to N++ Scintilla edit

### DIFF
--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -575,6 +575,10 @@ void FunctionListPanel::notified(LPNMHDR notification)
 					}
 					PostMessage(_hParent, WM_COMMAND, SCEN_SETFOCUS << 16, reinterpret_cast<LPARAM>((*_ppEditView)->getHSelf()));
 				}
+				else if (ptvkd->wVKey == VK_ESCAPE)
+				{
+					PostMessage(_hParent, WM_COMMAND, SCEN_SETFOCUS << 16, reinterpret_cast<LPARAM>((*_ppEditView)->getHSelf()));
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
Escape key in Funtion List treeview switches to N++ Scintilla edit window (fix #8886).