### PR TITLE
Fix possible empty snapshot session on Windows reboot/shutdown

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2344,5 +2344,5 @@ void Notepad_plus::saveSession(const Session & session)
 
 void Notepad_plus::saveCurrentSession()
 {
-	::PostMessage(_pPublicInterface->getHSelf(), NPPM_INTERNAL_SAVECURRENTSESSION, 0, 0);
+	::SendMessage(_pPublicInterface->getHSelf(), NPPM_INTERNAL_SAVECURRENTSESSION, 0, 0);
 }


### PR DESCRIPTION
Save snapshot session immediately when needed (without incuring delay by using ::PostMessage).

Fix #7839 and latest user reported problems in #6133.