### PR TITLE
Fix #9078 - ESCAPE key closes ASCII Character Panel

### DIFF
--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -111,6 +111,11 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 							insertChar(static_cast<unsigned char>(i));
 							return TRUE;
 						}
+						case VK_ESCAPE:
+						{
+							::SendMessage(_hParent, NPPM_DMMHIDE, 0, reinterpret_cast<LPARAM>(_hSelf));
+							return TRUE;
+						}
 						default:
 							break;
 					}


### PR DESCRIPTION
Fix #9078 - This simple adds ESCAPE key closes panel functionality to the ASCII Character Panel (Edit => Character Panel).