### PR TITLE
Fix regression: Find button not enabled when activating window.

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -3315,7 +3315,7 @@ void FindReplaceDlg::enableProjectCheckmarks()
 				}
 			}
 		}
-		enableFindDlgItem (IDD_FINDINFILES_FIND_BUTTON, enable);
+		enableFindDlgItem (IDD_FINDINFILES_FIND_BUTTON, enable || (_currentStatus != FINDINPROJECTS_DLG));
 		enableFindDlgItem (IDD_FINDINFILES_REPLACEINPROJECTS, enable);
 	}
 }


### PR DESCRIPTION
Fixes the regression described here: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8125#issuecomment-798801190