### PR TITLE
Enhance -n -c -p command line args behavior

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -217,9 +217,12 @@ struct CmdLineParams
 	bool _isPreLaunch = false;
 	bool _showLoadingTime = false;
 	bool _alwaysOnTop = false;
-	int _line2go   = -1;
-	int _column2go = -1;
-	int _pos2go = -1;
+	int _line2go = 0;
+	bool _line2goPresent = false;
+	int _column2go = 0;
+	bool _column2goPresent = false;
+	int _pos2go = 0;
+	bool _pos2goPresent = false;
 
 	POINT _point;
 	bool _isPointXValid = false;
@@ -257,8 +260,11 @@ struct CmdLineParamsDTO
 	bool _openFoldersAsWorkspace = false;
 
 	int _line2go = 0;
+	bool _line2goPresent = false;
 	int _column2go = 0;
+	bool _column2goPresent = false;
 	int _pos2go = 0;
+	bool _pos2goPresent = false;
 
 	LangType _langType = L_EXTERNAL;
 
@@ -272,9 +278,12 @@ struct CmdLineParamsDTO
 		dto._openFoldersAsWorkspace = params._openFoldersAsWorkspace;
 
 		dto._line2go = params._line2go;
+		dto._line2goPresent = params._line2goPresent;
 		dto._column2go = params._column2go;
+		dto._column2goPresent = params._column2goPresent;
 		dto._pos2go = params._pos2go;
-		
+		dto._pos2goPresent = params._pos2goPresent;
+
 		dto._langType = params._langType;
 
 		return dto;

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -377,7 +377,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 		params = convertParamsToNotepadStyle(pCmdLineWithoutIgnores);
 	}
 
-	bool isParamePresent;
 	bool showHelp = isInList(FLAG_HELP, params);
 	bool isMultiInst = isInList(FLAG_MULTI_INSTANCE, params);
 	bool doFunctionListExport = isInList(FLAG_FUNCLSTEXPORT, params);

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -400,9 +400,9 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 	cmdLineParams._ghostTypingSpeed = getGhostTypingSpeedFromParam(params);
 
 	// getNumberFromParam should be run at the end, to not consuming the other params
-	cmdLineParams._line2go = getNumberFromParam('n', params, isParamePresent);
-    cmdLineParams._column2go = getNumberFromParam('c', params, isParamePresent);
-    cmdLineParams._pos2go = getNumberFromParam('p', params, isParamePresent);
+	cmdLineParams._line2go = getNumberFromParam('n', params, cmdLineParams._line2goPresent);
+    cmdLineParams._column2go = getNumberFromParam('c', params, cmdLineParams._column2goPresent);
+    cmdLineParams._pos2go = getNumberFromParam('p', params, cmdLineParams._pos2goPresent);
 	cmdLineParams._point.x = getNumberFromParam('x', params, cmdLineParams._isPointXValid);
 	cmdLineParams._point.y = getNumberFromParam('y', params, cmdLineParams._isPointYValid);
 


### PR DESCRIPTION
Fix #9146

@Yaron10 Please test

Notes:

* -p remains zero-based (we weren't out to change that with this issue/PR).
* -p has priority over the others if it is specified along with -n and/or -c
