### PR TITLE
Restore split-lines split-on-vertical-edge functionality

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1598,14 +1598,22 @@ void Notepad_plus::command(int id)
 				auto caretPos = _pEditView->execute(SCI_GETLINEENDPOSITION, lineRange.second);
 				_pEditView->execute(SCI_SETSELECTION, caretPos, anchorPos);
 				_pEditView->execute(SCI_TARGETFROMSELECTION);
-				if (_pEditView->execute(SCI_GETEDGEMODE) == EDGE_NONE)
+				int edgeMode = static_cast<int>(_pEditView->execute(SCI_GETEDGEMODE));
+				if (edgeMode == EDGE_NONE)
 				{
-					_pEditView->execute(SCI_LINESSPLIT);
+					_pEditView->execute(SCI_LINESSPLIT, 0);
 				}
 				else
 				{
-					auto textWidth = _pEditView->execute(SCI_TEXTWIDTH, STYLE_LINENUMBER, reinterpret_cast<LPARAM>("P"));
-					auto edgeCol = _pEditView->execute(SCI_GETEDGECOLUMN);
+					auto textWidth = _pEditView->execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
+					auto edgeCol = _pEditView->execute(SCI_GETEDGECOLUMN); // will work for edgeMode == EDGE_BACKGROUND
+					if (edgeMode == EDGE_MULTILINE)
+					{
+						NppParameters& nppParam = NppParameters::getInstance();
+						ScintillaViewParams& svp = const_cast<ScintillaViewParams&>(nppParam.getSVP());
+						edgeCol = svp._edgeMultiColumnPos.back();  // the LAST edge column specified by the user
+					}
+					++edgeCol;  // compensate for zero-based column number
 					_pEditView->execute(SCI_LINESSPLIT, textWidth * edgeCol);
 				}
 			}


### PR DESCRIPTION
Fix #8262

Implements a fix whereby the RIGHTMOST user specified value in the vertical edge box is the column to split by, e.g. 60 in the following example:

![image](https://user-images.githubusercontent.com/30118311/104496489-10854180-55a7-11eb-8a71-49265fe86b3e.png)

If the contents of the box were instead `60 40`, the split-by column would be 40, as that is the RIGHTMOST value.

-----------------------------------------------------------------

Also, fixes the problem pointed out [HERE](https://community.notepad-plus-plus.org/post/61615), specifically:

_"If the font size of the line numbers margin is set to a different value than the font size for documents, the “word-wrap at single-edge-line” code calculates a wrong wrapping position. This position has to be provided in pixels. To calculate this pixel value, a Scintilla function has to be called that calculates the width in pixels of a provided string from a provided text style. It seems like Notepad++'s internal code erroneously takes the text style of the line numbers margin font when calling this Scintilla function."_

by changing usage of `STYLE_LINENUMBER` to `STYLE_DEFAULT`.