### PR TITLE
Fix Project workspace changes lost on save cancel

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1178,7 +1178,8 @@ Do you want to recover your langs.xml?"/> <!-- HowToReproduce: Close Notepad++. 
 Please remove its root from the panel before you add folder &quot;$STR_REPLACE$&quot;."/> <!-- HowToReproduce: Add a folder like "c:\temp\aFolder\" into "Folder as Workspace" panel, then try to add "c:\temp\". -->
 
             <ProjectPanelChanged title="$STR_REPLACE$" message="The workspace was modified. Do you want to save it?"/>
-            <ProjectPanelChangedSaveError title="$STR_REPLACE$" message="Your workspace has not been saved."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+            <ProjectPanelSaveError title="$STR_REPLACE$" message="An error occurred while writing your workspace file.
+Your workspace has not been saved."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
             <ProjectPanelOpenDoSaveDirtyWsOrNot title="Open Workspace" message="The current workspace was modified. Do you want to save the current project?"/>
             <ProjectPanelNewDoSaveDirtyWsOrNot title="New Workspace" message="The current workspace was modified. Do you want to save the current project?"/>
             <ProjectPanelOpenFailed title="Open Workspace" message="The workspace could not be opened.


### PR DESCRIPTION
Fixes #9605

This PR is also intended to improve the handling of write errors to Project Panel workspace files. Notepad++ distinguishes now between write errors and cancelled Save As dialogs. Write errors are always reported with a message box, Save As cancellations are silent.

I simulated write errors to the workspace file with the command line `Notepad >> abc.npj`. There is no write possible to `abc.npj`, until the Windows Notepad is terminated. I write this here because of the comment in the `English.xml`, which says the write error is hard to reproduce.

