### PR TITLE
Disable Explorer Theme for TreeView

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1104,9 +1104,13 @@ namespace NppDarkMode
 		::SendMessage(hwnd, TB_SETCOLORSCHEME, 0, reinterpret_cast<LPARAM>(&scheme));
 	}
 
-	void setExplorerTheme(HWND hwnd, bool doEnable)
+	void setExplorerTheme(HWND hwnd, bool doEnable, bool isTreeView)
 	{
-		if (doEnable)
+		if (isTreeView)
+		{
+			SetWindowTheme(hwnd, nullptr, nullptr);
+		}
+		else if (doEnable)
 		{
 			NppDarkMode::allowDarkModeForWindow(hwnd, NppDarkMode::isEnabled() && NppDarkMode::isExperimentalEnabled());
 			SetWindowTheme(hwnd, L"Explorer", nullptr);

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -87,5 +87,5 @@ namespace NppDarkMode
 	void setDarkTooltips(HWND hwnd, ToolTipsType type);
 	void setDarkLineAbovePanelToolbar(HWND hwnd);
 
-	void setExplorerTheme(HWND hwnd, bool doEnable);
+	void setExplorerTheme(HWND hwnd, bool doEnable, bool isTreeView = false);
 }

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -174,7 +174,7 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
-			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true);
+			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true, true);
 			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
 			return TRUE;
 		}

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -896,7 +896,7 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
-			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true);
+			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true, true);
 			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
 			return TRUE;
 		}

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -101,7 +101,7 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 		{
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 			
-			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true);
+			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true, true);
 			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
 			return TRUE;
 		}

--- a/PowerEditor/src/WinControls/TreeView/TreeView.cpp
+++ b/PowerEditor/src/WinControls/TreeView/TreeView.cpp
@@ -43,7 +43,7 @@ void TreeView::init(HINSTANCE hInst, HWND parent, int treeViewID)
 							_hInst,
 							nullptr);
 
-	NppDarkMode::setExplorerTheme(_hSelf, true);
+	NppDarkMode::setExplorerTheme(_hSelf, true, true);
 	NppDarkMode::setDarkTooltips(_hSelf, NppDarkMode::ToolTipsType::treeview);
 
 	int itemHeight = NppParameters::getInstance()._dpiManager.scaleY(CY_ITEMHEIGHT);


### PR DESCRIPTION
I am quite busy now, so until I have time and figure out how to do custom draw for treeview, I will disable eplorer theme.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10061