### PR TITLE
Disallow Goto dlg offset option from moving to position inside multibyte char or between CR and LF

### DIFF
--- a/PowerEditor/src/ScitillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/GoToLineDlg.cpp
@@ -62,11 +62,19 @@ INT_PTR CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 						}
 						else
 						{
-							auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, line);
+							int posToGoto = 0;
+							if (line > 0)
+							{
+								// make sure not jumping into the middle of a multibyte character
+								// or into the middle of a CR/LF pair for Windows files
+								auto before = (*_ppEditView)->execute(SCI_POSITIONBEFORE, line);
+								posToGoto = static_cast<int>((*_ppEditView)->execute(SCI_POSITIONAFTER, before));
+							}
+							auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, posToGoto);
 							(*_ppEditView)->execute(SCI_ENSUREVISIBLE, sci_line);
-							(*_ppEditView)->execute(SCI_GOTOPOS, line);
+							(*_ppEditView)->execute(SCI_GOTOPOS, posToGoto);
 						}
-                    }
+					}
 
 					SCNotification notification = {};
 					notification.nmhdr.code = SCN_PAINTED;


### PR DESCRIPTION
Fixes #9101 and #9125 

Quick reproduction methods:

for 9101:
UTF-8 document containing this single character: 𝅙
use goto dialog (Ctrl+g) to move to offset 1
type any character, e.g. `a`
observe data corruption:
![image](https://user-images.githubusercontent.com/30118311/98597569-38a2ac80-22a7-11eb-91d5-2f61fa56f2ca.png)

for 9125:
UTF-8 document with Windows format with 2 lines, no characters on line 1 (just a CRLF line-ending)
turn visible line endings on
use goto dialog (Ctrl+g) to move to offset 1
type any character, e.g. `a`
observe data corruption in line-endings:
![image](https://user-images.githubusercontent.com/30118311/98597883-aa7af600-22a7-11eb-8fdd-50fb68f0d31c.png)

The fix moves the caret to the nearest position after the desired position that puts the caret on a real character border.  Other types of fixes are certainly possible, if desired.

