### PR TITLE
Make "Clipboard History" and "Character Panel" togglable

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -37,6 +37,8 @@
 #include "functionListPanel.h"
 #include "ProjectPanel.h"
 #include "fileBrowser.h"
+#include "clipboardHistoryPanel.h"
+#include "ansiCharPanel.h"
 #include "Sorters.h"
 #include "verifySignedfile.h"
 #include "md5.h"
@@ -698,13 +700,35 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_CHAR_PANEL:
 		{
-			launchAnsiCharPanel();
+			if (_pAnsiCharPanel && (!_pAnsiCharPanel->isClosed()))
+			{
+				_pAnsiCharPanel->display(false);
+				_pAnsiCharPanel->setClosed(true);
+				checkMenuItem(IDM_EDIT_CHAR_PANEL, false);
+			}
+			else
+			{
+				checkMenuItem(IDM_EDIT_CHAR_PANEL, true);
+				launchAnsiCharPanel();
+				_pAnsiCharPanel->setClosed(false);
+			}
 		}
 		break;
 
 		case IDM_EDIT_CLIPBOARDHISTORY_PANEL:
 		{
-			launchClipboardHistoryPanel();
+			if (_pClipboardHistoryPanel && (!_pClipboardHistoryPanel->isClosed()))
+			{
+				_pClipboardHistoryPanel->display(false);
+				_pClipboardHistoryPanel->setClosed(true);
+				checkMenuItem(IDM_EDIT_CLIPBOARDHISTORY_PANEL, false);
+			}
+			else
+			{
+				checkMenuItem(IDM_EDIT_CLIPBOARDHISTORY_PANEL, true);
+				launchClipboardHistoryPanel();
+				_pClipboardHistoryPanel->setClosed(false);
+			}
 		}
 		break;
 


### PR DESCRIPTION
Make "Clipboard History" and "Character Panel" have the same behaviour of the other dockable panels.

Fix #9094