### PR TITLE
Allow custom URL schemes.

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2628,7 +2628,7 @@ bool isUrlQueryDelimiter(TCHAR const c)
 	return false;
 }
 
-bool isUrlSchemeSupported(INTERNET_SCHEME s)
+bool isUrlSchemeSupported(INTERNET_SCHEME s, TCHAR *url)
 {
 	switch (s)
 	{
@@ -2638,6 +2638,17 @@ bool isUrlSchemeSupported(INTERNET_SCHEME s)
 		case INTERNET_SCHEME_MAILTO:
 		case INTERNET_SCHEME_FILE:
 			return true;
+	}
+	generic_string const mySchemes = (NppParameters::getInstance()).getNppGUI()._customizedShemes + TEXT(" ");
+	TCHAR *p = (TCHAR *)mySchemes.c_str();
+	while (*p)
+	{
+		int i = 0;
+		while (p [i] && (p [i] != ' ')) i++;
+		if (i == 0) return false;
+		if (generic_strnicmp (url, p, i) == 0) return true;
+		p += i;
+		while (*p == ' ') p++;
 	}
 	return false;
 }
@@ -2863,7 +2874,7 @@ bool isUrl(TCHAR * text, int textLen, int start, int* segmentLen)
 			URL_COMPONENTS url;
 			memset (& url, 0, sizeof(url));
 			url.dwStructSize = sizeof(url);
-			bool r  = InternetCrackUrl(& text [start], len, 0, & url) && isUrlSchemeSupported(url.nScheme);
+			bool r  = InternetCrackUrl(& text [start], len, 0, & url) && isUrlSchemeSupported(url.nScheme, & text [start]);
 			if (r)
 			{
 				while (removeUnwantedTrailingCharFromUrl (& text [start], & len));

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -4442,6 +4442,17 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			}
 		}
 
+		else if (!lstrcmp(nm, TEXT("URL customized schemes")))
+		{
+			TiXmlNode *n = childNode->FirstChild();
+			if (n)
+			{
+				const TCHAR* val = n->Value();
+				if (val)
+				_nppGUI._customizedShemes = val;
+			}
+		}
+
 		else if (!lstrcmp(nm, TEXT("CheckHistoryFiles")))
 		{
 			TiXmlNode *n = childNode->FirstChild();
@@ -5998,6 +6009,12 @@ void NppParameters::createXmlTreeFromGUIParams()
 		GUIConfigElement->InsertEndChild(TiXmlText(szStr));
 	}
 
+	// <GUIConfig name="URL customized schemes">svn://</GUIConfig>
+	{
+		TiXmlElement *GUIConfigElement = (newGUIRoot->InsertEndChild(TiXmlElement(TEXT("GUIConfig"))))->ToElement();
+		GUIConfigElement->SetAttribute(TEXT("name"), TEXT("URL customized schemes"));
+		GUIConfigElement->InsertEndChild(TiXmlText(_nppGUI._customizedShemes.c_str()));
+	}
 	// <GUIConfig name = "globalOverride" fg = "no" bg = "no" font = "no" fontSize = "no" bold = "no" italic = "no" underline = "no" / >
 	{
 		TiXmlElement *GUIConfigElement = (newGUIRoot->InsertEndChild(TiXmlElement(TEXT("GUIConfig"))))->ToElement();

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -849,6 +849,7 @@ struct NppGUI final
 	bool _isWordCharDefault = true;
 	std::string _customWordChars;
 	urlMode _styleURL = urlUnderLineFg;
+	generic_string _customizedShemes = TEXT("");
 	NewDocDefaultSettings _newDocDefaultSettings;
 
 


### PR DESCRIPTION
As discussed in #9155, a configuration `NotepadPlus\GUIConfigs\URL customized schemes` is added to `config.xml`. It contains a space-separated list of additional URL schemes, which should be accepted in addition to the standard URL schemes.