### PR TITLE
Correct locale while compiling the regex.

### DIFF
--- a/scintilla/boostregex/BoostRegExSearch.cxx
+++ b/scintilla/boostregex/BoostRegExSearch.cxx
@@ -416,7 +416,7 @@ void BoostRegexSearch::EncodingDependent<CharT, CharacterIterator>::compileRegex
 {
 	if (_lastCompileFlags != compileFlags || _lastRegexString != regex)
 	{
-		std::locale l = std::locale("");
+		std::locale l = std::locale::global(std::locale(""));
 		_regex = Regex(CharTPtr(regex), static_cast<regex_constants::syntax_option_type>(compileFlags));
 		std::locale::global(l);
 		_lastRegexString = regex;


### PR DESCRIPTION
This is a correction of PR #9707. @MarkusBodensee noticed [here](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/86c66bba90cc3f49323cdcae77173099122c75dc#r49146650), that this line doesn't stick to the plan.