### PR TITLE
Reword command name of Run menu's Open file in new instance

### DIFF
--- a/PowerEditor/src/shortcuts.xml
+++ b/PowerEditor/src/shortcuts.xml
@@ -10,7 +10,7 @@
     <UserDefinedCommands>
         <Command name="Get PHP help" Ctrl="no" Alt="yes" Shift="no" Key="112">https://www.php.net/$(CURRENT_WORD)</Command>
         <Command name="Wikipedia Search" Ctrl="no" Alt="yes" Shift="no" Key="114">https://en.wikipedia.org/wiki/Special:Search?search=$(CURRENT_WORD)</Command>
-        <Command name="Open file in another instance" Ctrl="no" Alt="yes" Shift="no" Key="117">$(NPP_FULL_FILE_PATH) $(CURRENT_WORD) -nosession -multiInst</Command>
+        <Command name="Open file in another instance" Ctrl="no" Alt="yes" Shift="no" Key="117">$(NPP_FULL_FILE_PATH) -nosession -multiInst</Command>
     </UserDefinedCommands>
     <PluginCommands />
     <ScintillaKeys />

--- a/PowerEditor/src/shortcuts.xml
+++ b/PowerEditor/src/shortcuts.xml
@@ -10,7 +10,7 @@
     <UserDefinedCommands>
         <Command name="Get PHP help" Ctrl="no" Alt="yes" Shift="no" Key="112">https://www.php.net/$(CURRENT_WORD)</Command>
         <Command name="Wikipedia Search" Ctrl="no" Alt="yes" Shift="no" Key="114">https://en.wikipedia.org/wiki/Special:Search?search=$(CURRENT_WORD)</Command>
-        <Command name="Open file in another instance" Ctrl="no" Alt="yes" Shift="no" Key="117">$(NPP_FULL_FILE_PATH) -nosession -multiInst</Command>
+        <Command name="Open selected file path in new instance" Ctrl="no" Alt="yes" Shift="no" Key="117">$(NPP_FULL_FILE_PATH) $(CURRENT_WORD) -nosession -multiInst</Command>
     </UserDefinedCommands>
     <PluginCommands />
     <ScintillaKeys />


### PR DESCRIPTION
Fix #9724

...at least the really broken part.

@donho I saw no reason for `$(CURRENT_WORD)` to be a parameter to the command, so this PR removes it -- do you see any reason for it to be there?  I suspect a copy-paste-forgetToRemove bug from the previous command when this one was created.