### PR TITLE
Add context menu to ShowAllCharacters toolbar button

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -499,13 +499,33 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				}
 			}
 			else // From tool bar
+			{
+				LPNMMOUSE lpnm = (LPNMMOUSE)notification;
+				if (lpnm->dwItemSpec == IDM_VIEW_ALL_CHARACTERS)
+				{
+					ContextMenu viewAllCharsToolbarButtonContextMenu;
+					std::vector<MenuItemUnit> itemUnitArray;
+					NativeLangSpeaker* nativeLangSpeaker = NppParameters::getInstance().getNativeLangSpeaker();
+					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_TAB_SPACE, 
+						nativeLangSpeaker->getNativeLangMenuString(IDM_VIEW_TAB_SPACE, TEXT("Show White Space and TAB"))));
+					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_EOL, 
+						nativeLangSpeaker->getNativeLangMenuString(IDM_VIEW_EOL, TEXT("Show End of Line"))));
+					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_ALL_CHARACTERS, 
+						nativeLangSpeaker->getNativeLangMenuString(IDM_VIEW_ALL_CHARACTERS, TEXT("Show All Characters"))));
+					viewAllCharsToolbarButtonContextMenu.create(_pPublicInterface->getHSelf(), itemUnitArray);
+					ScintillaViewParams& svp = (ScintillaViewParams&)(NppParameters::getInstance()).getSVP();
+					viewAllCharsToolbarButtonContextMenu.checkItem(IDM_VIEW_TAB_SPACE, svp._whiteSpaceShow && !svp._eolShow);
+					viewAllCharsToolbarButtonContextMenu.checkItem(IDM_VIEW_EOL, !svp._whiteSpaceShow && svp._eolShow);
+					viewAllCharsToolbarButtonContextMenu.checkItem(IDM_VIEW_ALL_CHARACTERS, svp._whiteSpaceShow && svp._eolShow);
+					viewAllCharsToolbarButtonContextMenu.display(p);
+				}
 				return TRUE;
-			//break;
+			}
 
 			if (!_tabPopupMenu.isCreated())
 			{
 				// IMPORTANT: If list below is modified, you have to change the value of tabContextMenuItemPos[] in localization.cpp file
-                std::vector<MenuItemUnit> itemUnitArray;
+				std::vector<MenuItemUnit> itemUnitArray;
 				itemUnitArray.push_back(MenuItemUnit(IDM_FILE_CLOSE, TEXT("Close")));
 				itemUnitArray.push_back(MenuItemUnit(IDM_FILE_CLOSEALL_BUT_CURRENT, TEXT("Close All BUT This")));
 				itemUnitArray.push_back(MenuItemUnit(IDM_FILE_CLOSEALL_TOLEFT, TEXT("Close All to the Left")));

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -169,19 +169,19 @@ generic_string NativeLangSpeaker::getSpecialMenuEntryName(const char *entryName)
 	return TEXT("");
 }
 
-generic_string NativeLangSpeaker::getNativeLangMenuString(int itemID) const
+generic_string NativeLangSpeaker::getNativeLangMenuString(int itemID, const generic_string& defaultString) const
 {
 	if (!_nativeLangA)
-		return TEXT("");
+		return defaultString;
 
 	TiXmlNodeA *node = _nativeLangA->FirstChild("Menu");
-	if (!node) return TEXT("");
+	if (!node) return defaultString;
 
 	node = node->FirstChild("Main");
-	if (!node) return TEXT("");
+	if (!node) return defaultString;
 
 	node = node->FirstChild("Commands");
-	if (!node) return TEXT("");
+	if (!node) return defaultString;
 
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 
@@ -200,7 +200,7 @@ generic_string NativeLangSpeaker::getNativeLangMenuString(int itemID) const
 			}
 		}
 	}
-	return TEXT("");
+	return defaultString;
 }
 
 generic_string NativeLangSpeaker::getShortcutNameString(int itemID) const

--- a/PowerEditor/src/localization.h
+++ b/PowerEditor/src/localization.h
@@ -46,7 +46,7 @@ public:
 	bool changeDlgLang(HWND hDlg, const char *dlgTagName, char *title = NULL, size_t titleMaxSize = 0);
 	void changeLangTabDrapContextMenu(HMENU hCM);
 	generic_string getSpecialMenuEntryName(const char *entryName) const;
-	generic_string getNativeLangMenuString(int itemID) const;
+	generic_string getNativeLangMenuString(int itemID, const generic_string& defaultString = TEXT("")) const;
 	generic_string getShortcutNameString(int itemID) const;
 
 	void changeMenuLang(HMENU menuHandle, generic_string & pluginsTrans, generic_string & windowTrans);


### PR DESCRIPTION
Fix #9740 

Or at least make the button more useful by adding a right-click context menu that quickly allows setting any of the FOUR setting choices (rather than only TWO states that the button currently allows).

In the following the ¶ was right-clicked upon to generate the popup menu:

![image](https://user-images.githubusercontent.com/30118311/114482580-c9721100-9bd4-11eb-8a74-ed42f001e9f1.png)
