### PR TITLE
Remove TreeView Beep when pressing return key.

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -633,6 +633,9 @@ void FileBrowser::notified(LPNMHDR notification)
 			}
 			break;
 
+			case NM_RETURN:
+				SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, 1);
+			break;
 
 			case TVN_KEYDOWN:
 			{

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -561,6 +561,10 @@ void FunctionListPanel::notified(LPNMHDR notification)
 			}
 			break;
 
+			case NM_RETURN:
+				SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, 1);
+			break;
+
 			case TVN_KEYDOWN:
 			{
 				LPNMTVKEYDOWN ptvkd = (LPNMTVKEYDOWN)notification;

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -628,6 +628,10 @@ void ProjectPanel::notified(LPNMHDR notification)
 				openSelectFile();
 			}
 			break;
+
+			case NM_RETURN:
+				SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, 1);
+			break;
 	
 			case TVN_ENDLABELEDIT:
 			{


### PR DESCRIPTION
Fixes #8938.

The Windows TreeView control initiates a Default Beep sound, if it's `NM_RETURN` notification remains unhandled.
