### PR TITLE
Fix spelling in message box title about related folder as workspace

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1060,7 +1060,7 @@ void FileBrowser::addRootFolder(generic_string rootFolderPath)
 				NppParameters::getInstance().getNativeLangSpeaker()->messageBox("FolderAsWorspaceSubfolderExists",
 					_hParent,
 					TEXT("A sub-folder of the folder you want to add exists.\rPlease remove its root from the panel before you add folder \"$STR_REPLACE$\"."),
-					TEXT("Folder as Worspace adding folder problem"),
+					TEXT("Folder as Workspace adding folder problem"),
 					MB_OK,
 					0, // not used
 					rootFolderPath.c_str());


### PR DESCRIPTION
Change Workspace => Workspace in string used as a title.
String ID used for translation has a similar spelling mistake:
"FolderAsWorspaceSubfolderExists".
However, that is left unchanged to avoid unwanted changes in translation
files. That can be fixed separately if needed.

Fix #9259