### PR TITLE
Allow dynamic dark/light mode change for tooltips

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7554,6 +7554,9 @@ void Notepad_plus::refreshDarkMode()
 		::SendMessage(_pFileSwitcherPanel->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
 	}
 
+	::SendMessage(_mainDocTab.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+	::SendMessage(_subDocTab.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
+
 	SendMessage(_findReplaceDlg.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
 	SendMessage(_incrementFindDlg.getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, 0);
 	RedrawWindow(_pPublicInterface->getHSelf(), nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_FRAME | RDW_ALLCHILDREN);

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1044,25 +1044,16 @@ namespace NppDarkMode
 		bool useDark = NppDarkMode::isExperimentalEnabled() && NppDarkMode::isEnabled();
 
 		NppDarkMode::allowDarkModeForWindow(hwnd, useDark);
-		NppDarkMode::setTitleBarThemeColor(hwnd, useDark);
+		SetWindowTheme(hwnd, useDark ? L"Explorer" : nullptr, nullptr);
 
-		if (useDark)
-		{
-			SetWindowTheme(hwnd, L"Explorer", nullptr);
-		}
-		else
-		{
-			SetWindowTheme(hwnd, nullptr, nullptr);
-		}
+		NppDarkMode::setTitleBarThemeColor(hwnd, useDark);
 	}
 
 	void setDarkTooltips(HWND hwnd, ToolTipsType type)
 	{
-		if (NppDarkMode::isEnabled())
+		UINT msg = 0;
+		switch (type)
 		{
-			UINT msg = 0;
-			switch (type)
-			{
 			case NppDarkMode::ToolTipsType::toolbar:
 				msg = TB_GETTOOLTIPS;
 				break;
@@ -1072,22 +1063,24 @@ namespace NppDarkMode
 			case NppDarkMode::ToolTipsType::treeview:
 				msg = TVM_GETTOOLTIPS;
 				break;
+			case NppDarkMode::ToolTipsType::tabbar:
+				msg = TCM_GETTOOLTIPS;
+				break;
 			default:
 				msg = 0;
 				break;
-			}
+		}
 
-			if (!msg)
+		if (msg == 0)
+		{
+			SetWindowTheme(hwnd, NppDarkMode::isEnabled() ? L"DarkMode_Explorer" : nullptr, nullptr);
+		}
+		else
+		{
+			auto hTips = reinterpret_cast<HWND>(::SendMessage(hwnd, msg, 0, 0));
+			if (hTips != nullptr)
 			{
-				SetWindowTheme(hwnd, L"DarkMode_Explorer", NULL);
-			}
-			else
-			{
-				auto hTips = reinterpret_cast<HWND>(SendMessage(hwnd, msg, 0, 0));
-				if (hTips != nullptr)
-				{
-					SetWindowTheme(hTips, L"DarkMode_Explorer", NULL);
-				}
+				SetWindowTheme(hTips, NppDarkMode::isEnabled() ? L"DarkMode_Explorer" : nullptr, nullptr);
 			}
 		}
 	}

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -26,7 +26,8 @@ namespace NppDarkMode
 		tooltip,
 		toolbar,
 		listview,
-		treeview
+		treeview,
+		tabbar
 	};
 
 	void initDarkMode();				// pulls options from NppParameters

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -878,6 +878,9 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
+			NppDarkMode::setDarkTooltips(_shiftTrickUpTip, NppDarkMode::ToolTipsType::tooltip);
+			NppDarkMode::setDarkTooltips(_2ButtonsTip, NppDarkMode::ToolTipsType::tooltip);
+			NppDarkMode::setDarkTooltips(_filterTip, NppDarkMode::ToolTipsType::tooltip);
 			NppDarkMode::autoThemeChildControls(_hSelf);
 			return TRUE;
 		}

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -172,8 +172,11 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
+			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+
 			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true);
+			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
 			return TRUE;
 		}
 

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -23,7 +23,6 @@
 #include "RunDlg.h"
 #include "ReadDirectoryChanges.h"
 #include "menuCmdID.h"
-#include "Parameters.h"
 
 #define CX_BITMAP         16
 #define CY_BITMAP         16

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -837,8 +837,11 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
+			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+
 			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true);
+			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
 			return TRUE;
 		}
 
@@ -871,7 +874,7 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			}
 
 			switch (LOWORD(wParam))
-            {
+			{
 				case IDC_SORTBUTTON_FUNCLIST:
 				{
 					sortOrUnsort();

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -100,7 +100,9 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+			
 			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true);
+			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
 			return TRUE;
 		}
 

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -467,6 +467,12 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			return TRUE;
 		}
 
+		case NPPM_INTERNAL_REFRESHDARKMODE:
+		{
+			NppDarkMode::setDarkTooltips(hwnd, NppDarkMode::ToolTipsType::tabbar);
+			return TRUE;
+		}
+
 		case WM_MOUSEWHEEL:
 		{
 			// ..............................................................................

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -19,7 +19,6 @@
 #include <stdexcept>
 #include "TabBar.h"
 #include "Parameters.h"
-#include "NppDarkMode.h"
 
 #define	IDC_DRAG_TAB     1404
 #define	IDC_DRAG_INTERDIT_TAB 1405

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -74,6 +74,7 @@ INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::setExplorerTheme(_fileListView.getHSelf(), true);
+			NppDarkMode::setDarkTooltips(_fileListView.getHSelf(), NppDarkMode::ToolTipsType::listview);
 			return TRUE;
 		}
 


### PR DESCRIPTION
Allow dynamic dark/light mode change for tooltips

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10059