### PR TITLE
Fix Python Function List not showing functions

### DIFF
--- a/PowerEditor/Test/FunctionList/python/baddeftest/unitTest
+++ b/PowerEditor/Test/FunctionList/python/baddeftest/unitTest
@@ -1,0 +1,25 @@
+def invisible_function1(): # invisible because at file start
+    pass
+
+class VisibleClass1:
+    def __init__(self):
+        pass
+
+
+
+
+
+def invisible_function2(): # invisible because nothing but linebreaks between VisibleClass1 and invisible_function2
+    pass
+
+class VisibleClass2:
+    def __init__(self):
+        pass
+
+
+
+
+
+# visible because there is something between VisibleClass2 and visible_function
+def visible_function():
+    pass

--- a/PowerEditor/Test/FunctionList/python/baddeftest/unitTest.expected.result
+++ b/PowerEditor/Test/FunctionList/python/baddeftest/unitTest.expected.result
@@ -1,0 +1,1 @@
+{"leaves":["invisible_function1()","invisible_function2()","visible_function()"],"nodes":[{"leaves":["__init__(self)"],"name":"VisibleClass1"},{"leaves":["__init__(self)"],"name":"VisibleClass2"}],"root":"unitTest"}

--- a/PowerEditor/installer/functionList/python.xml
+++ b/PowerEditor/installer/functionList/python.xml
@@ -30,7 +30,7 @@
 				</function>
 			</classRange>
 			<function
-				mainExpr="\sdef\x20\K.+?(?=:)"
+				mainExpr="^def\x20\K.+?(?=:)"
 			>
 				<functionName>
 					<nameExpr expr=".*" />


### PR DESCRIPTION

Functions defined at the top of the file or below a class with nothing in between would not show in the Function List.

This changes the function regex to fix this. A small unit test that the old regex won't pass but the new will included.

Old regex:
![oldregex](https://user-images.githubusercontent.com/3857153/117568919-e258cf80-b077-11eb-83ba-0267dc2bb1c1.png)

New regex:
![newregex](https://user-images.githubusercontent.com/3857153/117568930-eedd2800-b077-11eb-9a3d-5b29add5a729.png)
