### PR TITLE
Improve high-dpi display

### DIFF
--- a/PowerEditor/src/dpiAware.manifest
+++ b/PowerEditor/src/dpiAware.manifest
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:windowsSettings
-         xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>

--- a/PowerEditor/src/dpiAware.manifest
+++ b/PowerEditor/src/dpiAware.manifest
@@ -3,7 +3,7 @@
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <asmv3:windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>

--- a/PowerEditor/src/dpiAware.manifest
+++ b/PowerEditor/src/dpiAware.manifest
@@ -3,7 +3,7 @@
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <asmv3:windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>


### PR DESCRIPTION
Fix #8115 (and probably others)

Seems to improve things on high-dpi monitors? (without any otherwise obvious problems)
Here's my result (a definite improvement) -- perhaps the screenshot removes some of the crispness of reality, though!
On the left is N++ 7.9.2; on the right is the result from this PR -- font size settings are the same for each.
This is running on Win10.
Would appreciate if others would try on various OS and monitor situations!

![image](https://user-images.githubusercontent.com/30118311/104132139-72487000-5349-11eb-98cf-aced88712cfd.png)

Credit (or blame) to @xianyun666
