### PR TITLE
Fix: use the generated SciLexer.dll which contains regExpr of Boost

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,8 @@ build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"\scintilla\win32
     - if "%configuration%"=="Unicode Debug" set scintilla_debug=DEBUG=1
     - if "%configuration%"=="Unicode Release" set scintilla_debug=
-    - if "%archi%"=="x86" nmake SUPPORT_XP=1 %scintilla_debug% BOOSTPATH=C:\Libraries\boost_1_69_0\ BOOSTREGEXLIBPATH=C:\Libraries\boost_1_69_0\lib32-msvc-14.1\ -f scintilla.mak
-    - if "%archi%"=="amd64" nmake SUPPORT_XP=1 %scintilla_debug% BOOSTPATH=C:\Libraries\boost_1_69_0\ BOOSTREGEXLIBPATH=C:\Libraries\boost_1_69_0\lib64-msvc-14.1\ -f scintilla.mak
+    - if "%archi%"=="x86" nmake %scintilla_debug% BOOSTPATH=C:\Libraries\boost_1_69_0\ BOOSTREGEXLIBPATH=C:\Libraries\boost_1_69_0\lib32-msvc-14.1\ -f scintilla.mak
+    - if "%archi%"=="amd64" nmake %scintilla_debug% BOOSTPATH=C:\Libraries\boost_1_69_0\ BOOSTREGEXLIBPATH=C:\Libraries\boost_1_69_0\lib64-msvc-14.1\ -f scintilla.mak
     - if "%Platform%"=="mingw-w64_810_X64" mingw32-make -j%NUMBER_OF_PROCESSORS%
     - cd "%APPVEYOR_BUILD_FOLDER%"\PowerEditor\visual.net\
     - if "%archi%" NEQ "" msbuild notepadPlus.vcxproj /p:configuration="%configuration%" /p:platform="%platform_input%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
@@ -68,11 +68,8 @@ after_build:
         if ($env:PLATFORM_INPUT -eq "Win32" -and $env:CONFIGURATION -eq "Unicode Debug") {
             Push-AppveyorArtifact "PowerEditor\visual.net\Unicode Debug\Notepad++.exe" -FileName "$nppFileName"
 
-            Start-FileDownload 'https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.9/npp.7.9.portable.minimalist.7z'
-            7z x -y npp.7.9.portable.minimalist.7z | Out-Null
-            #take SciLexer.dll from downloaded version due to dependency of the functionlist tests on a version build with boost regex
-            #what is not the case for the dll build on appveyor CI (would either need a very time consuming boost build or usage of nuget packages)
-            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\SciLexer.dll" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
+            #take SciLexer.dll from build since dependency of the functionlist tests on a version build with boost regex is fullfilled also for appveyor
+            Copy-Item "$env:APPVEYOR_BUILD_FOLDER\scintilla\bin\SciLexer.dll" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
             Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\visual.net\Unicode Debug\Notepad++.exe" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
             Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\src\langs.model.xml" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"
             Copy-Item "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\src\stylers.model.xml" -Destination "$env:APPVEYOR_BUILD_FOLDER\PowerEditor\bin"


### PR DESCRIPTION
fix #9581

- Remove the download last release part from Appveyor script and use the generated SciLexer.dll
- Could you please remove SUPPORT_XP from the script as well ?