### PR TITLE
Update dutch.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/dutch.xml
+++ b/PowerEditor/installer/nativeLang/dutch.xml
@@ -1,79 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-	Dutch localization for Notepad++ 7.5.6
-	Last modified Mon, Mar 26 2018 by Klaas Nekeman.
-	Please e-mail errors, suggestions etc. to knekeman(at)gmail.com.
-	Dutch localization for Notepad++ 7.8.7
-	Last modified Tue, May 26 2020 by xylographe <wr86420@gmail.com>.
+Dutch localization for Notepad++ 7.9.3
+Modifications on 2018-03-26 by Klaas Nekeman. Please e-mail errors, suggestions etc. to knekeman(at)gmail.com.
+Modifications on 2020-05-26 by xylographe <wr86420@gmail.com>.
+Modifications on 2021-01-28 by Thomas De Rocker (RockyTDR): added and translated missing strings for Notepad++ version 7.9.3. 
 -->
 <NotepadPlus>
-	<Native-Langue name="Nederlands" filename="dutch.xml" version="7.8.7">
+	<Native-Langue name="Nederlands" filename="dutch.xml" version="7.9.3">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
 				<Entries>
-					<Item menuId="file"     name="&amp;Bestand"/>
-					<Item menuId="edit"     name="Be&amp;werken"/>
-					<Item menuId="search"   name="&amp;Zoeken"/>
-					<Item menuId="view"     name="B&amp;eeld"/>
-					<Item menuId="encoding" name="&amp;Karakterset"/>
+					<Item menuId="file" name="&amp;Bestand"/>
+					<Item menuId="edit" name="Be&amp;werken"/>
+					<Item menuId="search" name="&amp;Zoeken"/>
+					<Item menuId="view" name="B&amp;eeld"/>
+					<Item menuId="encoding" name="&amp;Tekenset"/>
 					<Item menuId="language" name="&amp;Syntaxis"/>
 					<Item menuId="settings" name="&amp;Instellingen"/>
-					<Item menuId="tools"    name="&amp;Gereedschappen"/>
-					<Item menuId="macro"    name="&amp;Macro"/>
-					<Item menuId="run"      name="&amp;Uitvoeren"/>
-					<Item idName="Plugins"  name="&amp;Plugins"/>
-					<Item idName="Window"   name="&amp;Documenten"/>
+					<Item menuId="tools" name="&amp;Gereedschappen"/>
+					<Item menuId="macro" name="&amp;Macro"/>
+					<Item menuId="run" name="&amp;Uitvoeren"/>
+					<Item idName="Plugins" name="&amp;Plugins"/>
+					<Item idName="Window" name="&amp;Vensters"/>
 				</Entries>
 				<!-- Sub Menu Entries -->
 				<SubEntries>
-					<Item subMenuId="file-openFolder"           name="Bestandslocatie openen"/>
-					<Item subMenuId="file-closeMore"            name="Documenten sluiten"/>
-					<Item subMenuId="file-recentFiles"          name="Recent geopende bestanden"/>
-					<Item subMenuId="edit-copyToClipboard"      name="Kopiëren naar het klembord"/>
-					<Item subMenuId="edit-indent"               name="Insprong tekst"/>
-					<Item subMenuId="edit-convertCaseTo"        name="Hoofdlettergebruik"/>
-					<Item subMenuId="edit-lineOperations"       name="Regels bewerken"/>
-					<Item subMenuId="edit-comment"              name="Markeren als commentaar"/>
-					<Item subMenuId="edit-autoCompletion"       name="Automatisch aanvullen"/>
-					<Item subMenuId="edit-eolConversion"        name="Formaat"/>
-					<Item subMenuId="edit-blankOperations"      name="Uitlijnen"/>
-					<Item subMenuId="edit-pasteSpecial"         name="Plakken speciaal"/>
-					<Item subMenuId="edit-onSelection"          name="Voor selectie"/>
-					<Item subMenuId="search-markAll"            name="Alles markeren"/>
-					<Item subMenuId="search-unmarkAll"          name="Markering wissen"/>
-					<Item subMenuId="search-jumpUp"             name="Ga naar vorige markering"/>
-					<Item subMenuId="search-jumpDown"           name="Ga naar volgende markering"/>
-					<Item subMenuId="search-bookmark"           name="Bladwijzers"/>
-					<Item subMenuId="view-currentFileIn"        name="Document bekijken in"/>
-					<Item subMenuId="view-showSymbol"           name="Niet-afdrukbare tekens"/>
-					<Item subMenuId="view-zoom"                 name="In- en uitzoomen"/>
-					<Item subMenuId="view-moveCloneDocument"    name="Documentweergave"/>
-					<Item subMenuId="view-tab"                  name="Documenten"/>
-					<Item subMenuId="view-collapseLevel"        name="Sectie samenvouwen"/>
-					<Item subMenuId="view-uncollapseLevel"      name="Sectie uitvouwen"/>
-					<Item subMenuId="view-project"              name="Project"/>
-					<Item subMenuId="encoding-characterSets"    name="Meer"/>
-					<Item subMenuId="encoding-arabic"           name="Arabisch"/>
-					<Item subMenuId="encoding-baltic"           name="Baltisch"/>
-					<Item subMenuId="encoding-celtic"           name="Keltisch"/>
-					<Item subMenuId="encoding-cyrillic"         name="Cyrillisch"/>
-					<Item subMenuId="encoding-centralEuropean"  name="Centraal-Europees"/>
-					<Item subMenuId="encoding-chinese"          name="Chinees"/>
-					<Item subMenuId="encoding-easternEuropean"  name="Oost-Europees"/>
-					<Item subMenuId="encoding-greek"            name="Grieks"/>
-					<Item subMenuId="encoding-hebrew"           name="Hebreeuws"/>
-					<Item subMenuId="encoding-japanese"         name="Japans"/>
-					<Item subMenuId="encoding-korean"           name="Koreaans"/>
-					<Item subMenuId="encoding-northEuropean"    name="Noord-Europees"/>
-					<Item subMenuId="encoding-thai"             name="Thai"/>
-					<Item subMenuId="encoding-turkish"          name="Turks"/>
-					<Item subMenuId="encoding-westernEuropean"  name="West-Europees"/>
-					<Item subMenuId="encoding-vietnamese"       name="Vietnamees"/>
-					<Item subMenuId="language-userDefinedLanguage" name="Gebruikerssyntaxis"/>
-					<Item subMenuId="settings-import"           name="Importeren"/>
-					<Item subMenuId="tools-md5"                 name="MD5"/>
-					<Item subMenuId="tools-sha256"              name="SHA-256"/>
+					<Item subMenuId="file-openFolder" name="Bevattende map openen"/>
+					<Item subMenuId="file-closeMore" name="Meerdere sluiten"/>
+					<Item subMenuId="file-recentFiles" name="&amp;Recente bestanden"/>
+					<Item subMenuId="edit-copyToClipboard"	name="Naar klembord kopiëren"/>
+					<Item subMenuId="edit-indent" name="Inspringing tekst"/>
+					<Item subMenuId="edit-convertCaseTo" name="Hoofdlettergebruik"/>
+					<Item subMenuId="edit-lineOperations" name="Regels bewerken"/>
+					<Item subMenuId="edit-comment" name="Markeren als commentaar"/>
+					<Item subMenuId="edit-autoCompletion" name="Automatisch aanvullen"/>
+					<Item subMenuId="edit-eolConversion" name="Regeleinde-conversie"/>
+					<Item subMenuId="edit-blankOperations" name="Witruimte-bewerkingen"/>
+					<Item subMenuId="edit-pasteSpecial" name="Plakken speciaal"/>
+					<Item subMenuId="edit-onSelection" name="Voor selectie"/>
+					<Item subMenuId="search-markAll" name="Alles markeren"/>
+					<Item subMenuId="search-unmarkAll" name="Alle markeringen wissen"/>
+					<Item subMenuId="search-jumpUp" name="Omhoog springen"/>
+					<Item subMenuId="search-jumpDown" name="Omlaag springen"/>
+					<Item subMenuId="search-copyStyledText" name="Tekst met stijl kopiëren"/>
+					<Item subMenuId="search-bookmark" name="Bladwijzers"/>
+					<Item subMenuId="view-currentFileIn" name="Document weergeven in"/>
+					<Item subMenuId="view-showSymbol"  name="Niet-afdrukbare tekens"/>
+					<Item subMenuId="view-zoom"	 name="Zoomen"/>
+					<Item subMenuId="view-moveCloneDocument"  name="Huidig document verplaatsen/kopiëren"/>
+					<Item subMenuId="view-tab"	name="Tabbladen"/>
+					<Item subMenuId="view-collapseLevel" name="Niveau samenvouwen"/>
+					<Item subMenuId="view-uncollapseLevel" name="Niveau uitvouwen"/>
+					<Item subMenuId="view-project" name="Project"/>
+					<Item subMenuId="encoding-characterSets"  name="Tekenset"/>
+					<Item subMenuId="encoding-arabic"  name="Arabisch"/>
+					<Item subMenuId="encoding-baltic"  name="Baltisch"/>
+					<Item subMenuId="encoding-celtic"  name="Keltisch"/>
+					<Item subMenuId="encoding-cyrillic"	 name="Cyrillisch"/>
+					<Item subMenuId="encoding-centralEuropean" name="Centraal-Europees"/>
+					<Item subMenuId="encoding-chinese"	name="Chinees"/>
+					<Item subMenuId="encoding-easternEuropean" name="Oost-Europees"/>
+					<Item subMenuId="encoding-greek"  name="Grieks"/>
+					<Item subMenuId="encoding-hebrew"  name="Hebreeuws"/>
+					<Item subMenuId="encoding-japanese"	 name="Japans"/>
+					<Item subMenuId="encoding-korean" name="Koreaans"/>
+					<Item subMenuId="encoding-northEuropean" name="Noord-Europees"/>
+					<Item subMenuId="encoding-thai" name="Thai"/>
+					<Item subMenuId="encoding-turkish" name="Turks"/>
+					<Item subMenuId="encoding-westernEuropean" name="West-Europees"/>
+					<Item subMenuId="encoding-vietnamese" name="Vietnamees"/>
+					<Item subMenuId="language-userDefinedLanguage" name="Aangepaste syntaxis"/>
+					<Item subMenuId="settings-import" name="Importeren"/>
+					<Item subMenuId="tools-md5" name="MD5"/>
+					<Item subMenuId="tools-sha256" name="SHA-256"/>
 				</SubEntries>
 
 				<!-- all menu items -->
@@ -82,7 +82,8 @@
 					<Item id="41002" name="&amp;Openen"/>
 					<Item id="41019" name="in Windows Verkenner"/>
 					<Item id="41020" name="in opdrachtprompt"/>
-					<Item id="41003" name="Sluiten"/>
+					<Item id="41025" name="Map als werkruimte"/>
+					<Item id="41003" name="&amp;Sluiten"/>
 					<Item id="41004" name="Alles slui&amp;ten"/>
 					<Item id="41005" name="Overige documenten sluiten"/>
 					<Item id="41009" name="Documenten aan de linkerkant sluiten"/>
@@ -92,403 +93,416 @@
 					<Item id="41007" name="Alles opslaan"/>
 					<Item id="41008" name="Ops&amp;laan als..."/>
 					<Item id="41010" name="Af&amp;drukken..."/>
-					<Item id="1001"  name="Direct afdrukken"/>
+					<Item id="1001"	 name="Nu afdrukken"/>
 					<Item id="41011" name="Af&amp;sluiten"/>
-					<Item id="41012" name="Sessie openen..."/>
+					<Item id="41012" name="Sessie laden..."/>
 					<Item id="41013" name="Sessie opslaan..."/>
-					<Item id="41014" name="Opnieuw openen"/>
-					<Item id="41015" name="Kopie opslaan..."/>
-					<Item id="41016" name="Verwijderen"/>
+					<Item id="41014" name="Opnieuw &amp;laden vanaf schijf"/>
+					<Item id="41015" name="Kopie opslaan als..."/>
+					<Item id="41016" name="Naar prullenbak verplaatsen"/>
 					<Item id="41017" name="Naam wijzigen..."/>
-					<Item id="41021" name="Laatste bestand opnieuw openen"/>
-					<Item id="41022" name="Bestandsmap als &amp;werkomgeving openen"/>
+					<Item id="41021" name="Recent gesloten bestand opnieuw openen"/>
+					<Item id="41022" name="Map als werkruimte openen..."/>
 					<Item id="41023" name="In standaardviewer openen"/>
 					<Item id="42001" name="K&amp;nippen"/>
 					<Item id="42002" name="&amp;Kopiëren"/>
 					<Item id="42003" name="&amp;Ongedaan maken"/>
-					<Item id="42004" name="&amp;Herhalen"/>
+					<Item id="42004" name="Opnieuw uitvoe&amp;ren"/>
 					<Item id="42005" name="&amp;Plakken"/>
 					<Item id="42006" name="&amp;Verwijderen"/>
 					<Item id="42007" name="&amp;Alles selecteren"/>
-					<Item id="42020" name="Selectie starten / stoppen"/>
-					<Item id="42008" name="Insprong vergroten"/>
-					<Item id="42009" name="Insprong verkleinen"/>
-					<Item id="42010" name="Regel dupliceren"/>
-					<Item id="42077" name="Opeenvolgende identieke regels wissen"/>
+					<Item id="42020" name="Selectie starten/stoppen"/>
+					<Item id="42008" name="Inspringing van regel vergroten"/>
+					<Item id="42009" name="Inspringing van regel verkleinen"/>
+					<Item id="42010" name="Huidige regel dupliceren"/>
+					<Item id="42079" name="Dubbele regels verwijderen"/>
+					<Item id="42077" name="Opeenvolgende identieke regels verwijderen"/>
 					<Item id="42012" name="Regels splitsen"/>
 					<Item id="42013" name="Regels samenvoegen"/>
 					<Item id="42014" name="Regel omhoog verplaatsen"/>
 					<Item id="42015" name="Regel omlaag verplaatsen"/>
-					<Item id="42059" name="Regels sorteren in oplopende volgorde"/>
-					<Item id="42060" name="Regels sorteren in aflopende volgorde"/>
-					<Item id="42061" name="Regels sorteren (hele getallen) oplopend"/>
-					<Item id="42062" name="Regels sorteren (hele getallen) aflopend"/>
-					<Item id="42063" name="Regels sorteren (decimalen &quot;,&quot;) oplopend"/>
-					<Item id="42064" name="Regels sorteren (decimalen &quot;,&quot;) aflopend"/>
-					<Item id="42065" name="Regels sorteren (decimalen &quot;.&quot;) oplopend"/>
-					<Item id="42066" name="Regels sorteren (decimalen &quot;.&quot;) aflopend"/>
-					<Item id="42016" name="Hoofdletters"/>
-					<Item id="42017" name="Kleine letters"/>
+					<Item id="42059" name="Regels lexicografisch oplopend sorteren"/>
+					<Item id="42060" name="Regels lexicografisch aflopend sorteren"/>
+					<Item id="42080" name="Regels lexicografisch oplopend hoofdletterongevoelig sorteren"/>
+					<Item id="42081" name="Regels lexicografisch aflopend hoofdletterongevoelig sorteren"/>
+					<Item id="42061" name="Regels als gehele getallen oplopend sorteren"/>
+					<Item id="42062" name="Regels als gehele getallen aflopend sorteren"/>
+					<Item id="42063" name="Regels als decimalen (komma) oplopend sorteren"/>
+					<Item id="42064" name="Regels als decimalen (komma) aflopend sorteren"/>
+					<Item id="42065" name="Regels als decimalen (punt) oplopend sorteren"/>
+					<Item id="42066" name="Regels als decimalen (punt) aflopend sorteren"/>
+					<Item id="42078" name="Regels willekeurig sorteren"/>
+					<Item id="42016" name="HOOFDLETTERS"/>
+					<Item id="42017" name="kleine letters"/>
 					<Item id="42067" name="Beginhoofdletters"/>
-					<Item id="42068" name="Beginhoofdletters (gemengd)"/>
+					<Item id="42068" name="Beginhoofdletters (mengeling)"/>
 					<Item id="42069" name="Zinshoofdletters"/>
-					<Item id="42070" name="Zinshoofdletters (gemengd)"/>
-					<Item id="42071" name="Hoofd- en kleine letters inverteren"/>
-					<Item id="42072" name="Willekeurige hoofdletters"/>
+					<Item id="42070" name="Zinshoofdletters (mengeling)"/>
+					<Item id="42071" name="hOOFD- EN KLEINE LETTERS INVERTEREN"/>
+					<Item id="42072" name="WilLeKEUriGe hOoFdlEtteRs"/>
 					<Item id="42073" name="Bestand openen"/>
-					<Item id="42074" name="Bestandsmap openen in Windows Verkenner"/>
-					<Item id="42075" name="Zoek op Internet"/>
-					<Item id="42076" name="Wijzig de zoekmachine..."/>
+					<Item id="42074" name="Bevattende map openen in Windows Verkenner"/>
+					<Item id="42075" name="Zoeken op internet"/>
+					<Item id="42076" name="Zoekmachine wijzigen..."/>
 					<Item id="42018" name="Opname &amp;starten"/>
 					<Item id="42019" name="Opname st&amp;oppen"/>
-					<Item id="42021" name="Macro &amp;afspelen"/>
+					<Item id="42021" name="&amp;Afspelen"/>
 					<Item id="42022" name="Regelcommentaar aan/uit"/>
 					<Item id="42023" name="Blokcommentaar inschakelen"/>
 					<Item id="42047" name="Blokcommentaar uitschakelen"/>
-					<Item id="42024" name="Spaties voor regeleinden wissen"/>
-					<Item id="42042" name="Insprong wissen"/>
-					<Item id="42043" name="Insprong en spaties voor regeleinden wissen"/>
+					<Item id="42024" name="Spaties aan het einde wissen"/>
+					<Item id="42042" name="Spaties aan het begin wissen"/>
+					<Item id="42043" name="Spaties aan begin en einde wissen"/>
 					<Item id="42044" name="Regeleinden omzetten in spaties"/>
 					<Item id="42045" name="Regeleinden en overbodige witruimte wissen"/>
 					<Item id="42046" name="Tabs omzetten in spaties"/>
 					<Item id="42054" name="Alle spaties omzetten in tabs"/>
-					<Item id="42053" name="Insprong omzetten in tabs"/>
-					<Item id="42038" name="HTML-indeling invoegen"/>
-					<Item id="42039" name="RTF-indeling invoegen"/>
-					<Item id="42048" name="Kopiëren (Binair)"/>
-					<Item id="42049" name="Knippen (Binair)"/>
-					<Item id="42050" name="Plakken (Binair)"/>
-					<Item id="42037" name="Tekstkolom..."/>
-					<Item id="42034" name="Reeks bewerken..."/>
-					<Item id="42051" name="ASCII-karakters"/>
-					<Item id="42052" name="Klembord"/>
-					<Item id="42025" name="Macro ops&amp;laan"/>
+					<Item id="42053" name="Inspringing omzetten in tabs"/>
+					<Item id="42038" name="HTML-inhoud plakken"/>
+					<Item id="42039" name="RTF-inhoud plakken"/>
+					<Item id="42048" name="Binaire inhoud kopiëren"/>
+					<Item id="42049" name="Binaire inhoud knippen"/>
+					<Item id="42050" name="Binaire inhoud plakken"/>
+					<Item id="42082" name="Koppeling kopiëren"/>
+					<Item id="42037" name="Kolom-modus voor selecteren..."/>
+					<Item id="42034" name="Kolom-bewerker..."/>
+					<Item id="42051" name="ASCII-tekenvenster"/>
+					<Item id="42052" name="Geschiedenis van klembord"/>
+					<Item id="42025" name="Momenteel opgenomen macro ops&amp;laan..."/>
 					<Item id="42026" name="Tekstrichting rechts-links"/>
 					<Item id="42027" name="Tekstrichting links-rechts"/>
-					<Item id="42028" name="Alleen-lezen"/>
-					<Item id="42029" name="Bestandslocatie kopiëren"/>
-					<Item id="42030" name="Bestandsnaam kopiëren"/>
-					<Item id="42031" name="Maplocatie kopiëren"/>
+					<Item id="42028" name="Instellen als alleen-lezen"/>
+					<Item id="42029" name="Huidig bestandspad naar klembord kopiëren"/>
+					<Item id="42030" name="Huidige bestandsnaam naar klembord kopiëren"/>
+					<Item id="42031" name="Pad naar huidige map naar klembord kopiëren"/>
 					<Item id="42032" name="Macro meerdere keren uitvoeren..."/>
 					<Item id="42033" name="Alleen-lezen opheffen"/>
 					<Item id="42035" name="Regelcommentaar aan"/>
 					<Item id="42036" name="Regelcommentaar uit"/>
 					<Item id="42055" name="Lege regels verwijderen"/>
-					<Item id="42056" name="Regels met alleen spaties of tabs verwijderen"/>
-					<Item id="42057" name="Regeleinde invoegen voor deze regel"/>
-					<Item id="42058" name="Regeleinde invoegen na deze regel"/>
+					<Item id="42056" name="Lege regels (met alleen spaties of tabs) verwijderen"/>
+					<Item id="42057" name="Lege regel invoegen boven de huidige"/>
+					<Item id="42058" name="Lege regel invoegen onder de huidige"/>
 					<Item id="43001" name="&amp;Zoeken..."/>
 					<Item id="43002" name="&amp;Volgende zoeken"/>
-					<Item id="43003" name="Verv&amp;angen..."/>
-					<Item id="43004" name="&amp;Ga naar regel..."/>
-					<Item id="43005" name="&amp;Bladwijzer invoegen"/>
-					<Item id="43006" name="V&amp;olgende bladwijzer"/>
-					<Item id="43007" name="Vo&amp;rige bladwijzer"/>
-					<Item id="43008" name="Alle bladwijzers ver&amp;wijderen"/>
-					<Item id="43018" name="Aan bladwijzer gekoppelde regels knippen"/>
-					<Item id="43019" name="Aan bladwijzer gekoppelde regels kopiëren"/>
-					<Item id="43020" name="Aan bladwijzer gekoppelde regels plakken"/>
-					<Item id="43021" name="Aan bladwijzer gekoppelde regels wissen"/>
+					<Item id="43003" name="Ve&amp;rvangen..."/>
+					<Item id="43004" name="&amp;Ga naar..."/>
+					<Item id="43005" name="Bladwijzer invoegen"/>
+					<Item id="43006" name="Volgende bladwijzer"/>
+					<Item id="43007" name="Vorige bladwijzer"/>
+					<Item id="43008" name="Alle bladwijzers wissen"/>
+					<Item id="43018" name="Regels met bladwijzers knippen"/>
+					<Item id="43019" name="Regels met bladwijzers kopiëren"/>
+					<Item id="43020" name="Plakken in regels met bladwijzers (vervangen)"/>
+					<Item id="43021" name="Regels met bladwijzers wissen"/>
 					<Item id="43051" name="Regels zonder bladwijzer wissen"/>
 					<Item id="43050" name="Bladwijzers omkeren"/>
-					<Item id="43052" name="Zoeken naar karakter in bereik..."/>
+					<Item id="43052" name="Zoeken naar tekens in bereik..."/>
 					<Item id="43053" name="Alles selecteren tussen bij elkaar horende haakjes"/>
-					<Item id="43009" name="Ga naar overeenkomende &amp;accolade"/>
+					<Item id="43009" name="Ga naar overeenkomende accolade"/>
 					<Item id="43010" name="Vorig&amp;e zoeken"/>
 					<Item id="43011" name="&amp;Snel zoeken..."/>
-					<Item id="43013" name="Zoeken in &amp;bestanden"/>
-					<Item id="43014" name="Volgende zoeken (afzonderlijk)"/>
-					<Item id="43015" name="Vorige zoeken (afzonderlijk)"/>
-					<Item id="43022" name="1e markering"/>
-					<Item id="43023" name="1e markering wissen"/>
-					<Item id="43024" name="2e markering"/>
-					<Item id="43025" name="2e markering wissen"/>
-					<Item id="43026" name="3e markering"/>
-					<Item id="43027" name="3e markering wissen"/>
-					<Item id="43028" name="4e markering"/>
-					<Item id="43029" name="4e markering wissen"/>
-					<Item id="43030" name="5e markering"/>
-					<Item id="43031" name="5e markering wissen"/>
-					<Item id="43032" name="Alle markeringen wissen"/>
-					<Item id="43033" name="1e markering"/>
-					<Item id="43034" name="2e markering"/>
-					<Item id="43035" name="3e markering"/>
-					<Item id="43036" name="4e markering"/>
-					<Item id="43037" name="5e markering"/>
-					<Item id="43038" name="Zoekterm"/>
-					<Item id="43039" name="1e markering"/>
-					<Item id="43040" name="2e markering"/>
-					<Item id="43041" name="3e markering"/>
-					<Item id="43042" name="4e markering"/>
-					<Item id="43043" name="5e markering"/>
-					<Item id="43044" name="Zoekterm"/>
+					<Item id="43013" name="Zoeken in bestanden"/>
+					<Item id="43014" name="(Vluchtig) volgende zoeken"/>
+					<Item id="43015" name="(Vluchtig) vorige zoeken"/>
+					<Item id="43022" name="Met behulp van stijl 1"/>
+					<Item id="43023" name="Stijl 1 wissen"/>
+					<Item id="43024" name="Met behulp van stijl 2"/>
+					<Item id="43025" name="Stijl 2 wissen"/>
+					<Item id="43026" name="Met behulp van stijl 3"/>
+					<Item id="43027" name="Stijl 3 wissen"/>
+					<Item id="43028" name="Met behulp van stijl 4"/>
+					<Item id="43029" name="Stijl 4 wissen"/>
+					<Item id="43030" name="Met behulp van stijl 5"/>
+					<Item id="43031" name="Stijl 5 wissen"/>
+					<Item id="43032" name="Alle stijlen wissen"/>
+					<Item id="43033" name="Stijl 1"/>
+					<Item id="43034" name="Stijl 2"/>
+					<Item id="43035" name="Stijl 3"/>
+					<Item id="43036" name="Stijl 4"/>
+					<Item id="43037" name="Stijl 5"/>
+					<Item id="43038" name="Stijl zoeken"/>
+					<Item id="43039" name="Stijl 1"/>
+					<Item id="43040" name="Stijl 2"/>
+					<Item id="43041" name="Stijl 3"/>
+					<Item id="43042" name="Stijl 4"/>
+					<Item id="43043" name="Stijl 5"/>
+					<Item id="43044" name="Stijl zoeken"/>
+					<Item id="43055" name="Stijl 1"/>
+					<Item id="43056" name="Stijl 2"/>
+					<Item id="43057" name="Stijl 3"/>
+					<Item id="43058" name="Stijl 4"/>
+					<Item id="43059" name="Stijl 5"/>
+					<Item id="43060" name="Alle stijlen"/>
+					<Item id="43061" name="Stijl zoeken (gemarkeerd)"/>
 					<Item id="43045" name="Gevonden resultaten"/>
-					<Item id="43046" name="Volgende zoekterm"/>
-					<Item id="43047" name="Vorige zoekterm"/>
-					<Item id="43048" name="Markeren en volgende zoeken"/>
-					<Item id="43049" name="Markeren en vorige zoeken"/>
+					<Item id="43046" name="Volgend zoekresultaat"/>
+					<Item id="43047" name="Vorig zoekresultaat"/>
+					<Item id="43048" name="Selecteren en volgende zoeken"/>
+					<Item id="43049" name="Selecteren en vorige zoeken"/>
 					<Item id="43054" name="Markeren..."/>
 					<Item id="44009" name="Interface verbergen"/>
 					<Item id="44010" name="Gegevensstructuur samenvouwen"/>
-					<Item id="44019" name="Alle karakters weergeven"/>
-					<Item id="44020" name="Insprong weergeven"/>
-					<Item id="44022" name="Automatische &amp;terugloop"/>
-					<Item id="44023" name="Inzoomen"/>
-					<Item id="44024" name="Uitzoomen"/>
+					<Item id="44019" name="Alle tekens weergeven"/>
+					<Item id="44020" name="Aanduiding voor inspringing weergeven"/>
+					<Item id="44022" name="Automatische terugloop"/>
+					<Item id="44023" name="&amp;Inzoomen (Ctrl + Omhoog scrollen)"/>
+					<Item id="44024" name="&amp;Uitzoomen (Ctrl + Omlaag scrollen)"/>
 					<Item id="44025" name="Spaties en tabs weergeven"/>
 					<Item id="44026" name="Regeleindemarkering weergeven"/>
 					<Item id="44029" name="Gegevensstructuur uitvouwen"/>
-					<Item id="44030" name="Huidige sectie samenvouwen"/>
-					<Item id="44031" name="Huidige sectie uitvouwen"/>
+					<Item id="44030" name="Huidig niveau samenvouwen"/>
+					<Item id="44031" name="Huidig niveau uitvouwen"/>
 					<Item id="44049" name="Samenvatting..."/>
-					<Item id="44080" name="Documentstructuur"/>
+					<Item id="44080" name="Overzichtskaart van document"/>
 					<Item id="44084" name="Functielijst"/>
-					<Item id="44085" name="Map als &amp;werkomgeving"/>
-					<Item id="44086" name="1e document"/>
-					<Item id="44087" name="2e document"/>
-					<Item id="44088" name="3e document"/>
-					<Item id="44089" name="4e document"/>
-					<Item id="44090" name="5e document"/>
-					<Item id="44091" name="6e document"/>
-					<Item id="44092" name="7e document"/>
-					<Item id="44093" name="8e document"/>
-					<Item id="44094" name="9e document"/>
-					<Item id="44095" name="Volgende document"/>
-					<Item id="44096" name="Vorige document"/>
-					<Item id="44097" name="&amp;Monitoren (tail -f)"/>
-					<Item id="44098" name="Document vooruit verplaatsen"/>
-					<Item id="44099" name="Document achteruit verplaatsen"/>
+					<Item id="44085" name="Map als werkruimte"/>
+					<Item id="44086" name="Tabblad 1"/>
+					<Item id="44087" name="Tabblad 2"/>
+					<Item id="44088" name="Tabblad 3"/>
+					<Item id="44089" name="Tabblad 4"/>
+					<Item id="44090" name="Tabblad 5"/>
+					<Item id="44091" name="Tabblad 6"/>
+					<Item id="44092" name="Tabblad 7"/>
+					<Item id="44093" name="Tabblad 8"/>
+					<Item id="44094" name="Tabblad 9"/>
+					<Item id="44095" name="Volgend tabblad"/>
+					<Item id="44096" name="Vorig tabblad"/>
+					<Item id="44097" name="Monitoren (tail -f)"/>
+					<Item id="44098" name="Tabblad vooruit verplaatsen"/>
+					<Item id="44099" name="Tabblad achteruit verplaatsen"/>
 					<Item id="44032" name="Volledig scherm"/>
-					<Item id="44033" name="Standaard"/>
+					<Item id="44033" name="Standaardzoom herstellen"/>
 					<Item id="44034" name="Altijd op voorgrond"/>
-					<Item id="44035" name="&amp;Verticaal scrollen koppelen"/>
-					<Item id="44036" name="&amp;Horizontaal scrollen koppelen"/>
+					<Item id="44035" name="Verticaal scrollen koppelen "/>
+					<Item id="44036" name="Horizontaal scrollen koppelen"/>
 					<Item id="44041" name="Terugloopmarkering weergeven"/>
-					<Item id="44072" name="Actieve deelvenster wisselen"/>
-					<Item id="44081" name="Project 1"/>
-					<Item id="44082" name="Project 2"/>
-					<Item id="44083" name="Project 3"/>
-					<Item id="45001" name="Windows-indeling"/>
-					<Item id="45002" name="Unix-indeling"/>
-					<Item id="45003" name="Mac-indeling"/>
+					<Item id="44072" name="Actief deelvenster wisselen"/>
+					<Item id="44081" name="Projectpaneel 1"/>
+					<Item id="44082" name="Projectpaneel 2"/>
+					<Item id="44083" name="Projectpaneel 3"/>
+					<Item id="45001" name="Windows (CR LF)"/>
+					<Item id="45002" name="Unix (LF)"/>
+					<Item id="45003" name="Macintosh (CR)"/>
 					<Item id="45004" name="ANSI"/>
 					<Item id="45005" name="UTF-8-BOM"/>
-					<Item id="45006" name="UCS-2 Big Endian"/>
-					<Item id="45007" name="UCS-2 Little Endian"/>
-					<Item id="45008" name="UTF-8 (zonder BOM)"/>
-					<Item id="45009" name="Naar ANSI converteren"/>
-					<Item id="45010" name="Naar UTF-8 (zonder BOM) converteren"/>
-					<Item id="45011" name="Naar UTF-8-BOM converteren"/>
-					<Item id="45012" name="Naar UCS-2 Big Endian converteren"/>
-					<Item id="45013" name="Naar UCS-2 Little Endian converteren"/>
-					<Item id="45060" name="Big5 (Taiwan)"/>
-					<Item id="45061" name="GB2312 (China)"/>
+					<Item id="45006" name="UCS-2 BE BOM"/>
+					<Item id="45007" name="UCS-2 LE BOM"/>
+					<Item id="45008" name="UTF-8"/>
+					<Item id="45009" name="Converteren naar ANSI"/>
+					<Item id="45010" name="Converteren naar UTF-8"/>
+					<Item id="45011" name="Converteren naar UTF-8-BOM"/>
+					<Item id="45012" name="Converteren naar UCS-2 BE BOM"/>
+					<Item id="45013" name="Converteren naar UCS-2 LE BOM"/>
+					<Item id="45060" name="Big5 (traditioneel)"/>
+					<Item id="45061" name="GB2312 (vereenvoudigd)"/>
 					<Item id="45054" name="OEM 861: Ĳslands"/>
-					<Item id="45057" name="OEM 865: Deens &amp;&amp; Noors"/>
+					<Item id="45057" name="OEM 865: Deens en Noors"/>
 					<Item id="45053" name="OEM 860: Portugees"/>
-					<Item id="45056" name="OEM 863: Canadees-Frans"/>
+					<Item id="45056" name="OEM 863: Frans"/>
 
 					<Item id="10001" name="Naar deelvenster verplaatsen"/>
 					<Item id="10002" name="Naar deelvenster kopiëren"/>
 					<Item id="10003" name="Naar een nieuw venster verplaatsen"/>
 					<Item id="10004" name="Naar een nieuw venster kopiëren"/>
 
-					<Item id="46001" name="&amp;Opmaak..."/>
-					<Item id="46250" name="Syntaxismarkering ontwerpen..."/>
-					<Item id="46300" name="Syntaxismarkering map openen..."/>
+					<Item id="46001" name="Stijlconfigurator..."/>
+					<Item id="46250" name="Aangepaste syntaxismarkering ontwerpen..."/>
+					<Item id="46300" name="Map met aangepaste syntaxissen openen..."/>
 					<Item id="46180" name="Aangepast"/>
-					<Item id="47000" name="Over..."/>
-					<Item id="47010" name="Opdrachtregelargumenten..."/>
-					<Item id="47001" name="Notepad++ website bezoeken"/>
-					<Item id="47002" name=" » Project"/>
-					<Item id="47003" name=" » Documentatie"/>
-					<Item id="47004" name=" » Forum"/>
-					<Item id="47011" name=" » Live ondersteuning"/>
-					<Item id="47012" name="Foutenopsporingsgegevens..."/>
+					<Item id="47000" name="Over Notepad++"/>
+					<Item id="47010" name="Opdrachtregel-argumenten..."/>
+					<Item id="47001" name="Notepad++ website"/>
+					<Item id="47002" name="Notepad++ projectpagina"/>
+					<Item id="47003" name="Online documentatie"/>
+					<Item id="47004" name="Notepad++ gemeenschap (forum)"/>
+					<Item id="47011" name="Live ondersteuning"/>
+					<Item id="47012" name="Foutopsporingsinformatie..."/>
 					<Item id="47005" name="Meer plugins zoeken"/>
-					<Item id="47006" name="Op updates controleren..."/>
-					<Item id="47009" name="Proxyserver-instellingen..."/>
-					<Item id="48005" name="Plugin importeren..."/>
-					<Item id="48006" name="Thema importeren..."/>
-					<Item id="48018" name="Contextmenu &amp;wijzigen..."/>
-					<Item id="48009" name="&amp;Sneltoetsen..."/>
-					<Item id="48011" name="&amp;Voorkeuren..."/>
-					<Item id="48014" name="Plugin map openen..."/>
-					<Item id="48015" name="Plugin beheer..."/>
+					<Item id="47006" name="Notepad++ bijwerken"/>
+					<Item id="47009" name="Proxy instellen voor bijwerken..."/>
+					<Item id="48005" name="Plugins importeren..."/>
+					<Item id="48006" name="Stijlthema's importeren..."/>
+					<Item id="48018" name="Contextmenu wijzigen..."/>
+					<Item id="48009" name="Sneltoetsen..."/>
+					<Item id="48011" name="Voorkeuren..."/>
+					<Item id="48014" name="Plugin-map openen..."/>
+					<Item id="48015" name="Pluginbeheer..."/>
 					<Item id="48501" name="Genereren..."/>
-					<Item id="48502" name="Genereren voor bestanden..."/>
-					<Item id="48503" name="Genereren naar klembord"/>
+					<Item id="48502" name="Genereren van bestanden..."/>
+					<Item id="48503" name="Genereren van selectie naar klembord"/>
 					<Item id="48504" name="Genereren..."/>
-					<Item id="48505" name="Genereren voor bestanden..."/>
-					<Item id="48506" name="Genereren naar klembord"/>
-					<Item id="49000" name="&amp;Uitvoeren..."/>
-					<Item id="50000" name="Functie aanvullen"/>
-					<Item id="50001" name="Woord aanvullen"/>
+					<Item id="48505" name="Genereren van bestanden..."/>
+					<Item id="48506" name="Genereren van selectie naar klembord"/>
+					<Item id="49000" name="Uitvoe&amp;ren..."/>
+
+					<Item id="50000" name="Functies aanvullen"/>
+					<Item id="50001" name="Woorden aanvullen"/>
 					<Item id="50002" name="Functie-argumenten weergeven"/>
-					<Item id="50003" name="Vorige document"/>
-					<Item id="50004" name="Volgende document"/>
-					<Item id="50005" name="Macro opname aan/uit"/>
+					<Item id="50005" name="Macro-opname aan/uit"/>
 					<Item id="50006" name="Bestandspad aanvullen"/>
 					<Item id="44042" name="Regels verbergen"/>
-					<Item id="42040" name="Alle recentelijk geopende bestanden openen"/>
+					<Item id="42040" name="Alle recent geopende bestanden openen"/>
 					<Item id="42041" name="Bestandsgeschiedenis wissen"/>
-					<Item id="48016" name="Macro's &amp;wijzigen..."/>
-					<Item id="48017" name="Opdrachten &amp;wijzigen..."/>
+					<Item id="48016" name="Sneltoets wijzigen/macro verwijderen..."/>
+					<Item id="48017" name="Sneltoets wijzigen/opdracht verwijderen..."/>
 				</Commands>
 			</Main>
 			<Splitter>
 			</Splitter>
 			<TabBar>
-				<Item CMID="0"  name="Sluiten"/>
-				<Item CMID="1"  name="Overige documenten sluiten"/>
-				<Item CMID="2"  name="Opslaan"/>
-				<Item CMID="3"  name="Opslaan als..."/>
-				<Item CMID="4"  name="Afdrukken"/>
-				<Item CMID="5"  name="Naar deelvenster verplaatsen"/>
-				<Item CMID="6"  name="Naar deelvenster kopiëren"/>
-				<Item CMID="7"  name="Bestandslocatie kopiëren"/>
-				<Item CMID="8"  name="Bestandsnaam kopiëren"/>
-				<Item CMID="9"  name="Maplocatie kopiëren"/>
-				<Item CMID="10" name="Naam wijzigen"/>
-				<Item CMID="11" name="Verwijderen"/>
-				<Item CMID="12" name="Alleen-lezen"/>
-				<Item CMID="13" name="Alleen-lezen opheffen"/>
-				<Item CMID="14" name="Naar een nieuw venster verplaatsen"/>
-				<Item CMID="15" name="Naar een nieuw venster kopiëren"/>
-				<Item CMID="16" name="Opnieuw openen"/>
-				<Item CMID="17" name="Documenten aan de linkerkant sluiten"/>
-				<Item CMID="18" name="Documenten aan de rechterkant sluiten"/>
-				<Item CMID="19" name="Bestand weergeven in Windows Verkenner"/>
-				<Item CMID="20" name="Opdrachtprompt openen"/>
-				<Item CMID="21" name="In standaardviewer openen"/>
-				<Item CMID="22" name="Ongewijzigde documenten sluiten"/>
+					<Item CMID="0" name="Sluiten"/>
+					<Item CMID="1" name="Overige documenten sluiten"/>
+					<Item CMID="2" name="Opslaan"/>
+					<Item CMID="3" name="Opslaan als..."/>
+					<Item CMID="4" name="Afdrukken..."/>
+					<Item CMID="5" name="Naar deelvenster verplaatsen"/>
+					<Item CMID="6" name="Naar deelvenster kopiëren"/>
+					<Item CMID="7" name="Volledig bestandspad naar klembord kopiëren"/>
+					<Item CMID="8" name="Bestandsnaam naar klembord kopiëren"/>
+					<Item CMID="9" name="Pad naar huidige map naar klembord kopiëren"/>
+					<Item CMID="10" name="Naam wijzigen..."/>
+					<Item CMID="11" name="Naar prullenbak verplaatsen"/>
+					<Item CMID="12" name="Alleen-lezen"/>
+					<Item CMID="13" name="Alleen-lezen opheffen"/>
+					<Item CMID="14" name="Naar een nieuw venster verplaatsen"/>
+					<Item CMID="15" name="Naar een nieuw venster kopiëren"/>
+					<Item CMID="16" name="Opnieuw laden"/>
+					<Item CMID="17" name="Documenten aan de linkerkant sluiten"/>
+					<Item CMID="18" name="Documenten aan de rechterkant sluiten"/>
+					<Item CMID="19" name="Bevattende map in Verkenner weergeven"/>
+					<Item CMID="20" name="Bevattende map in opdrachtprompt openen"/>
+					<Item CMID="21" name="In standaardviewer openen"/>
+					<Item CMID="22" name="Ongewijzigde documenten sluiten"/>
+					<Item CMID="23" name="Bevattende map als werkruimte openen"/>
 			</TabBar>
 		</Menu>
 
 		<Dialog>
 			<Find title="" titleFind="Zoeken" titleReplace="Vervangen" titleFindInFiles="Zoeken in bestanden" titleMark="Markeren">
-				<Item id="1"    name="&amp;Volgende zoeken"/>
-				<Item id="1722" name="Achteruit"/>
-				<Item id="2"    name="Sluiten"/>
+				<Item id="1"	name="Volgende zoeken"/>
+				<Item id="1722" name="Achterwaarts"/>
+				<Item id="2"	name="Sluiten"/>
 				<Item id="1620" name="Zoeken naar:"/>
-				<Item id="1603" name="Losse &amp;woorden"/>
-				<Item id="1604" name="&amp;Kapitalen onderscheiden"/>
-				<Item id="1605" name="Reguliere e&amp;xpressie"/>
+				<Item id="1603" name="Alleen volledige &amp;woorden"/>
+				<Item id="1604" name="Hoofdlettergevoelig"/>
+				<Item id="1605" name="Re&amp;guliere expressie"/>
 				<Item id="1606" name="&amp;Documenteinde negeren"/>
 				<Item id="1614" name="Gevonden woorden &amp;tellen"/>
-				<Item id="1615" name="Alle &amp;markeren"/>
-				<Item id="1616" name="Bladwijzer invoegen"/>
-				<Item id="1618" name="Markering opnieuw instellen"/>
+				<Item id="1615" name="Alles markeren"/>
+				<Item id="1616" name="Blad&amp;wijzer toevoegen aan regel"/>
+				<Item id="1618" name="Markering wissen bij opnieuw zoeken"/>
 				<Item id="1611" name="Vervangen door:"/>
 				<Item id="1608" name="V&amp;ervangen"/>
-				<Item id="1609" name="&amp;Alle vervangen"/>
+				<Item id="1609" name="&amp;Alles vervangen"/>
 				<Item id="1687" name="Bij focusverlies"/>
 				<Item id="1688" name="Altijd"/>
-				<Item id="1632" name="In &amp;selectie"/>
-				<Item id="1633" name="Wissen"/>
+				<Item id="1632" name="In select&amp;ie"/>
+				<Item id="1633" name="Alle markeringen wissen"/>
 				<Item id="1635" name="In alle ge&amp;opende bestanden vervangen"/>
 				<Item id="1636" name="In alle geopende &amp;bestanden zoeken"/>
 				<Item id="1654" name="Filters:"/>
 				<Item id="1655" name="Map:"/>
-				<Item id="1656" name="Zoeken in bestanden"/>
-				<Item id="1658" name="Submappen doorzoeken"/>
-				<Item id="1659" name="Verborgen mappen"/>
-				<Item id="1624" name="Zoekmethode"/>
+				<Item id="1656" name="Alles zoeken"/>
+				<Item id="1658" name="In submappen"/>
+				<Item id="1659" name="In verborgen mappen"/>
+				<Item id="1624" name="Zoekmodus"/>
 				<Item id="1625" name="&amp;Normaal"/>
 				<Item id="1626" name="&amp;Uitgebreid (\n, \r, \t, \0, \x...)"/>
 				<Item id="1660" name="Vervangen in bestanden"/>
 				<Item id="1661" name="Huidige bestandsmap"/>
-				<Item id="1641" name="In dit document zoeken"/>
+				<Item id="1641" name="Alles in dit document zoeken"/>
 				<Item id="1686" name="Transparantie"/>
 				<Item id="1703" name="&amp;. vindt \n en \r"/>
 				<Item id="1721" name="▲"/>
 				<Item id="1723" name="▼ Volgende"/>
+				<Item id="1725" name="Gemarkeerde tekst kopiëren"/>
 			</Find>
 
-			<FindCharsInRange title="Karakter zoeken in bereik...">
-				<Item id="2"    name="Sluiten"/>
+			<FindCharsInRange title="Tekens zoeken in bereik...">
+				<Item id="2" name="Sluiten"/>
 				<Item id="2901" name="Extended ASCII (128-255)"/>
-				<Item id="2902" name="ASCII (0-128)"/>
+				<Item id="2902" name="ASCII (0-127)"/>
 				<Item id="2903" name="Aangepast:"/>
-				<Item id="2906" name="Omhoog"/>
-				<Item id="2907" name="Omlaag"/>
+				<Item id="2906" name="Om&amp;hoog"/>
+				<Item id="2907" name="Om&amp;laag"/>
 				<Item id="2908" name="Richting"/>
 				<Item id="2909" name="Documenteinde negeren"/>
-				<Item id="2910" name="&amp;Volgende zoeken"/>
+				<Item id="2910" name="Zoeken"/>
 			</FindCharsInRange>
 
-			<GoToLine title="Ga naar regel">
-				<Item id="2007" name="Regelnummer"/>
-				<Item id="2008" name="Karakterpositie"/>
-				<Item id="1"    name="OK"/>
-				<Item id="2"    name="Annuleren"/>
-				<Item id="2004" name="Huidig regelnummer:"/>
-				<Item id="2005" name="Regelnummer:"/>
-				<Item id="2006" name="Limiet:"/>
+			<GoToLine title="Ga naar...">
+				<Item id="2007" name="Rege&amp;l"/>
+				<Item id="2008" name="P&amp;ositie"/>
+				<Item id="1"	name="Gaan"/>
+				<Item id="2"	name="Annuleren"/>
+				<Item id="2004" name="U bent hier:"/>
+				<Item id="2005" name="U wilt gaan naar:"/>
+				<Item id="2006" name="U kunt niet verder gaan dan:"/>
 			</GoToLine>
 
-			<Run title="Uitvoeren">
-				<Item id="1903" name="Naam van programma, map of document:"/>
-				<Item id="1"    name="OK"/>
-				<Item id="2"    name="Annuleren"/>
+			<Run title="Uitvoeren...">
+				<Item id="1903" name="Het uit te voeren programma"/>
+				<Item id="1"	name="Uitvoeren"/>
+				<Item id="2"	name="Annuleren"/>
 				<Item id="1904" name="Opslaan..."/>
 			</Run>
 
-			<MD5FromFilesDlg title="MD5 code voor bestanden genereren">
+			<MD5FromFilesDlg title="MD5-code voor bestanden genereren">
 				<Item id="1922" name="Bestanden selecteren..."/>
 				<Item id="1924" name="Naar klembord kopiëren"/>
-				<Item id="2"    name="Sluiten"/>
+				<Item id="2"	name="Sluiten"/>
 			</MD5FromFilesDlg>
 
-			<MD5FromTextDlg title="MD5 code genereren">
-				<Item id="1932" name="Elke regel als aparte tekst interpreteren"/>
+			<MD5FromTextDlg title="MD5-code genereren">
+				<Item id="1932" name="Elke regel als een aparte string behandelen"/>
 				<Item id="1934" name="Naar klembord kopiëren"/>
-				<Item id="2"    name="Sluiten"/>
+				<Item id="2"	name="Sluiten"/>
 			</MD5FromTextDlg>
 
-			<SHA256FromFilesDlg title="SHA-256 code voor bestanden genereren">
+			<SHA256FromFilesDlg title="SHA-256-code voor bestanden genereren">
 				<Item id="1922" name="Bestanden selecteren..."/>
 				<Item id="1924" name="Naar klembord kopiëren"/>
-				<Item id="2"    name="Sluiten"/>
+				<Item id="2"	name="Sluiten"/>
 			</SHA256FromFilesDlg>
 
-			<SHA256FromTextDlg title="SHA-256 code genereren">
-				<Item id="1932" name="Elke regel als aparte tekst interpreteren"/>
+			<SHA256FromTextDlg title="SHA-256-code genereren">
+				<Item id="1932" name="Elke regel als een aparte string behandelen"/>
 				<Item id="1934" name="Naar klembord kopiëren"/>
-				<Item id="2"    name="Sluiten"/>
+				<Item id="2"	name="Sluiten"/>
 			</SHA256FromTextDlg>
 
-			<PluginsAdminDlg title="Plugin beheer" titleAvailable="Beschikbaar" titleUpdates="Updates" titleInstalled="Geïnstalleerd">
-				<ColumnPlugin   name="Naam"/>
-				<ColumnVersion  name="Versie"/>
+			<PluginsAdminDlg title="Plugin-beheer" titleAvailable="Beschikbaar" titleUpdates="Updates" titleInstalled="Geïnstalleerd">
+				<ColumnPlugin	name="Plugin"/>
+				<ColumnVersion	name="Versie"/>
 				<Item id="5501" name="Zoeken:"/>
 				<Item id="5503" name="Installeren"/>
-				<Item id="5504" name="Updaten"/>
+				<Item id="5504" name="Bijwerken"/>
 				<Item id="5505" name="Verwijderen"/>
 				<Item id="5508" name="Volgende"/>
-				<Item id="2"    name="Sluiten"/>
+				<Item id="2"	name="Sluiten"/>
 			</PluginsAdminDlg>
 
-			<StyleConfig title="Opmaak">
-				<Item id="2"    name="&amp;Annuleren"/>
-				<Item id="2301" name="&amp;Opslaan"/>
+			<StyleConfig title="Stijlconfigurator">
+				<Item id="2"	name="Annuleren"/>
+				<Item id="2301" name="Opslaan en sluiten"/>
 				<Item id="2303" name="Transparantie"/>
-				<Item id="2306" name="Thema:"/>
+				<Item id="2306" name="Thema selecteren: "/>
 				<SubDialog>
 					<Item id="2204" name="Vet"/>
 					<Item id="2205" name="Cursief"/>
-					<Item id="2206" name="Voorgrond"/>
-					<Item id="2207" name="Achtergrond"/>
+					<Item id="2206" name="Voorgrondkleur"/>
+					<Item id="2207" name="Achtergrondkleur"/>
 					<Item id="2208" name="Lettertype:"/>
-					<Item id="2209" name="Lettergrootte:"/>
-					<Item id="2211" name="Functie:"/>
-					<Item id="2212" name="Kleur"/>
+					<Item id="2209" name="Tekengrootte:"/>
+					<Item id="2211" name="Stijl:"/>
+					<Item id="2212" name="Kleurstijl"/>
 					<Item id="2213" name="Tekenstijl"/>
 					<Item id="2214" name="Std. extensies"/>
-					<Item id="2216" name="Extra extensies"/>
+					<Item id="2216" name="Aangepaste extensies"/>
 					<Item id="2218" name="Onderstrepen"/>
 					<Item id="2219" name="Standaard trefwoorden"/>
-					<Item id="2221" name="Extra trefwoorden"/>
+					<Item id="2221" name="Aangepaste trefwoorden"/>
 					<Item id="2225" name="Syntaxis:"/>
 					<Item id="2226" name="Voorgrondkleur vervangen"/>
 					<Item id="2227" name="Achtergrondkleur vervangen"/>
@@ -500,111 +514,183 @@
 				</SubDialog>
 			</StyleConfig>
 
-			<ShortcutMapper title="Sneltoetsen Mapper">
+			<ShortcutMapper title="Sneltoetsen-mapper">
 				<Item id="2602" name="Wijzigen"/>
 				<Item id="2603" name="Verwijderen"/>
 				<Item id="2606" name="Wissen"/>
 				<Item id="2607" name="Filter: "/>
-				<Item id="1"    name="Sluiten"/>
-				<ColumnName             name="Naam"/>
-				<ColumnShortcut         name="Sneltoets"/>
-				<ColumnCategory         name="Categorie"/>
-				<ColumnPlugin           name="Plugin"/>
-				<MainMenuTab            name="Hoofdmenu"/>
-				<MacrosTab              name="Macros"/>
-				<RunCommandsTab         name="Uitvoer commandos"/>
-				<PluginCommandsTab      name="Plugin commandos"/>
-				<ScintillaCommandsTab   name="Scintilla commandos"/>
-				<ConflictInfoOk         name="Geen conflicten voor dit commando."/>
-				<ConflictInfoEditing    name="Geen conflicten ..."/>
+				<Item id="1" name="Sluiten"/>
+				<ColumnName name="Naam"/>
+				<ColumnShortcut name="Sneltoets"/>
+				<ColumnCategory name="Categorie"/>
+				<ColumnPlugin name="Plugin"/>
+				<MainMenuTab name="Hoofdmenu"/>
+				<MacrosTab name="Macro's"/>
+				<RunCommandsTab name="Uitvoer-opdrachten"/>
+				<PluginCommandsTab name="Plugin-opdrachten"/>
+				<ScintillaCommandsTab name="Scintilla-opdrachten"/>
+				<ConflictInfoOk name="Geen sneltoets-conflicten voor dit item."/>
+				<ConflictInfoEditing name="Geen conflicten..."/>
+				<MainCommandNames>
+					<Item id="41019" name="Bevattende map in Verkenner openen"/>
+					<Item id="41020" name="Bevattende map in Opdrachtprompt openen"/>
+					<Item id="41021" name="Recent gesloten bestand herstellen"/>
+					<Item id="45001" name="Regeleinde-conversie naar Windows (CR LF)"/>
+					<Item id="45002" name="Regeleinde-conversie naar Unix (LF)"/>
+					<Item id="45003" name="Regeleinde-conversie naar Macintosh (CR)"/>
+					<Item id="43022" name="Tekst markeren met stijl 1"/>
+					<Item id="43024" name="Tekst markeren met stijl 2"/>
+					<Item id="43026" name="Tekst markeren met stijl 3"/>
+					<Item id="43028" name="Tekst markeren met stijl 4"/>
+					<Item id="43030" name="Tekst markeren met stijl 5"/>
+					<Item id="43023" name="Markeringen met stijl 1 wissen"/>
+					<Item id="43025" name="Markeringen met stijl 2 wissen"/>
+					<Item id="43027" name="Markeringen met stijl 3 wissen"/>
+					<Item id="43029" name="Markeringen met stijl 4 wissen"/>
+					<Item id="43031" name="Markeringen met stijl 5 wissen"/>
+					<Item id="43032" name="Markeringen met om het even welke stijl wissen"/>
+					<Item id="43033" name="Vorige markering met stijl 1"/>
+					<Item id="43034" name="Vorige markering met stijl 2"/>
+					<Item id="43035" name="Vorige markering met stijl 3"/>
+					<Item id="43036" name="Vorige markering met stijl 4"/>
+					<Item id="43037" name="Vorige markering met stijl 5"/>
+					<Item id="43038" name="Vorige markering aangemaakt met 'markeren'"/>
+					<Item id="43039" name="Volgende markering met stijl 1"/>
+					<Item id="43040" name="Volgende markering met stijl 2"/>
+					<Item id="43041" name="Volgende markering met stijl 3"/>
+					<Item id="43042" name="Volgende markering met stijl 4"/>
+					<Item id="43043" name="Volgende markering met stijl 5"/>
+					<Item id="43044" name="Volgende markering aangemaakt met 'markeren'"/>
+					<Item id="43055" name="Tekst met stijl kopiëren - stijl 1"/>
+					<Item id="43056" name="Tekst met stijl kopiëren - stijl 2"/>
+					<Item id="43057" name="Tekst met stijl kopiëren - stijl 3"/>
+					<Item id="43058" name="Tekst met stijl kopiëren - stijl 4"/>
+					<Item id="43059" name="Tekst met stijl kopiëren - stijl 5"/>
+					<Item id="43060" name="Tekst met stijl kopiëren - alle stijlen"/>
+					<Item id="43061" name="Tekst met stijl kopiëren - stijl zoeken (gemarkeerd)"/>
+					<Item id="44100" name="Huidig bestand weergeven in Firefox"/>
+					<Item id="44101" name="Huidig bestand weergeven in Chrome"/>
+					<Item id="44103" name="Huidig bestand weergeven in IE"/>
+					<Item id="44102" name="Huidig bestand weergeven in Edge"/>
+					<Item id="50003" name="Wisselen naar vorig document"/>
+					<Item id="50004" name="Wisselen naar volgend document"/>
+					<Item id="44051" name="Niveau 1 samenvouwen"/>
+					<Item id="44052" name="Niveau 2 samenvouwen"/>
+					<Item id="44053" name="Niveau 3 samenvouwen"/>
+					<Item id="44054" name="Niveau 4 samenvouwen"/>
+					<Item id="44055" name="Niveau 5 samenvouwen"/>
+					<Item id="44056" name="Niveau 6 samenvouwen"/>
+					<Item id="44057" name="Niveau 7 samenvouwen"/>
+					<Item id="44058" name="Niveau 8 samenvouwen"/>
+					<Item id="44061" name="Niveau 1 uitvouwen"/>
+					<Item id="44062" name="Niveau 2 uitvouwen"/>
+					<Item id="44063" name="Niveau 3 uitvouwen"/>
+					<Item id="44064" name="Niveau 4 uitvouwen"/>
+					<Item id="44065" name="Niveau 5 uitvouwen"/>
+					<Item id="44066" name="Niveau 6 uitvouwen"/>
+					<Item id="44067" name="Niveau 7 uitvouwen"/>
+					<Item id="44068" name="Niveau 8 uitvouwen"/>
+					<Item id="44081" name="Projectpaneel 1 aan/uit"/>
+					<Item id="44082" name="Projectpaneel 2 aan/uit"/>
+					<Item id="44083" name="Projectpaneel 3 aan/uit"/>
+					<Item id="44085" name="Map als werkruimte aan/uit"/>
+					<Item id="44080" name="Overzichtskaart van document aan/uit"/>
+					<Item id="44084" name="Functielijst aan/uit"/>
+					<Item id="50005" name="Macro-opname aan/uit"/>
+					<Item id="44104" name="Wisselen naar projectpaneel 1"/>
+					<Item id="44105" name="Wisselen naar projectpaneel 2"/>
+					<Item id="44106" name="Wisselen naar projectpaneel 3"/>
+					<Item id="44107" name="Wisselen naar map als werkruimte"/>
+					<Item id="44108" name="Wisselen naar functielijst"/>
+				</MainCommandNames>
 			</ShortcutMapper>
 			<ShortcutMapperSubDialg title="Sneltoets">
-				<Item id="1"    name="OK"/>
-				<Item id="2"    name="Annuleren"/>
+				<Item id="1" name="Ok"/>
+				<Item id="2" name="Annuleren"/>
 				<Item id="5006" name="Naam"/>
 				<Item id="5008" name="Toevoegen"/>
 				<Item id="5009" name="Verwijderen"/>
 				<Item id="5010" name="Toepassen"/>
-				<Item id="5007" name="Hiermee verwijdert u de sneltoets voor dit commando"/>
+				<Item id="5007" name="Dit zal de sneltoets van deze opdracht verwijderen"/>
 				<Item id="5012" name="CONFLICTEN GEVONDEN!"/>
 			</ShortcutMapperSubDialg>
-			<UserDefine title="Syntaxismarkering ontwerpen">
-				<Item id="20001" name="Dock"/>
+			<UserDefine title="Aangepaste syntaxismarkering">
+				<Item id="20001" name="Vastzetten"/>
 				<Item id="20002" name="Naam wijzigen"/>
 				<Item id="20003" name="Nieuw..."/>
 				<Item id="20004" name="Verwijderen"/>
 				<Item id="20005" name="Opslaan als..."/>
 				<Item id="20007" name="Opmaakprofiel:"/>
 				<Item id="20009" name="Extensies:"/>
-				<Item id="20012" name="Kapitalen negeren"/>
+				<Item id="20012" name="Hoofdletters negeren"/>
 				<Item id="20011" name="Transparantie"/>
 				<Item id="20015" name="Importeren..."/>
 				<Item id="20016" name="Exporteren..."/>
 				<StylerDialog title="Opmaak">
-					<Item id="25030" name="Tekenstijl"/>
+					<Item id="25030" name="Lettertype-opties"/>
 					<Item id="25006" name="Kleur voorgrond"/>
 					<Item id="25007" name="Kleur achtergrond"/>
-					<Item id="25031" name="Lettertype:"/>
-					<Item id="25032" name="Lettergrootte:"/>
+					<Item id="25031" name="Naam:"/>
+					<Item id="25032" name="Grootte:"/>
 					<Item id="25001" name="Vet"/>
 					<Item id="25002" name="Cursief"/>
 					<Item id="25003" name="Onderstrepen"/>
-					<Item id="25029" name="Uitlijnen:"/>
-					<Item id="25008" name="1e bereik"/>
-					<Item id="25009" name="2e bereik"/>
-					<Item id="25010" name="3e bereik"/>
-					<Item id="25011" name="4e bereik"/>
-					<Item id="25012" name="5e bereik"/>
-					<Item id="25013" name="6e bereik"/>
-					<Item id="25014" name="7e bereik"/>
-					<Item id="25015" name="8e bereik"/>
-					<Item id="25018" name="1e groep trefwoorden"/>
-					<Item id="25019" name="2e groep trefwoorden"/>
-					<Item id="25020" name="3e groep trefwoorden"/>
-					<Item id="25021" name="4e groep trefwoorden"/>
-					<Item id="25022" name="5e groep trefwoorden"/>
-					<Item id="25023" name="6e groep trefwoorden"/>
-					<Item id="25024" name="7e groep trefwoorden"/>
-					<Item id="25025" name="8e groep trefwoorden"/>
-					<Item id="25016" name="Commentaar (regels)"/>
-					<Item id="25017" name="Commentaar (blok)"/>
-					<Item id="25026" name="Operatoren (type 1)"/>
-					<Item id="25027" name="Operatoren (type 2)"/>
+					<Item id="25029" name="Nesten:"/>
+					<Item id="25008" name="Scheidingsteken 1"/>
+					<Item id="25009" name="Scheidingsteken 2"/>
+					<Item id="25010" name="Scheidingsteken 3"/>
+					<Item id="25011" name="Scheidingsteken 4"/>
+					<Item id="25012" name="Scheidingsteken 5"/>
+					<Item id="25013" name="Scheidingsteken 6"/>
+					<Item id="25014" name="Scheidingsteken 7"/>
+					<Item id="25015" name="Scheidingsteken 8"/>
+					<Item id="25018" name="Trefwoord 1"/>
+					<Item id="25019" name="Trefwoord 2"/>
+					<Item id="25020" name="Trefwoord 3"/>
+					<Item id="25021" name="Trefwoord 4"/>
+					<Item id="25022" name="Trefwoord 5"/>
+					<Item id="25023" name="Trefwoord 6"/>
+					<Item id="25024" name="Trefwoord 7"/>
+					<Item id="25025" name="Trefwoord 8"/>
+					<Item id="25016" name="Commentaar"/>
+					<Item id="25017" name="Commentaarregel"/>
+					<Item id="25026" name="Operator 1"/>
+					<Item id="25027" name="Operator 2"/>
 					<Item id="25028" name="Getallen"/>
-					<Item id="1"     name="OK"/>
-					<Item id="2"     name="Annuleren"/>
+					<Item id="1" name="Ok"/>
+					<Item id="2" name="Annuleren"/>
 				</StylerDialog>
 				<Folder title="Algemeen">
-					<Item id="21101" name="Standaard opmaak"/>
+					<Item id="21101" name="Standaardstijl"/>
 					<Item id="21102" name="Opmaak"/>
 					<Item id="21105" name="Documentatie"/>
 					<Item id="21104" name="Online handleiding:"/>
 					<Item id="21106" name="Lege regels samenvouwen"/>
 					<Item id="21220" name="Code samenvouwen (type 1)"/>
-					<Item id="21224" name="1e voorwaarde:"/>
-					<Item id="21225" name="2e voorwaarde:"/>
+					<Item id="21224" name="Begin:"/>
+					<Item id="21225" name="Midden:"/>
 					<Item id="21226" name="Einde:"/>
 					<Item id="21227" name="Opmaak"/>
 					<Item id="21320" name="Code samenvouwen (type 2)"/>
-					<Item id="21324" name="1e voorwaarde:"/>
-					<Item id="21325" name="2e voorwaarde:"/>
+					<Item id="21324" name="Begin:"/>
+					<Item id="21325" name="Midden:"/>
 					<Item id="21326" name="Einde:"/>
 					<Item id="21327" name="Opmaak"/>
 					<Item id="21420" name="Code samenvouwen (trefwoorden in commentaar)"/>
-					<Item id="21424" name="1e voorwaarde:"/>
-					<Item id="21425" name="2e voorwaarde:"/>
+					<Item id="21424" name="Begin:"/>
+					<Item id="21425" name="Midden:"/>
 					<Item id="21426" name="Einde:"/>
 					<Item id="21427" name="Opmaak"/>
 				</Folder>
 				<Keywords title="Trefwoorden">
-					<Item id="22101" name="1e groep"/>
-					<Item id="22201" name="2e groep"/>
-					<Item id="22301" name="3e groep"/>
-					<Item id="22401" name="4e groep"/>
-					<Item id="22451" name="5e groep"/>
-					<Item id="22501" name="6e groep"/>
-					<Item id="22551" name="7e groep"/>
-					<Item id="22601" name="8e groep"/>
+					<Item id="22101" name="Groep 1"/>
+					<Item id="22201" name="Groep 2"/>
+					<Item id="22301" name="Groep 3"/>
+					<Item id="22401" name="Groep 4"/>
+					<Item id="22451" name="Groep 5"/>
+					<Item id="22501" name="Groep 6"/>
+					<Item id="22551" name="Groep 7"/>
+					<Item id="22601" name="Groep 8"/>
 					<Item id="22121" name="Als voorvoegsel"/>
 					<Item id="22221" name="Als voorvoegsel"/>
 					<Item id="22321" name="Als voorvoegsel"/>
@@ -623,75 +709,75 @@
 					<Item id="22622" name="Opmaak"/>
 				</Keywords>
 				<Comment title="Commentaar / Getallen">
-					<Item id="23003" name="Regel als commentaar markeren:"/>
-					<Item id="23004" name="Vanaf elke positie"/>
-					<Item id="23005" name="Vanaf het begin van de regel"/>
-					<Item id="23006" name="Vanaf eerste tekst"/>
-					<Item id="23001" name="Commentaar kan samengevouwen worden"/>
+					<Item id="23003" name="Positie van regelcommentaar"/>
+					<Item id="23004" name="Overal toestaan"/>
+					<Item id="23005" name="Forceren aan begin van regel"/>
+					<Item id="23006" name="Voorafgaande witruimte toestaan"/>
+					<Item id="23001" name="Commentaar samenvouwen toestaan"/>
 					<Item id="23326" name="Opmaak"/>
-					<Item id="23323" name="Begin:"/>
-					<Item id="23324" name="Voortzetting:"/>
-					<Item id="23325" name="Einde:"/>
-					<Item id="23301" name="Commentaar (regels)"/>
+					<Item id="23323" name="Begin"/>
+					<Item id="23324" name="Teken voortzetten"/>
+					<Item id="23325" name="Einde"/>
+					<Item id="23301" name="Stijl commentaarregels"/>
 					<Item id="23124" name="Opmaak"/>
-					<Item id="23122" name="Begin:"/>
-					<Item id="23123" name="Einde:"/>
-					<Item id="23101" name="Commentaar (blok)"/>
-					<Item id="23201" name="Getallen"/>
+					<Item id="23122" name="Begin"/>
+					<Item id="23123" name="Einde"/>
+					<Item id="23101" name="Stijl commentaar"/>
+					<Item id="23201" name="Stijl getallen"/>
 					<Item id="23220" name="Opmaak"/>
-					<Item id="23230" name="Prefix 1:"/>
-					<Item id="23232" name="Prefix 2:"/>
-					<Item id="23234" name="Extras 1:"/>
-					<Item id="23236" name="Extras 2:"/>
-					<Item id="23238" name="Suffix 1:"/>
-					<Item id="23240" name="Suffix 2:"/>
-					<Item id="23242" name="Range:"/>
-					<Item id="23244" name="Decimaalteken"/>
+					<Item id="23230" name="Prefix 1"/>
+					<Item id="23232" name="Prefix 2"/>
+					<Item id="23234" name="Extra's 1"/>
+					<Item id="23236" name="Extra's 2"/>
+					<Item id="23238" name="Suffix 1"/>
+					<Item id="23240" name="Suffix 2"/>
+					<Item id="23242" name="Bereik:"/>
+					<Item id="23244" name="Scheidingsteken decimalen"/>
 					<Item id="23245" name="Punt"/>
 					<Item id="23246" name="Komma"/>
 					<Item id="23247" name="Beide"/>
 				</Comment>
-				<Operator title="Operatoren">
-					<Item id="24101" name="Operatoren"/>
+				<Operator title="Operatoren en scheidingstekens">
+					<Item id="24101" name="Stijl operatoren"/>
 					<Item id="24113" name="Opmaak"/>
-					<Item id="24116" name="Operatoren (type 1)"/>
-					<Item id="24117" name="Operatoren (type 2)"/>
-					<Item id="24201" name="1e bereik"/>
+					<Item id="24116" name="Operatoren 1"/>
+					<Item id="24117" name="Operatoren 2 (scheid.tek. vereist)"/>
+					<Item id="24201" name="Stijl scheidingsteken 1"/>
 					<Item id="24220" name="Begin:"/>
 					<Item id="24221" name="Uitzondering:"/>
-					<Item id="24222" name="Einde: "/>
+					<Item id="24222" name="Einde:"/>
 					<Item id="24223" name="Opmaak"/>
-					<Item id="24301" name="2e bereik"/>
+					<Item id="24301" name="Stijl scheidingsteken 2"/>
 					<Item id="24320" name="Begin:"/>
 					<Item id="24321" name="Uitzondering:"/>
 					<Item id="24322" name="Einde:"/>
 					<Item id="24323" name="Opmaak"/>
-					<Item id="24401" name="3e bereik"/>
+					<Item id="24401" name="Stijl scheidingsteken 3"/>
 					<Item id="24420" name="Begin:"/>
 					<Item id="24421" name="Uitzondering:"/>
 					<Item id="24422" name="Einde:"/>
 					<Item id="24423" name="Opmaak"/>
-					<Item id="24451" name="4e bereik"/>
+					<Item id="24451" name="Stijl scheidingsteken 4"/>
 					<Item id="24470" name="Begin:"/>
 					<Item id="24471" name="Uitzondering:"/>
 					<Item id="24472" name="Einde:"/>
 					<Item id="24473" name="Opmaak"/>
-					<Item id="24501" name="5e bereik"/>
+					<Item id="24501" name="Stijl scheidingsteken 5"/>
 					<Item id="24520" name="Begin:"/>
 					<Item id="24521" name="Uitzondering:"/>
 					<Item id="24522" name="Einde:"/>
 					<Item id="24523" name="Opmaak"/>
-					<Item id="24551" name="6e bereik"/>
+					<Item id="24551" name="Stijl scheidingsteken 6"/>
 					<Item id="24570" name="Begin:"/>
 					<Item id="24571" name="Uitzondering:"/>
 					<Item id="24572" name="Einde:"/>
 					<Item id="24573" name="Opmaak"/>
-					<Item id="24601" name="7e bereik"/>
+					<Item id="24601" name="Stijl scheidingsteken 7"/>
 					<Item id="24620" name="Begin:"/>
 					<Item id="24621" name="Uitzondering:"/>
 					<Item id="24622" name="Einde:"/>
 					<Item id="24623" name="Opmaak"/>
-					<Item id="24651" name="8e bereik"/>
+					<Item id="24651" name="Stijl scheidingsteken 8"/>
 					<Item id="24670" name="Begin:"/>
 					<Item id="24671" name="Uitzondering:"/>
 					<Item id="24672" name="Einde:"/>
@@ -701,125 +787,130 @@
 			<Preference title="Voorkeuren">
 				<Item id="6001" name="Sluiten"/>
 				<Global title="Algemeen">
-					<Item id="6101" name="Pictogrammen"/>
-					<Item id="6102" name="Niet weergeven"/>
-					<Item id="6103" name="Klein"/>
-					<Item id="6104" name="Groot"/>
-					<Item id="6105" name="Modern"/>
+					<Item id="6101" name="Werkbalk"/>
+					<Item id="6102" name="Verbergen"/>
+					<Item id="6103" name="Kleine pictogrammen"/>
+					<Item id="6104" name="Grote pictogrammen"/>
+					<Item id="6105" name="Standaardpictogrammen"/>
 
-					<Item id="6106" name="Documentweergave"/>
+					<Item id="6106" name="Tabblad-balk"/>
 					<Item id="6107" name="Kleine tabs"/>
 					<Item id="6108" name="Slepen en neerzetten uitschakelen"/>
-					<Item id="6109" name="Inactieve tabs camoufleren"/>
-					<Item id="6110" name="Actieve tab accentueren"/>
+					<Item id="6109" name="Inactieve tabbladen camoufleren"/>
+					<Item id="6110" name="Actieve tabbladen accentueren"/>
 
 					<Item id="6111" name="Statusbalk weergeven"/>
-					<Item id="6112" name="Knop sluiten weergeven"/>
+					<Item id="6112" name="Knop sluiten op elke tab weergeven"/>
 					<Item id="6113" name="Document sluiten door dubbelklikken"/>
-					<Item id="6118" name="Tabs verbergen"/>
+					<Item id="6118" name="Verbergen"/>
 					<Item id="6119" name="Tabs in meerdere rijen weergeven"/>
 					<Item id="6120" name="Verticale tabs"/>
-					<Item id="6121" name="Afsluiten na sluiten laatste document"/>
+					<Item id="6121" name="Afsluiten bij sluiten van laatste tab"/>
 
-					<Item id="6122" name="Menubalk verbergen (Tonen met Alt of F10)"/>
+					<Item id="6122" name="Menubalk verbergen (tonen met Alt of F10)"/>
 					<Item id="6123" name="Taal"/>
 
-					<Item id="6125" name="Documentenlijst"/>
+					<Item id="6125" name="Documentenlijst-paneel"/>
 					<Item id="6126" name="Weergeven"/>
 					<Item id="6127" name="Extensiekolom verbergen"/>
+
+					<Item id="6128" name="Alternatieve pictogrammen"/>
 				</Global>
-				<Scintillas title="Weergave">
-					<Item id="6216" name="Aanwijzer"/>
+				<Scintillas title="Bewerken">
+					<Item id="6216" name="Cursor-instellingen"/>
 					<Item id="6217" name="Breedte:"/>
 					<Item id="6219" name="Knippersnelheid:"/>
-					<Item id="6221" name="0"/>
-					<Item id="6222" name="100"/>
-					<Item id="6224" name="Meervoudig bewerken"/>
-					<Item id="6225" name="Activeren"/>
-					<Item id="6201" name="Gegevensstructuur"/>
-					<Item id="6202" name="Basis"/>
-					<Item id="6203" name="Pijl"/>
-					<Item id="6204" name="Cirkel"/>
-					<Item id="6205" name="Vierkant"/>
-					<Item id="6226" name="Verborgen"/>
-
+					<Item id="6221" name="100"/>
+					<Item id="6222" name="0"/>
+					<Item id="6225" name="Meervoudig bewerken inschakelen (Ctrl + klikken/selecteren)"/>
 					<Item id="6227" name="Automatische terugloop"/>
 					<Item id="6228" name="Standaard"/>
-					<Item id="6229" name="Uitlijnen"/>
-					<Item id="6230" name="Inspringen"/>
-
-					<Item id="6206" name="Regelnummers weergeven"/>
-					<Item id="6207" name="Bladwijzers weergeven"/>
-					<Item id="6208" name="Regeleinde weergeven"/>
-					<Item id="6234" name="Geavanceerd scrollen uitschakelen&#xD;(ivm eventuele touchpadproblemen)"/>
-
-					<Item id="6211" name="Regeleinde"/>
-					<Item id="6213" name="Achtergrond"/>
-					<Item id="6237" name="Voeg een kolommarkering toe door haar positie aan te geven met een geheel getal.&#xD;Definieer meerdere kolommarkeringen door hun posities met witruimte te scheiden."/>
-					<Item id="6214" name="Actieve regel markeren"/>
-					<Item id="6215" name="ClearType inschakelen"/>
-					<Item id="6231" name="Breedte vensterrand"/>
-					<Item id="6235" name="Geen rand"/>
-					<Item id="6236" name="Activeer scrollen voorbij laatste regel"/>
+					<Item id="6229" name="Uitgelijnd"/>
+					<Item id="6230" name="Ingesprongen"/>
+					<Item id="6234" name="Geavanceerd scrollen uitschakelen (ivm eventuele touchpadproblemen)"/>
+					<Item id="6214" name="Markeren van huidige regel inschakelen"/>
+					<Item id="6215" name="ClearType-lettertype inschakelen"/>
+					<Item id="6236" name="Scrollen voorbij laatste regel inschakelen"/>
+					<Item id="6239" name="Selectie behouden bij rechtsklikken buiten selectie"/>
 				</Scintillas>
 
+				<MarginsBorderEdge title="Marges/grens/rand">
+					<Item id="6201" name="Stijl map-marge"/>
+					<Item id="6202" name="Eenvoudig"/>
+					<Item id="6203" name="Pijl"/>
+					<Item id="6204" name="Cirkelboom"/>
+					<Item id="6205" name="Vierkante boom"/>
+					<Item id="6226" name="Geen"/>
+					<Item id="6291" name="Regelnummer"/>
+					<Item id="6206" name="Weergeven"/>
+					<Item id="6292" name="Dynamische breedte"/>
+					<Item id="6293" name="Constante breedte"/>
+					<Item id="6207" name="Bladwijzers weergeven"/>
+					<Item id="6211" name="Instellingen verticale rand"/>
+					<Item id="6213" name="Achtergrondmodus"/>
+					<Item id="6237" name="Voeg uw kolommarkering toe door de positie aan te geven met een decimaal getal.
+U kunt verschillende kolommarkeringen vastleggen door gebruik te maken van spaties om de verschillende getallen van elkaar te scheiden."/>
+					<Item id="6231" name="Breedte rand"/>
+					<Item id="6235" name="Geen rand"/>
+				</MarginsBorderEdge>
+
 				<NewDoc title="Nieuw document">
-					<Item id="6401" name="Indeling"/>
-					<Item id="6402" name="Windows"/>
-					<Item id="6403" name="Unix"/>
-					<Item id="6404" name="Mac"/>
-					<Item id="6405" name="Karakterset"/>
+					<Item id="6401" name="Formaat (regeleinde)"/>
+					<Item id="6402" name="Windows (CR LF)"/>
+					<Item id="6403" name="Unix (LF)"/>
+					<Item id="6404" name="Macintosh (CR)"/>
+					<Item id="6405" name="Tekenset"/>
 					<Item id="6406" name="ANSI"/>
-					<Item id="6407" name="UTF-8 (zonder BOM)"/>
-					<Item id="6408" name="UTF-8-BOM"/>
-					<Item id="6409" name="UCS-2 Big Endian"/>
-					<Item id="6410" name="UCS-2 Little Endian"/>
-					<Item id="6411" name="Syntaxis:"/>
+					<Item id="6407" name="UTF-8"/>
+					<Item id="6408" name="UTF-8 met BOM"/>
+					<Item id="6409" name="UCS-2 Big Endian met BOM"/>
+					<Item id="6410" name="UCS-2 Little Endian met BOM"/>
+					<Item id="6411" name="Standaard syntaxis:"/>
 					<Item id="6419" name="Nieuw document"/>
-					<Item id="6420" name="ANSI-codering negeren"/>
+					<Item id="6420" name="Toepassen op geopende ANSI-bestanden"/>
 				</NewDoc>
 
-				<DefaultDir title="Standaardlocatie">
-					<Item id="6413" name="Standaardlocatie voor laden en opslaan"/>
-					<Item id="6414" name="Huidige documentlocatie"/>
-					<Item id="6415" name="Laatst gekozen map"/>
-					<Item id="6431" name="Bij neerzetten, alle bestanden uit map openen ipv map als werkomgeving te openen"/>
+				<DefaultDir title="Standaardmap">
+					<Item id="6413" name="Standaardmap voor openen/opslaan"/>
+					<Item id="6414" name="Huidig document volgen"/>
+					<Item id="6415" name="Laatst gebruikte map onthouden"/>
+					<Item id="6431" name="Bij neerzetten van een map alle bestanden openen in plaats van de map als werkruimte te starten"/>
 				</DefaultDir>
 
 				<FileAssoc title="Bestandsassociaties">
 					<Item id="4008" name="Herstart Notepad++ in de beheerdersmodus om deze functie te kunnen gebruiken."/>
-					<Item id="4009" name="Beschikbare extensies:"/>
+					<Item id="4009" name="Ondersteund:"/>
 					<Item id="4010" name="Geregistreerd:"/>
 				</FileAssoc>
 				<Language title="Syntaxismarkering">
-					<Item id="6505" name="Ingeschakeld:"/>
-					<Item id="6506" name="Uitgeschakeld:"/>
-					<Item id="6507" name="Compacte indeling activeren"/>
-					<Item id="6508" name="Syntaxis menu"/>
-					<Item id="6301" name="Tabs"/>
-					<Item id="6302" name="Omzetten in spaties"/>
-					<Item id="6303" name="Tabgrootte:"/>
-					<Item id="6510" name="Standaardwaarde"/>
-					<Item id="6335" name="Backslash als SQL escape-teken interpreteren"/>
+					<Item id="6505" name="Beschikbare items"/>
+					<Item id="6506" name="Uitgeschakelde items"/>
+					<Item id="6507" name="Compacte indeling inschakelen"/>
+					<Item id="6508" name="Syntaxis-menu"/>
+					<Item id="6301" name="Tab-instellingen"/>
+					<Item id="6302" name="Vervangen door spaties"/>
+					<Item id="6303" name="Tabgrootte: "/>
+					<Item id="6510" name="Standaardwaarde gebruiken"/>
+					<Item id="6335" name="Backslash als SQL escape-teken behandelen"/>
 				</Language>
 
 				<Highlighting title="Markeren">
 					<Item id="6333" name="Slim markeren"/>
-					<Item id="6326" name="Activeren"/>
-					<Item id="6332" name="Kapitalen onderscheiden"/>
-					<Item id="6338" name="Losse woorden"/>
-					<Item id="6339" name="Gebruik zoekvensterinstellingen"/>
-					<Item id="6340" name="Markeer deelvenster"/>
-					<Item id="6329" name="Markeer overeenkomende tags"/>
-					<Item id="6327" name="Activeren"/>
-					<Item id="6328" name="Markeer tagattributen"/>
-					<Item id="6330" name="Markeer commentaar/PHP/ASP gebied"/>
+					<Item id="6326" name="Inschakelen"/>
+					<Item id="6332" name="Hoofdlettergevoelig"/>
+					<Item id="6338" name="Alleen volledige woorden"/>
+					<Item id="6339" name="Zoekvensterinstellingen gebruiken"/>
+					<Item id="6340" name="Deelvenster markeren"/>
+					<Item id="6329" name="Overeenkomende tags markeren"/>
+					<Item id="6327" name="Inschakelen"/>
+					<Item id="6328" name="Tag-attributen markeren"/>
+					<Item id="6330" name="Commentaar/PHP/ASP-gebied markeren"/>
 				</Highlighting>
 
 				<Print title="Afdrukken">
 					<Item id="6601" name="Regelnummers afdrukken"/>
-					<Item id="6602" name="Kleur"/>
-					<Item id="6603" name="Standaard"/>
+					<Item id="6602" name="Kleuropties"/>
+					<Item id="6603" name="Zoals weergegeven op het scherm"/>
 					<Item id="6604" name="Negatief"/>
 					<Item id="6605" name="Zwart-wit"/>
 					<Item id="6606" name="Geen achtergrondkleur"/>
@@ -840,52 +931,59 @@
 					<Item id="6720" name="Links"/>
 					<Item id="6721" name="Midden"/>
 					<Item id="6722" name="Rechts"/>
-					<Item id="6723" name="Invoegen"/>
-					<Item id="6725" name="Autoveld:"/>
-					<Item id="6727" name="Positie:"/>
-					<Item id="6728" name="Pagina"/>
+					<Item id="6723" name="Toevoegen"/>
+					<Item id="6725" name="Variabele:"/>
+					<Item id="6727" name="Instellingen voor variabele"/>
+					<Item id="6728" name="Kop- en voettekst"/>
 				</Print>
+
+				<Searching title="Zoeken">
+					<Item id="6901" name="Het zoekveld in het zoekvenster niet invullen met het geselecteerde woord"/>
+					<Item id="6902" name="Monospace-lettertype gebruiken in het zoekvenster (Notepad++ moet opnieuw worden opgestart)"/>
+					<Item id="6903" name="Zoekvenster blijft open na zoekopdracht die naar het resultaatvenster uitvoert"/>
+					<Item id="6904" name="Alles vervangen in alle geopende documenten bevestigen"/>
+				</Searching>
 
 				<RecentFilesHistory title="Recente bestanden">
 					<Item id="6304" name="Recent geopende bestanden"/>
 					<Item id="6306" name="Maximaal aantal bestanden in lijst:"/>
-					<Item id="6305" name="Niet controleren op wijzigingen"/>
-					<Item id="6429" name="Weergave"/>
-					<Item id="6424" name="Submenu activeren"/>
-					<Item id="6425" name="Bestandsnaam weergeven"/>
-					<Item id="6426" name="Bestandslocatie weergeven"/>
-					<Item id="6427" name="Maximaal aantal karakters:"/>
+					<Item id="6305" name="Niet controleren tijdens starten"/>
+					<Item id="6429" name="Weergeven"/>
+					<Item id="6424" name="In submenu"/>
+					<Item id="6425" name="Alleen bestandsnaam"/>
+					<Item id="6426" name="Volledig pad en bestandsnaam"/>
+					<Item id="6427" name="Maximaal aantal tekens:"/>
 				</RecentFilesHistory>
 
-				<Backup title="Reservekopieën">
-					<Item id="6817" name="Sessie momentopname en periodieke reservekopieën"/>
-					<Item id="6818" name="Sessie en aangebrachte wijzigingen herstellen"/>
-					<Item id="6819" name="Informatie elke"/>
+				<Backup title="Back-up">
+					<Item id="6817" name="Sessie-momentopname en regelmatige back-up"/>
+					<Item id="6818" name="Sessie-momentopname en regelmatige back-up inschakelen"/>
+					<Item id="6819" name="Back-up elke"/>
 					<Item id="6821" name="seconden bijwerken"/>
 					<Item id="6822" name="Map:"/>
-					<Item id="6309" name="Activeren"/>
-					<Item id="6801" name="Reservekopieën"/>
+					<Item id="6309" name="Huidige sessie onthouden voor volgende start"/>
+					<Item id="6801" name="Back-up bij opslaan"/>
 					<Item id="6315" name="Geen"/>
-					<Item id="6316" name="Standaard"/>
-					<Item id="6317" name="Per wijziging"/>
-					<Item id="6804" name="In aangepaste map plaatsen"/>
+					<Item id="6316" name="Eenvoudige back-up"/>
+					<Item id="6317" name="Uitgebreide back-up"/>
+					<Item id="6804" name="Aangepaste map voor back-up"/>
 					<Item id="6803" name="Map:"/>
 				</Backup>
 
 				<AutoCompletion title="Automatisch aanvullen">
 					<Item id="6115" name="Automatisch inspringen"/>
 					<Item id="6807" name="Automatisch aanvullen"/>
-					<Item id="6808" name="Activeren"/>
+					<Item id="6808" name="Inschakelen"/>
 					<Item id="6809" name="Functies aanvullen"/>
 					<Item id="6810" name="Woorden aanvullen"/>
 					<Item id="6816" name="Functies en woorden aanvullen"/>
-					<Item id="6824" name="Negeer nummers"/>
+					<Item id="6824" name="Nummers negeren"/>
 					<Item id="6811" name="Vanaf"/>
 					<Item id="6813" name="tekens"/>
-					<Item id="6814" name="Geldige invoer: 1 - 9"/>
+					<Item id="6814" name="Geldige invoer: 1-9"/>
 					<Item id="6815" name="Functie-argumenten weergeven tijdens typen"/>
 					<Item id="6851" name="Automatisch invoegen"/>
-					<Item id="6857" name="HTML/XML sluit-tag"/>
+					<Item id="6857" name=" HTML/XML sluit-tag"/>
 					<Item id="6858" name="Begin"/>
 					<Item id="6859" name="Einde"/>
 					<Item id="6860" name="Gekoppeld paar 1:"/>
@@ -893,113 +991,116 @@
 					<Item id="6866" name="Gekoppeld paar 3:"/>
 				</AutoCompletion>
 
-				<MultiInstance title="Bestanden openen">
-					<Item id="6151" name="Bestanden openen"/>
-					<Item id="6152" name="Sessie bestand openen in een nieuw venster"/>
-					<Item id="6153" name="Alle bestanden openen in een nieuw venster"/>
-					<Item id="6154" name="Alle bestanden openen in hetzelfde venster"/>
-					<Item id="6155" name="* Wijziging van deze instelling treedt in werking na het opnieuw starten van Notepad++"/>
+				<MultiInstance title="Meerdere instanties">
+					<Item id="6151" name="Instellingen voor meerdere instanties"/>
+					<Item id="6152" name="Sessies openen in een nieuwe instantie van Notepad++"/>
+					<Item id="6153" name="Altijd in modus meerdere instanties"/>
+					<Item id="6154" name="Standaard (enkele instantie)"/>
+					<Item id="6155" name="* Wijziging van deze instelling vereist een herstart van Notepad++"/>
 				</MultiInstance>
 
-				<Delimiter title="Tekst selecteren">
-					<Item id="6251" name="Tekst selecteren tussen de volgende karakters (Ctrl + dubbelklik)"/>
+				<Delimiter title="Scheidingstekens">
+					<Item id="6251" name="Instellingen voor selectie tussen scheidingstekens (Ctrl + dubbelklikken)"/>
 					<Item id="6252" name="Begin"/>
 					<Item id="6255" name="Einde"/>
-					<Item id="6256" name="Selecteer tekst over meerdere regels"/>
+					<Item id="6256" name="Over meerdere regels toestaan"/>
 					<Item id="6161" name="Woordtekenlijst"/>
-					<Item id="6162" name="Gebruik de standaard lijst"/>
-					<Item id="6163" name="Aanvullende woordtekens&#xD;(niet gebruiken, tenzij je weet waar je mee bezig bent)"/>
+					<Item id="6162" name="De standaard-woordtekenlijst gebruiken"/>
+					<Item id="6163" name="Aanvullende woordtekens
+(niet gebruiken, tenzij u weet waar u mee bezig bent)"/>
 				</Delimiter>
 
 				<Cloud title="Online opslag">
 					<Item id="6262" name="Instellingen online opslaan"/>
 					<Item id="6263" name="Instellingen niet online opslaan"/>
 					<Item id="6267" name="Pad naar online opslag:"/>
+					<Item id="6318" name="Instellingen voor klikbare koppelingen"/>
+					<Item id="6319" name="Inschakelen"/>
+					<Item id="6320" name="Geen onderstreping"/>
+					<Item id="6350" name="Modus volledig vak inschakelen"/>
+					<Item id="6264" name="Aangepaste URI-schema's:"/>
 				</Cloud>
 
 				<SearchEngine title="Zoekmachine">
-					<Item id="6271" name="Zoekmachine (voor &quot;Zoek op Internet&quot;)"/>
+					<Item id="6271" name="Zoekmachine (voor &quot;zoeken op Internet&quot;)"/>
 					<Item id="6272" name="DuckDuckGo"/>
 					<Item id="6273" name="Google"/>
 					<Item id="6274" name="Bing"/>
 					<Item id="6275" name="Yahoo!"/>
-					<Item id="6276" name="Stel zelf de zoekmachine in:"/>
-					<!-- Don't change anything after "Voorbeeld:" -->
+					<Item id="6276" name="Zelf uw zoekmachine instellen:"/>
+					<!-- Don't change anything after Example: -->
 					<Item id="6278" name="Voorbeeld: https://www.google.com/search?q=$(CURRENT_WORD)"/>
 				</SearchEngine>
 
 				<MISC title="Overig">
 					<ComboBox id="6347">
 						<Element name="Inschakelen"/>
-						<Element name="Inschakelen voor alle documenten"/>
+						<Element name="Inschakelen voor alle geopende documenten"/>
 						<Element name="Uitschakelen"/>
 					</ComboBox>
-					<Item id="6308" name="Minimaliseren naar systeemvak"/>
+					<Item id="6308" name="Naar systeemvak minimaliseren"/>
 					<Item id="6312" name="Bestandswijziging detecteren"/>
-					<Item id="6313" name="Automatisch bijwerken"/>
-					<Item id="6318" name="Hyperlinks"/>
-					<Item id="6325" name="Ga naar de laatste regel na wijziging"/>
-					<Item id="6319" name="Activeren"/>
-					<Item id="6320" name="Niet onderstrepen"/>
+					<Item id="6313" name="In stilte bijwerken"/>
+					<Item id="6325" name="Ga naar de laatste regel na bijwerken"/>
 					<Item id="6322" name="Bestandsextensie sessie:"/>
 					<Item id="6323" name="Notepad++ automatisch bijwerken"/>
+					<Item id="6351" name="Filter voor bestandsextensie in het opslaan-dialoogvenster instellen op *.*"/>
 					<Item id="6324" name="Wisselen tussen documenten (Ctrl+Tab)"/>
 					<Item id="6331" name="Alleen de bestandsnaam in de titelbalk weergeven"/>
-					<Item id="6334" name="Karakterset automatisch detecteren"/>
-					<Item id="6314" name="Monospace-lettertype in Zoeken/Vervangen invoervakken (Notepad++ herstart nodig)"/>
-					<Item id="6337" name="Bestandsextensie werkomgeving:"/>
-					<Item id="6114" name="Activeren"/>
+					<Item id="6334" name="Tekenset automatisch detecteren"/>
+					<Item id="6349" name="DirectWrite gebruiken (kan de weergave van speciale tekens verbeteren. Notepad++ moet opnieuw gestart worden)"/>
+					<Item id="6337" name="Bestandsextensie werkruimte:"/>
+					<Item id="6114" name="Inschakelen"/>
 					<Item id="6117" name="Volgorde van wisselen onthouden"/>
-					<Item id="6344" name="Document voorvertoning"/>
-					<Item id="6345" name="Voorvertoning bij tab"/>
-					<Item id="6346" name="Voorvertoning bij documentstructuur"/>
-					<Item id="6348" name="Zoeken/Vervangen invoervakken niet voorinvullen"/>
+					<Item id="6344" name="Document kort weergeven"/>
+					<Item id="6345" name="Kort weergeven bij tab"/>
+					<Item id="6346" name="Kort weergeven bij overzichtskaart"/>
 				</MISC>
 			</Preference>
 			<MultiMacro title="Macro meerdere keren uitvoeren">
-				<Item id="1"    name="Start"/>
-				<Item id="2"    name="Stop"/>
+				<Item id="1" name="Sta&amp;rt"/>
+				<Item id="2" name="St&amp;op"/>
 				<Item id="8006" name="Macro selecteren:"/>
 				<Item id="8001" name="Macro"/>
-				<Item id="8002" name="Uitvoeren tot documenteinde"/>
 				<Item id="8005" name="keer uitvoeren"/>
+				<Item id="8002" name="Uitvoeren tot document&amp;einde"/>
 			</MultiMacro>
-			<Window title="Documenten">
-				<Item id="1"    name="Activeren"/>
-				<Item id="2"    name="OK"/>
-				<Item id="7002" name="Opslaan"/>
-				<Item id="7003" name="Sluiten"/>
-				<Item id="7004" name="Sorteren"/>
+			<Window title="Vensters">
+				<Item id="1" name="&amp;Activeren"/>
+				<Item id="2" name="&amp;Ok"/>
+				<Item id="7002" name="Op&amp;slaan"/>
+				<Item id="7003" name="S&amp;luiten"/>
+				<Item id="7004" name="&amp;Tabs sorteren"/>
 			</Window>
-			<ColumnEditor title="Reeks bewerken">
-				<Item id="2023" name="Tekst invoegen"/>
-				<Item id="2033" name="Nummer invoegen"/>
-				<Item id="2030" name="Beginnummer:"/>
-				<Item id="2031" name="Verhogen met:"/>
-				<Item id="2035" name="Voorloopnullen"/>
-				<Item id="2036" name="Nummer herhalen:"/>
+			<ColumnEditor title="Kolom-bewerker">
+				<Item id="2023" name="&amp;Tekst invoegen"/>
+				<Item id="2033" name="&amp;Nummer invoegen"/>
+				<Item id="2030" name="Beg&amp;innummer:"/>
+				<Item id="2031" name="&amp;Verhogen met:"/>
+				<Item id="2035" name="Voor&amp;loopnullen"/>
+				<Item id="2036" name="He&amp;rhalen:"/>
 				<Item id="2032" name="Indeling"/>
-				<Item id="2024" name="Decimaal"/>
-				<Item id="2025" name="Octaal"/>
-				<Item id="2026" name="Hexadecimaal"/>
-				<Item id="2027" name="Binair"/>
-				<Item id="1"    name="OK"/>
-				<Item id="2"    name="Annuleren"/>
+				<Item id="2024" name="&amp;Decimaal"/>
+				<Item id="2025" name="&amp;Octaal"/>
+				<Item id="2026" name="&amp;Hexadecimaal"/>
+				<Item id="2027" name="&amp;Binair"/>
+				<Item id="1" name="Ok"/>
+				<Item id="2" name="Annuleren"/>
 			</ColumnEditor>
-			<FindInFinder title="Zoek in zoekresultaten">
-				<Item id="1"    name="Vind allen"/>
-				<Item id="2"    name="Sluiten"/>
+			<FindInFinder title="Zoeken in zoekresultaten">
+				<Item id="1"	name="Alles zoeken"/>
+				<Item id="2"	name="Sluiten"/>
 				<Item id="1711" name="Zoeken naar:"/>
 				<Item id="1713" name="Alleen zoeken in gevonden regels"/>
-				<Item id="1714" name="Losse &amp;woorden"/>
-				<Item id="1715" name="&amp;Kapitalen onderscheiden"/>
-				<Item id="1716" name="Zoekmethode"/>
-				<Item id="1717" name="Normaal"/>
+				<Item id="1714" name="Alleen volledige woorden"/>
+				<Item id="1715" name="&amp;Hoofdlettergevoelig"/>
+				<Item id="1716" name="Zoekmodus"/>
+				<Item id="1717" name="&amp;Normaal"/>
 				<Item id="1719" name="Reguliere e&amp;xpressie"/>
 				<Item id="1718" name="Uitgebreid (\n, \r, \t, \0, \x...)"/>
-				<Item id="1720" name="&amp;. vind \n en \r"/>
+				<Item id="1720" name="&amp;. vindt \n en \r"/>
 			</FindInFinder>
-			<DoSaveOrNot title="Bestand opslaan">
+			<DoSaveOrNot title="Opslaan">
 				<Item id="1761" name="Bestand &quot;$STR_REPLACE$&quot; opslaan?"/>
 				<Item id="6" name="&amp;Ja"/>
 				<Item id="7" name="&amp;Nee"/>
@@ -1008,301 +1109,174 @@
 				<Item id="5" name="N&amp;ee op alles"/>
 			</DoSaveOrNot>
 		</Dialog>
+		<MessageBox> <!-- $INT_REPLACE$ is a place holder, don't translate it -->
+			<ContextMenuXmlEditWarning title="Contextmenu wijzigen" message="Met het wijzigen van het contextmenu kunt u Notepad++ aan uw persoonlijke voorkeur aanpassen.
+Wijzigingen worden zichtbaar na het opnieuw starten van Notepad++."/>
+			<SaveCurrentModifWarning title="Huidige wijziging opslaan" message="U moet de huidige wijziging opslaan.
+Alle opgeslagen wijzigingen kunnen niet ongedaan worden gemaakt.
 
-		<MessageBox>
-			<!-- $INT_REPLACE$ is a place holder, don't translate it -->
-			<ContextMenuXmlEditWarning
-				title="Contextmenu wijzigen"
-				message="Met het wijzigen van het contextmenu kunt u Notepad++ aan uw persoonlijke voorkeur aanpassen.&#xD;&#xD;Wijzigingen worden zichtbaar na het opnieuw starten van Notepad++."
-			/>
-			<NppHelpAbsentWarning
-				title="Offline documentatie ontbreekt"
-				message="&#xD; is niet gevonden.&#xD;&#xD;Bezoek de website om de online documentatie te raadplegen."
-			/>
-			<SaveCurrentModifWarning
-				title="Bestand is gewijzigd"
-				message="Deze bewerking kan niet ongedaan worden gemaakt. Controleer of wijzigingen moeten worden opgeslagen.&#xD;&#xD;Wilt u toch doorgaan?"
-			/>
-			<LoseUndoAbilityWarning
-				title="Bewerking ongedaan maken niet mogelijk"
-				message="Deze bewerking kan niet ongedaan worden gemaakt.&#xD;&#xD;Doorgaan?"
-			/>
-			<CannotMoveDoc
-				title="Bestand verplaatsen niet mogelijk"
-				message="Dit bestand is gewijzigd. Sla het bestand op en probeer het opnieuw."
-			/>
-			<DocReloadWarning
-				title="Bestand opnieuw openen"
-				message="Weet u zeker dat u dit bestand opnieuw wilt openen?&#xD;&#xD;U verliest aangebrachte wijzigingen!"
-			/>
-			<FileLockedWarning
-				title="Bestand opslaan mislukt"
-				message="Dit bestand is mogelijk in gebruik door een ander programma.&#xD;&#xD;Sluit andere programma's en probeer het opnieuw."
-			/>
-			<FileAlreadyOpenedInNpp
-				title="Bestand is al geopend"
-				message="Dit bestand is al geopend in Notepad++."
-			/>
-			<DeleteFileFailed
-				title="Bestand verwijderen mislukt"
-				message="Er is een fout opgetreden bij het verwijderen van dit bestand."
-			/>
-			<NbFileToOpenImportantWarning
-				title="Bestand openen"
-				message="$INT_REPLACE$ bestanden worden geopend.&#xD;&#xD;Doorgaan?"
-			/>
-			<SettingsOnCloudError
-				title="Online opslaan mislukt"
-				message="Er is een fout opgetreden bij het schrijven naar de online opslaglocatie.&#xD;Controleer of het pad correct is opgegeven onder Voorkeuren."
-			/>
-			<FilePathNotFoundWarning
-				title="Bestand openen"
-				message="Het te openen bestand bestaat niet."
-			/>
-			<SessionFileInvalidError
-				title="Kan sessie niet laden"
-				message="Sessie bestand is beschadigd of ongeldig."
-			/>
-			<DroppingFolderAsProjectModeWarning
-				title="Ongeldige actie"
-				message="Omdat u zich in de Map-als-Werkomgeving modus bevindt, kunt U alleen bestanden of mappen neerzetten, niet allebei.&#xD;U moet &quot;Bij neerzetten alle bestanden uit de map openen ipv de map als werkomgeving te openen&quot; in&#xD;de &quot;Standaardlocatie&quot; sectie van het Voorkeuren dialoogvenster aanvinken om deze operatie te laten werken."
-			/>
-			<SortingError
-				title="Sorteerfout"
-				message="Niet in staat om numerieke sortering uit te voeren door lijn $INT_REPLACE$."
-			/>
-			<ColumnModeTip
-				title="Kolommodus Tip"
-				message="Gebruik &quot;ALT + Mouse Selectie&quot; of &quot;Alt + Shift + pijltjes toets&quot; om over te schakelen naar de kolommodus."
-			/>
-			<BufferInvalidWarning
-				title="Opslaan mislukt"
-				message="Kan niet opslaan: Buffer is ongeldig."
-			/>
-			<DoCloseOrNot
-				title="Bestand sluiten"
-				message="Het bestand &quot;$STR_REPLACE$&quot; bestaat niet meer.&#xD;Bewaar dit bestand in de editor?"
-			/>
-			<DoDeleteOrNot
-				title="Bestand verwijderen"
-				message="Het bestand &quot;$STR_REPLACE$&quot;&#xD; zal naar uw prullenbak worden verplaatst en het document zal worden gesloten.&#xD;Doorgaan?"
-			/>
-			<NoBackupDoSaveFile
-				title="Bestand opslaan"
-				message="Uw bestandsresevekopie kan niet worden gevonden (mogelijk van buitenaf verwijderd).&#xD;Sla het bestand op, anders zullen uw gegevens verloren gaan.&#xD;Wilt u bestand &quot;$STR_REPLACE$&quot; opslaan?"
-			/>
-			<DoReloadOrNot
-				title="Bestand opnieuw openen"
-				message="Het bestand&#xD;&quot;$STR_REPLACE$&quot;&#xD;is gewijzigd door een ander programma.&#xD;Wilt u het opnieuw laden?"
-			/>
-			<DoReloadOrNotAndLooseChange
-				title="Bestand opnieuw openen"
-				message="Het bestand&#xD;&quot;$STR_REPLACE$&quot;&#xD;is gewijzigd door een ander programma.&#xD;Wilt u het opnieuw laden en de wijzigingen die in Notepad++ zijn gemaakt verliezen?"
-			/>
-			<PrehistoricSystemDetected
-				title="Prehistorisch systeem gedetecteerd"
-				message="Het lijkt erop dat je nog steeds een prehistorisch systeem gebruikt. Deze functie werkt alleen op een modern systeem, sorry."
-			/>
-			<XpUpdaterProblem
-				title="Notepad++ Updater"
-				message="Notepad++ updater is niet compatibel met XP vanwege de verouderde beveiligingslaag onder XP.&#xD;Wilt u naar Notepad++ pagina gaan om de nieuwste versie te downloaden?"
-			/>
-			<GUpProxyConfNeedAdminMode
-				title="Proxyserver-instellingen"
-				message="Herstart Notepad++ in de beheerdersmodus om de Proxyserver-instellingen te wijzigen."
-			/>
-			<DocTooDirtyToMonitor
-				title="Bestandswijzigingen bewaak probleem"
-				message="Het document is gewijzigd. Bewaar de wijzigingen voordat u het bewaken van bestandswijzigingen activeert."
-			/>
-			<DocNoExistToMonitor
-				title="Bestandswijzigingen bewaak probleem"
-				message="Het bestand moet bestaan om voor wijzigingen te kunnen worden bewaakt."
-			/>
-			<FileTooBigToOpen
-				title="Bestandsgrootte probleem"
-				message="Bestand is te groot om te openen met Notepad++"
-			/>
-			<CreateNewFileOrNot
-				title="Nieuw bestand"
-				message="&quot;$STR_REPLACE$&quot; bestaat niet. Aanmaken?"
-			/>
-			<CreateNewFileError
-				title="Nieuw bestand"
-				message="Kan het bestand &quot;$STR_REPLACE$&quot; niet aanmaken."
-			/>
-			<OpenFileError
-				title="Bestand openen"
-				message="Kan bestand &quot;$STR_REPLACE$&quot; niet openen."
-			/>
-			<FileBackupFailed
-				title="Bestandsreserviekopie"
-				message="De vorige versie van het bestand kon niet worden opgeslagen in de reservekopiemap &quot;$STR_REPLACE$&quot;.&#xD;&#xD;Wilt u het huidige bestand toch opslaan?"
-			/>
-			<LoadStylersFailed
-				title="Opmaak voorkeuren"
-				message="Laden van &quot;$STR_REPLACE$&quot; mislukt!"
-			/>
-			<LoadLangsFailed
-				title="Taal voorkeuren"
-				message="Laden van &quot;langs.xml&quot; mislukt!&#xD;Wilt u uw &quot;langs.xml&quot; herstellen?"
-			/>
-			<LoadLangsFailedFinal
-				title="Taal voorkeuren"
-				message="Laden van &quot;langs.xml&quot; mislukt!"
-			/>
-			<FolderAsWorspaceSubfolderExists
-				title="Map als Werkomgeving"
-				message="Er bestaat een submap van de map die u wilt toevoegen.&#xD;Verwijder de submap voordat u map &quot;$STR_REPLACE$&quot; toevoegt."
-			/>
-			<ProjectPanelChanged
-				title="$STR_REPLACE$"
-				message="De werkomgeving is aangepast. Wilt u het opslaan?"
-			/>
-			<ProjectPanelChangedSaveError
-				title="$STR_REPLACE$"
-				message="Uw werkomgeving is niet opgeslagen."
-			/>
-			<ProjectPanelOpenDoSaveDirtyWsOrNot
-				title="Werkomgeving openen"
-				message="De huidige werkomgeving is aangepast. Wilt u het huidige project opslaan?"
-			/>
-			<ProjectPanelNewDoSaveDirtyWsOrNot
-				title="Nieuwe werkomgeving"
-				message="De huidige werkomgeving is aangepast. Wilt u het huidige project opslaan?"
-			/>
-			<ProjectPanelOpenFailed
-				title="Werkomgeving openen"
-				message="De werkomgeving kon niet worden geopend.&#xD;Het lijkt erop dat het te openen bestand geen geldig projectbestand is."
-			/>
-			<ProjectPanelRemoveFolderFromProject
-				title="Map uit project verwijderen"
-				message="De werkomgeving kon niet worden geopend.&#xD;Het lijkt erop dat het te openen bestand geen geldig projectbestand is."
-			/>
-			<ProjectPanelRemoveFileFromProject
-				title="Bestand uit project verwijderen"
-				message="Weet u zeker dat u dit bestand uit het project wilt verwijderen?"
-			/>
-			<ProjectPanelReloadError
-				title="Werkomgeving laden"
-				message="Kan het bestand om opnieuw te laden niet vinden."
-			/>
-			<ProjectPanelReloadDirty
-				title="Werkomgeving laden"
-				message="De huidige werkomgeving is aangepast. Herladen zal alle wijzigingen weggooien.&#xD;Wilt u doorgaan?"
-			/>
-			<UDLNewNameError
-				title="UDL Probleem"
-				message="Deze naam wordt gebruikt door een andere taal,&#xD;geef een andere naam."
-			/>
-			<UDLRemoveCurrentLang
-				title="Verwijder huidige taal"
-				message="Weet u het zeker?"
-			/>
-			<SCMapperDoDeleteOrNot
-				title="Weet u het zeker?"
-				message="Weet u zeker dat u deze sneltoets wilt verwijderen?"
-			/>
-			<FindCharRangeValueError
-				title="Waarde bereik probleem"
-				message="U moet een waarde tussen 0 en 255 geven."
-			/>
-			<OpenInAdminMode
-				title="Bestand opslaan"
-				message="Het bestand kan niet worden opgeslagen, het kan zijn beveiligd.&#xD; Wilt u Notepad++ starten in de beheerdersmodus?"
-			/>
-			<OpenInAdminModeWithoutCloseCurrent
-				title="Bestand opslaan"
-				message="Het bestand kan niet worden opgeslagen, het kan zijn beveiligd.&#xD; Wilt u Notepad++ starten in de beheerdersmodus?"
-			/>
-			<OpenInAdminModeFailed
-				title="Openen in beheerdersmodus mislukt"
-				message="Notepad++ kan niet worden geopend in de beheerdersmodus."
-			/>
-			<ViewInBrowser
-				title="Document bekijken in browser"
-				message="Applicatie niet gevonden op uw computer."
-			/>
-			<ExitToUpdatePlugins
-				title="Notepad++ afsluiten"
-				message="Notepad++ moet afsluiten om de update te voltooien.&#xD;Vervolgens zal Notepad++ opnieuw starten.&#xD;&#xD;Wilt u doorgaan?"
-			/>
-			<NeedToRestartToLoadPlugins
-				title="Notepad++ opnieuw starten"
-				message="Start Notepad++ opnieuw op om de geïnstalleerde plug-ins te activeren."
-			/>
+Doorgaan?"/> <!-- HowToReproduce: when you openned file is modified but unsaved yet, and you are changing file encoding. -->
+			<LoseUndoAbilityWarning title="Waarschuwing voor verlies van mogelijkheid tot ongedaan maken" message="U moet de huidige wijziging opslaan.
+Alle opgeslagen wijzigingen kunnen niet ongedaan worden gemaakt.
+
+Doorgaan?"/> <!-- HowToReproduce: when you openned file is modified and saved, then you are changing file encoding. -->
+			<CannotMoveDoc title="Verplaatsen naar nieuwe instantie van Notepad++" message="Document is gewijzigd. Sla het op en probeer het dan opnieuw."/> <!-- HowToReproduce: From your Notepad++ drag & drop a clean (not dirty) file to outside of Notepad++, another instance of Notepad++ will be created. Then from your first Notepad++ drag & drop an unsaved file to the new instance. -->
+			<DocReloadWarning title="Opnieuw laden" message="Weet u zeker dat u het huidige bestand opnieuw wilt laden en de wijzigingen die u in Notepad++ hebt gemaakt wilt verliezen?"/>
+			<FileLockedWarning title="Opslaan mislukt" message="Controleer of dit bestand in een ander programma is geopend"/>
+			<FileAlreadyOpenedInNpp title="" message="Het bestand is al geopend in Notepad++."/> <!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
+			<RenameTabTemporaryNameAlreadyInUse title="Naam wijzigen mislukt" message="De opgegeven naam is al in gebruik op een ander tabblad."/> <!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
+			<DeleteFileFailed title="Bestand verwijderen" message="Verwijderen van bestand mislukt"/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+
+			<NbFileToOpenImportantWarning title="Het aantal geopende bestanden is te groot" message="U staat op het punt om $INT_REPLACE$ bestanden te openen.
+Weet u zeker dat u ze wilt openen?"/> <!-- HowToReproduce: Check "Open all files of folder instead of launching Folder as Workspace on folder dropping" in "Default Directory" of Preferences dialog, then drop a folder which contains more then 200 files into Notepad++. -->
+			<SettingsOnCloudError title="Online instellingen" message="Het lijkt erop dat het pad van de online instellingen is ingesteld op een alleen-lezen-schijf,
+of op een map waarvoor privilege-rechten nodig zijn voor schrijftoegang.
+Uw online instellingen zullen geannuleerd worden. Stel een coherente waarde in via het voorkeurenvenster."/>
+			<FilePathNotFoundWarning title="Bestand openen" message="Het bestand dat u probeert te openen, bestaat niet."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<SessionFileInvalidError title="Kon sessie niet laden" message="Sessiebestand is beschadigd of ongeldig."/> <!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
+			<DroppingFolderAsProjectModeWarning title="Ongeldige actie" message="U kunt alleen bestanden of mappen neerzetten, maar niet allebei tegelijk, omdat u in projectmodus map neerzetten zit.
+U moet &quot;vij neerzetten van een map alle bestanden openen in plaats van de map als werkruimte te starten&quot; inschakelen in de sectie &quot;standaardmap&quot; van het voorkeurenvenster om deze handeling te laten werken."/>
+			<SortingError title="Sorteerfout" message="Kan numerieke sortering niet uitvoeren vanwege regel $INT_REPLACE$."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<ColumnModeTip title="Tip voor kolom-modus" message="Gebruik &quot;ALT+muisselectie&quot; of &quot;Alt+Shift+pijltoets&quot; om te wisselen naar kolom-modus."/>
+			<BufferInvalidWarning title="Opslaan mislukt" message="Kan niet opslaan: buffer is ongeldig."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<DoCloseOrNot title="Niet-bestaand bestand behouden" message="Het bestand &quot;$STR_REPLACE$&quot; bestaat niet meer.
+Dit bestand in de editor houden?"/>
+			<DoDeleteOrNot title="Bestand verwijderen" message="Het bestand &quot;$STR_REPLACE$&quot;
+zal naar uw prullenbak verplaatst worden en dit document zal gesloten worden.
+Doorgaan?"/>
+			<NoBackupDoSaveFile title="Opslaan" message="Uw back-upbestand kan niet teruggevonden (verwijderd van buitenaf).
+Als u het niet opslaat zullen uw gegevens verloren gaan.
+Wilt u bestand &quot;$STR_REPLACE$&quot; opslaan?"/>
+			<DoReloadOrNot title="Opnieuw laden" message="&quot;$STR_REPLACE$&quot;
+
+Dit bestand is gewijzigd door een ander programma.
+Wilt u het opnieuw laden?"/>
+			<DoReloadOrNotAndLooseChange title="Opnieuw laden" message="&quot;$STR_REPLACE$&quot;
+
+Dit bestand is gewijzigd door een ander programma.
+Wilt u het opnieuw laden en de wijzigingen gemaakt in Notepad++ verliezen?"/>
+			<PrehistoricSystemDetected title="Prehistorisch systeem gedetecteerd" message="Het lijkt erop dat u nog steeds een prehistorisch systeem gebruikt.Deze functie werkt alleen op een modern systeem, sorry."/> <!-- HowToReproduce: Launch "Document Map" under Windows XP. -->
+			<XpUpdaterProblem title="Notepad++ updater" message="Notepad++ updater is niet compatibel met XP vanwege de verouderde beveiligingslaag onder XP.
+Wilt u naar de Notepad++-pagina gaan om de laatste versie te downloaden?"/> <!-- HowToReproduce: Run menu "? -> Update Notepad++" under Windows XP. -->
+			<GUpProxyConfNeedAdminMode title="Proxy-instellingen" message="Start Notepad++ opnieuw in beheerdersmodus om de proxy te configureren."/>
+			<DocTooDirtyToMonitor title="Monitoring-probleem" message="Het document is vervuild. Sla de wijziging op voordat u het monitort."/>
+			<DocNoExistToMonitor title="Monitoring-probleem" message="Het bestand moet bestaan om gemonitord te worden."/>
+			<FileTooBigToOpen title="Probleem met bestandsgrootte" message="Het bestand is te groot om te worden geopend met Notepad++"/> <!-- HowToReproduce: Try to open a 4GB file (it's not easy to reproduce, it depends on your system). -->
+			<CreateNewFileOrNot title="Nieuw bestand aanmaken" message="&quot;$STR_REPLACE$&quot; bestaat niet. Bestand aanmaken?"/>
+			<CreateNewFileError title="Nieuw bestand aanmaken" message="Kan bestand &quot;$STR_REPLACE$&quot; niet aanmaken."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<OpenFileError title="FOUT" message="Kan bestand &quot;$STR_REPLACE$&quot; niet openen."/>
+			<FileBackupFailed title="Back-up van bestand mislukt" message="De vorige versie van het bestand kon niet worden opgeslagen in de back-upmap in &quot;$STR_REPLACE$&quot;.
+
+Wilt u het huidige bestand toch opslaan?"/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<LoadStylersFailed title="Laden van stylers.xml mislukt" message="Laden van &quot;$STR_REPLACE$&quot; mislukt!"/>
+			<LoadLangsFailed title="Configurator" message="Laden van langs.xml mislukt!
+Wilt u uw langs.xml herstellen?"/> <!-- HowToReproduce: Close Notepad++. Use another editor to remove all content of "langs.xml" (0 length) then save it. Open Notepad++. -->
+			<LoadLangsFailedFinal title="Configurator" message="Laden van langs.xml mislukt!"/> <!-- HowToReproduce: Close Notepad++. Use another editor to make "langs.xml" an invalid xml file then save it. Open Notepad++. -->
+			<FolderAsWorspaceSubfolderExists title="Probleem met toevoegen van map bij map als werkruimte" message="Er bestaat een submap van de map die u wilt toevoegen.
+Verwijder zijn hoofdmap van het venster voordat u map &quot;$STR_REPLACE$&quot; toevoegt."/> <!-- HowToReproduce: Add a folder like "c:\temp\aFolder\" into "Folder as Workspace" panel, then try to add "c:\temp\". -->
+
+			<ProjectPanelChanged title="$STR_REPLACE$" message="De werkruimte is gewijzigd. Wilt u ze opslaan?"/>
+			<ProjectPanelChangedSaveError title="$STR_REPLACE$" message="Uw werkruimte is niet opgeslagen."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<ProjectPanelOpenDoSaveDirtyWsOrNot title="Werkruimte openen" message="De huidige werkruimte is gewijzigd. Wilt u het huidige project opslaan?"/>
+			<ProjectPanelNewDoSaveDirtyWsOrNot title="Nieuwe werkruimte" message="De huidige werkruimte is gewijzigd. Wilt u het huidige project opslaan?"/>
+			<ProjectPanelOpenFailed title="Werkruimte openen" message="De werkruimte kon niet geopend worden.
+Het lijkt erop dat het te openen bestand geen geldig projectbestand is."/>
+			<ProjectPanelRemoveFolderFromProject title="Map verwijderen uit project" message="Alle onderliggende items zullen verwijderd worden.
+Weet u zeker dat u deze map uit het project wilt verwijderen?"/>
+			<ProjectPanelRemoveFileFromProject title="Bestand verwijderen uit project" message="Weet u zeker dat u dit bestand uit het project wilt verwijderen?"/>
+			<ProjectPanelReloadError title="Werkruimte opnieuw laden" message="Kan het bestand om opnieuw te laden niet terugvinden."/>
+			<ProjectPanelReloadDirty title="Werkruimte opnieuw laden" message="De huidige werkruimte is gewijzigd. Opnieuw laden zal alle wijzigingen weggooien.
+Wilt u doorgaan?"/>
+			<UDLNewNameError title="UDL-fout" message="Deze naam wordt gebruikt door een andere taal.
+Geef een andere naam op."/>
+			<UDLRemoveCurrentLang title="Huidige taal verwijderen" message="Weet u het zeker?"/>
+			<SCMapperDoDeleteOrNot title="Weet u het zeker?" message="Weet u zeker dat u deze snelkoppeling wilt verwijderen?"/>
+			<FindCharRangeValueError title="Probleem met bereik van waarde" message="U moet een waarde opgeven tussen 0 en 255."/>
+			<OpenInAdminMode title="Opslaan mislukt" message="Het bestand kan niet opgeslagen worden en kan beveiligd zijn.
+Wilt u Notepad++ starten in beheerdersmodus?"/>
+			<OpenInAdminModeWithoutCloseCurrent title="Opslaan mislukt" message="Het bestand kan niet opgeslagen worden en kan beveiligd zijn.
+Wilt u Notepad++ starten in beheerdersmodus?"/>
+			<OpenInAdminModeFailed title="Openen in beheerdersmodus mislukt" message="Notepad++ kan niet geopend worden in beheerdersmodus."/> <!-- HowToReproduce: When you have no Admin privilege and you try to save a modified file in a protected location (for example: any file in sub-folder of "C:\Program Files\". This message will appear after replying "Yes" to "Open in Admin mode" dialog. -->
+			<ViewInBrowser title="Huidig bestand in browser weergeven" message="Toepassing kan niet op uw systeem worden teruggevonden."/>
+			<ExitToUpdatePlugins title="Notepad++ staat op het punt om af te sluiten" message="Als u op 'ja' klikt, zal u Notepad++ afsluiten om de acties verder te zetten.
+Notepad++ zal opnieuw starten nadat alle acties afgewerkt zijn.
+Doorgaan?"/>
+			<NeedToRestartToLoadPlugins title="Notepad++ moet opnieuw gestart worden" message="U moet Notepad++ opnieuw starten om de geïnstalleerde plug-ins te laden."/> <!-- HowToReproduce: Import a plugin via menu "Settings->Import->Import Plugin(s)...". -->
 		</MessageBox>
-
 		<ClipboardHistory>
-			<PanelTitle name="Klembord"/>
+			<PanelTitle name="Geschiedenis van klembord"/>
 		</ClipboardHistory>
 		<DocSwitcher>
 			<PanelTitle name="Documentenlijst"/>
 			<ColumnName name="Naam"/>
-			<ColumnExt  name="Ext."/>
+			<ColumnExt name="Ext."/>
 		</DocSwitcher>
 		<WindowsDlg>
 			<ColumnName name="Naam"/>
 			<ColumnPath name="Pad"/>
 			<ColumnType name="Type"/>
 			<ColumnSize name="Grootte"/>
+			<NbDocsTotal name="totaal aantal documenten:"/>
 		</WindowsDlg>
 		<AsciiInsertion>
-			<PanelTitle name="ASCII-karakters / HTML-entiteiten"/>
-			<ColumnVal  name="Dec"/>
-			<ColumnHex  name="Hex"/>
-			<ColumnChar name="Karakter"/>
-			<ColumnHtmlNumber name="Entiteitnummer"/>
-			<ColumnHtmlName name="Entiteitnaam"/>
+			<PanelTitle name="ASCII-tekens / HTML-entiteiten"/>
+			<ColumnVal name="Dec"/>
+			<ColumnHex name="Hex"/>
+			<ColumnChar name="Teken"/>
+			<ColumnHtmlNumber name="HTML-nummer"/>
+			<ColumnHtmlName name="HTML-code"/>
 		</AsciiInsertion>
 		<DocumentMap>
-			<PanelTitle name="Documentstructuur"/>
+			<PanelTitle name="Overzichtskaart van document"/>
 		</DocumentMap>
 		<FunctionList>
 			<PanelTitle name="Functielijst"/>
-			<SortTip    name="Sorteren"/>
-			<ReloadTip  name="Opnieuw laden"/>
+			<SortTip name="Sorteren"/>
+			<ReloadTip name="Opnieuw laden"/>
 		</FunctionList>
 		<FolderAsWorkspace>
-			<PanelTitle name="Map als Werkomgeving"/>
-			<SelectFolderFromBrowserString name="Selecteer een map om toe te voegen aan het Map-als-Werkomgeving paneel"/>
+			<PanelTitle name="Map als Werkruimte"/>
+			<SelectFolderFromBrowserString name="Selecteer een map om toe te voegen aan het paneel map-als-werkruimte"/>
+			<ExpandAllFoldersTip name="Alle mappen uitvouwen"/>
+			<CollapseAllFoldersTip name="Alle mappen samenvouwen"/>
+			<LocateCurrentFileTip name="Huidig bestand lokaliseren"/>
 			<Menus>
 				<Item id="3511" name="Verwijderen"/>
 				<Item id="3512" name="Alles verwijderen"/>
 				<Item id="3513" name="Toevoegen"/>
-				<Item id="3514" name="Uitvoeren"/>
+				<Item id="3514" name="Uitvoeren via systeem"/>
 				<Item id="3515" name="Openen"/>
-				<Item id="3516" name="Kopieer pad"/>
-				<Item id="3517" name="Zoek in bestanden..."/>
-				<Item id="3518" name="Locatie openen in Windows Verkenner"/>
+				<Item id="3516" name="Pad kopiëren"/>
+				<Item id="3517" name="Zoeken in bestanden..."/>
+				<Item id="3518" name="Locatie openen in Verkenner"/>
 				<Item id="3519" name="Locatie openen in opdrachtprompt"/>
 				<Item id="3520" name="Bestandsnaam kopiëren"/>
 			</Menus>
 		</FolderAsWorkspace>
 		<ProjectManager>
-			<PanelTitle        name="Project"/>
-			<WorkspaceRootName name="Werkmap"/>
-			<NewProjectName    name="Nieuw project"/>
-			<NewFolderName     name="Nieuwe map"/>
+			<PanelTitle name="Project"/>
+			<WorkspaceRootName name="Werkruimte"/>
+			<NewProjectName name="Projectnaam"/>
+			<NewFolderName name="Mapnaam"/>
 			<Menus>
 				<Entries>
-					<Item id="0" name="Werkmap"/>
-					<Item id="1" name="Aanpassen..."/>
+					<Item id="0" name="Werkruimte"/>
+					<Item id="1" name="Bewerken"/>
 				</Entries>
 				<WorkspaceMenu>
-					<Item id="3122" name="Nieuw"/>
-					<Item id="3123" name="Openen"/>
-					<Item id="3124" name="Opnieuw openen"/>
+					<Item id="3122" name="Nieuwe werkruimte"/>
+					<Item id="3123" name="Werkruimte openen"/>
+					<Item id="3124" name="Werkruimte opnieuw laden"/>
 					<Item id="3125" name="Opslaan"/>
 					<Item id="3126" name="Opslaan als..."/>
-					<Item id="3127" name="Kopie opslaan..."/>
-					<Item id="3121" name="Project toevoegen"/>
+					<Item id="3127" name="Kopie opslaan als..."/>
+					<Item id="3121" name="Nieuw project toevoegen"/>
 				</WorkspaceMenu>
 				<ProjectMenu>
 					<Item id="3111" name="Naam wijzigen"/>
 					<Item id="3112" name="Map toevoegen"/>
 					<Item id="3113" name="Bestanden toevoegen..."/>
-					<Item id="3117" name="Mappenstructuur toevoegen..."/>
+					<Item id="3117" name="Bestanden uit map toevoegen..."/>
 					<Item id="3114" name="Verwijderen"/>
 					<Item id="3118" name="Omhoog verplaatsen"/>
 					<Item id="3119" name="Omlaag verplaatsen"/>
@@ -1311,15 +1285,15 @@
 					<Item id="3111" name="Naam wijzigen"/>
 					<Item id="3112" name="Map toevoegen"/>
 					<Item id="3113" name="Bestanden toevoegen..."/>
+					<Item id="3117" name="Bestanden uit map toevoegen..."/>
 					<Item id="3114" name="Verwijderen"/>
-					<Item id="3117" name="Mappenstructuur toevoegen..."/>
 					<Item id="3118" name="Omhoog verplaatsen"/>
 					<Item id="3119" name="Omlaag verplaatsen"/>
 				</FolderMenu>
 				<FileMenu>
 					<Item id="3111" name="Naam wijzigen"/>
 					<Item id="3115" name="Verwijderen"/>
-					<Item id="3116" name="Bestandslocatie wijzigen..."/>
+					<Item id="3116" name="Bestandspad wijzigen"/>
 					<Item id="3118" name="Omhoog verplaatsen"/>
 					<Item id="3119" name="Omlaag verplaatsen"/>
 				</FileMenu>
@@ -1327,231 +1301,101 @@
 		</ProjectManager>
 		<MiscStrings>
 			<!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders -->
-			<word-chars-list-tip
-				value="Hiermee kan een extra teken aan de huidige woordtekenlijst worden toegevoegd. Deze lijst bepaalt wat als woord wordt gezien bij dubbelklik op een selectie en bij het zoeken met de &quot;Losse woorden&quot;-optie aangevinkt."
-			/>
-			<word-chars-list-warning-begin
-				value="Let op: "
-			/>
-			<word-chars-list-space-warning
-				value="$INT_REPLACE$ spatie(s)"
-			/>
-			<word-chars-list-tab-warning
-				value="$INT_REPLACE$ tab(s)"
-			/>
-			<word-chars-list-warning-end
-				value="  in de woordtekenlijst."
-			/>
-			<cloud-invalid-warning
-				value="Ongeldig pad."
-			/>
-			<cloud-restart-warning
-				value="Start Notepad++ opnieuw op om de instellingen te activeren."
-			/>
-			<cloud-select-folder
-				value="Selecteer een map waar Notepad++ instellingen leest en opslaat"
-			/>
-			<shift-change-direction-tip
-				value="Gebruik Shift + Enter om in omgekeerde richting te zoeken"
-			/>
-			<two-find-buttons-tip
-				value="2-zoek-knoppen modus"
-			/>
-			<find-in-files-filter-tip
-				value="In cpp, cxx, hpp en hxx bestanden zoeken:&#xD;*.cpp *.cxx *.hpp *.hxx&#xD;&#xD;In alle bestanden behalve exe, obj en log zoeken:&#xD;*.* !*.exe !*.obj !*.log"
-			/>
-			<find-status-top-reached
-				value="Zoeken: 1ste locatie vanuit document einde gevonden. De start van het document is gepasseerd."
-			/>
-			<find-status-end-reached
-				value="Zoeken: 1ste locatie vanuit document begin gevonden. Het einde van het document is gepasseerd."
-			/>
-			<find-status-replaceinfiles-1-replaced
-				value="Vervangen in bestanden: Tekst is op 1 locatie vervangen"
-			/>
-			<find-status-replaceinfiles-nb-replaced
-				value="Vervangen in bestanden: Tekst is op $INT_REPLACE$ locaties vervangen"
-			/>
-			<find-status-replaceinfiles-re-malformed
-				value="Vervangen in geopende bestanden: De reguliere expressie is misvormd"
-			/>
-			<find-status-replaceinopenedfiles-1-replaced
-				value="Vervangen in geopende bestanden: Tekst is op 1 locatie vervangen"
-			/>
-			<find-status-replaceinopenedfiles-nb-replaced
-				value="Vervangen in geopende bestanden: Tekst is op $INT_REPLACE$ locaties vervangen"
-			/>
-			<find-status-mark-re-malformed
-				value="Markeren: De reguliere expressie is misvormd"
-			/>
-			<find-status-invalid-re
-				value="Zoeken: De reguliere expressie is misvormd"
-			/>
-			<find-status-mark-1-match
-				value="1 locatie gevonden"
-			/>
-			<find-status-mark-nb-matches
-				value="$INT_REPLACE$ locaties gevonden"
-			/>
-			<find-status-count-re-malformed
-				value="Tellen: De reguliere expressie is misvormd"
-			/>
-			<find-status-count-1-match
-				value="Tellen: Tekst is op 1 locatie gevonden"
-			/>
-			<find-status-count-nb-matches
-				value="Tellen: Tekst is op $INT_REPLACE$ locaties gevonden"
-			/>
-			<find-status-replaceall-re-malformed
-				value="Alle vervangen: De reguliere expressie is misvormd"
-			/>
-			<find-status-replaceall-1-replaced
-				value="Alle vervangen: Tekst is op 1 locatie vervangen"
-			/>
-			<find-status-replaceall-nb-replaced
-				value="Alle vervangen: Tekst is op $INT_REPLACE$ locaties vervangen"
-			/>
-			<find-status-replaceall-readonly
-				value="Alle vervangen: Kan tekst niet vervangen. Huidige document heeft alleen-lezen modus"
-			/>
-			<find-status-replace-end-reached
-				value="Vervangen: Tekst is op 1 locatie vervangen. Einde van het document is gepasseerd"
-			/>
-			<find-status-replace-top-reached
-				value="Vervangen: Tekst is op 1 locatie vervangen. Start van het document is gepasseerd"
-			/>
-			<find-status-replaced-next-found
-				value="Vervangen: Tekst is op 1 locatie vervangen. Nieuwe locatie gevonden"
-			/>
-			<find-status-replaced-next-not-found
-				value="Vervangen: Tekst is op 1 locatie vervangen. Geen nieuwe locatie gevonden"
-			/>
-			<find-status-replace-not-found
-				value="Vervangen: Tekst niet gevonden"
-			/>
-			<find-status-replace-readonly
-				value="Vervangen: Kan tekst niet vervangen. Huidige document heeft alleen-lezen modus"
-			/>
-			<find-status-cannot-find
-				value="Zoeken: Kan tekst &quot;$STR_REPLACE$&quot; niet vinden"
-			/>
-			<finder-find-in-finder
-				value="Zoek in deze zoekresultaten..."
-			/>
-			<finder-close-this
-				value="Sluit deze zoekresultaten"
-			/>
-			<finder-collapse-all
-				value="Alle samenvouwen"
-			/>
-			<finder-uncollapse-all
-				value="Alle uitvouwen"
-			/>
-			<finder-copy
-				value="Kopiëren"
-			/>
-			<finder-select-all
-				value="Alle selecteren"
-			/>
-			<finder-clear-all
-				value="Alle wissen"
-			/>
-			<finder-open-all
-				value="Alle openen"
-			/>
-			<common-ok
-				value="OK"
-			/>
-			<common-cancel
-				value="Annuleren"
-			/>
-			<common-name
-				value="Naam: "
-			/>
-			<tabrename-title
-				value="Huidige tab hernoemen"
-			/>
-			<tabrename-newname
-				value="Nieuwe naam: "
-			/>
-			<recent-file-history-maxfile
-				value="Max. bestand: "
-			/>
-			<language-tabsize
-				value="Tabgrootte: "
-			/>
-			<userdefined-title-new
-				value="Nieuwe syntaxis aanmaken..."
-			/>
-			<userdefined-title-save
-				value="Huidige syntaxis opslaan als..."
-			/>
-			<userdefined-title-rename
-				value="Huidige syntaxis hernoemen"
-			/>
-			<autocomplete-nb-char
-				value="Karakters: "
-			/>
-			<edit-verticaledge-nb-col
-				value="Kolommen: "
-			/>
-			<summary
-				value="Documentinformatie"
-			/>
-			<summary-filepath
-				value="Bestandsnaam: "
-			/>
-			<summary-filecreatetime
-				value="Gemaakt: "
-			/>
-			<summary-filemodifytime
-				value="Gewijzigd: "
-			/>
-			<summary-nbchar
-				value="Lettertekens: "
-			/>
-			<summary-nbword
-				value="Woorden: "
-			/>
-			<summary-nbline
-				value="Regels: "
-			/>
-			<summary-nbbyte
-				value="Documentgrootte: "
-			/>
-			<summary-nbsel1
-				value=" geselecteerde tekens ("
-			/>
-			<summary-nbsel2
-				value=" bytes) in "
-			/>
-			<summary-nbrange
-				value=" selecties"
-			/>
-			<replace-in-files-confirm-title
-				value="Vervanging bevestigen"
-			/>
-			<replace-in-files-confirm-directory
-				value="Wilt u alle locaties vervangen in: "
-			/>
-			<replace-in-files-confirm-filetype
-				value="Voor bestandstype: "
-			/>
-			<find-result-caption
-				value="Zoekresultaten"
-			/>
-			<find-result-title
-				value="Zoeken"
-			/>
-			<find-result-title-info
-				value="($INT_REPLACE1$ treffers in $INT_REPLACE2$ uit $INT_REPLACE3$ bestanden)"
-			/>
-			<find-result-title-info-extra
-				value=" - Regelfiltermodus: alleen treffers tonen"
-			/>
-			<find-result-hits
-				value="($INT_REPLACE$ treffers)"
-			/>
+			<word-chars-list-tip value="Hiermee kan een extra teken aan de huidige woordtekenlijst worden toegevoegd. Deze lijst bepaalt wat als woord wordt gezien bij dubbelklikken op een selectie en bij het zoeken met de optie &quot;volledige woorden&quot; aangevinkt."/> <!-- HowToReproduce: In "Delimiter" section of Preferences dialog, hover your mouse on the "?" button. -->
+
+			<word-chars-list-warning-begin value="Let op: "/>
+			<word-chars-list-space-warning value="$INT_REPLACE$ spatie(s)"/>
+			<word-chars-list-tab-warning value="$INT_REPLACE$ tab(s)"/>
+			<word-chars-list-warning-end value="  in de woordtekenlijst."/> <!-- HowToReproduce: In "Delimiter" section of Preferences dialog, check "Add your character as part of word\r(don't choose it unless you know what you're doing)", then type a white-space in the text field. -->
+			<cloud-invalid-warning value="Ongeldig pad."/>
+			<cloud-restart-warning value="Start Notepad++ opnieuw op om de instellingen door te voeren."/>
+			<cloud-select-folder value="Selecteer een map waar Notepad++ instellingen leest en opslaat"/><!-- HowToReproduce: In "Cloud" section of Preferences dialog, check "Set your cloud location path here: ", then click the button "...". This message is displayed in the "Browse For Folder" dialog. -->
+			<shift-change-direction-tip value="Gebruik Shift + Enter om in omgekeerde richting te zoeken"/>
+			<two-find-buttons-tip value="modus met 2-zoekknoppen"/>
+			<find-in-files-filter-tip value="In cpp, cxx, h, hxx en hpp- bestanden zoeken:
+*.cpp *.cxx *.h *.hxx *.hpp
+
+In alle bestanden behalve exe, obj en log zoeken:
+*.* !*.exe !*.obj !*.log"/> <!-- HowToReproduce: Tip of mouse hovered on "Filters" label in "Find in Files" secction of Find dialog. -->
+			<find-status-top-reached value="Zoeken: eerste overeenkomst vanaf einde van document gevonden. Het begin van het document is bereikt."/>
+			<find-status-end-reached value="Zoeken: eerste overeenkomst vanaf begin van document gevonden. Het einde van het document is bereikt."/>
+			<find-status-replaceinfiles-1-replaced value="Vervangen in bestanden: 1 overeenkomst vervangen"/>
+			<find-status-replaceinfiles-nb-replaced value="Vervangen in bestanden: $INT_REPLACE$ overeenkomsten vervangen"/>
+			<find-status-replaceinfiles-re-malformed value="Vervangen in geopende bestanden: de reguliere expressie is misvormd"/>
+			<find-status-replaceinopenedfiles-1-replaced value="Vervangen in geopende bestanden: 1 overeenkomst vervangen"/>
+			<find-status-replaceinopenedfiles-nb-replaced value="Vervangen in geopende bestanden: $INT_REPLACE$ overeenkomsten vervangen"/>
+			<find-status-mark-re-malformed value="Markeren: de reguliere expressie om te zoeken is misvormd"/>
+			<find-status-invalid-re value="Zoeken: ongeldige reguliere expressie"/>
+			<find-status-mark-1-match value="Markeren: 1 overeenkomst"/>
+			<find-status-mark-nb-matches value="Markeren: $INT_REPLACE$ overeenkomsten"/>
+			<find-status-count-re-malformed value="Tellen: de reguliere expressie om te zoeken is misvormd"/>
+			<find-status-count-1-match value="Tellen: 1 overeenkomst"/>
+			<find-status-count-nb-matches value="Tellen: $INT_REPLACE$ overeenkomsten"/>
+			<find-status-replaceall-re-malformed value="Alles vervangen: de reguliere expressie is misvormd"/>
+			<find-status-replaceall-1-replaced value="Alles vervangen: 1 overeenkomst vervangen"/>
+			<find-status-replaceall-nb-replaced value="Alles vervangen: $INT_REPLACE$ overeenkomsten vervangen"/>
+			<find-status-replaceall-readonly value="Alles vervangen: kan tekst niet vervangen. Huidig document is alleen-lezen"/>
+			<find-status-replace-end-reached value="Vervangen: eerste overeenkomst vanaf begin van document vervangen. Het einde van het document is bereikt"/>
+			<find-status-replace-top-reached value="Vervangen: eerste overeenkomst vanaf einde van document vervangen. Het begin van het document is bereikt"/>
+			<find-status-replaced-next-found value="Vervangen: 1 overeenkomst vervangen. Volgende overeenkomst gevonden"/>
+			<find-status-replaced-next-not-found value="Vervangen: 1 overeenkomst vervangen. Geen nieuwe overeenkomsten gevonden"/>
+			<find-status-replace-not-found value="Vervangen: geen overeenkomst gevonden"/>
+			<find-status-replace-readonly value="Vervangen: kan tekst niet vervangen. Huidig document is alleen-lezen"/>
+			<find-status-cannot-find value="Zoeken: kan tekst &quot;$STR_REPLACE$&quot; niet vinden"/>
+			<find-status-scope-selection value="in geselecteerde tekst"/>
+			<find-status-scope-all value="in volledig bestand"/>
+			<find-status-scope-backward value="vanaf begin van bestand tot cursor"/>
+			<find-status-scope-forward value="vanaf cursor naar einde van bestand"/>
+			<finder-find-in-finder value="Zoeken in deze zoekresultaten..."/>
+			<finder-close-this value="Deze zoekresultaten sluiten"/>
+			<finder-collapse-all value="Alles samenvouwen"/>
+			<finder-uncollapse-all value="Alles uitvouwen"/>
+			<finder-copy value="Geselecteerde regel(s) kopiëren"/>
+			<finder-copy-verbatim value="Kopiëren"/>
+			<finder-select-all value="Alles selecteren"/>
+			<finder-clear-all value="Alles wissen"/>
+			<finder-open-all value="Alles openen"/>
+			<finder-wrap-long-lines value="Lange regels laten teruglopen"/>
+			<common-ok value="Ok"/>
+			<common-cancel value="Annuleren"/>
+			<common-name value="Naam: "/>
+			<tabrename-title value="Huidige tab hernoemen"/>
+			<tabrename-newname value="Nieuwe naam: "/>
+			<recent-file-history-maxfile value="Max. bestanden: "/>
+			<language-tabsize value="Tabgrootte: "/>
+			<userdefined-title-new value="Nieuwe syntaxis aanmaken..."/>
+			<userdefined-title-save value="Huidige syntaxis opslaan als..."/>
+			<userdefined-title-rename value="Huidige syntaxis hernoemen"/>
+			<autocomplete-nb-char value="Tekens: "/>
+			<edit-verticaledge-nb-col value="Kolommen:"/>
+			<summary value="Documentinformatie"/>
+			<summary-filepath value="Volledig bestandspad: "/>
+			<summary-filecreatetime value="Aangemaakt: "/>
+			<summary-filemodifytime value="Gewijzigd: "/>
+			<summary-nbchar value="Tekens (zonder regeleindes): "/>
+			<summary-nbword value="Woorden: "/>
+			<summary-nbline value="Regels: "/>
+			<summary-nbbyte value="Documentlengte: "/>
+			<summary-nbsel1 value=" geselecteerde tekens ("/>
+			<summary-nbsel2 value=" bytes) in "/>
+			<summary-nbrange value=" selecties"/>
+			<find-in-files-progress-title value="Voortgang van zoeken in bestanden..."/>
+			<replace-in-files-confirm-title value="Weet u het zeker?"/>
+			<replace-in-files-confirm-directory value="Wilt u alle overeenkomsten vervangen in: "/>
+			<replace-in-files-confirm-filetype value="Voor bestandstype:"/>
+			<replace-in-files-progress-title value="Voortgang van vervangen in bestanden..."/>
+			<replace-in-open-docs-confirm-title value="Weet u het zeker?"/>
+			<replace-in-open-docs-confirm-message value="Weet u zeker dat u alle overeenkomsten in alle geopende documenten wilt vervangen?"/>
+			<find-result-caption value="Zoekresultaten"/>
+			<find-result-title value="Zoeken"/> <!-- Must not begin with space or tab character -->
+			<find-result-title-info value="($INT_REPLACE1$ overeenkomsten in $INT_REPLACE2$ uit $INT_REPLACE3$ bestanden)"/>
+			<find-result-title-info-selections value="($INT_REPLACE1$ overeenkomsten in $INT_REPLACE2$ selecties van $INT_REPLACE3$ doorzocht)"/>
+			<find-result-title-info-extra value=" - Regelfiltermodus: alleen gefilterde resultaten weergeven"/>
+			<find-result-hits value="($INT_REPLACE$ overeenkomsten)"/>
+			<find-result-line-prefix value="Regel"/> <!-- Must not begin with space or tab character -->
+			<find-regex-zero-length-match value="nullengte-overeenkomst" />
+			<session-save-folder-as-workspace value="Map als werkruimte opslaan" />
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>
+


### PR DESCRIPTION
- Add and translate missing strings for Notepad++ version 7.9.3 Dutch translation
- synchronize lay-out of Dutch file with English source file to make future comparison in WinMerge easier
- complete re-check and update of all translations
- indentations between English source and Dutch translations are still different

replaces #9461 and #9439

@donho How can the indentations be changed in an official way? See attached WinMerge reports.

- Dutch vs English (indentation mismatch) - used for this pull request
- Dutch vs English (indentation match) - not accepted for pull request (#9461)

[WinMerge report Dutch vs English (indentation differences).zip](https://github.com/notepad-plus-plus/notepad-plus-plus/files/5887441/WinMerge.report.Dutch.vs.English.indentation.differences.zip)
