### PR TITLE
Add new API NPPM_ADDTOOLBARICON_FORDARKMODE for dark mode

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -145,8 +145,8 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	#define NPPM_SETMENUITEMCHECK	(NPPMSG + 40)
 	//void WM_PIMENU_CHECK(UINT	funcItem[X]._cmdID, TRUE/FALSE)
 
-	#define NPPM_ADDTOOLBARICON (NPPMSG + 41)
-	//void NPPM_ADDTOOLBARICON(UINT funcItem[X]._cmdID, toolbarIcons iconHandles)
+	#define NPPM_ADDTOOLBARICON_DEPRECATED (NPPMSG + 41)
+	//void NPPM_ADDTOOLBARICON(UINT funcItem[X]._cmdID, toolbarIcons iconHandles) -- DEPRECATED : use NPPM_ADDTOOLBARICON_FORDARKMODE instead
 	//2 formats of icon are needed: .ico & .bmp 
 	//Both handles below should be set so the icon will be displayed correctly if toolbar icon sets are changed by users
 		struct toolbarIcons {

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -146,7 +146,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	//void WM_PIMENU_CHECK(UINT	funcItem[X]._cmdID, TRUE/FALSE)
 
 	#define NPPM_ADDTOOLBARICON (NPPMSG + 41)
-	//void NPPM_ADDTOOLBARICON(UINT funcItem[X]._cmdID, toolbarIcons icon)
+	//void NPPM_ADDTOOLBARICON(UINT funcItem[X]._cmdID, toolbarIcons iconHandles)
 	//2 formats of icon are needed: .ico & .bmp 
 	//Both handles below should be set so the icon will be displayed correctly if toolbar icon sets are changed by users
 		struct toolbarIcons {
@@ -243,7 +243,6 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// Reloads Buffer
 	// wParam: Buffer to reload
 	// lParam: 0 if no alert, else alert
-
 
 	#define NPPM_GETBUFFERLANGTYPE (NPPMSG + 64)
 	// INT NPPM_GETBUFFERLANGTYPE(UINT_PTR bufferID, 0)
@@ -439,6 +438,16 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// INT NPPM_GETLINENUMBERWIDTHMODE(0, 0)
 	// Get line number margin width in dynamic width mode (LINENUMWIDTH_DYNAMIC) or constant width mode (LINENUMWIDTH_CONSTANT)
 
+	#define NPPM_ADDTOOLBARICON_FORDARKMODE (NPPMSG + 101)
+	// void NPPM_ADDTOOLBARICON_FORDARKMODE(UINT funcItem[X]._cmdID, toolbarIconsWithDarkMode iconHandles)
+	// Use NPPM_ADDTOOLBARICON_FORDARKMODE instead obsolete NPPM_ADDTOOLBARICON which doesn't support the dark mode
+	// 2 formats / 3 icons are needed:  1 * BMP + 2 * ICO 
+	// All 3 handles below should be set so the icon will be displayed correctly if toolbar icon sets are changed by users, also in dark mode
+	struct toolbarIconsWithDarkMode {
+		HBITMAP	hToolbarBmp;
+		HICON	hToolbarIcon;
+		HICON	hToolbarIconDarkMode;
+	};
 
 #define VAR_NOT_RECOGNIZED 0
 #define FULL_CURRENT_PATH 1

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -439,7 +439,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// Get line number margin width in dynamic width mode (LINENUMWIDTH_DYNAMIC) or constant width mode (LINENUMWIDTH_CONSTANT)
 
 	#define NPPM_ADDTOOLBARICON_FORDARKMODE (NPPMSG + 101)
-	// void NPPM_ADDTOOLBARICON_FORDARKMODE(UINT funcItem[X]._cmdID, toolbarIconsWithDarkMode iconHandles)
+	// VOID NPPM_ADDTOOLBARICON_FORDARKMODE(UINT funcItem[X]._cmdID, toolbarIconsWithDarkMode iconHandles)
 	// Use NPPM_ADDTOOLBARICON_FORDARKMODE instead obsolete NPPM_ADDTOOLBARICON which doesn't support the dark mode
 	// 2 formats / 3 icons are needed:  1 * BMP + 2 * ICO 
 	// All 3 handles below should be set so the icon will be displayed correctly if toolbar icon sets are changed by users, also in dark mode

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2161,6 +2161,12 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return TRUE;
 		}
 
+		case NPPM_ADDTOOLBARICON_FORDARKMODE:
+		{
+			_toolBar.registerDynBtnDM(static_cast<UINT>(wParam), reinterpret_cast<toolbarIconsWithDarkMode*>(lParam));
+			return TRUE;
+		}
+
 		case NPPM_SETMENUITEMCHECK:
 		{
 			::CheckMenuItem(_mainMenuHandle, static_cast<UINT>(wParam), MF_BYCOMMAND | (static_cast<BOOL>(lParam) ? MF_CHECKED : MF_UNCHECKED));

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2155,7 +2155,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return NULL;
 		}
 
-		case NPPM_ADDTOOLBARICON:
+		case NPPM_ADDTOOLBARICON_DEPRECATED:
 		{
 			_toolBar.registerDynBtn(static_cast<UINT>(wParam), reinterpret_cast<toolbarIcons*>(lParam), _pPublicInterface->getAbsentIcoHandle());
 			return TRUE;

--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
@@ -123,10 +123,10 @@ void ToolBarIcons::reInit(int size)
 		_iconListVector[HLIST_DISABLE2].addIcon(i._hIcon);
 
 
-		_iconListVector[HLIST_DEFAULT_DM].addIcon(i._hIcon);
-		_iconListVector[HLIST_DISABLE_DM].addIcon(i._hIcon);
-		_iconListVector[HLIST_DEFAULT_DM2].addIcon(i._hIcon);
-		_iconListVector[HLIST_DISABLE_DM2].addIcon(i._hIcon);
+		_iconListVector[HLIST_DEFAULT_DM].addIcon(i._hIcon_DM ? i._hIcon_DM : i._hIcon);
+		_iconListVector[HLIST_DISABLE_DM].addIcon(i._hIcon_DM ? i._hIcon_DM : i._hIcon);
+		_iconListVector[HLIST_DEFAULT_DM2].addIcon(i._hIcon_DM ? i._hIcon_DM : i._hIcon);
+		_iconListVector[HLIST_DISABLE_DM2].addIcon(i._hIcon_DM ? i._hIcon_DM : i._hIcon);
 	}
 }
 

--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
@@ -69,9 +69,10 @@ typedef struct
 } ToolBarButtonUnit;
 
 struct DynamicCmdIcoBmp {
-	UINT		_message;		// identification of icon in tool bar (menu ID)
-	HBITMAP		_hBmp;			// bitmap for toolbar
-	HICON		_hIcon;			// icon for toolbar
+	UINT _message = 0;         // identification of icon in tool bar (menu ID)
+	HBITMAP _hBmp = nullptr;   // bitmap for toolbar
+	HICON _hIcon = nullptr;    // icon for toolbar
+	HICON _hIcon_DM = nullptr; // dark mode icon for toolbar
 };
 
 typedef std::vector<ToolBarButtonUnit> ToolBarIconIDs;

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
@@ -372,15 +372,30 @@ void ToolBar::reset(bool create)
 	}
 }
 
-void ToolBar::registerDynBtn(UINT messageID, toolbarIcons* tIcon, HICON absentIco)
+void ToolBar::registerDynBtn(UINT messageID, toolbarIcons* iconHandles, HICON absentIco)
 {
 	// Note: Register of buttons only possible before init!
-	if ((_hSelf == NULL) && (messageID != 0) && (tIcon->hToolbarBmp != NULL))
+	if ((_hSelf == NULL) && (messageID != 0) && (iconHandles->hToolbarBmp != NULL))
 	{
 		DynamicCmdIcoBmp dynList;
 		dynList._message = messageID;
-		dynList._hBmp = tIcon->hToolbarBmp;
-		dynList._hIcon = tIcon->hToolbarIcon ? tIcon->hToolbarIcon : absentIco;
+		dynList._hBmp = iconHandles->hToolbarBmp;
+		dynList._hIcon = iconHandles->hToolbarIcon ? iconHandles->hToolbarIcon : absentIco;
+		_vDynBtnReg.push_back(dynList);
+	}
+}
+
+void ToolBar::registerDynBtnDM(UINT messageID, toolbarIconsWithDarkMode* iconHandles)
+{
+	// Note: Register of buttons only possible before init!
+	if ((_hSelf == NULL) && (messageID != 0) && (iconHandles->hToolbarBmp != NULL) && 
+		(iconHandles->hToolbarIcon != NULL) && (iconHandles->hToolbarIconDarkMode != NULL))
+	{
+		DynamicCmdIcoBmp dynList;
+		dynList._message = messageID;
+		dynList._hBmp = iconHandles->hToolbarBmp;
+		dynList._hIcon = iconHandles->hToolbarIcon;
+		dynList._hIcon_DM = iconHandles->hToolbarIconDarkMode;
 		_vDynBtnReg.push_back(dynList);
 	}
 }

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.h
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.h
@@ -94,7 +94,8 @@ public :
 		return _toolBarIcons.replaceIcon(whichLst, iconIndex, iconLocation);
 	};
 
-	void registerDynBtn(UINT message, toolbarIcons* hBmp, HICON absentIco);
+	void registerDynBtn(UINT message, toolbarIcons* iconHandles, HICON absentIco);
+	void registerDynBtnDM(UINT message, toolbarIconsWithDarkMode* iconHandles);
 
 	void doPopop(POINT chevPoint);	//show the popup if buttons are hidden
 


### PR DESCRIPTION
Usage:
void NPPM_ADDTOOLBARICON_FORDARKMODE(UINT funcItem[X]._cmdID, toolbarIconsWithDarkMode iconHandles)

This new API NPPM_ADDTOOLBARICON_FORDARKMODE is for replacing obsolete NPPM_ADDTOOLBARICON which doesn't support the dark mode.
2 formats / 3 icons are needed:  1 * BMP + 2 * ICO
All 3 handles below should be set so the icon will be displayed correctly if toolbar icon sets are changed by users, also in dark mode.
	struct toolbarIconsWithDarkMode {
		HBITMAP	hToolbarBmp;
		HICON	hToolbarIcon;
		HICON	hToolbarIconDarkMode;
	};