### PR TITLE
Dark mode tab drawing should work for multiline and vertical tabs

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -879,7 +879,7 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			}
 
 			LONG_PTR dwStyle = GetWindowLongPtr(hwnd, GWL_STYLE);
-			if (!(dwStyle & TCS_OWNERDRAWFIXED) || (dwStyle & TCS_BOTTOM) || (dwStyle & TCS_BUTTONS))
+			if (!(dwStyle & TCS_OWNERDRAWFIXED))
 			{
 				break;
 			}


### PR DESCRIPTION
Turns out it already works, just need to ignore the part that was skipping it.