### PR TITLE
Fix PHP parser rule (for function list) several bugs

### DIFF
--- a/PowerEditor/Test/FunctionList/php/unitTest
+++ b/PowerEditor/Test/FunctionList/php/unitTest
@@ -14,6 +14,32 @@
  ************************************************************************
  */
 require_once "../PagSeguroLibrary/PagSeguroLibrary.php";
+
+function for123(){
+    alert 'nothing';
+}
+
+abstract class PageGrille extends PageMotsBleus{
+	abstract function GetTypeGrille() ; // blabla blabla
+	abstract function GetGrilleJSON($p_grilleId); // Retourn JSON
+
+	function CleanStr($pStr){
+		return str_replace ( "\\" , "" , $pStr);
+	}
+
+	function GetJavascriptMajax() {
+		return "ABC";
+	}
+}
+
+function stringContainAsterisk_test1(){
+	$target = '/path/to/files/*';
+}
+
+function stringContainAsterisk_test2(){
+	$target = '/path/to/files/*.jpg';
+}
+
 class NotificationListener
 {
     public static function main()
@@ -86,4 +112,5 @@ class NotificationListener
         echo LogPagSeguro::getHtml($count);
     }
 }
+
 NotificationListener::main();

--- a/PowerEditor/Test/FunctionList/php/unitTest.expected.result
+++ b/PowerEditor/Test/FunctionList/php/unitTest.expected.result
@@ -1,1 +1,1 @@
-{"nodes":[{"leaves":["main","transactionNotification","authorizationNotification","preApprovalNotification","printLog"],"name":"NotificationListener"}],"root":"unitTest"}
+{"leaves":["for123()","stringContainAsterisk_test1()","stringContainAsterisk_test2()"],"nodes":[{"leaves":["GetTypeGrille","GetGrilleJSON","CleanStr","GetJavascriptMajax"],"name":"PageGrille"},{"leaves":["main","transactionNotification","authorizationNotification","preApprovalNotification","printLog"],"name":"NotificationListener"}],"root":"unitTest"}

--- a/PowerEditor/installer/functionList/php.xml
+++ b/PowerEditor/installer/functionList/php.xml
@@ -12,190 +12,190 @@
 		<!-- PHP - Personal Home Page / PHP Hypertext Preprocessor             -->
 
 		<parser
-            displayName="PHP - Personal Home Page / PHP Hypertext Preprocessor"
-            id         ="php_syntax"
-            commentExpr="(?x)                                               # free-spacing (see `RegEx - Pattern Modifiers`)
-                            (?s:\x2F\x2A.*?\x2A\x2F)                        # Multi Line Comment  x2F -> '/'  x2A -> '*'  
-                        |   (?m-s:(?:\x23|\x2F{2}).*$)                      # Single Line Comment 1 # and 2 //
-                      #  |   (?s:\x22(?:[^\x22\x24\x5C]|\x5C.)*\x22)         # String Literal - Double Quoted
-                        |   (?s:\x22(?:[^\x22\x5C]|\x5C.)*\x22)         # String Literal - Double Quoted
-                        |   (?s:\x27(?:[^\x27\x5C]|\x5C.)*\x27)             # String Literal - Single Quoted
-                        |   (?:                                             # Here Document
-                                \x3C{3}(?'HDID'[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*)[^\r\n]*(?:\r?\n|\n?\r)
-                                (?s:.*?)
-                                (?:\r?\n|\n?\r)\k'HDID'                     # close with exactly the same identifier, in the first column
-                            )
-                        |   (?:                                             # Now Document
-                                \x3C{3}\x27(?'NDID'[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*)\x27[^\r\n]*(?:\r?\n|\n?\r)
-                                (?s:.*?)
-                                (?:\r?\n|\n?\r)\k'NDID'                     # close with exactly the same identifier, in the first column
-                            )
-                        "
-        >
-            <classRange
-                mainExpr    ="(?x)                                          # free-spacing (see `RegEx - Pattern Modifiers`)
-                        (?(DEFINE)                                          # definition of sub-routines
-                            (?'VALID_ID'
-                                \b(?!(?-i:                                  # keywords (case-sensitive), not to be used as identifier
-                                    a(?:bstract|nd|rray|s)
-                                |   b(?:ool|reak)
-                                |   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
-                                |   d(?:e(?:clare|fault)|ie|o)
-                                |   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
-                                |   f(?:alse|loat|inal|or(?:each)?|unction)
-                                |   g(?:lobal|oto)
-                                |   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
-                                |   list
-                                |   mixed
-                                |   n(?:amespace|ew|u(?:ll|meric))
-                                |   o(?:r|bject)
-                                |   p(?:r(?:i(?:nt|vate)|otected)|ublic)
-                                |   re(?:quire(?:_once)?|turn)
-                                |   s(?:t(?:atic|ring)|witch)
-                                |   t(?:hrow|r(?:ait|ue|y))
-                                |   u(?:nset|se)
-                                |   var
-                                |   while
-                                |   xor
-                                |   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
-                                )\b)
-                                [A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*            # valid character combination for identifiers
-                            )
-                            (?'INTERFACE_LIST'
-                                \s+(?:\x5C|(?&amp;VALID_ID))+
-                                (?:
-                                    \s*,
-                                    \s*(?:\x5C|(?&amp;VALID_ID))+
-                                )*
-                            )
-                        )
-                        (?m-i)                                              # ^ and $ match at line-breaks, case-sensitive
-                        ^\h*                                                # optional leading white-space at start-of-line
-                        (?:
-                            (?:(?-i:abstract|final)\s+)?                    # optional class entry type
-                            (?-i:class)\s+
-                            \K                                              # discard text matched so far
-                            (?&amp;VALID_ID)                                # identifier used as class name
-                            (?:                                             # optional extends-from-class
-                                \s+(?-i:extends)
-                                \s+(?:\x5C|(?&amp;VALID_ID))+
-                            )?
-                            (?:                                             # optional implements-class/interfaces
-                                \s+(?-i:implements)
-                                (?&amp;INTERFACE_LIST)
-                            )?
-                        |
-                            (?-i:interface)\s+
-                            \K                                              # discard text matched so far
-                            (?&amp;VALID_ID)                                # identifier used as interface name
-                            (?:                                             # optional extends-from list
-                                \s+(?-i:extends)
-                                (?&amp;INTERFACE_LIST)
-                            )?
-                        |
-                            (?-i:trait)\s+
-                            \K                                              # discard text matched so far
-                            (?&amp;VALID_ID)                                # identifier used as trait name
-                        )
-                        \s*\{
-                    "
-                openSymbole ="\{"
-                closeSymbole="\}"
-            >
-                <className>
-                    <nameExpr expr="[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" />
-                </className>
-                <function
-                    mainExpr="(?x)                                          # free-spacing (see `RegEx - Pattern Modifiers`)
-                            (?m-i)                                          # ^ and $ match at line-breaks, case-sensitive
-                            ^\h*                                            # optional leading white-space at start-of-line
-                            (?:(?-i:                                        # field modifiers
-                                    p(?:r(?:ivate|otected)|ublic)           # - access modifiers
-                                |   abstract|final|static                   # - ...
-                            )\s+)*                                          # require a white-space separator
-                            (?-i:function)\s+
-                            \K                                              # discard text matched so far
-                            (?:\x26\s*)?                                    # optionally a reference
-                            (?'VALID_ID'                                    # valid identifier, use as subroutine
-                                \b(?!(?-i:                                  # keywords (case-sensitive), not to be used as identifier
-                                    a(?:bstract|nd|rray|s)
-                                |   b(?:ool|reak)
-                                |   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
-                                |   d(?:e(?:clare|fault)|ie|o)
-                                |   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
-                                |   f(?:alse|loat|inal|or(?:each)?|unction)
-                                |   g(?:lobal|oto)
-                                |   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
-                                |   list
-                                |   mixed
-                                |   n(?:amespace|ew|u(?:ll|meric))
-                                |   o(?:r|bject)
-                                |   p(?:r(?:i(?:nt|vate)|otected)|ublic)
-                                |   re(?:quire(?:_once)?|turn)
-                                |   s(?:t(?:atic|ring)|witch)
-                                |   t(?:hrow|r(?:ait|ue|y))
-                                |   u(?:nset|se)
-                                |   var
-                                |   while
-                                |   xor
-                                |   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
-                                )\b)
-                                [A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*            # valid character combination for identifiers
-                            )                                               # identifier used as method name
-                            \s*\(                                           # start of function parameters
-                            (?:[^{;]*(?:\{|;))                              # start of function body  or abstract function without body
-                        "
-                >
-                    <functionName>
-                        <funcNameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*\s*\((?:[^/{]|/(?![*/]))*" />
-                        <!-- comment out the following node to display the method with parameters -->
-                        <funcNameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" />  
-                    </functionName>
-                </function>
-            </classRange>
-            <function
-                mainExpr="(?x)                                              # free-spacing (see `RegEx - Pattern Modifiers`)
-                        (?m-i)                                              # ^ and $ match at line-breaks, case-sensitive
-                        ^\h*                                                # optional leading white-space at start-of-line
-                        (?-i:function)\s+
-                        \K                                                  # discard text matched so far
-                        (?:\x26\s*)?                                        # optionally a reference
-                        (?'VALID_ID'                                        # valid identifier, use as subroutine
-                            \b(?!(?-i:                                      # keywords (case-sensitive), not to be used as identifier
-                                a(?:bstract|nd|rray|s)
-                            |   b(?:ool|reak)
-                            |   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
-                            |   d(?:e(?:clare|fault)|ie|o)
-                            |   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
-                            |   f(?:alse|loat|inal|or(?:each)?|unction)
-                            |   g(?:lobal|oto)
-                            |   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
-                            |   list
-                            |   mixed
-                            |   n(?:amespace|ew|u(?:ll|meric))
-                            |   o(?:r|bject)
-                            |   p(?:r(?:i(?:nt|vate)|otected)|ublic)
-                            |   re(?:quire(?:_once)?|turn)
-                            |   s(?:t(?:atic|ring)|witch)
-                            |   t(?:hrow|r(?:ait|ue|y))
-                            |   u(?:nset|se)
-                            |   var
-                            |   while
-                            |   xor
-                            |   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
-                            )\b)
-                            [A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*                # valid character combination for identifiers
-                        )                                                   # identifier used as function name
-                        \s*\(                                               # start of function parameters
-                        [^{]*\{                                             # start of function body 
-                    "
-            >
-                <functionName>
-                    <nameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*\s*\((?:[^/{]|/(?![*/]))*" />
-                    <!-- comment out the following node to display the function with its parameters -->
-                    <!-- <nameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" /> -->
-                </functionName>
-            </function>
-        </parser>
+			displayName="PHP - Personal Home Page / PHP Hypertext Preprocessor"
+			id         ="php_syntax"
+			commentExpr="(?x)                                               # free-spacing (see `RegEx - Pattern Modifiers`)
+							(?s:\x2F\x2A.*?\x2A\x2F)                        # Multi Line Comment  x2F -> '/'  x2A -> '*'  
+						|	(?m-s:(?:\x23|\x2F{2}).*$)                      # Single Line Comment 1 # and 2 //
+					  # |	(?s:\x22(?:[^\x22\x24\x5C]|\x5C.)*\x22)         # String Literal - Double Quoted
+						|	(?s:\x22(?:[^\x22\x5C]|\x5C.)*\x22)         # String Literal - Double Quoted
+						|	(?s:\x27(?:[^\x27\x5C]|\x5C.)*\x27)             # String Literal - Single Quoted
+						|	(?:                                             # Here Document
+								\x3C{3}(?'HDID'[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*)[^\r\n]*(?:\r?\n|\n?\r)
+								(?s:.*?)
+								(?:\r?\n|\n?\r)\k'HDID'                     # close with exactly the same identifier, in the first column
+							)
+						|	(?:                                             # Now Document
+								\x3C{3}\x27(?'NDID'[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*)\x27[^\r\n]*(?:\r?\n|\n?\r)
+								(?s:.*?)
+								(?:\r?\n|\n?\r)\k'NDID'                     # close with exactly the same identifier, in the first column
+							)
+						"
+		>
+			<classRange
+				mainExpr    ="(?x)                                          # free-spacing (see `RegEx - Pattern Modifiers`)
+						(?(DEFINE)                                          # definition of sub-routines
+							(?'VALID_ID'
+								\b(?!(?-i:                                  # keywords (case-sensitive), not to be used as identifier
+									a(?:bstract|nd|rray|s)
+								|   b(?:ool|reak)
+								|   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
+								|   d(?:e(?:clare|fault)|ie|o)
+								|   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
+								|   f(?:alse|loat|inal|or(?:each)?|unction)
+								|   g(?:lobal|oto)
+								|   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
+								|   list
+								|   mixed
+								|   n(?:amespace|ew|u(?:ll|meric))
+								|   o(?:r|bject)
+								|   p(?:r(?:i(?:nt|vate)|otected)|ublic)
+								|   re(?:quire(?:_once)?|turn)
+								|   s(?:t(?:atic|ring)|witch)
+								|   t(?:hrow|r(?:ait|ue|y))
+								|   u(?:nset|se)
+								|   var
+								|   while
+								|   xor
+								|   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
+								)\b)
+								[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*            # valid character combination for identifiers
+							)
+							(?'INTERFACE_LIST'
+								\s+(?:\x5C|(?&amp;VALID_ID))+
+								(?:
+									\s*,
+									\s*(?:\x5C|(?&amp;VALID_ID))+
+								)*
+							)
+						)
+						(?m-i)                                              # ^ and $ match at line-breaks, case-sensitive
+						^\h*                                                # optional leading white-space at start-of-line
+						(?:
+							(?:(?-i:abstract|final)\s+)?                    # optional class entry type
+							(?-i:class)\s+
+							\K                                              # discard text matched so far
+							(?&amp;VALID_ID)                                # identifier used as class name
+							(?:                                             # optional extends-from-class
+								\s+(?-i:extends)
+								\s+(?:\x5C|(?&amp;VALID_ID))+
+							)?
+							(?:                                             # optional implements-class/interfaces
+								\s+(?-i:implements)
+								(?&amp;INTERFACE_LIST)
+							)?
+						|
+							(?-i:interface)\s+
+							\K                                              # discard text matched so far
+							(?&amp;VALID_ID)                                # identifier used as interface name
+							(?:                                             # optional extends-from list
+								\s+(?-i:extends)
+								(?&amp;INTERFACE_LIST)
+							)?
+						|
+							(?-i:trait)\s+
+							\K                                              # discard text matched so far
+							(?&amp;VALID_ID)                                # identifier used as trait name
+						)
+						\s*\{
+					"
+				openSymbole ="\{"
+				closeSymbole="\}"
+			>
+				<className>
+					<nameExpr expr="[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" />
+				</className>
+				<function
+					mainExpr="(?x)                                          # free-spacing (see `RegEx - Pattern Modifiers`)
+							(?m-i)                                          # ^ and $ match at line-breaks, case-sensitive
+							^\h*                                            # optional leading white-space at start-of-line
+							(?:(?-i:                                        # field modifiers
+									p(?:r(?:ivate|otected)|ublic)           # - access modifiers
+								|   abstract|final|static                   # - ...
+							)\s+)*                                          # require a white-space separator
+							(?-i:function)\s+
+							\K                                              # discard text matched so far
+							(?:\x26\s*)?                                    # optionally a reference
+							(?'VALID_ID'                                    # valid identifier, use as subroutine
+								\b(?!(?-i:                                  # keywords (case-sensitive), not to be used as identifier
+									a(?:bstract|nd|rray|s)
+								|   b(?:ool|reak)
+								|   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
+								|   d(?:e(?:clare|fault)|ie|o)
+								|   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
+								|   f(?:alse|loat|inal|or(?:each)?|unction)
+								|   g(?:lobal|oto)
+								|   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
+								|   list
+								|   mixed
+								|   n(?:amespace|ew|u(?:ll|meric))
+								|   o(?:r|bject)
+								|   p(?:r(?:i(?:nt|vate)|otected)|ublic)
+								|   re(?:quire(?:_once)?|turn)
+								|   s(?:t(?:atic|ring)|witch)
+								|   t(?:hrow|r(?:ait|ue|y))
+								|   u(?:nset|se)
+								|   var
+								|   while
+								|   xor
+								|   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
+								)\b)
+								[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*            # valid character combination for identifiers
+							)                                               # identifier used as method name
+							\s*\(                                           # start of function parameters
+							(?:[^{;]*(?:\{|;))                              # start of function body  or abstract function without body
+						"
+				>
+					<functionName>
+						<funcNameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*\s*\((?:[^/{]|/(?![*/]))*" />
+						<!-- comment out the following node to display the method with parameters -->
+						<funcNameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" />  
+					</functionName>
+				</function>
+			</classRange>
+			<function
+				mainExpr="(?x)                                              # free-spacing (see `RegEx - Pattern Modifiers`)
+						(?m-i)                                              # ^ and $ match at line-breaks, case-sensitive
+						^\h*                                                # optional leading white-space at start-of-line
+						(?-i:function)\s+
+						\K                                                  # discard text matched so far
+						(?:\x26\s*)?                                        # optionally a reference
+						(?'VALID_ID'                                        # valid identifier, use as subroutine
+							\b(?!(?-i:                                      # keywords (case-sensitive), not to be used as identifier
+								a(?:bstract|nd|rray|s)
+							|   b(?:ool|reak)
+							|   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
+							|   d(?:e(?:clare|fault)|ie|o)
+							|   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
+							|   f(?:alse|loat|inal|or(?:each)?|unction)
+							|   g(?:lobal|oto)
+							|   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
+							|   list
+							|   mixed
+							|   n(?:amespace|ew|u(?:ll|meric))
+							|   o(?:r|bject)
+							|   p(?:r(?:i(?:nt|vate)|otected)|ublic)
+							|   re(?:quire(?:_once)?|turn)
+							|   s(?:t(?:atic|ring)|witch)
+							|   t(?:hrow|r(?:ait|ue|y))
+							|   u(?:nset|se)
+							|   var
+							|   while
+							|   xor
+							|   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
+							)\b)
+							[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*                # valid character combination for identifiers
+						)                                                   # identifier used as function name
+						\s*\(                                               # start of function parameters
+						[^{]*\{                                             # start of function body 
+					"
+			>
+				<functionName>
+					<nameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*\s*\((?:[^/{]|/(?![*/]))*" />
+					<!-- comment out the following node to display the function with its parameters -->
+					<!-- <nameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" /> -->
+				</functionName>
+			</function>
+		</parser>
 	</functionList>
 </NotepadPlus>

--- a/PowerEditor/installer/functionList/php.xml
+++ b/PowerEditor/installer/functionList/php.xml
@@ -12,41 +12,190 @@
 		<!-- PHP - Personal Home Page / PHP Hypertext Preprocessor             -->
 
 		<parser
-			id         ="php_syntax"
-			displayName="PHP"
-			commentExpr="(?s:/\*.*?\*/)|(?m-s://.*?$)"
-		>
-			<classRange
-				mainExpr    ="^\s*(class|abstract\s+class|final\s+class|interface|trait)[\t\x20]+[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*(\s*|\s*(extends|implements|(extends\s+(\\|[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*)+\s+implements))\s+(\,\s*|(\\|[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*))+\s*)?\{"
-				openSymbole ="\{"
-				closeSymbole="\}"
-			>
-				<className>
-					<nameExpr expr="(class|abstract\s+class|final\s+class|interface|trait)\s+\w+" />
-					<nameExpr expr="\s+\w+\Z" />
-					<nameExpr expr="\w+\Z" />
-				</className>
-				<function
-					mainExpr="^\s*((static|public|protected|private|final)*(\s+(static|public|protected|private|final))+\s+)?(function\s+)+(\w+(\s+\w+)?(\s+|\*\s+|\s+\*|\s+\*\s+))?(\w+\s*::)?(?!(if|while|for|switch))[\w~]+\s*\([^\{]*\{"
-				>
-					<functionName>
-						<funcNameExpr expr="(?!(if|while|for|switch))\w+\s*\([^\{]*" />
-						<!-- comment out the following node to display the method with parameters -->
-						<funcNameExpr expr="(?!(if|while|for|switch))\w+" />
-					</functionName>
-				</function>
-			</classRange>
-			<function
-				mainExpr="^\s*function\s+\w+\s*\("
-			>
-				<functionName>
-					<nameExpr expr="(?!(if|while|for))\w+\s*\(" />
-					<nameExpr expr="(?!(if|while|for))\w+" />
-				</functionName>
-				<className>
-					<nameExpr expr="\w+(?=\s*::)" />
-				</className>
-			</function>
-		</parser>
+            displayName="PHP - Personal Home Page / PHP Hypertext Preprocessor"
+            id         ="php_syntax"
+            commentExpr="(?x)                                               # free-spacing (see `RegEx - Pattern Modifiers`)
+                            (?s:\x2F\x2A.*?\x2A\x2F)                        # Multi Line Comment  x2F -> '/'  x2A -> '*'  
+                        |   (?m-s:(?:\x23|\x2F{2}).*$)                      # Single Line Comment 1 # and 2 //
+                      #  |   (?s:\x22(?:[^\x22\x24\x5C]|\x5C.)*\x22)         # String Literal - Double Quoted
+                        |   (?s:\x22(?:[^\x22\x5C]|\x5C.)*\x22)         # String Literal - Double Quoted
+                        |   (?s:\x27(?:[^\x27\x5C]|\x5C.)*\x27)             # String Literal - Single Quoted
+                        |   (?:                                             # Here Document
+                                \x3C{3}(?'HDID'[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*)[^\r\n]*(?:\r?\n|\n?\r)
+                                (?s:.*?)
+                                (?:\r?\n|\n?\r)\k'HDID'                     # close with exactly the same identifier, in the first column
+                            )
+                        |   (?:                                             # Now Document
+                                \x3C{3}\x27(?'NDID'[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*)\x27[^\r\n]*(?:\r?\n|\n?\r)
+                                (?s:.*?)
+                                (?:\r?\n|\n?\r)\k'NDID'                     # close with exactly the same identifier, in the first column
+                            )
+                        "
+        >
+            <classRange
+                mainExpr    ="(?x)                                          # free-spacing (see `RegEx - Pattern Modifiers`)
+                        (?(DEFINE)                                          # definition of sub-routines
+                            (?'VALID_ID'
+                                \b(?!(?-i:                                  # keywords (case-sensitive), not to be used as identifier
+                                    a(?:bstract|nd|rray|s)
+                                |   b(?:ool|reak)
+                                |   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
+                                |   d(?:e(?:clare|fault)|ie|o)
+                                |   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
+                                |   f(?:alse|loat|inal|or(?:each)?|unction)
+                                |   g(?:lobal|oto)
+                                |   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
+                                |   list
+                                |   mixed
+                                |   n(?:amespace|ew|u(?:ll|meric))
+                                |   o(?:r|bject)
+                                |   p(?:r(?:i(?:nt|vate)|otected)|ublic)
+                                |   re(?:quire(?:_once)?|turn)
+                                |   s(?:t(?:atic|ring)|witch)
+                                |   t(?:hrow|r(?:ait|ue|y))
+                                |   u(?:nset|se)
+                                |   var
+                                |   while
+                                |   xor
+                                |   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
+                                )\b)
+                                [A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*            # valid character combination for identifiers
+                            )
+                            (?'INTERFACE_LIST'
+                                \s+(?:\x5C|(?&amp;VALID_ID))+
+                                (?:
+                                    \s*,
+                                    \s*(?:\x5C|(?&amp;VALID_ID))+
+                                )*
+                            )
+                        )
+                        (?m-i)                                              # ^ and $ match at line-breaks, case-sensitive
+                        ^\h*                                                # optional leading white-space at start-of-line
+                        (?:
+                            (?:(?-i:abstract|final)\s+)?                    # optional class entry type
+                            (?-i:class)\s+
+                            \K                                              # discard text matched so far
+                            (?&amp;VALID_ID)                                # identifier used as class name
+                            (?:                                             # optional extends-from-class
+                                \s+(?-i:extends)
+                                \s+(?:\x5C|(?&amp;VALID_ID))+
+                            )?
+                            (?:                                             # optional implements-class/interfaces
+                                \s+(?-i:implements)
+                                (?&amp;INTERFACE_LIST)
+                            )?
+                        |
+                            (?-i:interface)\s+
+                            \K                                              # discard text matched so far
+                            (?&amp;VALID_ID)                                # identifier used as interface name
+                            (?:                                             # optional extends-from list
+                                \s+(?-i:extends)
+                                (?&amp;INTERFACE_LIST)
+                            )?
+                        |
+                            (?-i:trait)\s+
+                            \K                                              # discard text matched so far
+                            (?&amp;VALID_ID)                                # identifier used as trait name
+                        )
+                        \s*\{
+                    "
+                openSymbole ="\{"
+                closeSymbole="\}"
+            >
+                <className>
+                    <nameExpr expr="[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" />
+                </className>
+                <function
+                    mainExpr="(?x)                                          # free-spacing (see `RegEx - Pattern Modifiers`)
+                            (?m-i)                                          # ^ and $ match at line-breaks, case-sensitive
+                            ^\h*                                            # optional leading white-space at start-of-line
+                            (?:(?-i:                                        # field modifiers
+                                    p(?:r(?:ivate|otected)|ublic)           # - access modifiers
+                                |   abstract|final|static                   # - ...
+                            )\s+)*                                          # require a white-space separator
+                            (?-i:function)\s+
+                            \K                                              # discard text matched so far
+                            (?:\x26\s*)?                                    # optionally a reference
+                            (?'VALID_ID'                                    # valid identifier, use as subroutine
+                                \b(?!(?-i:                                  # keywords (case-sensitive), not to be used as identifier
+                                    a(?:bstract|nd|rray|s)
+                                |   b(?:ool|reak)
+                                |   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
+                                |   d(?:e(?:clare|fault)|ie|o)
+                                |   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
+                                |   f(?:alse|loat|inal|or(?:each)?|unction)
+                                |   g(?:lobal|oto)
+                                |   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
+                                |   list
+                                |   mixed
+                                |   n(?:amespace|ew|u(?:ll|meric))
+                                |   o(?:r|bject)
+                                |   p(?:r(?:i(?:nt|vate)|otected)|ublic)
+                                |   re(?:quire(?:_once)?|turn)
+                                |   s(?:t(?:atic|ring)|witch)
+                                |   t(?:hrow|r(?:ait|ue|y))
+                                |   u(?:nset|se)
+                                |   var
+                                |   while
+                                |   xor
+                                |   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
+                                )\b)
+                                [A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*            # valid character combination for identifiers
+                            )                                               # identifier used as method name
+                            \s*\(                                           # start of function parameters
+                            (?:[^{;]*(?:\{|;))                              # start of function body  or abstract function without body
+                        "
+                >
+                    <functionName>
+                        <funcNameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*\s*\((?:[^/{]|/(?![*/]))*" />
+                        <!-- comment out the following node to display the method with parameters -->
+                        <funcNameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" />  
+                    </functionName>
+                </function>
+            </classRange>
+            <function
+                mainExpr="(?x)                                              # free-spacing (see `RegEx - Pattern Modifiers`)
+                        (?m-i)                                              # ^ and $ match at line-breaks, case-sensitive
+                        ^\h*                                                # optional leading white-space at start-of-line
+                        (?-i:function)\s+
+                        \K                                                  # discard text matched so far
+                        (?:\x26\s*)?                                        # optionally a reference
+                        (?'VALID_ID'                                        # valid identifier, use as subroutine
+                            \b(?!(?-i:                                      # keywords (case-sensitive), not to be used as identifier
+                                a(?:bstract|nd|rray|s)
+                            |   b(?:ool|reak)
+                            |   c(?:a(?:llable|se|tch)|l(?:ass|one)|on(?:st|tinue))
+                            |   d(?:e(?:clare|fault)|ie|o)
+                            |   e(?:cho|lse(?:if)?|mpty|nd(?:declare|for(?:each)?|if|switch|while)|val|x(?:it|tends))
+                            |   f(?:alse|loat|inal|or(?:each)?|unction)
+                            |   g(?:lobal|oto)
+                            |   i(?:f|mplements|n(?:clude(?:_once)?|st(?:anceof|eadof)|t(?:erface)?)|sset)
+                            |   list
+                            |   mixed
+                            |   n(?:amespace|ew|u(?:ll|meric))
+                            |   o(?:r|bject)
+                            |   p(?:r(?:i(?:nt|vate)|otected)|ublic)
+                            |   re(?:quire(?:_once)?|turn)
+                            |   s(?:t(?:atic|ring)|witch)
+                            |   t(?:hrow|r(?:ait|ue|y))
+                            |   u(?:nset|se)
+                            |   var
+                            |   while
+                            |   xor
+                            |   __(?:halt_compiler|(?:CLASS|DIR|F(?:ILE|UNCTION)|LINE|METHOD|NAMESPACE|TRAIT)__)
+                            )\b)
+                            [A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*                # valid character combination for identifiers
+                        )                                                   # identifier used as function name
+                        \s*\(                                               # start of function parameters
+                        [^{]*\{                                             # start of function body 
+                    "
+            >
+                <functionName>
+                    <nameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*\s*\((?:[^/{]|/(?![*/]))*" />
+                    <!-- comment out the following node to display the function with its parameters -->
+                    <!-- <nameExpr expr="(?:\x26\s*)?[A-Za-z_\x7F-\xFF][\w\x7F-\xFF]*" /> -->
+                </functionName>
+            </function>
+        </parser>
 	</functionList>
 </NotepadPlus>


### PR DESCRIPTION
1. Fix the function name gets truncated issue if function starts with reserved words (ie. if, while, for, switch...).
2. Fix abstact function and classes not recognized by parser rule.
3. Fix function detection fails on string containing asterisk issue.

Contributed by @MAPJe71 & @TutoInformatik :
https://community.notepad-plus-plus.org/topic/15124/php-function-list-and-abstract-functions/18?_=1604532045222

Fix #3321, fix #5045, fix #4627, fix #4606, fix #8855, fix #4208, fix #981, fix #2522, fix #1103, fix  #4712, fix #3560, fix #5150, fix #4606.