### PR TITLE
Plugin admin to use UTF-8 transformation for author/description

### DIFF
--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -656,10 +656,10 @@ bool loadFromJson(PluginViewList & pl, const json& j)
 			pi->_displayName = wmc.char2wchar(valStr.c_str(), CP_ACP);
 
 			valStr = i.at("author").get<std::string>();
-			pi->_author = wmc.char2wchar(valStr.c_str(), CP_ACP);
+			pi->_author = wmc.char2wchar(valStr.c_str(), CP_UTF8);
 
 			valStr = i.at("description").get<std::string>();
-			pi->_description = wmc.char2wchar(valStr.c_str(), CP_ACP);
+			pi->_description = wmc.char2wchar(valStr.c_str(), CP_UTF8);
 
 			valStr = i.at("id").get<std::string>();
 			pi->_id = wmc.char2wchar(valStr.c_str(), CP_ACP);


### PR DESCRIPTION
Fix #9266

- use UTF-8 input transformation for plugin author and description
- rreverted (update nlohmann json to v3.9.1 with performance and security improvements)

![grafik](https://user-images.githubusercontent.com/12630740/102134327-a4ec6f00-3e56-11eb-9b94-38725476a569.png)
