### PR TITLE
Finder dialog needs new parent

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -544,7 +544,7 @@ void Finder::gotoFoundLine()
 	const FoundInfo fInfo = *(_pMainFoundInfos->begin() + lno);
 
 	// Switch to another document
-	if (!::SendMessage(::GetParent(_hParent), WM_DOOPEN, 0, reinterpret_cast<LPARAM>(fInfo._fullPath.c_str()))) return;
+	if (!::SendMessage(_hParent, WM_DOOPEN, 0, reinterpret_cast<LPARAM>(fInfo._fullPath.c_str()))) return;
 
 	(*_ppEditView)->_positionRestoreNeeded = false;
 	Searching::displaySectionCentered(fInfo._start, fInfo._end, *_ppEditView);
@@ -2355,7 +2355,7 @@ void FindReplaceDlg::findAllIn(InWhat op)
 	if (!_pFinder)
 	{
 		_pFinder = new Finder();
-		_pFinder->init(_hInst, _hSelf, _ppEditView);
+		_pFinder->init(_hInst, (*_ppEditView)->getHParent(), _ppEditView);
 		_pFinder->setVolatiled(false);
 		
 		tTbData	data = {0};
@@ -2418,8 +2418,7 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		_pFinder->_scintView.setMakerStyle(FOLDER_STYLE_SIMPLE);
 
 		_pFinder->_scintView.display();
-		_pFinder->display();
-		::SendMessage(_hParent, NPPM_DMMHIDE, 0, reinterpret_cast<LPARAM>(_pFinder->getHSelf()));
+		_pFinder->display(false);
 		::UpdateWindow(_hParent);
 		justCreated = true;
 	}
@@ -2459,7 +2458,7 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		else
 		{
 			// Show finder
-			::SendMessage(_hParent, NPPM_DMMSHOW, 0, reinterpret_cast<LPARAM>(_pFinder->getHSelf()));
+			_pFinder->display();
 			getFocus(); // no hits
 		}
 	}
@@ -2471,7 +2470,7 @@ Finder * FindReplaceDlg::createFinder()
 {
 	Finder *pFinder = new Finder();
 
-	pFinder->init(_hInst, _hSelf, _ppEditView);
+	pFinder->init(_hInst, (*_ppEditView)->getHParent(), _ppEditView);
 	
 	tTbData	data = { 0 };
 	pFinder->create(&data, false);
@@ -2532,7 +2531,6 @@ Finder * FindReplaceDlg::createFinder()
 	pFinder->_scintView.setMakerStyle(FOLDER_STYLE_SIMPLE);
 
 	pFinder->_scintView.display();
-	pFinder->display();
 	::UpdateWindow(_hParent);
 	
 	pFinder->setFinderStyle();
@@ -2547,7 +2545,7 @@ Finder * FindReplaceDlg::createFinder()
 	::SendMessage(pFinder->getHSelf(), WM_SIZE, 0, 0);
 
 	// Show finder
-	::SendMessage(_hParent, NPPM_DMMSHOW, 0, reinterpret_cast<LPARAM>(pFinder->getHSelf()));
+	pFinder->display();
 	pFinder->_scintView.getFocus();
 
 	return pFinder;
@@ -3214,7 +3212,7 @@ LRESULT FAR PASCAL FindReplaceDlg::finderProc(HWND hwnd, UINT message, WPARAM wP
 		if (wParam == VK_RETURN)
 			pFinder->gotoFoundLine();
 		else if (wParam == VK_ESCAPE)
-			::SendMessage(::GetParent(pFinder->getHParent()), NPPM_DMMHIDE, 0, reinterpret_cast<LPARAM>(pFinder->getHSelf()));
+			pFinder->display(false);
 		else // VK_DELETE
 			pFinder->deleteResult();
 		return 0;
@@ -3578,7 +3576,7 @@ void Finder::openAll()
 
 	for (size_t i = 0; i < sz; ++i)
 	{
-		::SendMessage(::GetParent(_hParent), WM_DOOPEN, 0, reinterpret_cast<LPARAM>(_pMainFoundInfos->at(i)._fullPath.c_str()));
+		::SendMessage(_hParent, WM_DOOPEN, 0, reinterpret_cast<LPARAM>(_pMainFoundInfos->at(i)._fullPath.c_str()));
 	}
 }
 
@@ -3774,7 +3772,7 @@ INT_PTR CALLBACK Finder::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 			{
 				case NPPM_INTERNAL_FINDINFINDERDLG:
 				{
-					::SendMessage(::GetParent(_hParent), NPPM_INTERNAL_FINDINFINDERDLG, reinterpret_cast<WPARAM>(this), 0);
+					::SendMessage(_hParent, NPPM_INTERNAL_FINDINFINDERDLG, reinterpret_cast<WPARAM>(this), 0);
 					return TRUE;
 				}
 
@@ -3782,7 +3780,7 @@ INT_PTR CALLBACK Finder::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				{
 					if (_canBeVolatiled)
 					{
-						::SendMessage(::GetParent(_hParent), NPPM_DMMHIDE, 0, reinterpret_cast<LPARAM>(_hSelf));
+						::SendMessage(_hParent, NPPM_DMMHIDE, 0, reinterpret_cast<LPARAM>(_hSelf));
 						setClosed(true);
 					}
 					return TRUE;

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -316,7 +316,7 @@ public :
 		// Show finder and set focus
 		if (_pFinder) 
 		{
-			::SendMessage(_hParent, NPPM_DMMSHOW, 0, reinterpret_cast<LPARAM>(_pFinder->getHSelf()));
+			_pFinder->display();
 			_pFinder->_scintView.getFocus();
 		}
 	};


### PR DESCRIPTION
Fixes #8199. 

Problem: All dialogs which inherit from `DockingDlgInterface` have `_pPublicInterface->getHSelf()` as parent, except the `Finder` dialog.

This has drawbacks:
- The display method of the `Finder` dialog doesn't work, that's why it has been replaced by `SendMessage NPPM_DMMSHOW/HIDE` calls to the parent of Find/Replace dialog in many places
- All messages for the public interface are sent to parent of parent instead of parent
- If the `Finder` starts before the Find/Replace dialog has been displayed (see #8199 how to do this), then the `Finder` dialog has no parent.

This PR gives the `Finder` docking dialog the parent window it is entitled to: the public interface window.

