### PR TITLE
Make Ascii panel's column header apply to dark mode

### DIFF
--- a/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
@@ -66,7 +66,8 @@ void ListView::init(HINSTANCE hInst, HWND parent)
 	if (_columnInfos.size())
 	{
 		LVCOLUMN lvColumn;
-		lvColumn.mask = LVCF_TEXT | LVCF_WIDTH;
+		lvColumn.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_FMT;
+		lvColumn.fmt = HDF_OWNERDRAW;
 
 		short i = 0;
 		for (auto it = _columnInfos.begin(); it != _columnInfos.end(); ++it)
@@ -168,6 +169,33 @@ std::vector<size_t> ListView::getCheckedIndexes() const
 
 LRESULT ListView::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
+	switch (Message)
+	{
+		case WM_DRAWITEM:
+		{
+			DRAWITEMSTRUCT* pdis = (DRAWITEMSTRUCT*)lParam;
+
+
+			HDITEM hdi;
+			TCHAR  lpBuffer[256];
+
+			hdi.mask = HDI_TEXT;
+			hdi.pszText = lpBuffer;
+			hdi.cchTextMax = 256;
+
+			Header_GetItem(pdis->hwndItem, pdis->itemID, &hdi);
+			
+			COLORREF textColor = RGB(0, 0, 0);
+			if (NppDarkMode::isEnabled())
+				textColor = NppDarkMode::getDarkerTextColor();
+
+			SetTextColor(pdis->hDC, textColor);
+			SetBkMode(pdis->hDC, TRANSPARENT);
+
+			::DrawText(pdis->hDC, lpBuffer, lstrlen(lpBuffer), &(pdis->rcItem), DT_SINGLELINE | DT_VCENTER | DT_CENTER);
+		}
+		return TRUE;
+	}
 	return ::CallWindowProc(_defaultProc, hwnd, Message, wParam, lParam);
 }
 

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
@@ -74,7 +74,7 @@ void ListView::init(HINSTANCE hInst, HWND parent)
 		{
 			lvColumn.cx = static_cast<int>(it->_width);
 			lvColumn.pszText = const_cast<TCHAR *>(it->_label.c_str());
-			ListView_InsertColumn(_hSelf, ++i, &lvColumn);
+			ListView_InsertColumn(_hSelf, ++i, &lvColumn);  // index is not 0 based but 1 based
 		}
 	}
 }

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -119,6 +119,38 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 				}
 				break;
 
+				case NM_CUSTOMDRAW:
+				{
+					static bool becomeDarkMode = false;
+					static bool becomeLightMode = false;
+					HWND hHeader = ListView_GetHeader(_listView.getHSelf());
+					if (NppDarkMode::isEnabled())
+					{
+						if (!becomeDarkMode)
+						{
+							NppDarkMode::setExplorerTheme(hHeader, false);
+							becomeDarkMode = true;
+						}
+						becomeLightMode = false;
+						auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>((LPNMHDR)lParam);
+						FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
+						nmtbcd->clrText = NppDarkMode::getTextColor();
+						nmtbcd->clrBtnFace = NppDarkMode::getBackgroundColor();
+						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW);
+					}
+					else
+					{
+						if (!becomeLightMode)
+						{
+							NppDarkMode::setExplorerTheme(hHeader, true);
+							becomeLightMode = true;
+						}
+						becomeDarkMode = false;
+						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
+					}
+				}
+				break;
+
 				default:
 					break;
 			}

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -132,11 +132,12 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 							becomeDarkMode = true;
 						}
 						becomeLightMode = false;
+
 						auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>((LPNMHDR)lParam);
+						SetBkMode(nmtbcd->nmcd.hdc, TRANSPARENT);
 						FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
 						nmtbcd->clrText = RGB(255, 255, 255);
 						SetTextColor(nmtbcd->nmcd.hdc, RGB(255, 255, 255));
-						SetBkMode(nmtbcd->nmcd.hdc, TRANSPARENT);
 						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW);
 					}
 					else

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -134,8 +134,9 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 						becomeLightMode = false;
 						auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>((LPNMHDR)lParam);
 						FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
-						nmtbcd->clrText = NppDarkMode::getTextColor();
-						nmtbcd->clrBtnFace = NppDarkMode::getBackgroundColor();
+						nmtbcd->clrText = RGB(255, 255, 255);
+						SetTextColor(nmtbcd->nmcd.hdc, RGB(255, 255, 255));
+						SetBkMode(nmtbcd->nmcd.hdc, TRANSPARENT);
 						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW);
 					}
 					else

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -82,6 +82,39 @@ INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, 
 		{
 			switch (((LPNMHDR)lParam)->code)
 			{
+				case NM_CUSTOMDRAW:
+				{
+					static bool becomeDarkMode = false;
+					static bool becomeLightMode = false;
+					HWND hHeader = ListView_GetHeader(_fileListView.getHSelf());
+					if (NppDarkMode::isEnabled())
+					{
+						if (!becomeDarkMode)
+						{
+							NppDarkMode::setExplorerTheme(hHeader, false);
+							becomeDarkMode = true;
+						}
+						becomeLightMode = false;
+
+						auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>((LPNMHDR)lParam);
+						SetBkMode(nmtbcd->nmcd.hdc, TRANSPARENT);
+						FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
+						nmtbcd->clrText = RGB(255, 255, 255);
+						SetTextColor(nmtbcd->nmcd.hdc, RGB(255, 255, 255));
+						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW);
+					}
+					else
+					{
+						if (!becomeLightMode)
+						{
+							NppDarkMode::setExplorerTheme(hHeader, true);
+							becomeLightMode = true;
+						}
+						becomeDarkMode = false;
+						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
+					}
+				}
+				break;
 				case NM_DBLCLK:
 				{
 					LPNMITEMACTIVATE lpnmitem = (LPNMITEMACTIVATE) lParam;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -84,6 +84,32 @@ void VerticalFileSwitcherListView::destroy()
 
 LRESULT VerticalFileSwitcherListView::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
+	switch (Message)
+	{
+		case WM_DRAWITEM:
+		{
+			DRAWITEMSTRUCT* pdis = (DRAWITEMSTRUCT*)lParam;
+
+			HDITEM hdi;
+			TCHAR  lpBuffer[256];
+
+			hdi.mask = HDI_TEXT;
+			hdi.pszText = lpBuffer;
+			hdi.cchTextMax = 256;
+
+			Header_GetItem(pdis->hwndItem, pdis->itemID, &hdi);
+
+			COLORREF textColor = RGB(0, 0, 0);
+			if (NppDarkMode::isEnabled())
+				textColor = NppDarkMode::getDarkerTextColor();
+
+			SetTextColor(pdis->hDC, textColor);
+			SetBkMode(pdis->hDC, TRANSPARENT);
+
+			::DrawText(pdis->hDC, lpBuffer, lstrlen(lpBuffer), &(pdis->rcItem), DT_SINGLELINE | DT_VCENTER | DT_CENTER);
+		}
+		return TRUE;
+	}
 	return ::CallWindowProc(_defaultProc, hwnd, Message, wParam, lParam);
 }
 
@@ -353,9 +379,10 @@ void VerticalFileSwitcherListView::insertColumn(const TCHAR *name, int width, in
 {
 	LVCOLUMN lvColumn;
  
-	lvColumn.mask = LVCF_TEXT | LVCF_WIDTH;
+	lvColumn.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_FMT;
 	lvColumn.cx = width;
 	lvColumn.pszText = (TCHAR *)name;
+	lvColumn.fmt = HDF_OWNERDRAW;
 	ListView_InsertColumn(_hSelf, index, &lvColumn);
 }
 

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -106,7 +106,7 @@ LRESULT VerticalFileSwitcherListView::runProc(HWND hwnd, UINT Message, WPARAM wP
 			SetTextColor(pdis->hDC, textColor);
 			SetBkMode(pdis->hDC, TRANSPARENT);
 
-			::DrawText(pdis->hDC, lpBuffer, lstrlen(lpBuffer), &(pdis->rcItem), DT_SINGLELINE | DT_VCENTER | DT_CENTER);
+			::DrawText(pdis->hDC, lpBuffer, lstrlen(lpBuffer), &(pdis->rcItem), DT_SINGLELINE | DT_VCENTER | DT_LEFT);
 		}
 		return TRUE;
 	}
@@ -129,11 +129,12 @@ void VerticalFileSwitcherListView::initList()
 		RECT rc;
 		::GetClientRect(_hParent, &rc);
 		int totalWidth = rc.right - rc.left;
-		
+		const int extColWidth =80;
+
 		if (columnCount == 0)
 		{
 			generic_string nameStr = pNativeSpeaker->getAttrNameStr(TEXT("Name"), FS_ROOTNODE, FS_CLMNNAME);
-			insertColumn(nameStr.c_str(), (isExtColumn ? totalWidth - 50 : totalWidth), 0);
+			insertColumn(nameStr.c_str(), (isExtColumn ? totalWidth - extColWidth : totalWidth), 1);
 		}
 		
 		if (isExtColumn)
@@ -143,14 +144,14 @@ void VerticalFileSwitcherListView::initList()
 			lvc.mask = LVCF_WIDTH;
 			SendMessage(_hSelf, LVM_GETCOLUMN, 0, reinterpret_cast<LPARAM>(&lvc));
 			
-			if (lvc.cx + 50 > totalWidth)
+			if (lvc.cx + extColWidth > totalWidth)
 			{
-				lvc.cx = totalWidth - 50;
+				lvc.cx = totalWidth - extColWidth;
 				SendMessage(_hSelf, LVM_SETCOLUMN, 0, reinterpret_cast<LPARAM>(&lvc));
 			}
 			
 			generic_string extStr = pNativeSpeaker->getAttrNameStr(TEXT("Ext."), FS_ROOTNODE, FS_CLMNEXT);
-			insertColumn(extStr.c_str(), 50, 1);
+			insertColumn(extStr.c_str(), extColWidth, 2);
 		}
 	}
 	
@@ -383,7 +384,7 @@ void VerticalFileSwitcherListView::insertColumn(const TCHAR *name, int width, in
 	lvColumn.cx = width;
 	lvColumn.pszText = (TCHAR *)name;
 	lvColumn.fmt = HDF_OWNERDRAW;
-	ListView_InsertColumn(_hSelf, index, &lvColumn);
+	ListView_InsertColumn(_hSelf, index, &lvColumn); // index is not 0 based but 1 based
 }
 
 void VerticalFileSwitcherListView::resizeColumns(int totalWidth)


### PR DESCRIPTION
When Ascii panel in dark mode, the column header doesn't follow.
This PR is trying apply it to dark mode.