### PR TITLE
Add context menu for encoding in status bar

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -441,6 +441,13 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 						return TRUE;
 					TrackPopupMenu(hEolFormatMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
 				}
+				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_UNICODE_TYPE))
+				{
+					POINT p;
+					::GetCursorPos(&p);
+					HMENU hLangMenu = ::GetSubMenu(_mainMenuHandle, MENUINDEX_FORMAT);
+					TrackPopupMenu(hLangMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
+				}
 			}
 			break;
 		}
@@ -476,6 +483,13 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					if (!hEolFormatMenu)
 						return TRUE;
 					TrackPopupMenu(hEolFormatMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
+				}
+				else if (lpnm->dwItemSpec == DWORD(STATUSBAR_UNICODE_TYPE))
+				{
+					POINT p;
+					::GetCursorPos(&p);
+					HMENU hLangMenu = ::GetSubMenu(_mainMenuHandle, MENUINDEX_FORMAT);
+					TrackPopupMenu(hLangMenu, 0, p.x, p.y, 0, _pPublicInterface->getHSelf(), NULL);
 				}
 				return TRUE;
 			}


### PR DESCRIPTION
Allow double click or right click on status bar with encoding part to open context menu for encoding.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9998