### PR TITLE
Fix UNC path with quotes handling in File Open/Save Dialog

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -391,18 +391,6 @@ private:
 				return eq;
 			},
 			'\\');
-		// If there are two or more double backslash, then change it to single.
-		// Start from 2nd element to keep a path that starts from "\\".
-		auto last = std::unique(fileName.begin() + 1, fileName.end(),
-			[](generic_string::value_type a, generic_string::value_type b)
-			{
-				return a == b && a == '\\';
-			});
-		if (last != fileName.end())
-		{
-			fileName.erase(last, fileName.end());
-			transformed = true;
-		}
 		return transformed;
 	}
 


### PR DESCRIPTION
Remove a workaround for double backslash that leads to problems.
Originally, the double backslash workaround was needed to address #5368.
But now, the app isn't stuck when such path is used, so the problem is gone.

Fix #9582