### PR TITLE
Fix bug where search-results won't jump focus into 'new 1' file

### DIFF
--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -1463,7 +1463,12 @@ BufferID FileManager::getBufferFromName(const TCHAR* name)
 	for (size_t i = 0; i < _buffers.size(); i++)
 	{
 		if (OrdinalIgnoreCaseCompareStrings(name, _buffers.at(i)->getFullPathName()) == 0)
-			return _buffers.at(i)->getID();
+		{
+			if (_buffers.at(i)->_referees[0]->isVisible())
+			{
+				return _buffers.at(i)->getID();
+			}
+		}
 	}
 	return BUFFER_INVALID;
 }


### PR DESCRIPTION
Fixes #8461 , #9098 

When a "buffer" is created, it is given a name "new (digit)" where "digit" is allowed to repeat if the buffer being created is not visible to the user.  This is likely so that if the user has only one tab open and it is labeled "new 1" and they press Ctrl+n that they aren't faced with the "awkwardness" of having "new 5" being opened, if the "system" has opened some invisible buffers for its own use in the meanwhile.

A real problem when the code wants to get a buffer by its name, because potentially several "new 1" (for example) buffers can simultaneously exist -- which one should be returned?  The answer should be "the visible one", which this PR satisfies.