### PR TITLE
Makes find next/prev result work on find in finder results

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2333,7 +2333,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		else if (op == ProcessFindInFinder)
 		{
 			if (pFindersInfo && pFindersInfo->_pDestFinder)
-				pFinder = pFindersInfo->_pDestFinder;
+				_pFinder = pFindersInfo->_pDestFinder;
 			else
 				pFinder = _pFinder;
 		}

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -2332,8 +2332,11 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		}
 		else if (op == ProcessFindInFinder)
 		{
-			if (pFindersInfo && pFindersInfo->_pDestFinder)
+			if (pFindersInfo && pFindersInfo->_pDestFinder) 
+			{
+				pFinder = pFindersInfo->_pDestFinder;
 				_pFinder = pFindersInfo->_pDestFinder;
+			}
 			else
 				pFinder = _pFinder;
 		}


### PR DESCRIPTION
Fixes #9080

This is a one line fix that fixes the issue whereby the "find next result" button does not work when searching inside the result found by a previous search, and instead, showed the original search result's search terms. 
Now it works as expected, allowing us to cycle through the new search term's result instead. 

The fix works by assigning the data from  pFindersInfo->_pDestFinder which has conveniently already stored the information from finding the new find in finder result to _pFinder where it can be accessed by the Find Next Result function. 

The Find Next/Prev button has not been changed, and as such it will still cycle through the initial search result. For example if you search for "Jack" in a file first, and then search for "Jill" in the search results for "Jack", the "Find Next" button will still cycle through "Jack". 
