### PR TITLE
Close all tabs in stack with single action

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1436,6 +1436,7 @@ Find in all files except exe, obj &amp;&amp; log:
             <session-save-folder-as-workspace value="Save Folder as Workspace" />
             <tab-untitled-string value="new " />
             <file-save-assign-type value="&amp;Append extension" />
+            <close-panel-tip value="Close" />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
@@ -155,7 +155,7 @@ protected :
 	eMousePos isInRect(HWND hwnd, int x, int y);
 
 	// handling of toolbars
-	void doClose();
+	void doClose(BOOL closeAll);
 
 	// return new item
 	int  searchPosInTab(tTbData* pTbData);


### PR DESCRIPTION
Implements #8922. Shift-click closes the whole stack now.

I included the "Close" tooltip in localization, but I didn't  extend this tooltip yet for the following reason: If the side window is not docked, it has an original Windows title bar. The tooltip for the Close button in this title bar is always "Close", and cannot be modified in any easy way. So, if we extend the tooltip in the docked state only, we have two different tooltips, docked and undocked.

This could be overcome only by drawing an own title bar for the undocked side windows. In this case, the title bars of docked and undocked side windows could made look the same way. But I did not any experiment in this direction right now.