### PR TITLE
Add ability to delete from Find combobox history

### DIFF
--- a/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScitillaComponent/FindReplaceDlg.cpp
@@ -443,10 +443,9 @@ int FindReplaceDlg::saveComboHistory(int id, int maxcount, vector<generic_string
 	int count = static_cast<int32_t>(::SendMessage(hCombo, CB_GETCOUNT, 0, 0));
 	count = min(count, maxcount);
 
-    if (count == CB_ERR) return 0;
+	if (count == CB_ERR) return 0;
 
-    if (count)
-        strings.clear();
+	strings.clear();
 
 	if (saveEmpty)
 	{
@@ -456,7 +455,7 @@ int FindReplaceDlg::saveComboHistory(int id, int maxcount, vector<generic_string
 		}
 	}
 
-    for (int i = 0 ; i < count ; ++i)
+	for (int i = 0 ; i < count ; ++i)
 	{
 		auto cbTextLen = ::SendMessage(hCombo, CB_GETLBTEXTLEN, i, 0);
 		if (cbTextLen <= FINDREPLACE_MAXLENGTH - 1)
@@ -465,7 +464,7 @@ int FindReplaceDlg::saveComboHistory(int id, int maxcount, vector<generic_string
 			strings.push_back(generic_string(text));
 		}
 	}
-    return count;
+	return count;
 }
 
 void FindReplaceDlg::updateCombos()


### PR DESCRIPTION
Fix #9366 

When any of the _Find_ window comboboxes are dropped and an entry is highlighted, pressing the _Delete_ key will remove the highlighted entry:

* _Find what_ combobox
* _Replace with_ combobox
* _Directory_ combobox
* _Filters_ combobox

No method is provided for clearing all entries at once, but as the "depth" of the comboboxes is limited to a small amount, clearing one entry at a time (when one wants to clear all) is not overly burdensome.