### PR TITLE
Fix UTF iterators end too early.

### DIFF
--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -629,24 +629,18 @@ void Utf16_Iter::operator++()
 				m_highSurrogate = m_nCur16;
 			}
             else if (m_nCur16 < 0x80) {
-                pushout(static_cast<ubyte>(m_nCur16 & 0xFF));
+                pushout(static_cast<ubyte>(m_nCur16));
                 m_eState = eStart;
             } else if (m_nCur16 < 0x800) {
                 pushout(static_cast<ubyte>(0xC0 | m_nCur16 >> 6));
-                m_eState = e2Bytes2;
+                pushout(0x80 | m_nCur16 & 0x3f);
+                m_eState = eStart;
             } else {
-                pushout(static_cast<ubyte>(0xE0 | m_nCur16 >> 12));
-                m_eState = e3Bytes2;
+                pushout(0xE0 | (m_nCur16 >> 12));
+                pushout(0x80 | (m_nCur16 >> 6) & 0x3f);
+                pushout(0x80 | m_nCur16 & 0x3f);
+                m_eState = eStart;
             }
-            break;
-        case e2Bytes2:
-        case e3Bytes3:
-            pushout(static_cast<ubyte>(0x80 | m_nCur16 & 0x3F));
-            m_eState = eStart;
-            break;
-        case e3Bytes2:
-            pushout(static_cast<ubyte>(0x80 | ((m_nCur16 >> 6) & 0x3F)));
-            m_eState = e3Bytes3;
             break;
 		case eSurrogate:
 			read();
@@ -657,8 +651,8 @@ void Utf16_Iter::operator++()
 				pushout(0x80 | (code >> 12) & 0x3f);
 				pushout(0x80 | (code >>  6) & 0x3f);
 				pushout(0x80 | code & 0x3f);
-				m_eState = eStart;
 			}
+			m_eState = eStart;
 			break;
     }
 }

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -40,9 +40,6 @@ class Utf16_Iter : public Utf8_16 {
 public:
 	enum eState {
 	    eStart,
-	    e2Bytes2,
-	    e3Bytes2,
-	    e3Bytes3,
 		eSurrogate
 	};
 
@@ -52,7 +49,7 @@ public:
 	bool get(utf8 *c);
 	void operator++();
 	eState getState() { return m_eState; };
-	operator bool() { return m_pRead < m_pEnd; };
+	operator bool() { return (m_pRead < m_pEnd) || (m_out1st != m_outLst); };
 
 protected:
 	void read();
@@ -81,7 +78,7 @@ public:
 	bool canGet() const { return m_out1st != m_outLst; }
 	void toStart();
 	void operator++();
-	operator bool() { return m_pRead < m_pEnd; }
+	operator bool() { return (m_pRead < m_pEnd) || (m_out1st != m_outLst); }
 
 protected:
 	enum eState {eStart, eFollow};


### PR DESCRIPTION
Fixes the bug in `Utf16_Iter` described here: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/9599#issuecomment-825654605. I introduced this bug in 9599, it is a regression. Sorry for that. The problem is: If the last character of an UTF-16-coded file is greater then 0x7F, and hence needs more than one byte in UTF-8-encoding, only the 1st byte of the UTF-8 sequence arrives in the text buffer.

A similar bug does exist in `Utf8_Iter`, which is fixed too. This bug, at least, is no regression. It is also harder to reproduce. When writing an UTF-16-coded file, and 
- the code point of the last character in the text buffer is above 0x0FFFF, which means, two 16-bit codes need to be written instead of one, and 
- the position of the last character in the text buffer is 65536 (or any multiple of this),  

then only the first 16-bit code is written to the file.

The 65536 comes from the size of the intermediate buffer which is used while conversion:
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/6750be34328a274d829a9c19f4369a598b4a98a5/PowerEditor/src/Utf8_16.cpp#L344