### PR TITLE
Revert BrandingText to follow code of conduct

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -271,6 +271,6 @@ Section -FinishSection
   Call writeInstallInfoInRegistry
 SectionEnd
 
-BrandingText "Software is like sex: It's better when it's free"
+BrandingText "The best things in life are free. Notepad++ is free. So Notepad++ is the best"
 
 ; eof


### PR DESCRIPTION
The BrandingText is the text shown on the license page on the installer