### PR TITLE
Add ellipsis to Rename and Print on tab bar context menu

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -351,13 +351,13 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item CMID="1" name="Close All BUT This"/>
                     <Item CMID="2" name="Save"/>
                     <Item CMID="3" name="Save As..."/>
-                    <Item CMID="4" name="Print"/>
+                    <Item CMID="4" name="Print..."/>
                     <Item CMID="5" name="Move to Other View"/>
                     <Item CMID="6" name="Clone to Other View"/>
                     <Item CMID="7" name="Full File Path to Clipboard"/>
                     <Item CMID="8" name="Filename to Clipboard"/>
                     <Item CMID="9" name="Current Dir. Path to Clipboard"/>
-                    <Item CMID="10" name="Rename"/>
+                    <Item CMID="10" name="Rename..."/>
                     <Item CMID="11" name="Move to Recycle Bin"/>
                     <Item CMID="12" name="Read-Only"/>
                     <Item CMID="13" name="Clear Read-Only Flag"/>


### PR DESCRIPTION
The _File_ menus' rename and print commands have ellipsis (`...`) after their text, indicating that activating the menu item will cause an input window of some type to open:

![image](https://user-images.githubusercontent.com/30118311/98453550-6c0afd00-2128-11eb-9f26-198bd7e769cf.png)

But the "tab bar" right-click context menu equivalents have no ellipsis:

![image](https://user-images.githubusercontent.com/30118311/98453561-8e9d1600-2128-11eb-8430-154dee8d5570.png)

This issueless PR corrects this situation.