### PR TITLE
Rename sort randomly menu item, move it and reverse lines out of sorting section

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -130,7 +130,7 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="42065" name="Sort Lines As Decimals (Dot) Ascending"/>
                     <Item id="42066" name="Sort Lines As Decimals (Dot) Descending"/>
                     <Item id="42083" name="Reverse Line Order"/>
-                    <Item id="42078" name="Sort Lines Randomly"/>
+                    <Item id="42078" name="Randomize Line Order"/>
                     <Item id="42016" name="&amp;UPPERCASE"/>
                     <Item id="42017" name="&amp;lowercase"/>
                     <Item id="42067" name="&amp;Proper Case"/>

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -438,6 +438,8 @@ BEGIN
             MENUITEM "Remove Empty Lines (Containing Blank characters)", IDM_EDIT_REMOVEEMPTYLINESWITHBLANK
             MENUITEM "Insert Blank Line Above Current",                  IDM_EDIT_BLANKLINEABOVECURRENT
             MENUITEM "Insert Blank Line Below Current",                  IDM_EDIT_BLANKLINEBELOWCURRENT
+            MENUITEM "Reverse Line Order",                               IDM_EDIT_SORTLINES_REVERSE_ORDER
+            MENUITEM "Randomize Line Order",                             IDM_EDIT_SORTLINES_RANDOMLY
             MENUITEM SEPARATOR
             MENUITEM "Sort Lines Lexicographically Ascending",           IDM_EDIT_SORTLINES_LEXICOGRAPHIC_ASCENDING
             MENUITEM "Sort Lines Lex. Ascending Ignoring Case",          IDM_EDIT_SORTLINES_LEXICO_CASE_INSENS_ASCENDING
@@ -450,9 +452,6 @@ BEGIN
             MENUITEM "Sort Lines As Integers Descending",                IDM_EDIT_SORTLINES_INTEGER_DESCENDING
             MENUITEM "Sort Lines As Decimals (Comma) Descending",        IDM_EDIT_SORTLINES_DECIMALCOMMA_DESCENDING
             MENUITEM "Sort Lines As Decimals (Dot) Descending",          IDM_EDIT_SORTLINES_DECIMALDOT_DESCENDING
-            MENUITEM SEPARATOR
-            MENUITEM "Reverse Line Order",                               IDM_EDIT_SORTLINES_REVERSE_ORDER
-            MENUITEM "Sort Lines Randomly",                              IDM_EDIT_SORTLINES_RANDOMLY
         END
         POPUP "Comment/Uncomment"
         BEGIN


### PR DESCRIPTION
Note: no associated "issue".

* Rename "Sort Lines Randomly" on _Edit_ > _Line Operations_ menu to "Randomize Line Order"
* Move "Reverse Line Order" and "Randomize Line Order" so that they appear in the menu above the bottom section (which contains only the true sorting operations).

Screenshot relating to the change are here: https://github.com/notepad-plus-plus/npp-usermanual/pull/220#issuecomment-841648842
