### PR TITLE
Show a tooltip for the close tab menu item

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1392,6 +1392,7 @@ Find in all files except exe, obj &amp;&amp; log:
             <find-result-line-prefix value="Line"/> <!-- Must not begin with space or tab character -->
             <find-regex-zero-length-match value="zero length match" />
             <session-save-folder-as-workspace value="Save Folder as Workspace" />
+            <menu-close-tab value="Close active tab" />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1275,3 +1275,39 @@ int nbDigitsFromNbLines(size_t nbLines)
 	}
 	return nbDigits;
 }
+
+int findMenuItem(HMENU hmenu, UINT id)
+{
+	const int itemCount = ::GetMenuItemCount(hmenu);
+	for (int i = 0; i < itemCount; ++i)
+	{
+		if (::GetMenuItemID(hmenu, i) == id)
+			return i;
+	}
+	return -1;
+}
+
+RECT getDisplayRect(HWND hwnd)
+{
+	RECT fullscreenArea;
+	
+	//Preset view area, in case something fails, primary monitor values
+	fullscreenArea.top = 0;
+	fullscreenArea.left = 0;
+	fullscreenArea.right = GetSystemMetrics(SM_CXSCREEN);
+	fullscreenArea.bottom = GetSystemMetrics(SM_CYSCREEN);
+
+	HMONITOR currentMonitor;	//Handle to monitor where fullscreen should go
+	MONITORINFO mi{};			//Info of that monitor
+	//Caution, this will not work on windows 95, so probably add some checking of some sorts like Unicode checks, IF 95 were to be supported
+	currentMonitor = ::MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);	//should always be valid monitor handle
+	mi.cbSize = sizeof(MONITORINFO);
+	if (::GetMonitorInfo(currentMonitor, &mi) != FALSE)
+	{
+		fullscreenArea = mi.rcMonitor;
+		fullscreenArea.right -= fullscreenArea.left;
+		fullscreenArea.bottom -= fullscreenArea.top;
+	}
+
+	return fullscreenArea;
+}

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -73,6 +73,13 @@ std::vector<generic_string> tokenizeString(const generic_string & tokenString, c
 
 void ClientRectToScreenRect(HWND hWnd, RECT* rect);
 void ScreenRectToClientRect(HWND hWnd, RECT* rect);
+inline bool isInRect(const RECT& rect, int x, int y)
+{
+	return x > rect.left && y > rect.top && x < rect.right && y < rect.bottom;
+}
+
+// Returns bounds for the display that the window belongs to
+RECT getDisplayRect(HWND hwnd);
 
 std::wstring string2wstring(const std::string & rString, UINT codepage);
 std::string wstring2string(const std::wstring & rwString, UINT codepage);
@@ -226,3 +233,6 @@ template<typename T> size_t vecRemoveDuplicates(std::vector<T>& vec, bool isSort
 void trim(generic_string& str);
 
 int nbDigitsFromNbLines(size_t nbLines);
+
+// Returns menu item position by id or -1
+int findMenuItem(HMENU hmenu, UINT id);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5148,27 +5148,7 @@ void Notepad_plus::fullScreenToggle()
 		_beforeSpecialView._winPlace.length = sizeof(_beforeSpecialView._winPlace);
 		::GetWindowPlacement(_pPublicInterface->getHSelf(), &_beforeSpecialView._winPlace);
 
-		RECT fullscreenArea;		//RECT used to calculate window fullscreen size
-		//Preset view area, in case something fails, primary monitor values
-		fullscreenArea.top = 0;
-		fullscreenArea.left = 0;
-		fullscreenArea.right = GetSystemMetrics(SM_CXSCREEN);
-		fullscreenArea.bottom = GetSystemMetrics(SM_CYSCREEN);
-
-		//if (_winVersion != WV_NT)
-		{
-			HMONITOR currentMonitor;	//Handle to monitor where fullscreen should go
-			MONITORINFO mi;				//Info of that monitor
-			//Caution, this will not work on windows 95, so probably add some checking of some sorts like Unicode checks, IF 95 were to be supported
-			currentMonitor = ::MonitorFromWindow(_pPublicInterface->getHSelf(), MONITOR_DEFAULTTONEAREST);	//should always be valid monitor handle
-			mi.cbSize = sizeof(MONITORINFO);
-			if (::GetMonitorInfo(currentMonitor, &mi) != FALSE)
-			{
-				fullscreenArea = mi.rcMonitor;
-				fullscreenArea.right -= fullscreenArea.left;
-				fullscreenArea.bottom -= fullscreenArea.top;
-			}
-		}
+		RECT fullscreenArea = getDisplayRect(_pPublicInterface->getHSelf());
 
 		//Setup GUI
         int bs = buttonStatus_fullscreen;

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
@@ -206,11 +206,9 @@ private:
 	BOOL					_beginDrag;
 
 	// Is tooltip
-	BOOL					_bTabTTHover;
 	INT						_iLastHovered;
 
 	BOOL					_bCaptionTT;
-	BOOL					_bCapTTHover;
 	eMousePos				_hoverMPos;
 
 	int _captionHeightDynamic = HIGH_CAPTION;

--- a/PowerEditor/src/WinControls/ToolTip/ToolTip.h
+++ b/PowerEditor/src/WinControls/ToolTip/ToolTip.h
@@ -29,6 +29,7 @@ public :
 	void destroy(){
 		::DestroyWindow(_hSelf);
 		_hSelf = NULL;
+		_bTrackMouse = FALSE;
 	};
 
 // Attributes
@@ -37,9 +38,14 @@ public:
 // Implementation
 public:
 	virtual void init(HINSTANCE hInst, HWND hParent);
-	void Show(RECT rectTitle, const TCHAR* pszTitleText, int iXOff = 0, int iWidthOff = 0);
+	void show(const TCHAR* pszTitleText, int iXOff = 0, int iYOff = 0, const RECT& rectTitle = {});
+	void showAtCursor(const TCHAR* pszTitleText);
 
-protected:
+	// Post mouse events to hwnd as specified by flags
+	void trackMouse(HWND hwnd, DWORD flags = TME_HOVER | TME_LEAVE);
+	bool trackingMouse() const { return _bTrackMouse; }
+
+private:
     WNDPROC		_defaultProc = nullptr;
 	BOOL		_bTrackMouse = FALSE;
 	TOOLINFO	_ti;
@@ -48,5 +54,6 @@ protected:
         return (((ToolTip *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->runProc(Message, wParam, lParam));
     };
 	LRESULT runProc(UINT Message, WPARAM wParam, LPARAM lParam);
+	void reposition(const POINT& pt);
 };
 


### PR DESCRIPTION
Close tab menu item is the rightmost "X" in the menu row.

Extend ToolTip class:
- move mouse tracking code to class methods
- add a posibility to show it at the cursor position
- reposition if it is outside the display bounds

Fix #9256