### PR TITLE
Improve URL update on resize

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -525,9 +525,6 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				_pDocMap->reloadMap();
 			}
 
-			addHotSpot(_pEditView);
-			addHotSpot(_pNonEditView);
-
 			result = TRUE;
 			break;
 		}
@@ -2471,8 +2468,16 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_INTERNAL_UPDATECLICKABLELINKS:
 		{
-			addHotSpot(_pEditView);
-			addHotSpot(_pNonEditView);
+			ScintillaEditView* pView = reinterpret_cast<ScintillaEditView*>(wParam);
+			if (pView == NULL)
+			{
+				addHotSpot(_pEditView);
+				addHotSpot(_pNonEditView);
+			}
+			else
+			{
+				addHotSpot(pView);
+			}
 		}
 
 		default:

--- a/PowerEditor/src/ScitillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScitillaComponent/DocTabView.cpp
@@ -228,5 +228,6 @@ void DocTabView::reSizeTo(RECT & rc)
 		rc.bottom -= (borderWidth * 2);
 		_pView->reSizeTo(rc);
 	}
+	SendMessage(_hParent, NPPM_INTERNAL_UPDATECLICKABLELINKS, reinterpret_cast<WPARAM>(_pView), 0);
 }
 


### PR DESCRIPTION
Fixes #9032. 

The reason for the effect is, that the `addHotSpot` calls for resizing are in the `WM_SIZE` of the application. This works, as long as the size of the whole application changes, but not, when the application size remains constant and only the size of the document window inside the application changes.

The solution for this is, to remove the `addHotSpot` calls from the `WM_SIZE` of the application and add them to the `DocTabView::reSizeTo` function instead. Since `addHotSpot` cannot be called directly from this function, I took the detour over `NPPM_INTERNAL_UPDATECLICKABLELINKS`.