### PR TITLE
#9766 - Fix for 'Match Whole Word' option being enabled in Regular Expression Search

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -2791,6 +2791,7 @@ void FindReplaceDlg::enableFindInFilesControls(bool isEnable, bool projectPanels
 {
 	// Hide Items
 	showFindDlgItem(IDC_BACKWARDDIRECTION, !isEnable);
+	showFindDlgItem(IDWHOLEWORD, !isEnable);
 	showFindDlgItem(IDWRAP, !isEnable);
 	showFindDlgItem(IDCCOUNTALL, !isEnable);
 	showFindDlgItem(IDC_FINDALL_OPENEDFILES, !isEnable);


### PR DESCRIPTION
Ensured 'Match Whole Word' option is disabled in Regular Expression Search - #9766