### PR TITLE
TiXmlBase::StringEqual: ignoreCase parameter is mistreated

### DIFF
--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlparserA.cpp
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlparserA.cpp
@@ -293,7 +293,7 @@ bool TiXmlBaseA::StringEqual( const char* p,
 	{
 		const char* q = p;
 
-		if (ignoreCase)
+		if (!ignoreCase)
 		{
 			while ( *q && *tag && *q == *tag )
 			{

--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlparserA.cpp
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlparserA.cpp
@@ -920,6 +920,7 @@ const char* TiXmlUnknownA::Parse( const char* p, TiXmlParsingDataA* data )
 	if ( !p )
 	{
 		if ( document )	document->SetError( TIXMLA_ERROR_PARSING_UNKNOWN, 0, 0 );
+		return 0;
 	}
 	if ( *p == '>' )
 		return p+1;

--- a/PowerEditor/src/TinyXml/tinyxmlparser.cpp
+++ b/PowerEditor/src/TinyXml/tinyxmlparser.cpp
@@ -902,6 +902,7 @@ const TCHAR* TiXmlUnknown::Parse( const TCHAR* p, TiXmlParsingData* data )
 	if ( !p )
 	{
 		if ( document )	document->SetError( TIXML_ERROR_PARSING_UNKNOWN, 0, 0 );
+		return 0;
 	}
 	if ( *p == '>' )
 		return p+1;

--- a/PowerEditor/src/TinyXml/tinyxmlparser.cpp
+++ b/PowerEditor/src/TinyXml/tinyxmlparser.cpp
@@ -275,7 +275,7 @@ bool TiXmlBase::StringEqual( const TCHAR* p,
 	{
 		const TCHAR* q = p;
 
-		if (ignoreCase)
+		if (!ignoreCase)
 		{
 			while ( *q && *tag && *q == *tag )
 			{

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -162,7 +162,7 @@ void Shortcut::setName(const TCHAR * menuName, const TCHAR * shortcutName)
 	lstrcpyn(_menuName, menuName, nameLenMax);
 	TCHAR const * name = shortcutName ? shortcutName : menuName;
 	int i = 0, j = 0;
-	while (name[j] != 0 && i < nameLenMax)
+	while (name[j] != 0 && i < (nameLenMax-1))
 	{
 		if (name[j] != '&')
 		{


### PR DESCRIPTION
**`tinyXml - StringEqual`** :
The parameter _ignoreCase_ is reversed - so we don't ignore case when we should.

That means that in TiXmlNodeA::Identify for instance:
``` c++
const char* xmlHeader = { "<?xml" };
const char* commentHeader = { "<!--" };

if ( StringEqual( p, xmlHeader, true ) )
```
string '<?xml' would be compared as case sensitive, but  _commentHeader_ on the other characters would be lower-cased. (performance)

There are others examples showing the parameter should be treated in reverse (and not just renamed)