### PR TITLE
Dark mode listview header

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1117,6 +1117,18 @@ namespace NppDarkMode
 		::SendMessage(hwnd, TB_SETCOLORSCHEME, 0, reinterpret_cast<LPARAM>(&scheme));
 	}
 
+	void setDarkListView(HWND hwnd)
+	{
+		bool useDark = NppDarkMode::isEnabled() && NppDarkMode::isExperimentalEnabled();
+
+		HWND hHeader = ListView_GetHeader(hwnd);
+		NppDarkMode::allowDarkModeForWindow(hHeader, useDark);
+		SetWindowTheme(hHeader, L"ItemsView", nullptr);
+
+		NppDarkMode::allowDarkModeForWindow(hwnd, useDark);
+		SetWindowTheme(hwnd, L"Explorer", nullptr);
+	}
+
 	void setExplorerTheme(HWND hwnd, bool doEnable, bool isTreeView)
 	{
 		if (isTreeView)

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -89,6 +89,7 @@ namespace NppDarkMode
 	void setDarkScrollBar(HWND hwnd);
 	void setDarkTooltips(HWND hwnd, ToolTipsType type);
 	void setDarkLineAbovePanelToolbar(HWND hwnd);
+	void setDarkListView(HWND hwnd);
 
 	void setExplorerTheme(HWND hwnd, bool doEnable, bool isTreeView = false);
 }

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
@@ -186,7 +186,8 @@ LRESULT ListView::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
 						case CDDS_ITEMPREPAINT:
 						{
-							SetTextColor(nmcd->hdc, NppDarkMode::isEnabled() ? NppDarkMode::getDarkerTextColor() : GetSysColor(COLOR_BTNTEXT));
+							bool isDarkModeSupported = NppDarkMode::isEnabled() && NppDarkMode::isExperimentalEnabled();
+							SetTextColor(nmcd->hdc, isDarkModeSupported ? NppDarkMode::getDarkerTextColor() : GetSysColor(COLOR_BTNTEXT));
 							return CDRF_DODEFAULT;
 						}
 						break;

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -55,13 +55,13 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
-			NppDarkMode::setExplorerTheme(_listView.getHSelf(), true);
+			NppDarkMode::setDarkListView(_listView.getHSelf());
 			return TRUE;
 		}
 
 		case WM_NOTIFY:
 		{
-			switch (((LPNMHDR)lParam)->code)
+			switch (reinterpret_cast<LPNMHDR>(lParam)->code)
 			{
 				case DMN_CLOSE:
 				{
@@ -119,65 +119,33 @@ INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 				}
 				break;
 
-				case NM_CUSTOMDRAW:
-				{
-					static bool becomeDarkMode = false;
-					static bool becomeLightMode = false;
-					HWND hHeader = ListView_GetHeader(_listView.getHSelf());
-					if (NppDarkMode::isEnabled() && reinterpret_cast<LPNMHDR>(lParam)->hwndFrom == hHeader)
-					{
-						if (!becomeDarkMode)
-						{
-							NppDarkMode::setExplorerTheme(hHeader, false);
-							becomeDarkMode = true;
-						}
-						becomeLightMode = false;
-
-						auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(lParam);
-						SetBkMode(nmtbcd->nmcd.hdc, TRANSPARENT);
-						FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
-						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW);
-					}
-					else
-					{
-						if (!becomeLightMode)
-						{
-							NppDarkMode::setExplorerTheme(hHeader, true);
-							becomeLightMode = true;
-						}
-						becomeDarkMode = false;
-						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
-					}
-				}
-				break;
-
 				default:
 					break;
 			}
 		}
 		return TRUE;
 
-        case WM_SIZE:
-        {
-            int width = LOWORD(lParam);
-            int height = HIWORD(lParam);
+		case WM_SIZE:
+		{
+			int width = LOWORD(lParam);
+			int height = HIWORD(lParam);
 			::MoveWindow(_listView.getHSelf(), 0, 0, width, height, TRUE);
-            break;
-        }
+			break;
+		}
 
-        default :
-            return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
-    }
+		default :
+			return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
+	}
 	return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
 }
 
 void AnsiCharPanel::insertChar(unsigned char char2insert) const
 {
-    char charStr[2];
-    charStr[0] = char2insert;
-    charStr[1] = '\0';
-    wchar_t wCharStr[10];
-    char multiByteStr[10];
+	char charStr[2];
+	charStr[0] = char2insert;
+	charStr[1] = '\0';
+	wchar_t wCharStr[10];
+	char multiByteStr[10];
 	int codepage = (*_ppEditView)->getCurrentBuffer()->getEncoding();
 	if (codepage == -1)
 	{

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -73,48 +73,15 @@ INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, 
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
-			NppDarkMode::setExplorerTheme(_fileListView.getHSelf(), true);
+			NppDarkMode::setDarkListView(_fileListView.getHSelf());
 			NppDarkMode::setDarkTooltips(_fileListView.getHSelf(), NppDarkMode::ToolTipsType::listview);
 			return TRUE;
 		}
 
 		case WM_NOTIFY:
 		{
-			LPNMHDR notif = reinterpret_cast<LPNMHDR>(lParam);
-			switch (notif->code)
+			switch (reinterpret_cast<LPNMHDR>(lParam)->code)
 			{
-				case NM_CUSTOMDRAW:
-				{
-					static bool becomeDarkMode = false;
-					static bool becomeLightMode = false;
-					HWND hHeader = ListView_GetHeader(_fileListView.getHSelf());
-					if (NppDarkMode::isEnabled() && (notif->hwndFrom == hHeader))
-					{
-						if (!becomeDarkMode)
-						{
-							NppDarkMode::setExplorerTheme(hHeader, false);
-							becomeDarkMode = true;
-						}
-						becomeLightMode = false;
-
-						auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(notif);
-						SetBkMode(nmtbcd->nmcd.hdc, TRANSPARENT);
-						FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
-						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW);
-					}
-					else
-					{
-						if (!becomeLightMode)
-						{
-							NppDarkMode::setExplorerTheme(hHeader, true);
-							becomeLightMode = true;
-						}
-						becomeDarkMode = false;
-						SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
-					}
-				}
-				break;
-
 				case NM_DBLCLK:
 				{
 					LPNMITEMACTIVATE lpnmitem = (LPNMITEMACTIVATE) lParam;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -102,7 +102,8 @@ LRESULT VerticalFileSwitcherListView::runProc(HWND hwnd, UINT Message, WPARAM wP
 
 						case CDDS_ITEMPREPAINT:
 						{
-							SetTextColor(nmcd->hdc, NppDarkMode::isEnabled() ? NppDarkMode::getDarkerTextColor() : GetSysColor(COLOR_BTNTEXT));
+							bool isDarkModeSupported = NppDarkMode::isEnabled() && NppDarkMode::isExperimentalEnabled();
+							SetTextColor(nmcd->hdc, isDarkModeSupported ? NppDarkMode::getDarkerTextColor() : GetSysColor(COLOR_BTNTEXT));
 							return CDRF_DODEFAULT;
 						}
 						break;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -28,14 +28,14 @@ void VerticalFileSwitcherListView::init(HINSTANCE hInst, HWND parent, HIMAGELIST
 {
 	Window::init(hInst, parent);
 	_hImaLst = hImaLst;
-    INITCOMMONCONTROLSEX icex;
-    
-    // Ensure that the common control DLL is loaded. 
-    icex.dwSize = sizeof(INITCOMMONCONTROLSEX);
-    icex.dwICC  = ICC_LISTVIEW_CLASSES;
-    InitCommonControlsEx(&icex);
-    
-    // Create the list-view window in report view with label editing enabled.
+	INITCOMMONCONTROLSEX icex;
+
+	// Ensure that the common control DLL is loaded. 
+	icex.dwSize = sizeof(INITCOMMONCONTROLSEX);
+	icex.dwICC  = ICC_LISTVIEW_CLASSES;
+	InitCommonControlsEx(&icex);
+
+	// Create the list-view window in report view with label editing enabled.
 	int listViewStyles = LVS_REPORT /*| LVS_SINGLESEL*/ | LVS_AUTOARRANGE\
 						| LVS_SHAREIMAGELISTS | LVS_SHOWSELALWAYS;
 
@@ -55,7 +55,7 @@ void VerticalFileSwitcherListView::init(HINSTANCE hInst, HWND parent, HIMAGELIST
 		throw std::runtime_error("VerticalFileSwitcherListView::init : CreateWindowEx() function return null");
 	}
 
-	NppDarkMode::setExplorerTheme(_hSelf, true);
+	NppDarkMode::setDarkListView(_hSelf);
 	NppDarkMode::setDarkTooltips(_hSelf, NppDarkMode::ToolTipsType::listview);
 
 	::SetWindowLongPtr(_hSelf, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
@@ -86,29 +86,32 @@ LRESULT VerticalFileSwitcherListView::runProc(HWND hwnd, UINT Message, WPARAM wP
 {
 	switch (Message)
 	{
-		case WM_DRAWITEM:
+		case WM_NOTIFY:
 		{
-			DRAWITEMSTRUCT* pdis = (DRAWITEMSTRUCT*)lParam;
+			switch (reinterpret_cast<LPNMHDR>(lParam)->code)
+			{
+				case NM_CUSTOMDRAW:
+				{
+					LPNMCUSTOMDRAW nmcd = reinterpret_cast<LPNMCUSTOMDRAW>(lParam);
+					switch (nmcd->dwDrawStage)
+					{
+						case CDDS_PREPAINT:
+						{
+							return CDRF_NOTIFYITEMDRAW;
+						}
 
-			HDITEM hdi;
-			TCHAR  lpBuffer[256];
-
-			hdi.mask = HDI_TEXT;
-			hdi.pszText = lpBuffer;
-			hdi.cchTextMax = 256;
-
-			Header_GetItem(pdis->hwndItem, pdis->itemID, &hdi);
-
-			COLORREF textColor = RGB(0, 0, 0);
-			if (NppDarkMode::isEnabled())
-				textColor = NppDarkMode::getDarkerTextColor();
-
-			SetTextColor(pdis->hDC, textColor);
-			SetBkMode(pdis->hDC, TRANSPARENT);
-
-			::DrawText(pdis->hDC, lpBuffer, lstrlen(lpBuffer), &(pdis->rcItem), DT_SINGLELINE | DT_VCENTER | DT_LEFT);
+						case CDDS_ITEMPREPAINT:
+						{
+							SetTextColor(nmcd->hdc, NppDarkMode::isEnabled() ? NppDarkMode::getDarkerTextColor() : GetSysColor(COLOR_BTNTEXT));
+							return CDRF_DODEFAULT;
+						}
+						break;
+					}
+				}
+				break;
+			}
 		}
-		return TRUE;
+		break;
 	}
 	return ::CallWindowProc(_defaultProc, hwnd, Message, wParam, lParam);
 }
@@ -380,10 +383,9 @@ void VerticalFileSwitcherListView::insertColumn(const TCHAR *name, int width, in
 {
 	LVCOLUMN lvColumn;
  
-	lvColumn.mask = LVCF_TEXT | LVCF_WIDTH | LVCF_FMT;
+	lvColumn.mask = LVCF_TEXT | LVCF_WIDTH;
 	lvColumn.cx = width;
 	lvColumn.pszText = (TCHAR *)name;
-	lvColumn.fmt = HDF_OWNERDRAW;
 	ListView_InsertColumn(_hSelf, index, &lvColumn); // index is not 0 based but 1 based
 }
 


### PR DESCRIPTION
Use different approach to make listview header dark. 

@donho 
This will allow highlight, hot-tracking and sort arrow.

![image](https://user-images.githubusercontent.com/55940305/124451167-a474e080-dd74-11eb-8d54-c8a1b79dcf46.png)

![image](https://user-images.githubusercontent.com/55940305/124451071-8effb680-dd74-11eb-8f0a-4c22acce2937.png)


btw
I think I have figured how to make dark mode restartless, still need some code cleaning but I think I could do PR in few days.
Still some issue with scrollbar in treeview. But for other it is working.

Also dark mode seems to work in Windows 11.