### PR TITLE
Option to install COBOL autocomplete

### DIFF
--- a/PowerEditor/installer/nsisInclude/autoCompletion.nsh
+++ b/PowerEditor/installer/nsisInclude/autoCompletion.nsh
@@ -142,6 +142,11 @@ SectionGroup "Auto-completion Files" autoCompletionComponent
 		SetOutPath "$INSTDIR\autoCompletion"
 		File ".\APIs\autoit.xml"
 	${MementoSectionEnd}
+
+	${MementoSection} "COBOL" COBOL
+		SetOutPath "$INSTDIR\autoCompletion"
+		File ".\APIs\cobol.xml"
+	${MementoSectionEnd}
 SectionGroupEnd
 
 
@@ -245,6 +250,10 @@ SectionGroup un.autoCompletionComponent
 
 	Section un.autoit
 		Delete "$INSTDIR\autoCompletion\autoit.xml"
+	SectionEnd
+
+	Section un.cobol
+		Delete "$INSTDIR\autoCompletion\cobol.xml"
 	SectionEnd
 
 SectionGroupEnd


### PR DESCRIPTION
follow-up to adae1922cf87979c4909a63503cc843a4f701e15 / #4004
Since 2017 we have a file that needs to be manually installed... this PR fixes this.

I've used the chance to check: 26 API files in the repo, 25 installed - COBOL was the only one missing (and if you've one-time copied that to your installation it will just stay forever and you don't recognize that...