### PR TITLE
Fix save of new files problems with Session Manager plug in.

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1501,8 +1501,9 @@ int FileManager::getFileNameFromBuffer(BufferID id, TCHAR * fn2copy)
 
 int FileManager::docLength(Buffer* buffer) const
 {
+	Document curDoc = _pscratchTilla->execute(SCI_GETDOCPOINTER);
 	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, buffer->_doc);
 	int docLen = _pscratchTilla->getCurrentDocLen();
-	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, _scratchDocDefault);
+	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, curDoc);
 	return docLen;
 }


### PR DESCRIPTION
Fixes #9475 

Mechanics: The `FileManager` class uses `_pscratchTilla` to manipulate documents. The Session Manager plugin calls `NPPM_SAVECURRENTSESSION` while it is notified about the language change. While saving the session, `FileManager::docLength` is called, which should not switch the document attached to `_pscratchTilla`.

Maybe other functions of the `FileManager` class should restore the document pointer too.