### PR TITLE
Added batch processing of added and removed files in Folder as Workspace

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -244,27 +244,12 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 		case FB_ADDFILE:
 		{
-			const std::vector<generic_string> file2Change = *(std::vector<generic_string> *)lParam;
-			generic_string separator = TEXT("\\\\");
 
-			size_t sepPos = file2Change[0].find(separator);
-			if (sepPos == generic_string::npos)
-				return false;
+			std::vector<FilesToChange> groupedFiles = getFilesFromParam(lParam);
 
-			generic_string pathSuffix = file2Change[0].substr(sepPos + separator.length(), file2Change[0].length() - 1);
-
-			// remove prefix of file/folder in changeInfo, splite the remained path
-			vector<generic_string> linarPathArray = split(pathSuffix, '\\');
-
-			generic_string rootPath = file2Change[0].substr(0, sepPos);
-			generic_string path = rootPath;
-
-			generic_string addedFilePath = file2Change[0].substr(0, sepPos + 1);
-			addedFilePath += pathSuffix;
-			bool isAdded = addInTree(rootPath, addedFilePath, nullptr, linarPathArray);
-			if (!isAdded)
+			for (auto & group : groupedFiles) 
 			{
-				//MessageBox(NULL, addedFilePath.c_str(), TEXT("file/folder is not added"), MB_OK);
+				addToTree(group, nullptr);
 			}
 
 			break;
@@ -272,26 +257,14 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 		case FB_RMFILE:
 		{
-			const std::vector<generic_string> file2Change = *(std::vector<generic_string> *)lParam;
-			generic_string separator = TEXT("\\\\");
 
-			size_t sepPos = file2Change[0].find(separator);
-			if (sepPos == generic_string::npos)
-				return false;
+			std::vector<FilesToChange> groupedFiles = getFilesFromParam(lParam);
 
-			generic_string pathSuffix = file2Change[0].substr(sepPos + separator.length(), file2Change[0].length() - 1);
-
-			// remove prefix of file/folder in changeInfo, splite the remained path
-			vector<generic_string> linarPathArray = split(pathSuffix, '\\');
-
-			generic_string rootPath = file2Change[0].substr(0, sepPos);
-			// search recursively and modify the tree structure
-
-			bool isRemoved = deleteFromTree(rootPath, nullptr, linarPathArray);
-			if (!isRemoved)
+			for (auto & group : groupedFiles) 
 			{
-				//MessageBox(NULL, file2Change[0].c_str(), TEXT("file/folder is not removed"), MB_OK);
+				deleteFromTree(group);
 			}
+
 			break;
 		}
 
@@ -1138,10 +1111,8 @@ HTREEITEM FileBrowser::getRootFromFullPath(const generic_string & rootPath) cons
 
 HTREEITEM FileBrowser::findChildNodeFromName(HTREEITEM parent, const generic_string& label) const
 {
-	HTREEITEM childNodeFound = nullptr;
-
 	for (HTREEITEM hItemNode = _treeView.getChildFrom(parent);
-		hItemNode != NULL && childNodeFound == nullptr;
+		hItemNode != NULL;
 		hItemNode = _treeView.getNextSibling(hItemNode))
 	{
 		TCHAR textBuffer[MAX_PATH];
@@ -1154,10 +1125,10 @@ HTREEITEM FileBrowser::findChildNodeFromName(HTREEITEM parent, const generic_str
 
 		if (label == tvItem.pszText)
 		{
-			childNodeFound = hItemNode;
+			return hItemNode;
 		}
 	}
-	return childNodeFound;
+	return nullptr;
 }
 
 vector<generic_string> FileBrowser::getRoots() const
@@ -1190,49 +1161,118 @@ generic_string FileBrowser::getSelectedItemPath() const
 	return itemPath;
 }
 
-bool FileBrowser::addInTree(const generic_string& rootPath, const generic_string& addItemFullPath, HTREEITEM node, vector<generic_string> linarPathArray)
+std::vector<FileBrowser::FilesToChange> FileBrowser::getFilesFromParam(LPARAM lParam) const
+{
+	const std::vector<generic_string> filesToChange = *(std::vector<generic_string>*)lParam;
+	const generic_string separator = TEXT("\\\\");
+	const size_t separatorLength = separator.length();
+
+	std::vector<FilesToChange> groupedFiles;
+	for (size_t i = 0; i < filesToChange.size(); i++)
+	{
+		const size_t sepPos = filesToChange[i].find(separator);
+		if (sepPos == generic_string::npos)
+			continue;
+
+		const generic_string pathSuffix = filesToChange[i].substr(sepPos + separatorLength, filesToChange[i].length() - 1);
+
+		// remove prefix of file/folder in changeInfo, split the remained path
+		vector<generic_string> linarPathArray = split(pathSuffix, '\\');
+
+		const generic_string lastElement = linarPathArray.back();
+		linarPathArray.pop_back();
+
+		const generic_string rootPath = filesToChange[i].substr(0, sepPos);
+
+		const generic_string addedFilePath = filesToChange[i].substr(0, sepPos + 1) + pathSuffix;
+
+		generic_string commonPath = rootPath;
+
+		for (const auto & element : linarPathArray)
+		{
+			commonPath.append(TEXT("\\"));
+			commonPath.append(element);
+		}
+
+		commonPath.append(TEXT("\\"));
+
+		const auto it = std::find_if(groupedFiles.begin(), groupedFiles.end(), [&commonPath](const auto & group) { return group.commonPath == commonPath; });
+
+		if (it == groupedFiles.end())
+		{
+			// Add a new file group
+			FilesToChange group;
+			group.commonPath = commonPath;
+			group.rootPath = rootPath;
+			group.linarWithoutLastPathElement = linarPathArray;
+			group.files.push_back(lastElement);
+			groupedFiles.push_back(group);
+		}
+		else
+		{
+			// Add to an existing file group
+			it->files.push_back(lastElement);
+		}
+	}
+
+	return groupedFiles;
+}
+
+bool FileBrowser::addToTree(FilesToChange & group, HTREEITEM node)
 {
 	if (node == nullptr) // it's a root. Search the right root with rootPath
 	{
 		// Search
-		if ((node = getRootFromFullPath(rootPath)) == nullptr)
+		if ((node = getRootFromFullPath(group.rootPath)) == nullptr)
 			return false;
 	}
 
-	if (linarPathArray.size() == 1)
+	if (group.linarWithoutLastPathElement.size() == 0)
 	{
-		// Of course item to add should be exist on the disk
-		if (!::PathFileExists(addItemFullPath.c_str()))
-			return false;
+		// Items to add should exist on the disk
+		group.files.erase(std::remove_if(group.files.begin(), group.files.end(), 
+			[&group](const auto & file)
+			{
+				return !::PathFileExists((group.commonPath + file).c_str());
+			}),
+			group.files.end());
 
-		// Search : if no found, add
-		HTREEITEM childNodeFound = findChildNodeFromName(node, linarPathArray[0]);
-		if (childNodeFound != nullptr)
-			return false;
-
-		// No found, good - Action
-		if (::PathIsDirectory(addItemFullPath.c_str()))
+		if (group.files.empty()) 
 		{
-			SortingData4lParam* customData = new SortingData4lParam(TEXT(""), linarPathArray[0], true);
-			sortingDataArray.push_back(customData);
-
-			_treeView.addItem(linarPathArray[0].c_str(), node, INDEX_CLOSE_NODE, reinterpret_cast<LPARAM>(customData));
-		}
-		else
-		{
-			SortingData4lParam* customData = new SortingData4lParam(TEXT(""), linarPathArray[0], false);
-			sortingDataArray.push_back(customData);
-
-			_treeView.addItem(linarPathArray[0].c_str(), node, INDEX_LEAF, reinterpret_cast<LPARAM>(customData));
+			return false;
 		}
 
+		// Search: if not found, add
+		removeNamesAlreadyInNode(node, group.files);
+		if (group.files.empty()) 
+		{
+			return false;
+		}
+
+		// Not found, good - Action
+		for (auto & file : group.files) {
+			if (::PathIsDirectory((group.commonPath + file).c_str()))
+			{
+				SortingData4lParam* customData = new SortingData4lParam(TEXT(""), file, true);
+				sortingDataArray.push_back(customData);
+
+				_treeView.addItem(file.c_str(), node, INDEX_CLOSE_NODE, reinterpret_cast<LPARAM>(customData));
+			}
+			else
+			{
+				SortingData4lParam* customData = new SortingData4lParam(TEXT(""), file, false);
+				sortingDataArray.push_back(customData);
+
+				_treeView.addItem(file.c_str(), node, INDEX_LEAF, reinterpret_cast<LPARAM>(customData));
+			}
+		}
 		_treeView.customSorting(node, categorySortFunc, 0);
 		return true;
 	}
 	else
 	{
 		for (HTREEITEM hItemNode = _treeView.getChildFrom(node);
-			hItemNode != NULL ;
+			hItemNode != NULL;
 			hItemNode = _treeView.getNextSibling(hItemNode))
 		{
 			TCHAR textBuffer[MAX_PATH];
@@ -1243,15 +1283,33 @@ bool FileBrowser::addInTree(const generic_string& rootPath, const generic_string
 			tvItem.hItem = hItemNode;
 			SendMessage(_treeView.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
 
-			if (linarPathArray[0] == tvItem.pszText)
+			if (group.linarWithoutLastPathElement[0] == tvItem.pszText)
 			{
 				// search recursively the node for an action
-				linarPathArray.erase(linarPathArray.begin());
-				return addInTree(rootPath, addItemFullPath, hItemNode, linarPathArray);
+				group.linarWithoutLastPathElement.erase(group.linarWithoutLastPathElement.begin());
+				return addToTree(group, hItemNode);
 			}
 		}
 		return false;
 	}
+
+}
+
+bool FileBrowser::deleteFromTree(FilesToChange & group)
+{
+	std::vector<HTREEITEM> foundItems = findInTree(group, nullptr);
+
+	if (foundItems.empty() == true)
+	{
+		return false;
+	}
+
+	for (auto & item : foundItems)
+	{
+		_treeView.removeItem(item);
+	}
+
+	return true;
 }
 
 HTREEITEM FileBrowser::findInTree(const generic_string& rootPath, HTREEITEM node, std::vector<generic_string> linarPathArray) const
@@ -1297,15 +1355,102 @@ HTREEITEM FileBrowser::findInTree(const generic_string& rootPath, HTREEITEM node
 	}
 }
 
-bool FileBrowser::deleteFromTree(const generic_string& rootPath, HTREEITEM node, const std::vector<generic_string>& linarPathArray)
+std::vector<HTREEITEM> FileBrowser::findInTree(FilesToChange & group, HTREEITEM node) const
 {
-	HTREEITEM foundItem = findInTree(rootPath, node, linarPathArray);
-	if (foundItem == nullptr)
-			return false;
+	if (node == nullptr) // it's a root. Search the right root with rootPath
+	{
+		// Search
+		if ((node = getRootFromFullPath(group.rootPath)) == nullptr)
+		{
+			return {};
+		}
 
-	// found it, delete it
-	_treeView.removeItem(foundItem);
-	return true;
+		if (group.linarWithoutLastPathElement.empty())
+		{
+			// this is the root, nothing to search, return node
+			return { node };
+		}
+	}
+
+	if (group.linarWithoutLastPathElement.empty()) // nothing to search, return node
+	{
+		// Search
+		return findChildNodesFromNames(node, group.files);
+	}
+	else
+	{
+		for (HTREEITEM hItemNode = _treeView.getChildFrom(node);
+			hItemNode != NULL;
+			hItemNode = _treeView.getNextSibling(hItemNode))
+		{
+			TCHAR textBuffer[MAX_PATH];
+			TVITEM tvItem;
+			tvItem.mask = TVIF_TEXT;
+			tvItem.pszText = textBuffer;
+			tvItem.cchTextMax = MAX_PATH;
+			tvItem.hItem = hItemNode;
+			SendMessage(_treeView.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
+
+			if (group.linarWithoutLastPathElement[0] == tvItem.pszText)
+			{
+				// search recursively the node for an action
+				group.linarWithoutLastPathElement.erase(group.linarWithoutLastPathElement.begin());
+				return findInTree(group, hItemNode);
+			}
+		}
+		return {};
+	}
+}
+
+std::vector<HTREEITEM> FileBrowser::findChildNodesFromNames(HTREEITEM parent, std::vector<generic_string> & labels) const
+{
+	std::vector<HTREEITEM> itemNodes;
+
+	for (HTREEITEM hItemNode = _treeView.getChildFrom(parent);
+		hItemNode != NULL && !labels.empty();
+		hItemNode = _treeView.getNextSibling(hItemNode)
+		)
+	{
+		TCHAR textBuffer[MAX_PATH];
+		TVITEM tvItem;
+		tvItem.mask = TVIF_TEXT;
+		tvItem.pszText = textBuffer;
+		tvItem.cchTextMax = MAX_PATH;
+		tvItem.hItem = hItemNode;
+		SendMessage(_treeView.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
+
+		auto it = std::find(labels.begin(), labels.end(), tvItem.pszText);
+		if (it != labels.end())
+		{
+			labels.erase(it); // remove, as it was already found
+			itemNodes.push_back(hItemNode);
+		}
+	}
+	return itemNodes;
+}
+
+void FileBrowser::removeNamesAlreadyInNode(HTREEITEM parent, std::vector<generic_string> & labels) const
+{
+	// We have to search for the labels in the child nodes of parent, and remove the ones that already exist
+	for (HTREEITEM hItemNode = _treeView.getChildFrom(parent);
+		hItemNode != NULL && !labels.empty();
+		hItemNode = _treeView.getNextSibling(hItemNode)
+		)
+	{
+		TCHAR textBuffer[MAX_PATH];
+		TVITEM tvItem;
+		tvItem.mask = TVIF_TEXT;
+		tvItem.pszText = textBuffer;
+		tvItem.cchTextMax = MAX_PATH;
+		tvItem.hItem = hItemNode;
+		SendMessage(_treeView.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
+
+		auto it = std::find(labels.begin(), labels.end(), tvItem.pszText);
+		if (it != labels.end())
+		{
+			labels.erase(it);
+		}
+	}
 }
 
 bool FileBrowser::renameInTree(const generic_string& rootPath, HTREEITEM node, const std::vector<generic_string>& linarPathArrayFrom, const generic_string & renameTo)
@@ -1527,52 +1672,56 @@ DWORD WINAPI FolderUpdater::watching(void *params)
 			case WAIT_OBJECT_0 + 1:
 			// We've received a notification in the queue.
 			{
+				static const unsigned int MAX_BATCH_SIZE = 100;
+
+				DWORD dwPreviousAction = 0;
 				DWORD dwAction;
 				generic_string wstrFilename;
+
+				std::vector<generic_string> filesToChange;
 				// Process all available changes, ignore User actions
 				while (changes.Pop(dwAction, wstrFilename))
 				{
-					static generic_string oldName;
-					static std::vector<generic_string> file2Change;
-					file2Change.clear();
 
-					switch (dwAction)
+					// FILE_ACTION_ADDED and FILE_ACTION_REMOVED are done in batches
+					if (dwAction != FILE_ACTION_ADDED && dwAction != FILE_ACTION_REMOVED)
 					{
-						case FILE_ACTION_ADDED:
-							file2Change.push_back(wstrFilename);
-							::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_ADDFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&file2Change));
-							oldName = TEXT("");
-							break;
-
-						case FILE_ACTION_REMOVED:
-							file2Change.push_back(wstrFilename);
-							::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_RMFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&file2Change));
-							oldName = TEXT("");
-							break;
-
-						case FILE_ACTION_MODIFIED:
-							oldName = TEXT("");
-							break;
-
-						case FILE_ACTION_RENAMED_OLD_NAME:
-							oldName = wstrFilename;
-							break;
-
-						case FILE_ACTION_RENAMED_NEW_NAME:
-							if (!oldName.empty())
-							{
-								file2Change.push_back(oldName);
-								file2Change.push_back(wstrFilename);
-								//thisFolderUpdater->updateTree(dwAction, file2Change);
-								::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_RNFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&file2Change));
-							}
-							oldName = TEXT("");
-							break;
-
-						default:
-							oldName = TEXT("");
-							break;
+						processChange(dwAction, { wstrFilename }, thisFolderUpdater);
 					}
+					else 
+					{
+						// first iteration
+						if (dwPreviousAction == 0)
+						{
+							dwPreviousAction = dwAction;
+						}
+
+						if (dwPreviousAction == dwAction)
+						{
+							filesToChange.push_back(wstrFilename);
+
+							if (filesToChange.size() > MAX_BATCH_SIZE) // Process some so the editor doesn't block for too long
+							{
+								processChange(dwAction, filesToChange, thisFolderUpdater);
+								filesToChange.clear();
+							}
+						}
+						else
+						{
+							// Different action. Process the previous batch and start saving a new one
+							processChange(dwAction, filesToChange, thisFolderUpdater);
+							filesToChange.clear();
+
+							dwPreviousAction = dwAction;
+							filesToChange.push_back(wstrFilename);
+						}
+					}
+				}
+
+				// process the last changes
+				if (dwAction == FILE_ACTION_ADDED || dwAction == FILE_ACTION_REMOVED)
+				{
+					processChange(dwAction, filesToChange, thisFolderUpdater);
 				}
 			}
 			break;
@@ -1588,4 +1737,48 @@ DWORD WINAPI FolderUpdater::watching(void *params)
 	changes.Terminate();
 	//printStr(L"Quit watching thread");
 	return EXIT_SUCCESS;
+}
+
+void FolderUpdater::processChange(DWORD dwAction, std::vector<generic_string> filesToChange, FolderUpdater* thisFolderUpdater)
+{
+	static generic_string oldName;
+
+	switch (dwAction)
+	{
+	case FILE_ACTION_ADDED:
+
+		::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_ADDFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&filesToChange));
+		oldName = TEXT("");
+		break;
+
+	case FILE_ACTION_REMOVED:
+		
+		::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_RMFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&filesToChange));
+		oldName = TEXT("");
+		break;
+
+	case FILE_ACTION_MODIFIED:
+		oldName = TEXT("");
+		break;
+
+	case FILE_ACTION_RENAMED_OLD_NAME:
+		oldName = filesToChange.back();
+		break;
+
+	case FILE_ACTION_RENAMED_NEW_NAME:
+		if (!oldName.empty())
+		{
+			std::vector<generic_string> fileRename;
+			fileRename.push_back(oldName);
+			fileRename.push_back(filesToChange.back());
+			//thisFolderUpdater->updateTree(dwAction, fileRename);
+			::SendMessage((thisFolderUpdater->_pFileBrowser)->getHSelf(), FB_RNFILE, reinterpret_cast<WPARAM>(nullptr), reinterpret_cast<LPARAM>(&fileRename));
+		}
+		oldName = TEXT("");
+		break;
+
+	default:
+		oldName = TEXT("");
+		break;
+	}
 }

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1196,22 +1196,22 @@ std::vector<FileBrowser::FilesToChange> FileBrowser::getFilesFromParam(LPARAM lP
 
 		commonPath.append(TEXT("\\"));
 
-		const auto it = std::find_if(groupedFiles.begin(), groupedFiles.end(), [&commonPath](const auto & group) { return group.commonPath == commonPath; });
+		const auto it = std::find_if(groupedFiles.begin(), groupedFiles.end(), [&commonPath](const auto & group) { return group._commonPath == commonPath; });
 
 		if (it == groupedFiles.end())
 		{
 			// Add a new file group
 			FilesToChange group;
-			group.commonPath = commonPath;
-			group.rootPath = rootPath;
-			group.linarWithoutLastPathElement = linarPathArray;
-			group.files.push_back(lastElement);
+			group._commonPath = commonPath;
+			group._rootPath = rootPath;
+			group._linarWithoutLastPathElement = linarPathArray;
+			group._files.push_back(lastElement);
 			groupedFiles.push_back(group);
 		}
 		else
 		{
 			// Add to an existing file group
-			it->files.push_back(lastElement);
+			it->_files.push_back(lastElement);
 		}
 	}
 
@@ -1223,35 +1223,35 @@ bool FileBrowser::addToTree(FilesToChange & group, HTREEITEM node)
 	if (node == nullptr) // it's a root. Search the right root with rootPath
 	{
 		// Search
-		if ((node = getRootFromFullPath(group.rootPath)) == nullptr)
+		if ((node = getRootFromFullPath(group._rootPath)) == nullptr)
 			return false;
 	}
 
-	if (group.linarWithoutLastPathElement.size() == 0)
+	if (group._linarWithoutLastPathElement.size() == 0)
 	{
 		// Items to add should exist on the disk
-		group.files.erase(std::remove_if(group.files.begin(), group.files.end(), 
+		group._files.erase(std::remove_if(group._files.begin(), group._files.end(), 
 			[&group](const auto & file)
 			{
-				return !::PathFileExists((group.commonPath + file).c_str());
+				return !::PathFileExists((group._commonPath + file).c_str());
 			}),
-			group.files.end());
+			group._files.end());
 
-		if (group.files.empty()) 
+		if (group._files.empty()) 
 		{
 			return false;
 		}
 
 		// Search: if not found, add
-		removeNamesAlreadyInNode(node, group.files);
-		if (group.files.empty()) 
+		removeNamesAlreadyInNode(node, group._files);
+		if (group._files.empty()) 
 		{
 			return false;
 		}
 
 		// Not found, good - Action
-		for (auto & file : group.files) {
-			if (::PathIsDirectory((group.commonPath + file).c_str()))
+		for (auto & file : group._files) {
+			if (::PathIsDirectory((group._commonPath + file).c_str()))
 			{
 				SortingData4lParam* customData = new SortingData4lParam(TEXT(""), file, true);
 				sortingDataArray.push_back(customData);
@@ -1283,10 +1283,10 @@ bool FileBrowser::addToTree(FilesToChange & group, HTREEITEM node)
 			tvItem.hItem = hItemNode;
 			SendMessage(_treeView.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
 
-			if (group.linarWithoutLastPathElement[0] == tvItem.pszText)
+			if (group._linarWithoutLastPathElement[0] == tvItem.pszText)
 			{
 				// search recursively the node for an action
-				group.linarWithoutLastPathElement.erase(group.linarWithoutLastPathElement.begin());
+				group._linarWithoutLastPathElement.erase(group._linarWithoutLastPathElement.begin());
 				return addToTree(group, hItemNode);
 			}
 		}
@@ -1360,16 +1360,16 @@ std::vector<HTREEITEM> FileBrowser::findInTree(FilesToChange & group, HTREEITEM 
 	if (node == nullptr) // it's a root. Search the right root with rootPath
 	{
 		// Search
-		if ((node = getRootFromFullPath(group.rootPath)) == nullptr)
+		if ((node = getRootFromFullPath(group._rootPath)) == nullptr)
 		{
 			return {};
 		}
 	}
 
-	if (group.linarWithoutLastPathElement.empty())
+	if (group._linarWithoutLastPathElement.empty())
 	{
 		// Search
-		return findChildNodesFromNames(node, group.files);
+		return findChildNodesFromNames(node, group._files);
 	}
 	else
 	{
@@ -1385,10 +1385,10 @@ std::vector<HTREEITEM> FileBrowser::findInTree(FilesToChange & group, HTREEITEM 
 			tvItem.hItem = hItemNode;
 			SendMessage(_treeView.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
 
-			if (group.linarWithoutLastPathElement[0] == tvItem.pszText)
+			if (group._linarWithoutLastPathElement[0] == tvItem.pszText)
 			{
 				// search recursively the node for an action
-				group.linarWithoutLastPathElement.erase(group.linarWithoutLastPathElement.begin());
+				group._linarWithoutLastPathElement.erase(group._linarWithoutLastPathElement.begin());
 				return findInTree(group, hItemNode);
 			}
 		}

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1709,7 +1709,7 @@ DWORD WINAPI FolderUpdater::watching(void *params)
 						else
 						{
 							// Different action. Process the previous batch and start saving a new one
-							processChange(dwAction, filesToChange, thisFolderUpdater);
+							processChange(dwPreviousAction, filesToChange, thisFolderUpdater);
 							filesToChange.clear();
 
 							dwPreviousAction = dwAction;

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1364,15 +1364,9 @@ std::vector<HTREEITEM> FileBrowser::findInTree(FilesToChange & group, HTREEITEM 
 		{
 			return {};
 		}
-
-		if (group.linarWithoutLastPathElement.empty())
-		{
-			// this is the root, nothing to search, return node
-			return { node };
-		}
 	}
 
-	if (group.linarWithoutLastPathElement.empty()) // nothing to search, return node
+	if (group.linarWithoutLastPathElement.empty())
 	{
 		// Search
 		return findChildNodesFromNames(node, group.files);

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -103,6 +103,8 @@ private:
 	HANDLE _watchThreadHandle = nullptr;
 	HANDLE _EventHandle = nullptr;
 	static DWORD WINAPI watching(void *param);
+
+	static void processChange(DWORD dwAction, std::vector<generic_string> filesToChange, FolderUpdater* thisFolderUpdater);
 };
 
 struct SortingData4lParam {
@@ -143,11 +145,10 @@ public:
 	void addRootFolder(generic_string rootFolderPath);
 
 	HTREEITEM getRootFromFullPath(const generic_string & rootPath) const;
-	HTREEITEM findChildNodeFromName(HTREEITEM parent, const generic_string&) const;
+	HTREEITEM findChildNodeFromName(HTREEITEM parent, const generic_string& label) const;
 
-	bool addInTree(const generic_string& rootPath, const generic_string& addItemFullPath, HTREEITEM node, std::vector<generic_string> linarPathArray);
 	HTREEITEM findInTree(const generic_string& rootPath, HTREEITEM node, std::vector<generic_string> linarPathArray) const;
-	bool deleteFromTree(const generic_string& rootPath, HTREEITEM node, const std::vector<generic_string>& linarPathArray);
+
 	void deleteAllFromTree() {
 		popupMenuCmd(IDM_FILEBROWSER_REMOVEALLROOTS);
 	};
@@ -187,6 +188,25 @@ protected:
 	void popupMenuCmd(int cmdID);
 
 	bool selectCurrentEditingFile() const;
+
+	struct FilesToChange {
+		generic_string commonPath; // Common path between all the files. rootPath + linarWithoutLastPathElement
+		generic_string rootPath;
+		std::vector<generic_string> linarWithoutLastPathElement;
+		std::vector<generic_string> files; // file/folder names
+	};
+
+	std::vector<FilesToChange> getFilesFromParam(LPARAM lParam) const;
+
+	bool addToTree(FilesToChange & group, HTREEITEM node);
+
+	bool deleteFromTree(FilesToChange & group);
+
+	std::vector<HTREEITEM> findInTree(FilesToChange & group, HTREEITEM node) const;
+
+	std::vector<HTREEITEM> findChildNodesFromNames(HTREEITEM parent, std::vector<generic_string> & labels) const;
+
+	void removeNamesAlreadyInNode(HTREEITEM parent, std::vector<generic_string> & labels) const;
 
 	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void notified(LPNMHDR notification);

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -190,10 +190,10 @@ protected:
 	bool selectCurrentEditingFile() const;
 
 	struct FilesToChange {
-		generic_string commonPath; // Common path between all the files. rootPath + linarWithoutLastPathElement
-		generic_string rootPath;
-		std::vector<generic_string> linarWithoutLastPathElement;
-		std::vector<generic_string> files; // file/folder names
+		generic_string _commonPath; // Common path between all the files. _rootPath + _linarWithoutLastPathElement
+		generic_string _rootPath;
+		std::vector<generic_string> _linarWithoutLastPathElement;
+		std::vector<generic_string> _files; // file/folder names
 	};
 
 	std::vector<FilesToChange> getFilesFromParam(LPARAM lParam) const;


### PR DESCRIPTION
When using Folder as Workspace, every file added or removed is processed one at a time, so when many files are added or removed, Npp takes a long time to get back to a usable state (see #9203).

This PR changes processing of added or removed files to be done in batches. If multiple changes of the same type are received, they're grouped together for processing (with a maximum amount so Npp doesn't stay stuck forever). Processing of the files then groups them according to their paths, reducing the amount of calls to functions that traverse the TreeView.

Fixes #9203