### PR TITLE
Improve character case handling in RegEx

### DIFF
--- a/scintilla/boostregex/BoostRegExSearch.cxx
+++ b/scintilla/boostregex/BoostRegExSearch.cxx
@@ -304,10 +304,12 @@ Sci::Position BoostRegexSearch::FindText(Document* doc, Sci::Position startPosit
 			);
 		search._skip_windows_line_end_as_one_character = (sciSearchFlags & SCFIND_REGEXP_SKIPCRLFASONE) != 0;
 		
+		std::locale l = std::locale::global(std::locale(""));
 		Match match =
 			isUtf8 ? _utf8.FindText(search)
 			       : _ansi.FindText(search);
-		
+		std::locale::global(l);
+
 		if (match.found())
 		{
 			*lengthRet = match.length();
@@ -414,7 +416,9 @@ void BoostRegexSearch::EncodingDependent<CharT, CharacterIterator>::compileRegex
 {
 	if (_lastCompileFlags != compileFlags || _lastRegexString != regex)
 	{
+		std::locale l = std::locale("");
 		_regex = Regex(CharTPtr(regex), static_cast<regex_constants::syntax_option_type>(compileFlags));
+		std::locale::global(l);
 		_lastRegexString = regex;
 		_lastCompileFlags = compileFlags;
 	}
@@ -444,9 +448,11 @@ bool BoostRegexSearch::SearchParameters::isLineEnd(Sci::Position position)
 
 const char *BoostRegexSearch::SubstituteByPosition(Document* doc, const char *text, Sci::Position *length) {
 	delete[] _substituted;
+	std::locale l = std::locale::global(std::locale(""));
 	_substituted = (doc->CodePage() == SC_CP_UTF8)
 		? _utf8.SubstituteByPosition(text, length)
 		: _ansi.SubstituteByPosition(text, length);
+	std::locale::global(l);
 	return _substituted;
 }
 


### PR DESCRIPTION
Fixes #9636 

Background: Boost regex uses `std::towupper` and `std::towlower` to change the case. How this functions work, depends strongly on the "current global C locale". This is set by default to a special locale "C", which allows only ASCII characters. After setting the locale to "", the case conversion of none-ASCII characters is allowed too. 