### PR TITLE
Fix RegEx look behind operations

### DIFF
--- a/PowerEditor/installer/functionList/python.xml
+++ b/PowerEditor/installer/functionList/python.xml
@@ -16,13 +16,13 @@
 			commentExpr="(?s:'''.*?''')|(?m-s:#.*?$)"
 		>
 			<classRange
-				mainExpr    ="(?&lt;=^class\x20).*?(?=\n\S|\Z)"
+				mainExpr    ="^class\x20\K.*?(?=\n\S|\Z)"
 			>
 				<className>
 					<nameExpr expr="\w+(?=\s*[\(|:])" />
 				</className>
 				<function
-					mainExpr="(?&lt;=\sdef\x20).+?(?=:)"
+					mainExpr="\sdef\x20\K.+?(?=:)"
 				>
 					<functionName>
 						<funcNameExpr expr=".*" />
@@ -30,7 +30,7 @@
 				</function>
 			</classRange>
 			<function
-				mainExpr="(?&lt;=\sdef\x20).+?(?=:)"
+				mainExpr="\sdef\x20\K.+?(?=:)"
 			>
 				<functionName>
 					<nameExpr expr=".*" />

--- a/PowerEditor/installer/functionList/ruby.xml
+++ b/PowerEditor/installer/functionList/ruby.xml
@@ -16,7 +16,7 @@
 		>
 			<!-- within a class-->
 			<classRange
-				mainExpr    ="(?&lt;=^class\x20).*?(?=\n\S|\Z)"
+				mainExpr    ="^class\x20\K.*?(?=\n\S|\Z)"
 			>
 				<className>
 					<nameExpr expr="\w+" />
@@ -25,7 +25,7 @@
 					mainExpr="^\s*def\s+\w+"
 				>
 					<functionName>
-						<funcNameExpr expr="(?&lt;=def\s)\w+" />
+						<funcNameExpr expr="def\s\K\w+" />
 					</functionName>
 				</function>
 			</classRange>
@@ -34,7 +34,7 @@
 				mainExpr="^\s*def\s+\w+"
 			>
 				<functionName>
-					<nameExpr expr="(?&lt;=def\s)\w+" />
+					<nameExpr expr="def\s\K\w+" />
 				</functionName>
 			</function>
 		</parser>


### PR DESCRIPTION
Intended to fix #713, #1870, #2360 and #9004.

Does not fix #8434.

_Edit:_ should solve #4855 too, collides with PR #8926.

The modification cannot be verified in the AppVeyor build, because the AppVeyor build does not contain the Boost library. The modification cannot be applied to the build-in RegEx, because this doesn't support look-behind operations.

The modification itself is self-explanatory: If we want RegEx to look behind, then we need to specify a backstop position.

_Edit:_ I used Boost version 1_73_0 for this, may be, there are older Boost versions which don't have this parameter.

_Edit2:_ Just re-tested it with Boost version 1_70_0, it works there too. There are no significant code changes between 1_70_0 and 1_73_0 in the RegEx part of Boost, so that an upgrade to 1_73_0 would have no advantages.