### PR TITLE
update japanese.xml to v7.9.2

### DIFF
--- a/PowerEditor/installer/nativeLang/japanese.xml
+++ b/PowerEditor/installer/nativeLang/japanese.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <NotepadPlus>
-    <Native-Langue name="Japanese" filename="japanese.xml" version="7.9.1">
+    <Native-Langue name="Japanese" filename="japanese.xml" version="7.9.2">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -157,6 +157,7 @@
                     <Item id="42048" name="バイナリコンテンツをコピー"/>
                     <Item id="42049" name="バイナリコンテンツを切り取り"/>
                     <Item id="42050" name="バイナリコンテンツを貼り付け"/>
+                    <Item id="42082" name="リンクをコピー"/>
                     <Item id="42037" name="矩形モード..."/>
                     <Item id="42034" name="矩形編集..."/>
                     <Item id="42051" name="文字コード表"/>
@@ -354,13 +355,13 @@
                     <Item CMID="1" name="他のタブをすべて閉じる"/>
                     <Item CMID="2" name="上書き保存"/>
                     <Item CMID="3" name="名前を付けて保存..."/>
-                    <Item CMID="4" name="印刷"/>
+                    <Item CMID="4" name="印刷..."/>
                     <Item CMID="5" name="別のビューへ移動"/>
                     <Item CMID="6" name="別のビューへ複製"/>
                     <Item CMID="7" name="フルパスをコピー"/>
                     <Item CMID="8" name="ファイル名をコピー"/>
                     <Item CMID="9" name="ディレクトリをコピー"/>
-                    <Item CMID="10" name="名前の変更"/>
+                    <Item CMID="10" name="名前の変更..."/>
                     <Item CMID="11" name="ごみ箱に移動"/>
                     <Item CMID="12" name="読み取り専用モード"/>
                     <Item CMID="13" name="ファイルの読み取り専用を解除"/>
@@ -537,11 +538,11 @@
                     <Item id="45001" name="改行コードを Windows (CR LF) に変換"/>
                     <Item id="45002" name="改行コードを Unix (LF) に変換"/>
                     <Item id="45003" name="改行コードを Macintosh (CR) に変換"/>
-                    <Item id="43022" name="検索結果をスタイル1でマーク"/>
-                    <Item id="43024" name="検索結果をスタイル2でマーク"/>
-                    <Item id="43026" name="検索結果をスタイル3でマーク"/>
-                    <Item id="43028" name="検索結果をスタイル4でマーク"/>
-                    <Item id="43030" name="検索結果をスタイル5でマーク"/>
+                    <Item id="43022" name="スタイル1でマーク"/>
+                    <Item id="43024" name="スタイル2でマーク"/>
+                    <Item id="43026" name="スタイル3でマーク"/>
+                    <Item id="43028" name="スタイル4でマーク"/>
+                    <Item id="43030" name="スタイル5でマーク"/>
                     <Item id="43023" name="スタイル1のマークを解除"/>
                     <Item id="43025" name="スタイル2のマークを解除"/>
                     <Item id="43027" name="スタイル3のマークを解除"/>
@@ -821,37 +822,37 @@
                     <Item id="6219" name="点滅速度:"/>
                     <Item id="6221" name="速く"/>
                     <Item id="6222" name="遅く"/>
-                    <Item id="6224" name="一括編集"/>
-                    <Item id="6225" name="有効(Ctrl+クリック/選択)"/>
+                    <Item id="6225" name="一括編集を有効(Ctrl+クリック/選択)"/>
+                    <Item id="6227" name="行折り返し"/>
+                    <Item id="6228" name="デフォルト"/>
+                    <Item id="6229" name="端揃え"/>
+                    <Item id="6230" name="インデント"/>
+                    <Item id="6234" name="スクロールの拡張機能を無効にする(タッチパッドで問題になる場合)"/>
+                    <Item id="6214" name="現在行を強調表示する"/>
+                    <Item id="6215" name="フォントスムージングを有効にする"/>
+                    <Item id="6236" name="最終行を画面上端までスクロールできる"/>
+                    <Item id="6239" name="選択範囲外を右クリックしたときに選択を解除しない"/>
+                </Scintillas>
+
+                <MarginsBorderEdge title="余白部/枠線/ガイド線">
                     <Item id="6201" name="折り畳み表示スタイル"/>
                     <Item id="6202" name="シンプル"/>
                     <Item id="6203" name="矢印"/>
                     <Item id="6204" name="丸とツリー"/>
                     <Item id="6205" name="四角とツリー"/>
                     <Item id="6226" name="なし"/>
-
-                    <Item id="6227" name="行折り返し"/>
-                    <Item id="6228" name="デフォルト"/>
-                    <Item id="6229" name="端揃え"/>
-                    <Item id="6230" name="インデント"/>
-
-                    <Item id="6206" name="行番号を表示"/>
+                    <Item id="6291" name="行番号"/>
+                    <Item id="6206" name="表示する"/>
+                    <Item id="6292" name="表示に応じて幅を調整"/>
+                    <Item id="6293" name="最大桁数で幅を固定"/>
                     <Item id="6207" name="ブックマークを表示"/>
-                    <Item id="6208" name="指定桁で垂直線を表示"/>
-                    <Item id="6234" name="スクロールの拡張機能を無効にする
-(タッチパッドに問題がある場合)"/>
-
                     <Item id="6211" name="ガイド線の表示設定"/>
                     <Item id="6213" name="背景色で表示"/>
                     <Item id="6237" name="線を表示したい桁位置を指定してください。
 複数の値を半角スペースで区切って記入することで、複数の線を表示できます。"/>
-                    <Item id="6214" name="現在行を強調表示する"/>
-                    <Item id="6215" name="フォントスムージングを有効にする"/>
                     <Item id="6231" name="枠線幅"/>
                     <Item id="6235" name="枠を非表示"/>
-                    <Item id="6236" name="最終行を1行目までスクロールできる"/>
-                    <Item id="6239" name="選択範囲外を右クリックしたときに選択を解除しない"/>
-                </Scintillas>
+                </MarginsBorderEdge>
 
                 <NewDoc title="新規文書">
                     <Item id="6401" name="フォーマット(改行コード)"/>
@@ -1011,10 +1012,15 @@
 (意味がわからないならば、標準のままにすべきです)"/>
                 </Delimiter>
 
-                <Cloud title="クラウド">
+                <Cloud title="クラウド、ハイパーリンク">
                     <Item id="6262" name="クラウド設定"/>
                     <Item id="6263" name="クラウドを使用しない"/>
                     <Item id="6267" name="クラウドのパスを指定:"/>
+                    <Item id="6318" name="URIのハイパーリンク化"/>
+                    <Item id="6319" name="有効"/>
+                    <Item id="6320" name="下線を引かない"/>
+                    <Item id="6350" name="注目時に背景色を変える"/>
+                    <Item id="6264" name="カスタムURIスキーム："/>
                 </Cloud>
 
                 <SearchEngine title="検索エンジン">
@@ -1037,10 +1043,7 @@
                     <Item id="6308" name="タスクトレイに格納"/>
                     <Item id="6312" name="ファイルの状態監視"/>
                     <Item id="6313" name="自動で最新状態に更新"/>
-                    <Item id="6318" name="URLのハイパーリンク化"/>
                     <Item id="6325" name="更新後最後の行にスクロール"/>
-                    <Item id="6319" name="有効"/>
-                    <Item id="6320" name="下線を引かない"/>
                     <Item id="6322" name="セッションファイルの拡張子:"/>
                     <Item id="6323" name="Notepad++の自動アップデートを有効にする"/>
                     <Item id="6351" name="標準テキスト形式を保存するとき、ファイルの種類を .txt ではなく .* にする"/>
@@ -1048,7 +1051,6 @@
                     <Item id="6331" name="タイトルバーにファイル名のみ表示"/>
                     <Item id="6334" name="文字コードを自動判別"/>
                     <Item id="6349" name="DirectWriteを使用する（特殊な文字の描画が改善されます。Notepad++ の再起動が必要）"/>
-                    <Item id="6350" name="注目時に背景色を変える"/>
                     <Item id="6337" name="ワークスペースファイルの拡張子:"/>
                     <Item id="6114" name="有効"/>
                     <Item id="6117" name="最近使用した順で切り替える"/>
@@ -1124,6 +1126,7 @@
             <DocReloadWarning title="再読み込み" message="変更が失われますが、このドキュメントを本当に開き直しますか?"/>
             <FileLockedWarning title="警告: 保存失敗" message="このファイルを別のプログラムで開いていないか確認してください。"/>
             <FileAlreadyOpenedInNpp title="" message="そのファイルは既にNotepad++で開かれています。"/>
+            <RenameTabTemporaryNameAlreadyInUse title="名前の変更に失敗" message="指定された名前は、ほかのタブで使用されています。"/> <!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
             <DeleteFileFailed title="削除失敗" message="ファイルの削除に失敗しました。"/>
 
             <NbFileToOpenImportantWarning title="大量のファイルを開こうとしています" message="$INT_REPLACE$ 個のファイルを開こうとしています。
@@ -1215,6 +1218,7 @@ Notepad++ を管理者権限で立ち上げますか？"/>
             <ColumnPath name="パス"/>
             <ColumnType name="種類"/>
             <ColumnSize name="サイズ"/>
+            <NbDocsTotal name="文書数："/>
         </WindowsDlg>
         <AsciiInsertion>
             <PanelTitle name="ASCII文字挿入パネル"/>
@@ -1235,6 +1239,9 @@ Notepad++ を管理者権限で立ち上げますか？"/>
         <FolderAsWorkspace>
             <PanelTitle name="ワークスペース フォルダー"/>
             <SelectFolderFromBrowserString name="ワークスペース フォルダーに追加するフォルダーを選択"/>
+            <ExpandAllFoldersTip name="すべてのフォルダーを展開する"/>
+            <CollapseAllFoldersTip name="すべてのフォルダーを畳む"/>
+            <LocateCurrentFileTip name="現在のファイルを見つける"/>
             <Menus>
                 <Item id="3511" name="取り除く"/>
                 <Item id="3512" name="すべて取り除く"/>
@@ -1344,7 +1351,8 @@ Notepad++ を管理者権限で立ち上げますか？"/>
             <finder-close-this value="この検索結果を閉じる"/>
             <finder-collapse-all value="すべて折りたたむ"/>
             <finder-uncollapse-all value="すべて展開する"/>
-            <finder-copy value="コピー"/>
+            <finder-copy value="選択行をコピー"/>
+            <finder-copy-verbatim value="コピー"/>
             <finder-select-all value="すべて選択"/>
             <finder-clear-all value="すべてクリア"/>
             <finder-open-all value="すべて開く"/>
@@ -1383,6 +1391,7 @@ Notepad++ を管理者権限で立ち上げますか？"/>
             <find-result-title-info-selections value="($INT_REPLACE1$ 件が $INT_REPLACE2$ 個の選択範囲内で一致しました。検索した選択範囲は $INT_REPLACE3$ 個)"/>
             <find-result-title-info-extra value=" - 絞り込まれた検索結果のみを表示しています"/>
             <find-result-hits value="($INT_REPLACE$ 件の一致)"/>
+            <find-result-line-prefix value="行番号"/> <!-- Must not begin with space or tab character -->
             <find-regex-zero-length-match value="長さ0で一致しました" />
         </MiscStrings>
     </Native-Langue>


### PR DESCRIPTION
Follow-up for this commit:
* Make UI text consistent regarding search results (f5dcfc196aff5b41bb6db6e4b3044c26ab57cdf3)
Note: Diff of this PR is smaller than the commit above, but it's OK. Japanese translation was already translated correctly.