### PR TITLE
Fixed minor French typo on line 296

### DIFF
--- a/PowerEditor/installer/nativeLang/french.xml
+++ b/PowerEditor/installer/nativeLang/french.xml
@@ -293,7 +293,7 @@
                     <Item id="45056" name="OEM 863: français"/>
                     <Item id="46001" name="Configurateur de coloration syntaxique..."/>
                     <Item id="46250" name="Définir votre langage..."/>
-                    <Item id="46300" name="Ovrir le dossier des Langages utilisateur..."/>
+                    <Item id="46300" name="Ouvrir le dossier des Langages utilisateur..."/>
                     <Item id="46180" name="Langage utilisateur"/>
                     <Item id="47000" name="À propos de Notepad++..."/>
                     <Item id="47001" name="Site officiel Notepad++"/>


### PR DESCRIPTION
The sentence on line 296 read "Ovrir le dossier des Langages utilisateur..." when it should have read "Ouvrir le dossier des Langages utilisateur...". I fixed this issue.