### PR TITLE
Make Project Panel toolbar conform to dark mode

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -980,6 +980,11 @@ namespace NppDarkMode
 		SetWindowSubclass(hwnd, TabSubclass, g_tabSubclassID, 0);
 	}
 
+	void disableVisualStyle(HWND hwnd)
+	{
+		SetWindowTheme(hwnd, L"", L"");
+	}
+
 	void autoSubclassAndThemeChildControls(HWND hwndParent, bool subclass, bool theme)
 	{
 		struct Params

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -78,6 +78,7 @@ namespace NppDarkMode
 	void subclassGroupboxControl(HWND hwnd);
 	void subclassToolbarControl(HWND hwnd);
 	void subclassTabControl(HWND hwnd);
+	void disableVisualStyle(HWND hwnd);
 
 	void autoSubclassAndThemeChildControls(HWND hwndParent, bool subclass = true, bool theme = true);
 	void autoThemeChildControls(HWND hwndParent);

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -802,6 +802,24 @@ void ProjectPanel::notified(LPNMHDR notification)
 			break;
 		}
 	}
+	else if (notification->code == NM_CUSTOMDRAW && (notification->hwndFrom == _hToolbarMenu))
+	{
+		NMTBCUSTOMDRAW* nmtbcd = reinterpret_cast<NMTBCUSTOMDRAW*>(notification);
+		//if (nmtbcd->nmcd.dwDrawStage == CDDS_PREERASE)
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
+				nmtbcd->clrText = NppDarkMode::getTextColor();
+				SetTextColor(nmtbcd->nmcd.hdc, NppDarkMode::getTextColor());
+				SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_SKIPDEFAULT);
+			}
+			else
+			{
+				SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
+			}
+		}
+	}
 }
 
 void ProjectPanel::setWorkSpaceDirty(bool isDirty)


### PR DESCRIPTION
Project Panel toolbar is still in gray when Notepad++ in dark mode.
The goal of this PR is to fix this bug.
 
![image](https://user-images.githubusercontent.com/90293/122642422-a13deb80-d10a-11eb-97f7-027e3da4a741.png)
