### PR TITLE
Make line above panel toolbar dark.

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7524,6 +7524,27 @@ void Notepad_plus::refreshDarkMode()
 		NppDarkMode::setDarkTitleBar(docCont->getCaptionWnd());
 	}
 
+	if (_pProjectPanel_1)
+	{
+		::SendMessage(_pProjectPanel_1->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+	}
+	if (_pProjectPanel_2)
+	{
+		::SendMessage(_pProjectPanel_2->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+	}
+	if (_pProjectPanel_3)
+	{
+		::SendMessage(_pProjectPanel_3->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+	}
+	if (_pFuncList)
+	{
+		::SendMessage(_pFuncList->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+	}
+	if (_pFileBrowser)
+	{
+		::SendMessage(_pFileBrowser->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+	}
+
 	SendMessage(_findReplaceDlg.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
 	SendMessage(_incrementFindDlg.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
 	RedrawWindow(_pPublicInterface->getHSelf(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1091,4 +1091,23 @@ namespace NppDarkMode
 			}
 		}
 	}
+
+	void setDarkLineAbovePanelToolbar(HWND hwnd)
+	{
+		COLORSCHEME scheme;
+		scheme.dwSize = sizeof(COLORSCHEME);
+
+		if (NppDarkMode::isEnabled())
+		{
+			scheme.clrBtnHighlight = NppDarkMode::getBackgroundColor();
+			scheme.clrBtnShadow = NppDarkMode::getBackgroundColor();
+		}
+		else
+		{
+			scheme.clrBtnHighlight = CLR_DEFAULT;
+			scheme.clrBtnShadow = CLR_DEFAULT;
+		}
+
+		::SendMessage(hwnd, TB_SETCOLORSCHEME, 0, reinterpret_cast<LPARAM>(&scheme));
+	}
 }

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -84,4 +84,5 @@ namespace NppDarkMode
 
 	void setDarkTitleBar(HWND hwnd);
 	void setDarkTooltips(HWND hwnd, ToolTipsType type);
+	void setDarkLineAbovePanelToolbar(HWND hwnd);
 }

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -107,6 +107,7 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			_hToolbarMenu = CreateWindowEx(WS_EX_LAYOUTRTL, TOOLBARCLASSNAME, NULL, style, 0, 0, 0, 0, _hSelf, nullptr, _hInst, NULL);
 
 			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
+			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
 			TBBUTTON tbButtons[3];
 			// Add the bmap image into toolbar's imagelist
@@ -166,8 +167,14 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			_treeView.makeLabelEditable(false);
 			_treeView.display();
 
-            return TRUE;
-        }
+			return TRUE;
+		}
+
+		case NPPM_INTERNAL_REFRESHDARKMODE:
+		{
+			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+			break;
+		}
 
 		case WM_MOUSEMOVE:
 			if (_treeView.isDragging())

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -772,6 +772,7 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 								   0,0,0,0,_hSelf,nullptr, _hInst, NULL);
 
 			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
+			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
 			oldFunclstToolbarProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(_hToolbarMenu, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(funclstToolbarProc)));
 			TBBUTTON tbButtons[3];
@@ -831,8 +832,14 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			setTreeViewImageList(IDI_FUNCLIST_ROOT, IDI_FUNCLIST_NODE, IDI_FUNCLIST_LEAF);
 
 			_treeView.display();
-            return TRUE;
-        }
+			return TRUE;
+		}
+
+		case NPPM_INTERNAL_REFRESHDARKMODE:
+		{
+			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+			break;
+		}
 
 		case WM_DESTROY:
 			_treeView.destroy();

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -54,6 +54,9 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			int style = WS_CHILD | WS_VISIBLE | CCS_ADJUSTABLE | TBSTYLE_AUTOSIZE | TBSTYLE_FLAT | TBSTYLE_LIST;
 			_hToolbarMenu = CreateWindowEx(0,TOOLBARCLASSNAME,NULL, style,
 								   0,0,0,0,_hSelf, nullptr, _hInst, nullptr);
+
+			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+
 			TBBUTTON tbButtons[2];
 
 			NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
@@ -91,10 +94,15 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			if (!openWorkSpace(_workSpaceFilePath.c_str(), true))
 				newWorkSpace();
 
-            return TRUE;
-        }
+			return TRUE;
+		}
 
-		
+		case NPPM_INTERNAL_REFRESHDARKMODE:
+		{
+			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+			break;
+		}
+
 		case WM_MOUSEMOVE:
 			if (_treeView.isDragging())
 				_treeView.dragItem(_hSelf, LOWORD(lParam), HIWORD(lParam));


### PR DESCRIPTION
For Project panel, Function list panel and Folder as workplace panel.

before
![image](https://user-images.githubusercontent.com/55940305/122666671-4a81f180-d19e-11eb-8a1c-c7950bf363e3.png)
after
![image](https://user-images.githubusercontent.com/55940305/122666628-0989dd00-d19e-11eb-87ff-ca10c1d51e9b.png)

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10043
