### PR TITLE
Fix possible file corruption on file open for writing

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -125,7 +125,7 @@ generic_string relativeFilePathToFullFilePath(const TCHAR *relativeFilePath)
 
 void writeFileContent(const TCHAR *file2write, const char *content2write)
 {
-	FILE *f = generic_fopen(file2write, TEXT("w+c"));
+	FILE *f = generic_fopen(file2write, TEXT("wc"));
 	fwrite(content2write, sizeof(content2write[0]), strlen(content2write), f);
 	fflush(f);
 	fclose(f);

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -879,7 +879,21 @@ bool FileManager::backupCurrentBuffer()
 				::SetFileAttributes(fullpath, dwFileAttribs);
 			}
 
-			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc"));
+			FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("rb+c")); // Use "r+" to NOT destroy existing file contents on open
+			if (fp)
+			{
+				// On "r+" open success move file position to the very beginning of file
+				if (_fseeki64(fp, 0, SEEK_SET))
+				{
+					UnicodeConvertor.fclose(true);
+					fp = NULL;
+				}
+			}
+			else
+			{
+				fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc")); // If "r+" open fails file might not exist so try opening it anew with "w"
+			}
+
 			if (fp)
 			{
 				int lengthDoc = _pNotepadPlus->_pEditView->getCurrentDocLen();
@@ -1004,7 +1018,20 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 
 	int encoding = buffer->getEncoding();
 
-	FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc"));
+	FILE *fp = UnicodeConvertor.fopen(fullpath, TEXT("rb+c")); // Use "r+" to NOT destroy existing file contents on open
+	if (fp)
+	{
+		// On "r+" open success move file position to the very beginning of file
+		if (_fseeki64(fp, 0, SEEK_SET))
+		{
+			UnicodeConvertor.fclose(true);
+			fp = NULL;
+		}
+	}
+	else
+	{
+		fp = UnicodeConvertor.fopen(fullpath, TEXT("wbc")); // If "r+" open fails file might not exist so try opening it anew with "w"
+	}
 
 	if (!fp)
 	{

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -143,7 +143,7 @@ public:
 
 	FILE * fopen(const TCHAR *_name, const TCHAR *_type);
 	size_t fwrite(const void* p, size_t _size);
-	void   fclose();
+	void   fclose(bool keepOriginalLength = false);
 
 	size_t convert(char* p, size_t _size);
 	char* getNewBuf() { return reinterpret_cast<char*>(m_pNewBuf); }
@@ -155,5 +155,6 @@ protected:
 	ubyte* m_pNewBuf;
 	size_t m_nBufSize;
 	bool m_bFirstWrite;
+	bool m_bWriteFailure;
 };
 


### PR DESCRIPTION
Microsoft documentation for reference:
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=vs-2019
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fseek-fseeki64?view=vs-2019

Fix #5664