### PR TITLE
Bypass Windows caching when flushing files after write

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -125,7 +125,7 @@ generic_string relativeFilePathToFullFilePath(const TCHAR *relativeFilePath)
 
 void writeFileContent(const TCHAR *file2write, const char *content2write)
 {
-	FILE *f = generic_fopen(file2write, TEXT("w+"));
+	FILE *f = generic_fopen(file2write, TEXT("w+c"));
 	fwrite(content2write, sizeof(content2write[0]), strlen(content2write), f);
 	fflush(f);
 	fclose(f);
@@ -134,7 +134,7 @@ void writeFileContent(const TCHAR *file2write, const char *content2write)
 
 void writeLog(const TCHAR *logFileName, const char *log2write)
 {
-	FILE *f = generic_fopen(logFileName, TEXT("a+"));
+	FILE *f = generic_fopen(logFileName, TEXT("a+c"));
 	fwrite(log2write, sizeof(log2write[0]), strlen(log2write), f);
 	fputc('\n', f);
 	fflush(f);

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -879,7 +879,7 @@ bool FileManager::backupCurrentBuffer()
 				::SetFileAttributes(fullpath, dwFileAttribs);
 			}
 
-			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wb"));
+			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc"));
 			if (fp)
 			{
 				int lengthDoc = _pNotepadPlus->_pEditView->getCurrentDocLen();
@@ -1004,7 +1004,7 @@ bool FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool isCopy, g
 
 	int encoding = buffer->getEncoding();
 
-	FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wb"));
+	FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc"));
 	if (fp)
 	{
 		_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, buffer->_doc);	//generate new document
@@ -1495,9 +1495,10 @@ BufferID FileManager::getBufferFromDocument(Document doc)
 
 bool FileManager::createEmptyFile(const TCHAR * path)
 {
-	FILE * file = generic_fopen(path, TEXT("wb"));
+	FILE * file = generic_fopen(path, TEXT("wbc"));
 	if (!file)
 		return false;
+	fflush(file);
 	fclose(file);
 	return true;
 }

--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.cpp
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.cpp
@@ -816,10 +816,11 @@ bool TiXmlDocumentA::LoadUnicodeFilePath( const TCHAR* filename )
 bool TiXmlDocumentA::SaveFile( const char * filename ) const
 {
 	// The old c stuff lives on...
-	FILE* fp = fopen( filename, "w" );
+	FILE* fp = fopen( filename, "wc" );
 	if ( fp )
 	{
 		Print( fp, 0 );
+		fflush( fp );
 		fclose( fp );
 		return true;
 	}
@@ -828,10 +829,11 @@ bool TiXmlDocumentA::SaveFile( const char * filename ) const
 bool TiXmlDocumentA::SaveUnicodeFilePath( const TCHAR* filename ) const
 {
 	// The old c stuff lives on...
-	FILE* fp = generic_fopen( filename, TEXT("w") );
+	FILE* fp = generic_fopen( filename, TEXT("wc") );
 	if ( fp )
 	{
 		Print( fp, 0 );
+		fflush( fp );
 		fclose( fp );
 		return true;
 	}

--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -755,10 +755,11 @@ bool TiXmlDocument::LoadFile( const TCHAR* filename )
 bool TiXmlDocument::SaveFile( const TCHAR * filename ) const
 {
 	// The old c stuff lives on...
-	FILE* fp = generic_fopen( filename, TEXT("w") );
+	FILE* fp = generic_fopen( filename, TEXT("wc") );
 	if ( fp )
 	{
 		Print( fp, 0 );
+		fflush( fp );
 		fclose( fp );
 		return true;
 	}

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -360,7 +360,7 @@ size_t Utf8_16_Write::fwrite(const void* p, size_t _size)
         default:
             break;
     }
-    
+
     return ret;
 }
 
@@ -435,10 +435,17 @@ void Utf8_16_Write::setEncoding(UniMode eType)
 void Utf8_16_Write::fclose()
 {
 	if (m_pNewBuf)
+	{
 		delete [] m_pNewBuf;
+		m_pNewBuf = NULL;
+	}
 
 	if (m_pFile)
+	{
+		::fflush(m_pFile);
 		::fclose(m_pFile);
+		m_pFile = NULL;
+	}
 }
 
 


### PR DESCRIPTION
According Microsoft documentation this fixes the issues with saved file corruption (all NULs)
on sudden power loss or restart.

Fixes #6133

Microsoft documentation for reference:
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=vs-2019
https://docs.microsoft.com/en-us/cpp/c-runtime-library/stream-i-o?view=vs-2019

Quote from the later link:

> Files opened using the stream routines are buffered by default. The stdout and stderr functions are flushed whenever they are  full or, if you are writing to a character device, after each library call. If a program terminates abnormally, output buffers may not  be flushed, resulting in loss of data. Use fflush or _flushall to ensure that the buffer associated with a specified file or all open buffers are flushed to the operating system, which can cache data before writing it to disk. The commit-to-disk feature ensures that the flushed buffer contents are not lost in the event of a system failure.

> There are two ways to commit buffer contents to disk:

> Link with the file COMMODE.OBJ to set a global commit flag. The default setting of the global flag is n, for "no-commit."

> Set the mode flag to c with fopen or _fdopen.

> Any file specifically opened with either the c or the n flag behaves according to the flag, regardless of the state of the global commit/no-commit flag.