### PR TITLE
Add command line parameter to add string to title bar

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3466,6 +3466,13 @@ void Notepad_plus::setTitle()
 	if (_isAdministrator)
 		result += TEXT(" [Administrator]");
 
+	generic_string tbAdd = (NppParameters::getInstance()).getTitleBarAdd();
+	if (!tbAdd.empty())
+	{
+		result += TEXT(" - ");
+		result += tbAdd;
+	}
+
 	::SendMessage(_pPublicInterface->getHSelf(), WM_SETTEXT, 0, reinterpret_cast<LPARAM>(result.c_str()));
 }
 

--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -20,7 +20,7 @@
 
 const TCHAR COMMAND_ARG_HELP[] = TEXT("Usage :\r\
 \r\
-notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-LlangCode] [-nLineNumber] [-cColumnNumber] [-pPosition] [-xLeftPos] [-yTopPos] [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime] [-alwaysOnTop] [-openSession] [-r] [-qn=\"Easter egg name\" | -qt=\"a text to display.\" | -qf=\"D:\\my quote.txt\"] [-qSpeed1|2|3] [-quickPrint] [-settingsDir=\"d:\\your settings dir\\\"] [-openFoldersAsWorkspace] [filePath]\r\
+notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-LlangCode] [-nLineNumber] [-cColumnNumber] [-pPosition] [-xLeftPos] [-yTopPos] [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime] [-alwaysOnTop] [-openSession] [-r] [-qn=\"Easter egg name\" | -qt=\"a text to display.\" | -qf=\"D:\\my quote.txt\"] [-qSpeed1|2|3] [-quickPrint] [-settingsDir=\"d:\\your settings dir\\\"] [-openFoldersAsWorkspace]  [-titleAdd=\"additional title bar text\"][filePath]\r\
 \r\
 --help : This help message\r\
 -multiInst : Launch another Notepad++ instance\r\

--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -48,6 +48,7 @@ notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-LlangCode] [-nLineNum
 -quickPrint : Print the file given as argument then quit Notepad++\r\
 -settingsDir=\"d:\\your settings dir\\\": Override the default settings dir\r\
 -openFoldersAsWorkspace: open filePath of folder(s) as workspace\r\
+-titleAdd=\"string\": add string to Notepad++ title bar\r\
 filePath : file or folder name to open (absolute or relative path name)\r\
 ");
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1672,6 +1672,15 @@ public:
 		_cmdSettingsDir = settingsDir;
 	};
 
+	void setTitleBarAdd(const generic_string& titleAdd)
+	{
+		_titleBarAdditional = titleAdd;
+	}
+	generic_string getTitleBarAdd()
+	{
+		return _titleBarAdditional;
+	}
+
 	DPIManager _dpiManager;
 
 	generic_string static getSpecialFolderLocation(int folderKind);
@@ -1750,6 +1759,8 @@ private:
 	bool _isx64 = false; // by default 32-bit
 
 	generic_string _cmdSettingsDir;
+
+	generic_string _titleBarAdditional;
 
 public:
 	void setShortcutDirty() { _isAnyShortcutModified = true; };

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1676,6 +1676,7 @@ public:
 	{
 		_titleBarAdditional = titleAdd;
 	}
+
 	generic_string getTitleBarAdd()
 	{
 		return _titleBarAdditional;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1677,7 +1677,7 @@ public:
 		_titleBarAdditional = titleAdd;
 	}
 
-	generic_string getTitleBarAdd()
+	const generic_string& getTitleBarAdd() const
 	{
 		return _titleBarAdditional;
 	}

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -468,7 +468,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 	generic_string titleBarAdditional;
 	if (getParamValFromString(FLAG_TITLEBAR_ADD, params, titleBarAdditional))
 	{
-		if (titleBarAdditional.length() > 2)
+		if (titleBarAdditional.length() >= 2)
 		{
 			if (titleBarAdditional.front() == '"' && titleBarAdditional.back() == '"')
 			{

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -308,6 +308,7 @@ const TCHAR FLAG_PRINTANDQUIT[] = TEXT("-quickPrint");
 const TCHAR FLAG_NOTEPAD_COMPATIBILITY[] = TEXT("-notepadStyleCmdline");
 const TCHAR FLAG_OPEN_FOLDERS_AS_WORKSPACE[] = TEXT("-openFoldersAsWorkspace");
 const TCHAR FLAG_SETTINGS_DIR[] = TEXT("-settingsDir=");
+const TCHAR FLAG_TITLEBAR_ADD[] = TEXT("-titleAdd=");
 
 void doException(Notepad_plus_Window & notepad_plus_plus)
 {
@@ -464,10 +465,19 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 		nppParameters.setCmdSettingsDir(path);
 	}
 
+	generic_string titleBarAdditional;
+	if (getParamValFromString(FLAG_TITLEBAR_ADD, params, titleBarAdditional))
+	{
+		// could contain double quotes if contains white space
+		if (titleBarAdditional.c_str()[0] == '"' && titleBarAdditional.c_str()[titleBarAdditional.length() - 1] == '"')
+		{
+			titleBarAdditional = titleBarAdditional.substr(1, titleBarAdditional.length() - 2);
+		}
+		nppParameters.setTitleBarAdd(titleBarAdditional);
+	}
+
 	if (showHelp)
 		::MessageBox(NULL, COMMAND_ARG_HELP, TEXT("Notepad++ Command Argument Help"), MB_OK);
-
-
 
 	if (cmdLineParams._localizationPath != TEXT(""))
 	{

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -468,10 +468,12 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 	generic_string titleBarAdditional;
 	if (getParamValFromString(FLAG_TITLEBAR_ADD, params, titleBarAdditional))
 	{
-		// could contain double quotes if contains white space
-		if (titleBarAdditional.c_str()[0] == '"' && titleBarAdditional.c_str()[titleBarAdditional.length() - 1] == '"')
+		if (titleBarAdditional.length() > 2)
 		{
-			titleBarAdditional = titleBarAdditional.substr(1, titleBarAdditional.length() - 2);
+			if (titleBarAdditional.front() == '"' && titleBarAdditional.back() == '"')
+			{
+				titleBarAdditional = titleBarAdditional.substr(1, titleBarAdditional.length() - 2);
+			}
 		}
 		nppParameters.setTitleBarAdd(titleBarAdditional);
 	}


### PR DESCRIPTION
Fix #9539 

Example:

`notepad++ -titleAdd="for ArkadiuszMichalski"`

Result:

![image](https://user-images.githubusercontent.com/30118311/112678101-ed95ca00-8e40-11eb-8bd4-6a1a428e5504.png)
