### PR TITLE
Appveyor vs2019 with toolchain v142

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -487,7 +487,8 @@ void Notepad_plus::command(int id)
 			if (nppGui._searchEngineChoice == nppGui.se_custom)
 			{
 				url = nppGui._searchEngineCustom;
-				remove_if(url.begin(), url.end(), _istspace);
+				url.erase(std::remove_if(url.begin(), url.end(), [](_TUCHAR x) {return _istspace(x); }),
+					url.end());
 
 				auto httpPos = url.find(TEXT("http://"));
 				auto httpsPos = url.find(TEXT("https://"));

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -31,40 +31,40 @@
     <ProjectGuid>{FCF60E65-1B78-4D1D-AB59-4FC00AC8C248}</ProjectGuid>
     <RootNamespace>Notepad++</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 7.9.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 
 environment:
@@ -27,7 +27,7 @@ configuration:
 
 install:
     - if "%Platform%"=="mingw-w64_810_X64" set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
-    - if "%archi%" NEQ "" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%archi%" NEQ "" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
 build_script:
     - ps: |

--- a/boostregex/BoostRegExSearch.cxx
+++ b/boostregex/BoostRegExSearch.cxx
@@ -13,6 +13,9 @@
 #include <iterator> 
 #include <vector>
 #include <memory>
+#include <string>
+#include <string_view>
+#include <stdexcept>
 #include "Scintilla.h"
 #include "Platform.h"
 #include "ILoader.h"

--- a/boostregex/UTF8DocumentIterator.cxx
+++ b/boostregex/UTF8DocumentIterator.cxx
@@ -1,10 +1,14 @@
 ﻿#include "UTF8DocumentIterator.h"
 
 
+#include <string>
+#include <string_view>
+#include <stdexcept>
 
 #include "ILoader.h"
 #include "ILexer.h"
 #include "Scintilla.h"
+#include "Platform.h"
 
 
 
@@ -56,6 +60,27 @@ UTF8DocumentIterator::UTF8DocumentIterator(const UTF8DocumentIterator& copy) :
 		{
 				m_pos = m_end;
 		}
+}
+
+UTF8DocumentIterator& UTF8DocumentIterator::operator ++ ()
+{
+	PLATFORM_ASSERT(m_pos < m_end);
+	if (m_utf16Length == 2 && m_characterIndex == 0)
+	{
+		m_characterIndex = 1;
+	}
+	else
+	{
+		m_pos += m_utf8Length;
+
+		if (m_pos > m_end)
+		{
+			m_pos = m_end;
+		}
+		m_characterIndex = 0;
+		readCharacter();
+	}
+	return *this;
 }
 
 UTF8DocumentIterator& UTF8DocumentIterator::operator -- ()

--- a/boostregex/UTF8DocumentIterator.h
+++ b/boostregex/UTF8DocumentIterator.h
@@ -5,7 +5,6 @@
 #include <iterator>
 #include <vector>
 #include <memory>
-#include "Platform.h"
 #include "Position.h"
 
 namespace Scintilla {
@@ -41,27 +40,7 @@ public:
 			return *this;
 		}
 
-		UTF8DocumentIterator& operator ++ ()
-		{
-				PLATFORM_ASSERT(m_pos < m_end);
-				if (m_utf16Length == 2 && m_characterIndex == 0)
-				{
-					m_characterIndex = 1;
-				}
-				else
-				{
-					m_pos += m_utf8Length;
-
-					if (m_pos > m_end)
-					{
-						m_pos = m_end;
-					}
-					m_characterIndex = 0;
-					readCharacter();
-				}
-				return *this;
-		}
-
+		UTF8DocumentIterator& operator ++ ();
 		UTF8DocumentIterator& operator -- ();
 
 		Sci::Position pos() const

--- a/scintilla/win32/SciLexer.vcxproj
+++ b/scintilla/win32/SciLexer.vcxproj
@@ -30,13 +30,13 @@
     <ProjectGuid>{FBE04237-9C7B-4973-9C60-505975998B39}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SciLexer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <TargetName>lib$(ProjectName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Unicode Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
fix #9922

- adapted to build with VS2019 + v142
- as stated in #9922 the build with VS2019 +v141 is possible without code modifications (therefore the split into 2 commits, see https://ci.appveyor.com/project/chcg/notepad-plus-plus/builds/39403038)
- see https://ci.appveyor.com/project/chcg/notepad-plus-plus/builds/39478493 for a build of this changes with the older v141