### PR TITLE
Make Line text in Search-results translatable

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1386,6 +1386,7 @@ Find in all files except exe, obj &amp;&amp; log:
             <find-result-title-info-selections value="($INT_REPLACE1$ hits in $INT_REPLACE2$ selections of $INT_REPLACE3$ searched)"/>
             <find-result-title-info-extra value=" - Line Filter Mode: only display the filtered results"/>
             <find-result-hits value="($INT_REPLACE$ hits)"/>
+            <find-result-line-nb-prefix value="Line"/>
             <find-regex-zero-length-match value="zero length match" />
         </MiscStrings>
     </Native-Langue>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1381,12 +1381,12 @@ Find in all files except exe, obj &amp;&amp; log:
             <replace-in-open-docs-confirm-title value="Are you sure?"/>
             <replace-in-open-docs-confirm-message value="Are you sure you want to replace all occurrences in all open documents?"/>
             <find-result-caption value="Search results"/>
-            <find-result-title value="Search"/>
+            <find-result-title value="Search"/>   <!-- Must not begin with space or tab character -->
             <find-result-title-info value="($INT_REPLACE1$ hits in $INT_REPLACE2$ files of $INT_REPLACE3$ searched)"/>
             <find-result-title-info-selections value="($INT_REPLACE1$ hits in $INT_REPLACE2$ selections of $INT_REPLACE3$ searched)"/>
             <find-result-title-info-extra value=" - Line Filter Mode: only display the filtered results"/>
             <find-result-hits value="($INT_REPLACE$ hits)"/>
-            <find-result-line-nb-prefix value="Line"/>
+            <find-result-line-nb-prefix value="Line"/>   <!-- Must not contain any space characters -->
             <find-regex-zero-length-match value="zero length match" />
         </MiscStrings>
     </Native-Langue>

--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.h
@@ -170,6 +170,9 @@ private:
 
 	bool _longLinesAreWrapped = false;
 
+	generic_string _searchResultSearchPrefix;
+	generic_string _searchResultLineNbPrefix;
+
 	void setFinderReadOnly(bool isReadOnly) {
 		_scintView.execute(SCI_SETREADONLY, isReadOnly);
 	};

--- a/scintilla/lexers/LexSearchResult.cxx
+++ b/scintilla/lexers/LexSearchResult.cxx
@@ -60,25 +60,20 @@ static void ColouriseSearchResultLine(SearchResultMarkings* pMarkings, char *lin
 	{
 		styler.ColourTo(endPos, SCE_SEARCHRESULT_FILE_HEADER);
 	}
-	else if (lineBuffer[0] == '	')// \t - line info
+	else if (lineBuffer[0] == '\t')  // "\tLine 123: xxxxxxHITxxxxxx"
 	{
-		const unsigned int firstTokenLen = 4;
-		unsigned int currentPos;
+		unsigned int currentPos = 0;
 
-		styler.ColourTo(startLine + firstTokenLen, SCE_SEARCHRESULT_DEFAULT);
-		
-		for (currentPos = firstTokenLen; lineBuffer[currentPos] != ':'; currentPos++)
-		{
-			// Just make currentPos mover forward
-		}
+		while (lineBuffer[++currentPos] != ' ');  // move currentPos to after the first space on the line
+		styler.ColourTo(startLine + currentPos, SCE_SEARCHRESULT_DEFAULT);
 
+		while (lineBuffer[++currentPos] != ':');  // move currentPos to after the first colon on the line
 		styler.ColourTo(startLine + currentPos - 1, SCE_SEARCHRESULT_LINE_NUMBER);
-		
+
 		int currentStat = SCE_SEARCHRESULT_DEFAULT;
 
 		SearchResultMarking mi = pMarkings->_markings[linenum];
 
-		currentPos += 2; // skip ": "
 		size_t match_start = startLine + mi._start - 1;
 		size_t match_end = startLine + mi._end - 1;
 


### PR DESCRIPTION
Fix #9224

Notes: 

* Changes lexer code so that it no longer looks for a four-character wide fixed token on "Line" lines of search result; it looks for the first space character following the token instead.  This allows the translation of "Line" to be less or more characters long.  Translation restriction for "Line": Must not contain a space or a colon.  [**EDIT:** Second commit lifts the restriction on a colon being in the "Line" translation string, if user wants this for some reason.]

* Prepares the translated text for "Search" and "Line" output lines only once, when a search is begun (otherwise, for "Line" it would pointlessly and repeatedly prepare the same text over and over for each "Line" of the result).

* Eliminates the styling of the space character between "Line" and the digits of the line number (see image [HERE](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9224#issuecomment-738864831) for why this was wrong and was changed) 

* Performs some additional error checking on the user's translation for "Search" so that it is now impossible for a "Search" line to appear to the lexer as a "file" line or a "Line" line.  Translation restrictions for "Search": Must not start with a space or tab.