### PR TITLE
TiXmlBase::StringEqual: ignoreCase parameter is mistreated

### DIFF
--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlparserA.cpp
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlparserA.cpp
@@ -293,7 +293,7 @@ bool TiXmlBaseA::StringEqual( const char* p,
 	{
 		const char* q = p;
 
-		if (ignoreCase)
+		if (!ignoreCase)
 		{
 			while ( *q && *tag && *q == *tag )
 			{

--- a/PowerEditor/src/TinyXml/tinyxmlparser.cpp
+++ b/PowerEditor/src/TinyXml/tinyxmlparser.cpp
@@ -275,7 +275,7 @@ bool TiXmlBase::StringEqual( const TCHAR* p,
 	{
 		const TCHAR* q = p;
 
-		if (ignoreCase)
+		if (!ignoreCase)
 		{
 			while ( *q && *tag && *q == *tag )
 			{


### PR DESCRIPTION
[Issue #9545](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9545) 