### PR TITLE
Fixed smart highlighting of cloned view

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -861,8 +861,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			if (notification->nmhdr.hwndFrom != _pEditView->getHSelf()) // notification come from unfocus view - both views ae visible
 			{
 				//ScintillaEditView * unfocusView = isFromPrimary ? &_subEditView : &_mainEditView;
-				if (nppGui._smartHiliteOnAnotherView &&
-					_pEditView->getCurrentBufferID() != notifyView->getCurrentBufferID())
+				if (nppGui._smartHiliteOnAnotherView)
 				{
 					TCHAR selectedText[1024];
 					_pEditView->getGenericSelectedText(selectedText, sizeof(selectedText)/sizeof(TCHAR), false);

--- a/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScitillaComponent/SmartHighlighter.cpp
@@ -171,11 +171,15 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 
 	highlightViewWithWord(pHighlightView, text2FindW);
 
-	if (nppGUI._smartHiliteOnAnotherView && unfocusView && unfocusView->isVisible()
-		&& unfocusView->getCurrentBufferID() != pHighlightView->getCurrentBufferID())
-	{
-		// Clear marks
-		unfocusView->clearIndicator(SCE_UNIVERSAL_FOUND_STYLE_SMART);
+	if (nppGUI._smartHiliteOnAnotherView && unfocusView && unfocusView->isVisible())
+	{		
+		// Clear the indicator only when the view is not a clone, or it will clear what we have already hightlighted in the pHighlightView
+		if (unfocusView->getCurrentBufferID() != pHighlightView->getCurrentBufferID())
+		{	
+			unfocusView->clearIndicator(SCE_UNIVERSAL_FOUND_STYLE_SMART);
+		}
+		
+		// Hightlight the unfocused view even if it's a clone, as it might be in a different area of the document
 		highlightViewWithWord(unfocusView, text2FindW);
 	}
 


### PR DESCRIPTION
Smart highlighting with a cloned view and "Highlight another view" enabled was only highlighting the visible occurrences of the word in the Primary view, ignoring the cloned view. 

With this PR, the cloned view is highlighed correctly as if it weren't cloned.

Fixes #7910