### PR TITLE
Fix possible file corruption on file open for writing

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -125,7 +125,7 @@ generic_string relativeFilePathToFullFilePath(const TCHAR *relativeFilePath)
 
 void writeFileContent(const TCHAR *file2write, const char *content2write)
 {
-	FILE *f = generic_fopen(file2write, TEXT("w+c"));
+	FILE *f = generic_fopen(file2write, TEXT("wc"));
 	fwrite(content2write, sizeof(content2write[0]), strlen(content2write), f);
 	fflush(f);
 	fclose(f);

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -879,7 +879,21 @@ bool FileManager::backupCurrentBuffer()
 				::SetFileAttributes(fullpath, dwFileAttribs);
 			}
 
-			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc"));
+			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("rb+c")); // Use "r+" to NOT destroy existing file contents on open
+			if (fp)
+			{
+				// On "r+" open success move file position to the very beginning of file
+				if (_fseeki64(fp, 0, SEEK_SET))
+				{
+					UnicodeConvertor.fclose(true);
+					fp = NULL;
+				}
+			}
+			else
+			{
+				fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc")); // If "r+" open fails file might not exist so try opening it anew with "w"
+			}
+
 			if (fp)
 			{
 				int lengthDoc = _pNotepadPlus->_pEditView->getCurrentDocLen();
@@ -1004,7 +1018,21 @@ bool FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool isCopy, g
 
 	int encoding = buffer->getEncoding();
 
-	FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc"));
+	FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("rb+c")); // Use "r+" to NOT destroy existing file contents on open
+	if (fp)
+	{
+		// On "r+" open success move file position to the very beginning of file
+		if (_fseeki64(fp, 0, SEEK_SET))
+		{
+			UnicodeConvertor.fclose(true);
+			fp = NULL;
+		}
+	}
+	else
+	{
+		fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc")); // If "r+" open fails file might not exist so try opening it anew with "w"
+	}
+
 	if (fp)
 	{
 		_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, buffer->_doc);	//generate new document

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Utf8_16.h"
+#include <io.h>
 
 const Utf8_16::utf8 Utf8_16::k_Boms[][3] = {
 	{0x00, 0x00, 0x00},  // Unknown
@@ -432,7 +433,7 @@ void Utf8_16_Write::setEncoding(UniMode eType)
 }
 
 
-void Utf8_16_Write::fclose()
+void Utf8_16_Write::fclose(bool keepOriginalLength)
 {
 	if (m_pNewBuf)
 	{
@@ -442,6 +443,12 @@ void Utf8_16_Write::fclose()
 
 	if (m_pFile)
 	{
+		if (!keepOriginalLength)
+		{
+			const int fd = _fileno(m_pFile);
+			_chsize_s(fd, _ftelli64(m_pFile));
+		}
+
 		::fflush(m_pFile);
 		::fclose(m_pFile);
 		m_pFile = NULL;

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -143,7 +143,7 @@ public:
 
 	FILE * fopen(const TCHAR *_name, const TCHAR *_type);
 	size_t fwrite(const void* p, size_t _size);
-	void   fclose();
+	void   fclose(bool keepOriginalLength = false);
 
 	size_t convert(char* p, size_t _size);
 	char* getNewBuf() { return reinterpret_cast<char*>(m_pNewBuf); }


### PR DESCRIPTION
Do not destroy file contents when opening user file for writing.
This makes sure original file is not corrupted if file writing fails for some reason.

Microsoft documentation for reference:
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=vs-2019
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fseek-fseeki64?view=vs-2019

Fix #5664