### PR TITLE
Remove std::iterator from Boost Regex search code

### DIFF
--- a/boostregex/AnsiDocumentIterator.h
+++ b/boostregex/AnsiDocumentIterator.h
@@ -1,13 +1,35 @@
-﻿#ifndef ANSIDOCUMENTITERATOR_H_12481491281240
+﻿// This file is part of Notepad++ project
+// Copyright (C) 2021 Notepad++ authors.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// at your option any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef ANSIDOCUMENTITERATOR_H_12481491281240
 #define ANSIDOCUMENTITERATOR_H_12481491281240
 
 #include "Position.h"
 
 namespace Scintilla {
 
-class AnsiDocumentIterator : public std::iterator<std::bidirectional_iterator_tag, char>
+class AnsiDocumentIterator
 {
 public:
+	using iterator_category = std::bidirectional_iterator_tag;
+	using value_type = char;
+	using difference_type = ptrdiff_t;
+	using pointer = char*;
+	using reference = char&;
+
 	AnsiDocumentIterator() {};
 
 	AnsiDocumentIterator(Document* doc, Sci::Position pos, Sci::Position end) :

--- a/boostregex/BoostRegExSearch.cxx
+++ b/boostregex/BoostRegExSearch.cxx
@@ -10,7 +10,6 @@
  */
 
 #include <stdlib.h>
-#include <iterator> 
 #include <vector>
 #include <memory>
 #include <string_view>

--- a/boostregex/UTF8DocumentIterator.cxx
+++ b/boostregex/UTF8DocumentIterator.cxx
@@ -1,6 +1,20 @@
-﻿#include "UTF8DocumentIterator.h"
+﻿// This file is part of Notepad++ project
+// Copyright (C) 2021 Notepad++ authors.
 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// at your option any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "UTF8DocumentIterator.h"
 #include <string_view>
 #include <stdexcept>
 
@@ -8,8 +22,6 @@
 #include "ILexer.h"
 #include "Scintilla.h"
 #include "Platform.h"
-
-
 
 #include "CharacterCategory.h"
 #include "Position.h"

--- a/boostregex/UTF8DocumentIterator.h
+++ b/boostregex/UTF8DocumentIterator.h
@@ -1,8 +1,23 @@
-﻿#ifndef UTF8DOCUMENTITERATOR_H_3452843291318441149
+﻿// This file is part of Notepad++ project
+// Copyright (C) 2021 Notepad++ authors.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// at your option any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef UTF8DOCUMENTITERATOR_H_3452843291318441149
 #define UTF8DOCUMENTITERATOR_H_3452843291318441149
 
 #include <stdlib.h>
-#include <iterator>
 #include <vector>
 #include <memory>
 #include "Position.h"
@@ -11,60 +26,66 @@ namespace Scintilla {
 
 class Document;
 
-class UTF8DocumentIterator : public std::iterator<std::bidirectional_iterator_tag, wchar_t>
+class UTF8DocumentIterator
 {
 public:
-		UTF8DocumentIterator() {};
+	using iterator_category = std::bidirectional_iterator_tag;
+	using value_type = wchar_t;
+	using difference_type = ptrdiff_t;
+	using pointer = wchar_t*;
+	using reference = wchar_t&;
 
-		UTF8DocumentIterator(Document* doc, Sci::Position pos, Sci::Position end);
-		UTF8DocumentIterator(const UTF8DocumentIterator& copy);
+	UTF8DocumentIterator() {};
 
-		bool operator == (const UTF8DocumentIterator& other) const
-		{
-				return (ended() == other.ended()) && (m_doc == other.m_doc) && (m_pos == other.m_pos);
-		}
+	UTF8DocumentIterator(Document* doc, Sci::Position pos, Sci::Position end);
+	UTF8DocumentIterator(const UTF8DocumentIterator& copy);
 
-		bool operator != (const UTF8DocumentIterator& other) const
-		{
-				return !(*this == other);
-		}
+	bool operator == (const UTF8DocumentIterator& other) const
+	{
+		return (ended() == other.ended()) && (m_doc == other.m_doc) && (m_pos == other.m_pos);
+	}
 
-		wchar_t operator * () const
-		{
-			return m_character[m_characterIndex];
-		}
+	bool operator != (const UTF8DocumentIterator& other) const
+	{
+		return !(*this == other);
+	}
 
-		UTF8DocumentIterator& operator = (Sci::Position other)
-		{
-			m_pos = other;
-			return *this;
-		}
+	wchar_t operator * () const
+	{
+		return m_character[m_characterIndex];
+	}
+
+	UTF8DocumentIterator& operator = (Sci::Position other)
+	{
+		m_pos = other;
+		return *this;
+	}
 
 		UTF8DocumentIterator& operator ++ ();
 		UTF8DocumentIterator& operator -- ();
 
-		Sci::Position pos() const
-		{
-				return m_pos;
-		}
+	Sci::Position pos() const
+	{
+		return m_pos;
+	}
 
 private:
-		void readCharacter();
+	void readCharacter();
 
 
-		bool ended() const
-		{
-				return m_pos >= m_end;
-		}
+	bool ended() const
+	{
+		return m_pos >= m_end;
+	}
 
-		Sci::Position m_pos = 0;
-		wchar_t m_character[2];
-		Sci::Position m_end = 0;
-		int m_characterIndex = 0;
-		int m_utf8Length = 0;
-		int m_utf16Length = 0;
-		Document* m_doc = nullptr;
-		static const unsigned char m_firstByteMask[];
+	Sci::Position m_pos = 0;
+	wchar_t m_character[2];
+	Sci::Position m_end = 0;
+	int m_characterIndex = 0;
+	int m_utf8Length = 0;
+	int m_utf16Length = 0;
+	Document* m_doc = nullptr;
+	static const unsigned char m_firstByteMask[];
 };
 
 }


### PR DESCRIPTION
std::iterator was deprecated in C++17.
Remove it to fix the warnings and avoid other issues.

Fix #10035