### PR TITLE
Dark Mode independent of OS setting; statusbar improvements and dark buttons

### DIFF
--- a/PowerEditor/src/DarkMode/DarkMode.h
+++ b/PowerEditor/src/DarkMode/DarkMode.h
@@ -8,9 +8,10 @@ bool ShouldAppsUseDarkMode();
 bool AllowDarkModeForWindow(HWND hWnd, bool allow);
 bool IsHighContrast();
 void RefreshTitleBarThemeColor(HWND hWnd);
+void SetTitleBarThemeColor(HWND hWnd, BOOL dark);
 bool IsColorSchemeChangeMessage(LPARAM lParam);
 bool IsColorSchemeChangeMessage(UINT message, LPARAM lParam);
 void AllowDarkModeForApp(bool allow);
 void EnableDarkScrollBarForWindowAndChildren(HWND hwnd);
-void InitDarkMode(bool fixDarkScrollbar);
+void InitDarkMode(bool fixDarkScrollbar, bool dark);
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7503,8 +7503,39 @@ void Notepad_plus::restoreMinimizeDialogs()
 void Notepad_plus::refreshDarkMode()
 {
 	SendMessage(_pPublicInterface->getHSelf(), NPPM_SETEDITORBORDEREDGE, 0, NppParameters::getInstance().getSVP()._showBorderEdge);
+	if (NppDarkMode::isExperimentalEnabled())
+	{
+		NppDarkMode::allowDarkModeForApp(NppDarkMode::isEnabled());
+		NppDarkMode::allowDarkModeForWindow(_pPublicInterface->getHSelf(), NppDarkMode::isEnabled());
+		NppDarkMode::allowDarkModeForWindow(_findReplaceDlg.getHSelf(), NppDarkMode::isEnabled());
+		NppDarkMode::setTitleBarThemeColor(_pPublicInterface->getHSelf(), NppDarkMode::isEnabled());
+		NppDarkMode::setTitleBarThemeColor(_findReplaceDlg.getHSelf(), NppDarkMode::isEnabled());
+	}
 	RedrawWindow(_pPublicInterface->getHSelf(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
 	RedrawWindow(_findReplaceDlg.getHSelf(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
+
+	if (NppDarkMode::isExperimentalEnabled())
+	{
+		RECT rcClient;
+		
+		GetWindowRect(_pPublicInterface->getHSelf(), &rcClient);
+
+		// Inform application of the frame change.
+		SetWindowPos(_pPublicInterface->getHSelf(),
+			NULL,
+			rcClient.left, rcClient.top,
+			rcClient.right - rcClient.left, rcClient.bottom - rcClient.top,
+			SWP_FRAMECHANGED);
+
+		GetWindowRect(_findReplaceDlg.getHSelf(), &rcClient);
+
+		// Inform application of the frame change.
+		SetWindowPos(_findReplaceDlg.getHSelf(),
+			NULL,
+			rcClient.left, rcClient.top,
+			rcClient.right - rcClient.left, rcClient.bottom - rcClient.top,
+			SWP_FRAMECHANGED);
+	}
 }
 
 void Notepad_plus::launchDocumentBackupTask()

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7511,6 +7511,8 @@ void Notepad_plus::refreshDarkMode()
 		NppDarkMode::setTitleBarThemeColor(_pPublicInterface->getHSelf(), NppDarkMode::isEnabled());
 		NppDarkMode::setTitleBarThemeColor(_findReplaceDlg.getHSelf(), NppDarkMode::isEnabled());
 	}
+	SendMessage(_findReplaceDlg.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+	SendMessage(_incrementFindDlg.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
 	RedrawWindow(_pPublicInterface->getHSelf(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
 	RedrawWindow(_findReplaceDlg.getHSelf(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -70,7 +70,7 @@ LRESULT CALLBACK Notepad_plus_Window::Notepad_plus_Proc(HWND hwnd, UINT message,
 			pM30ide->_hSelf = hwnd;
 			::SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pM30ide));
 
-			if (NppDarkMode::isExperimentalEnabled() && NppDarkMode::isScrollbarHackEnabled())
+			if (NppDarkMode::isExperimentalEnabled() && NppDarkMode::isEnabled() && NppDarkMode::isScrollbarHackEnabled())
 			{
 				NppDarkMode::enableDarkScrollBarForWindowAndChildren(hwnd);
 			}
@@ -96,14 +96,14 @@ LRESULT Notepad_plus_Window::runProc(HWND hwnd, UINT message, WPARAM wParam, LPA
 			{
 				if (NppDarkMode::isExperimentalEnabled())
 				{
-					NppDarkMode::allowDarkModeForWindow(hwnd, true);
-					NppDarkMode::refreshTitleBarThemeColor(hwnd);
+					NppDarkMode::allowDarkModeForWindow(hwnd, NppDarkMode::isEnabled());
+					NppDarkMode::setTitleBarThemeColor(hwnd, NppDarkMode::isEnabled());
 				}
 
 				_notepad_plus_plus_core._pPublicInterface = this;
 				LRESULT lRet = _notepad_plus_plus_core.init(hwnd);
 
-				if (NppDarkMode::isExperimentalEnabled())
+				if (NppDarkMode::isExperimentalEnabled() && NppDarkMode::isEnabled())
 				{
 					RECT rcClient;
 					GetWindowRect(hwnd, &rcClient);
@@ -150,7 +150,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 	LRESULT result = FALSE;
 	NppParameters& nppParam = NppParameters::getInstance();
 
-	if (NppDarkMode::isDarkMenuEnabled() && NppDarkMode::runUAHWndProc(hwnd, message, wParam, lParam, &result))
+	if (NppDarkMode::isDarkMenuEnabled() && NppDarkMode::isEnabled() && NppDarkMode::runUAHWndProc(hwnd, message, wParam, lParam, &result))
 	{
 		return result;
 	}
@@ -181,11 +181,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_SETTINGCHANGE:
 		{
-			if (NppDarkMode::handleSettingChange(hwnd, lParam))
-			{
-				// dark mode may have been toggled by the OS
-				NppDarkMode::refreshDarkMode(hwnd, true);
-			}
+			NppDarkMode::handleSettingChange(hwnd, lParam);
 
 			return ::DefWindowProc(hwnd, message, wParam, lParam);
 		}

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -28,7 +28,7 @@ namespace NppDarkMode
 
 		if (_options.enableExperimental)
 		{
-			initExperimentalDarkMode(_options.enableScrollbarHack);
+			initExperimentalDarkMode(_options.enableScrollbarHack, _options.enable);
 		}
 	}
 
@@ -193,28 +193,19 @@ namespace NppDarkMode
 
 	// handle events
 
-	bool handleSettingChange(HWND hwnd, LPARAM lParam) // true if dark mode toggled
+	void handleSettingChange(HWND hwnd, LPARAM lParam)
 	{
+		UNREFERENCED_PARAMETER(hwnd);
+
 		if (!isExperimentalEnabled())
 		{
-			return false;
+			return;
 		}
 
-		bool toggled = false;
 		if (IsColorSchemeChangeMessage(lParam))
 		{
-			bool darkModeWasEnabled = g_darkModeEnabled;
 			g_darkModeEnabled = ShouldAppsUseDarkMode() && !IsHighContrast();
-
-			NppDarkMode::refreshTitleBarThemeColor(hwnd);
-
-			if (!!darkModeWasEnabled != !!g_darkModeEnabled)
-			{
-				toggled = true;
-			}
 		}
-
-		return toggled;
 	}
 
 	// processes messages related to UAH / custom menubar drawing.
@@ -349,9 +340,9 @@ namespace NppDarkMode
 
 	// from DarkMode.h
 
-	void initExperimentalDarkMode(bool fixDarkScrollbar)
+	void initExperimentalDarkMode(bool fixDarkScrollbar, bool dark)
 	{
-		::InitDarkMode(fixDarkScrollbar);
+		::InitDarkMode(fixDarkScrollbar, dark);
 	}
 
 	void allowDarkModeForApp(bool allow)
@@ -364,9 +355,9 @@ namespace NppDarkMode
 		return ::AllowDarkModeForWindow(hWnd, allow);
 	}
 
-	void refreshTitleBarThemeColor(HWND hWnd)
+	void setTitleBarThemeColor(HWND hWnd, bool dark)
 	{
-		::RefreshTitleBarThemeColor(hWnd);
+		::SetTitleBarThemeColor(hWnd, dark);
 	}
 
 	void enableDarkScrollBarForWindowAndChildren(HWND hwnd)

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -58,5 +58,8 @@ namespace NppDarkMode
 	void subclassGroupboxControl(HWND hwnd);
 	void subclassToolbarControl(HWND hwnd);
 	void subclassTabControl(HWND hwnd);
+
+	void autoSubclassAndThemeChildControls(HWND hwndParent, bool subclass = true, bool theme = true);
+	void autoThemeChildControls(HWND hwndParent);
 }
 

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -20,9 +20,6 @@ namespace NppDarkMode
 	bool isExperimentalEnabled();
 	bool isScrollbarHackEnabled();
 
-	bool isExperimentalActive();
-	bool isExperimentalSupported();
-
 	COLORREF invertLightness(COLORREF c);
 	COLORREF invertLightnessSofter(COLORREF c);
 
@@ -42,17 +39,17 @@ namespace NppDarkMode
 	HBRUSH getErrorBackgroundBrush();
 
 	// handle events
-	bool handleSettingChange(HWND hwnd, LPARAM lParam); // true if dark mode toggled
+	void handleSettingChange(HWND hwnd, LPARAM lParam);
 
 	// processes messages related to UAH / custom menubar drawing.
 	// return true if handled, false to continue with normal processing in your wndproc
 	bool runUAHWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam, LRESULT* lr);
 
 	// from DarkMode.h
-	void initExperimentalDarkMode(bool fixDarkScrollbar);
+	void initExperimentalDarkMode(bool fixDarkScrollbar, bool dark);
 	void allowDarkModeForApp(bool allow);
 	bool allowDarkModeForWindow(HWND hWnd, bool allow);
-	void refreshTitleBarThemeColor(HWND hWnd);
+	void setTitleBarThemeColor(HWND hWnd, bool dark);
 
 	// enhancements to DarkMode.h
 	void enableDarkScrollBarForWindowAndChildren(HWND hwnd);

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -876,22 +876,12 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 			return TRUE;
 		}
 
-		case WM_SETTINGCHANGE:
-		{
-			if (NppDarkMode::handleSettingChange(_hSelf, lParam))
-			{
-				// dark mode may have been toggled by the OS
-				NppDarkMode::refreshDarkMode(_hSelf, true);
-			}
-			break;
-		}
-
 		case WM_INITDIALOG :
 		{
 			if (NppDarkMode::isExperimentalEnabled())
 			{
-				NppDarkMode::allowDarkModeForWindow(_hSelf, true);
-				NppDarkMode::refreshTitleBarThemeColor(_hSelf);
+				NppDarkMode::allowDarkModeForWindow(_hSelf, NppDarkMode::isEnabled());
+				NppDarkMode::setTitleBarThemeColor(_hSelf, NppDarkMode::isEnabled());
 			}
 
 			EnumChildWindows(_hSelf, [](HWND hwnd, LPARAM) {


### PR DESCRIPTION
Still in progress but functional. A bit tricky with some things being able to toggle while Notepad++ is running, but that might be acceptable since we already state changing the experimental options requires restarting the application. 