### PR TITLE
Allowed clipboard history text to scale with panel

### DIFF
--- a/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
+++ b/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
@@ -187,7 +187,11 @@ void ClipboardHistoryPanel::drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 	COLORREF fgColor = _lbFgColor == -1?black:_lbFgColor; // fg black by default
 	COLORREF bgColor = _lbBgColor == -1?white:_lbBgColor; // bg white by default
 	
-	StringArray sa(_clipboardDataVector[lpDrawItemStruct->itemID], MAX_DISPLAY_LENGTH);
+	RECT windowPlacement;
+
+	::GetWindowRect(::GetDlgItem(_hSelf, IDC_LIST_CLIPBOARD), &windowPlacement);
+
+	StringArray sa(_clipboardDataVector[lpDrawItemStruct->itemID], (windowPlacement.right - windowPlacement.left) / 3);
 	TCHAR *ptStr = (TCHAR *)sa.getPointer();
 
 	//printStr(ptStr);


### PR DESCRIPTION
As requested by #9255 

Not sure if this is the best way. Also haven't been able to test on all resolutions. But this works for 1920 x 1080.

Let me know what I should do to further test this or if there is a better way.