### PR TITLE
Fix bug where -p0 cmd line arg causes wrong positioning

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5925,10 +5925,13 @@ std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * co
 
 			if (cpos != -1)
 			{
-				// make sure not jumping into the middle of a multibyte character
-				// or into the middle of a CR/LF pair for Windows files
-				auto before = _pEditView->execute(SCI_POSITIONBEFORE, cpos);
-				cpos = static_cast<int>(_pEditView->execute(SCI_POSITIONAFTER, before));
+				if (cpos > 0)
+				{
+					// make sure not jumping into the middle of a multibyte character
+					// or into the middle of a CR/LF pair for Windows files
+					auto before = _pEditView->execute(SCI_POSITIONBEFORE, cpos);
+					cpos = static_cast<int>(_pEditView->execute(SCI_POSITIONAFTER, before));
+				}
 				_pEditView->execute(SCI_GOTOPOS, cpos);
 			}
 			else if (cn == -1)


### PR DESCRIPTION
No "issue" for this; see https://github.com/notepad-plus-plus/notepad-plus-plus/pull/9143#issuecomment-727185265
Fixes small bug introduced by 9143