### PR TITLE
Make dark mode restartless

### DIFF
--- a/PowerEditor/src/DarkMode/DarkMode.cpp
+++ b/PowerEditor/src/DarkMode/DarkMode.cpp
@@ -17,7 +17,7 @@ enum IMMERSIVE_HC_CACHE_MODE
 };
 
 // 1903 18362
-enum PreferredAppMode
+enum class PreferredAppMode
 {
 	Default,
 	AllowDark,
@@ -85,7 +85,7 @@ fnSetWindowCompositionAttribute _SetWindowCompositionAttribute = nullptr;
 fnShouldAppsUseDarkMode _ShouldAppsUseDarkMode = nullptr;
 fnAllowDarkModeForWindow _AllowDarkModeForWindow = nullptr;
 fnAllowDarkModeForApp _AllowDarkModeForApp = nullptr;
-//fnFlushMenuThemes _FlushMenuThemes = nullptr;
+fnFlushMenuThemes _FlushMenuThemes = nullptr;
 fnRefreshImmersiveColorPolicyState _RefreshImmersiveColorPolicyState = nullptr;
 fnIsDarkModeAllowedForWindow _IsDarkModeAllowedForWindow = nullptr;
 fnGetIsImmersiveColorUsingHighContrast _GetIsImmersiveColorUsingHighContrast = nullptr;
@@ -173,7 +173,15 @@ void AllowDarkModeForApp(bool allow)
 	if (_AllowDarkModeForApp)
 		_AllowDarkModeForApp(allow);
 	else if (_SetPreferredAppMode)
-		_SetPreferredAppMode(allow ? ForceDark : Default);
+		_SetPreferredAppMode(allow ? PreferredAppMode::ForceDark : PreferredAppMode::Default);
+}
+
+void FlushMenuThemes()
+{
+	if (_FlushMenuThemes)
+	{
+		_FlushMenuThemes();
+	}
 }
 
 // limit dark scroll bar to specific windows and their children
@@ -204,7 +212,7 @@ bool IsWindowOrParentUsingDarkScrollBar(HWND hwnd)
 
 void FixDarkScrollBar()
 {
-	HMODULE hComctl = LoadLibraryExW(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+	HMODULE hComctl = LoadLibraryEx(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
 	if (hComctl)
 	{
 		auto addr = FindDelayLoadThunkInModule(hComctl, "uxtheme.dll", 49); // OpenNcThemeData
@@ -241,9 +249,9 @@ constexpr bool CheckBuildNumber(DWORD buildNumber)
 		buildNumber == 19043);  // 21H1
 }
 
-void InitDarkMode(bool fixDarkScrollbar, bool dark)
+void InitDarkMode()
 {
-	auto RtlGetNtVersionNumbers = reinterpret_cast<fnRtlGetNtVersionNumbers>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
+	auto RtlGetNtVersionNumbers = reinterpret_cast<fnRtlGetNtVersionNumbers>(GetProcAddress(GetModuleHandle(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
 	if (RtlGetNtVersionNumbers)
 	{
 		DWORD major, minor;
@@ -251,7 +259,7 @@ void InitDarkMode(bool fixDarkScrollbar, bool dark)
 		g_buildNumber &= ~0xF0000000;
 		if (major == 10 && minor == 0 && CheckBuildNumber(g_buildNumber))
 		{
-			HMODULE hUxtheme = LoadLibraryExW(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+			HMODULE hUxtheme = LoadLibraryEx(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
 			if (hUxtheme)
 			{
 				_OpenNcThemeData = reinterpret_cast<fnOpenNcThemeData>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(49)));
@@ -266,7 +274,7 @@ void InitDarkMode(bool fixDarkScrollbar, bool dark)
 				else
 					_SetPreferredAppMode = reinterpret_cast<fnSetPreferredAppMode>(ord135);
 
-				//_FlushMenuThemes = reinterpret_cast<fnFlushMenuThemes>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(136)));
+				_FlushMenuThemes = reinterpret_cast<fnFlushMenuThemes>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(136)));
 				_IsDarkModeAllowedForWindow = reinterpret_cast<fnIsDarkModeAllowedForWindow>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(137)));
 
 				_SetWindowCompositionAttribute = reinterpret_cast<fnSetWindowCompositionAttribute>(GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute"));
@@ -276,22 +284,27 @@ void InitDarkMode(bool fixDarkScrollbar, bool dark)
 					_ShouldAppsUseDarkMode &&
 					_AllowDarkModeForWindow &&
 					(_AllowDarkModeForApp || _SetPreferredAppMode) &&
-					//_FlushMenuThemes &&
+					_FlushMenuThemes &&
 					_IsDarkModeAllowedForWindow)
 				{
 					g_darkModeSupported = true;
-
-					AllowDarkModeForApp(dark);
-					_RefreshImmersiveColorPolicyState();
-
-					g_darkModeEnabled = _ShouldAppsUseDarkMode() && !IsHighContrast();
-
-					if (fixDarkScrollbar)
-					{
-						FixDarkScrollBar();
-					}
 				}
 			}
 		}
+	}
+}
+
+void SetDarkMode(bool useDark, bool fixDarkScrollbar)
+{
+	if (g_darkModeSupported)
+	{
+		AllowDarkModeForApp(useDark);
+		//_RefreshImmersiveColorPolicyState();
+		FlushMenuThemes();
+		if (useDark && fixDarkScrollbar)
+		{
+			FixDarkScrollBar();
+		}
+		g_darkModeEnabled = ShouldAppsUseDarkMode() && !IsHighContrast();
 	}
 }

--- a/PowerEditor/src/DarkMode/DarkMode.h
+++ b/PowerEditor/src/DarkMode/DarkMode.h
@@ -13,5 +13,5 @@ bool IsColorSchemeChangeMessage(LPARAM lParam);
 bool IsColorSchemeChangeMessage(UINT message, LPARAM lParam);
 void AllowDarkModeForApp(bool allow);
 void EnableDarkScrollBarForWindowAndChildren(HWND hwnd);
-void InitDarkMode(bool fixDarkScrollbar, bool dark);
-
+void InitDarkMode();
+void SetDarkMode(bool useDarkMode, bool fixDarkScrollbar);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7515,7 +7515,7 @@ void Notepad_plus::restoreMinimizeDialogs()
 void Notepad_plus::refreshDarkMode()
 {
 	SendMessage(_pPublicInterface->getHSelf(), NPPM_SETEDITORBORDEREDGE, 0, NppParameters::getInstance().getSVP()._showBorderEdge);
-	if (NppDarkMode::isExperimentalEnabled())
+	if (NppDarkMode::isExperimentalSupported())
 	{
 		NppDarkMode::allowDarkModeForApp(NppDarkMode::isEnabled());
 	}
@@ -7640,7 +7640,7 @@ void Notepad_plus::refreshDarkMode()
 		}
 	}
 
-	if (NppDarkMode::isExperimentalEnabled())
+	if (NppDarkMode::isExperimentalSupported())
 	{
 		RECT rcClient;
 		

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -70,7 +70,7 @@ LRESULT CALLBACK Notepad_plus_Window::Notepad_plus_Proc(HWND hwnd, UINT message,
 			pM30ide->_hSelf = hwnd;
 			::SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pM30ide));
 
-			if (NppDarkMode::isExperimentalEnabled() && NppDarkMode::isEnabled() && NppDarkMode::isScrollbarHackEnabled())
+			if (NppDarkMode::isExperimentalSupported())
 			{
 				NppDarkMode::enableDarkScrollBarForWindowAndChildren(hwnd);
 			}
@@ -99,7 +99,7 @@ LRESULT Notepad_plus_Window::runProc(HWND hwnd, UINT message, WPARAM wParam, LPA
 				_notepad_plus_plus_core._pPublicInterface = this;
 				LRESULT lRet = _notepad_plus_plus_core.init(hwnd);
 
-				if (NppDarkMode::isExperimentalEnabled() && NppDarkMode::isEnabled())
+				if (NppDarkMode::isEnabled() && NppDarkMode::isExperimentalSupported())
 				{
 					RECT rcClient;
 					GetWindowRect(hwnd, &rcClient);

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -16,7 +16,6 @@ namespace NppDarkMode
 	struct Options
 	{
 		bool enable = false;
-		bool enableExperimental = false;
 		bool enableMenubar = false;
 		bool enableScrollbarHack = false;
 	};
@@ -35,8 +34,8 @@ namespace NppDarkMode
 
 	bool isEnabled();
 	bool isDarkMenuEnabled();
-	bool isExperimentalEnabled();
 	bool isScrollbarHackEnabled();
+	bool isExperimentalSupported();
 
 	COLORREF invertLightness(COLORREF c);
 	COLORREF invertLightnessSofter(COLORREF c);
@@ -68,10 +67,11 @@ namespace NppDarkMode
 	void drawUAHMenuNCBottomLine(HWND hWnd);
 
 	// from DarkMode.h
-	void initExperimentalDarkMode(bool fixDarkScrollbar, bool dark);
+	void initExperimentalDarkMode();
+	void setDarkMode(bool useDark, bool fixDarkScrollbar);
 	void allowDarkModeForApp(bool allow);
 	bool allowDarkModeForWindow(HWND hWnd, bool allow);
-	void setTitleBarThemeColor(HWND hWnd, bool dark);
+	void setTitleBarThemeColor(HWND hWnd);
 
 	// enhancements to DarkMode.h
 	void enableDarkScrollBarForWindowAndChildren(HWND hwnd);
@@ -91,5 +91,6 @@ namespace NppDarkMode
 	void setDarkLineAbovePanelToolbar(HWND hwnd);
 	void setDarkListView(HWND hwnd);
 
-	void setExplorerTheme(HWND hwnd, bool doEnable, bool isTreeView = false);
+	void disableVisualStyle(HWND hwnd, bool doDisable);
+	void redrawTreeViewScrollBar(HWND hwnd);
 }

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5388,7 +5388,6 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			};
 
 			_nppGUI._darkmode.enable = parseYesNoBoolAttribute(TEXT("enable"));
-			_nppGUI._darkmode.enableExperimental = parseYesNoBoolAttribute(TEXT("enableExperimental"));
 			_nppGUI._darkmode.enableMenubar = parseYesNoBoolAttribute(TEXT("enableMenubar"));
 			_nppGUI._darkmode.enableScrollbarHack = parseYesNoBoolAttribute(TEXT("enableScrollbarHack"));
 		}
@@ -6414,7 +6413,6 @@ void NppParameters::createXmlTreeFromGUIParams()
 		};
 
 		setYesNoBoolAttribute(TEXT("enable"), _nppGUI._darkmode.enable);
-		setYesNoBoolAttribute(TEXT("enableExperimental"), _nppGUI._darkmode.enableExperimental);
 		setYesNoBoolAttribute(TEXT("enableMenubar"), _nppGUI._darkmode.enableMenubar);
 		setYesNoBoolAttribute(TEXT("enableScrollbarHack"), _nppGUI._darkmode.enableScrollbarHack);
 	}

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ListView.cpp
@@ -186,7 +186,7 @@ LRESULT ListView::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
 						case CDDS_ITEMPREPAINT:
 						{
-							bool isDarkModeSupported = NppDarkMode::isEnabled() && NppDarkMode::isExperimentalEnabled();
+							bool isDarkModeSupported = NppDarkMode::isEnabled() && NppDarkMode::isExperimentalSupported();
 							SetTextColor(nmcd->hdc, isDarkModeSupported ? NppDarkMode::getDarkerTextColor() : GetSysColor(COLOR_BTNTEXT));
 							return CDRF_DODEFAULT;
 						}

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -174,8 +174,8 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
-			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true, true);
 			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+			NppDarkMode::redrawTreeViewScrollBar(_treeView.getHSelf());
 			return TRUE;
 		}
 
@@ -197,10 +197,10 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 		}
 		return TRUE;
 
-        case WM_SIZE:
-        {
-            int width = LOWORD(lParam);
-            int height = HIWORD(lParam);
+		case WM_SIZE:
+		{
+			int width = LOWORD(lParam);
+			int height = HIWORD(lParam);
 			int extraValue = NppParameters::getInstance()._dpiManager.scaleX(4);
 
 			RECT toolbarMenuRect;
@@ -211,13 +211,13 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			HWND hwnd = _treeView.getHSelf();
 			if (hwnd)
 				::MoveWindow(hwnd, 0, toolbarMenuRect.bottom + extraValue, width, height - toolbarMenuRect.bottom - extraValue, TRUE);
-            break;
-        }
+			break;
+		}
 
-        case WM_CONTEXTMENU:
+		case WM_CONTEXTMENU:
 			if (!_treeView.isDragging())
 				showContextMenu(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
-        return TRUE;
+		return TRUE;
 
 		case WM_COMMAND:
 		{
@@ -248,12 +248,12 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 		}
 
 		case WM_DESTROY:
-        {
+		{
 			::DestroyWindow(_hToolbarMenu);
 			_treeView.destroy();
 			destroyMenus();
-            break;
-        }
+			break;
+		}
 
 		case FB_ADDFILE:
 		{
@@ -312,9 +312,9 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			break;
 		}
 
-        default :
-            return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
-    }
+		default :
+			return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
+	}
 	return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
 }
 
@@ -718,18 +718,10 @@ void FileBrowser::notified(LPNMHDR notification)
 	}
 	else if (notification->code == NM_CUSTOMDRAW && (notification->hwndFrom == _hToolbarMenu))
 	{
-		NMTBCUSTOMDRAW* nmtbcd = reinterpret_cast<NMTBCUSTOMDRAW*>(notification);
-		if (nmtbcd->nmcd.dwDrawStage == CDDS_PREERASE)
+		if (NppDarkMode::isEnabled())
 		{
-			if (NppDarkMode::isEnabled())
-			{
-				FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
-				SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_SKIPDEFAULT);
-			}
-			else
-			{
-				SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
-			}
+			auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(notification);
+			FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
 		}
 	}
 }
@@ -1060,7 +1052,7 @@ void FileBrowser::addRootFolder(generic_string rootFolderPath)
 	}
 
 	std::vector<generic_string> patterns2Match;
- 	patterns2Match.push_back(TEXT("*.*"));
+	patterns2Match.push_back(TEXT("*.*"));
 
 	TCHAR *label = ::PathFindFileName(rootFolderPath.c_str());
 	TCHAR rootLabel[MAX_PATH];

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -597,32 +597,10 @@ void FunctionListPanel::notified(LPNMHDR notification)
 	}
 	else if (notification->code == NM_CUSTOMDRAW && (notification->hwndFrom == _hToolbarMenu))
 	{
-		static bool becomeDarkMode = false;
-		static bool becomeLightMode = false;
 		if (NppDarkMode::isEnabled())
 		{
-			if (!becomeDarkMode)
-			{
-				NppDarkMode::setExplorerTheme(_hToolbarMenu, false);
-				becomeDarkMode = true;
-			}
-			becomeLightMode = false;
-
 			auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(notification);
 			FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
-			nmtbcd->clrText = NppDarkMode::getTextColor();
-			nmtbcd->clrHighlightHotTrack = NppDarkMode::getHighlightHotTrackColor();
-			SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW | TBCDRF_HILITEHOTTRACK);
-		}
-		else
-		{
-			if (!becomeLightMode)
-			{
-				NppDarkMode::setExplorerTheme(_hToolbarMenu, true);
-				becomeLightMode = true;
-			}
-			becomeDarkMode = false;
-			SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
 		}
 	}
 }
@@ -709,7 +687,7 @@ static WNDPROC oldFunclstToolbarProc = NULL;
 static LRESULT CALLBACK funclstToolbarProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
-    {
+	{
 		case WM_CTLCOLOREDIT :
 		{
 			return ::SendMessage(::GetParent(hwnd), WM_CTLCOLOREDIT, wParam, lParam);
@@ -762,8 +740,8 @@ void FunctionListPanel::setSort(bool isEnabled)
 
 INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
-    switch (message)
-    {
+	switch (message)
+	{
 		// Make edit field red if not found
 		case WM_CTLCOLOREDIT :
 		{
@@ -811,8 +789,8 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			return (LRESULT)hBrushBackground;
 		}
 
-        case WM_INITDIALOG :
-        {
+		case WM_INITDIALOG :
+		{
 			int editWidth = NppParameters::getInstance()._dpiManager.scaleX(100);
 			int editWidthSep = NppParameters::getInstance()._dpiManager.scaleX(105); //editWidth + 5
 			int editHeight = NppParameters::getInstance()._dpiManager.scaleY(20);
@@ -891,8 +869,8 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
-			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true, true);
 			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+			NppDarkMode::redrawTreeViewScrollBar(_treeView.getHSelf());
 			return TRUE;
 		}
 

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -831,7 +831,6 @@ INT_PTR CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				case IDC_CHECK_DARKMODE_ENABLE:
 					bool enableDarkMode = isCheckedOrNot(static_cast<int>(wParam));
 					nppGUI._darkmode.enable = enableDarkMode;
-					nppGUI._darkmode.enableExperimental = enableDarkMode;
 					nppGUI._darkmode.enableMenubar = enableDarkMode;
 					nppGUI._darkmode.enableScrollbarHack = enableDarkMode;
 

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -56,6 +56,7 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 								   0,0,0,0,_hSelf, nullptr, _hInst, nullptr);
 
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+			NppDarkMode::disableVisualStyle(_hToolbarMenu, NppDarkMode::isEnabled());
 
 			TBBUTTON tbButtons[2];
 
@@ -100,9 +101,10 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
-			
-			NppDarkMode::setExplorerTheme(_treeView.getHSelf(), true, true);
+			NppDarkMode::disableVisualStyle(_hToolbarMenu, NppDarkMode::isEnabled());
+
 			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+			NppDarkMode::redrawTreeViewScrollBar(_treeView.getHSelf());
 			return TRUE;
 		}
 
@@ -122,22 +124,22 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 		}
 		return TRUE;
 
-        case WM_SIZE:
-        {
-            int width = LOWORD(lParam);
-            int height = HIWORD(lParam);
-            RECT toolbarMenuRect;
-            ::GetClientRect(_hToolbarMenu, &toolbarMenuRect);
+		case WM_SIZE:
+		{
+			int width = LOWORD(lParam);
+			int height = HIWORD(lParam);
+			RECT toolbarMenuRect;
+			::GetClientRect(_hToolbarMenu, &toolbarMenuRect);
 
-            ::MoveWindow(_hToolbarMenu, 0, 0, width, toolbarMenuRect.bottom, TRUE);
+			::MoveWindow(_hToolbarMenu, 0, 0, width, toolbarMenuRect.bottom, TRUE);
 
 			HWND hwnd = _treeView.getHSelf();
 			if (hwnd)
 				::MoveWindow(hwnd, 0, toolbarMenuRect.bottom + 2, width, height - toolbarMenuRect.bottom - 2, TRUE);
-            break;
-        }
+			break;
+		}
 
-        case WM_CONTEXTMENU:
+		case WM_CONTEXTMENU:
 			if (!_treeView.isDragging())
 			{
 				int xPos = GET_X_LPARAM(lParam);
@@ -163,7 +165,7 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 					showContextMenu(xPos, yPos);
 				}
 			}
-        return TRUE;
+		return TRUE;
 
 		case WM_COMMAND:
 		{
@@ -172,16 +174,16 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 		}
 
 		case WM_DESTROY:
-        {
+		{
 			_treeView.destroy();
 			destroyMenus();
 			::DestroyWindow(_hToolbarMenu);
-            break;
-        }
+			break;
+		}
 
-        default :
-            return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
-    }
+		default :
+			return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
+	}
 	return DockingDlgInterface::run_dlgProc(message, wParam, lParam);
 }
 
@@ -230,7 +232,7 @@ void ProjectPanel::initMenus()
 	generic_string saveas_workspace = pNativeSpeaker->getProjectPanelLangMenuStr("WorkspaceMenu", IDM_PROJECT_SAVEASWS, PM_SAVEASWORKSPACE);
 	generic_string saveacopyas_workspace = pNativeSpeaker->getProjectPanelLangMenuStr("WorkspaceMenu", IDM_PROJECT_SAVEACOPYASWS, PM_SAVEACOPYASWORKSPACE);
 	generic_string newproject_workspace = pNativeSpeaker->getProjectPanelLangMenuStr("WorkspaceMenu", IDM_PROJECT_NEWPROJECT, PM_NEWPROJECTWORKSPACE);
-    generic_string findinprojects_workspace = pNativeSpeaker->getProjectPanelLangMenuStr("WorkspaceMenu", IDM_PROJECT_FINDINPROJECTSWS, PM_FINDINFILESWORKSPACE);
+	generic_string findinprojects_workspace = pNativeSpeaker->getProjectPanelLangMenuStr("WorkspaceMenu", IDM_PROJECT_FINDINPROJECTSWS, PM_FINDINFILESWORKSPACE);
 
 	::InsertMenu(_hWorkSpaceMenu, 0, MF_BYCOMMAND, IDM_PROJECT_NEWWS, new_workspace.c_str());
 	::InsertMenu(_hWorkSpaceMenu, 0, MF_BYCOMMAND, IDM_PROJECT_OPENWS, open_workspace.c_str());
@@ -451,34 +453,34 @@ bool ProjectPanel::saveWorkSpace()
 
 bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName)
 {
-    //write <NotepadPlus>: use the default file name if new file name is not given
+	//write <NotepadPlus>: use the default file name if new file name is not given
 	const TCHAR * fn2write = projectFileName?projectFileName:_workSpaceFilePath.c_str();
 	TiXmlDocument projDoc(fn2write);
-    TiXmlNode *root = projDoc.InsertEndChild(TiXmlElement(TEXT("NotepadPlus")));
+	TiXmlNode *root = projDoc.InsertEndChild(TiXmlElement(TEXT("NotepadPlus")));
 
 	TCHAR textBuffer[MAX_PATH];
 	TVITEM tvItem;
-    tvItem.mask = TVIF_TEXT;
-    tvItem.pszText = textBuffer;
-    tvItem.cchTextMax = MAX_PATH;
+	tvItem.mask = TVIF_TEXT;
+	tvItem.pszText = textBuffer;
+	tvItem.cchTextMax = MAX_PATH;
 
-    //for each project, write <Project>
-    HTREEITEM tvRoot = _treeView.getRoot();
-    if (!tvRoot)
-      return false;
+	//for each project, write <Project>
+	HTREEITEM tvRoot = _treeView.getRoot();
+	if (!tvRoot)
+		return false;
 
-    for (HTREEITEM tvProj = _treeView.getChildFrom(tvRoot);
-        tvProj != NULL;
-        tvProj = _treeView.getNextSibling(tvProj))
-    {        
-        tvItem.hItem = tvProj;
+		for (HTREEITEM tvProj = _treeView.getChildFrom(tvRoot);
+		tvProj != NULL;
+		tvProj = _treeView.getNextSibling(tvProj))
+	{
+		tvItem.hItem = tvProj;
 		SendMessage(_treeView.getHSelf(), TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
-        //printStr(tvItem.pszText);
+		//printStr(tvItem.pszText);
 
 		TiXmlNode *projRoot = root->InsertEndChild(TiXmlElement(TEXT("Project")));
 		projRoot->ToElement()->SetAttribute(TEXT("name"), tvItem.pszText);
 		buildProjectXml(projRoot, tvProj, fn2write);
-    }
+	}
 
 	if (!projDoc.SaveFile())
 	{
@@ -506,7 +508,7 @@ void ProjectPanel::buildProjectXml(TiXmlNode *node, HTREEITEM hItem, const TCHAR
 	tvItem.pszText = textBuffer;
 	tvItem.cchTextMax = MAX_PATH;
 
-    for (HTREEITEM hItemNode = _treeView.getChildFrom(hItem);
+	for (HTREEITEM hItemNode = _treeView.getChildFrom(hItem);
 		hItemNode != NULL;
 		hItemNode = _treeView.getNextSibling(hItemNode))
 	{
@@ -817,27 +819,11 @@ void ProjectPanel::notified(LPNMHDR notification)
 	{
 		if (NppDarkMode::isEnabled())
 		{
-			if (!_becomeDarkMode)
-			{
-				NppDarkMode::setExplorerTheme(_hToolbarMenu, false);
-				_becomeDarkMode = true;
-			}
-			_becomeLightMode = false;
 			auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(notification);
 			FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
 			nmtbcd->clrText = NppDarkMode::getTextColor();
 			nmtbcd->clrHighlightHotTrack = NppDarkMode::getHighlightHotTrackColor();
-			SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYSUBITEMDRAW | TBCDRF_HILITEHOTTRACK);
-		}
-		else
-		{
-			if (!_becomeLightMode)
-			{
-				NppDarkMode::setExplorerTheme(_hToolbarMenu, true);
-				_becomeLightMode = true;
-			}
-			_becomeDarkMode = false;
-			SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_DODEFAULT);
+			SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYITEMDRAW | TBCDRF_HILITEHOTTRACK);
 		}
 	}
 }

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -469,7 +469,7 @@ bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName)
 	if (!tvRoot)
 		return false;
 
-		for (HTREEITEM tvProj = _treeView.getChildFrom(tvRoot);
+	for (HTREEITEM tvProj = _treeView.getChildFrom(tvRoot);
 		tvProj != NULL;
 		tvProj = _treeView.getNextSibling(tvProj))
 	{

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
@@ -65,13 +65,13 @@ public:
 		_panelID = panelID;
 	}
 
-    virtual void display(bool toShow = true) const {
-        DockingDlgInterface::display(toShow);
-    };
+	virtual void display(bool toShow = true) const {
+		DockingDlgInterface::display(toShow);
+	};
 
-    void setParent(HWND parent2set){
-        _hParent = parent2set;
-    };
+	void setParent(HWND parent2set){
+		_hParent = parent2set;
+	};
 
 	void setPanelTitle(generic_string title) {
 		_panelTitle = title;
@@ -98,10 +98,10 @@ public:
 
 	virtual void setBackgroundColor(COLORREF bgColour) {
 		TreeView_SetBkColor(_treeView.getHSelf(), bgColour);
-    };
+	};
 	virtual void setForegroundColor(COLORREF fgColour) {
 		TreeView_SetTextColor(_treeView.getHSelf(), fgColour);
-    };
+	};
 	bool enumWorkSpaceFiles(HTREEITEM tvFrom, const std::vector<generic_string> & patterns, std::vector<generic_string> & fileNames);
 
 protected:
@@ -117,8 +117,6 @@ protected:
 	generic_string _selDirOfFilesFromDirDlg;
 	bool _isDirty = false;
 	int _panelID = 0;
-	bool _becomeDarkMode = false;
-	bool _becomeLightMode = false;
 
 	void initMenus();
 	void destroyMenus();
@@ -157,8 +155,8 @@ public :
 
 	int doDialog(const TCHAR *fn, bool isRTL = false);
 
-    virtual void destroy() {
-    };
+	virtual void destroy() {
+	};
 
 	generic_string getFullFilePath() {
 		return _fullFilePath;

--- a/PowerEditor/src/WinControls/TreeView/TreeView.cpp
+++ b/PowerEditor/src/WinControls/TreeView/TreeView.cpp
@@ -43,7 +43,6 @@ void TreeView::init(HINSTANCE hInst, HWND parent, int treeViewID)
 							_hInst,
 							nullptr);
 
-	NppDarkMode::setExplorerTheme(_hSelf, true, true);
 	NppDarkMode::setDarkTooltips(_hSelf, NppDarkMode::ToolTipsType::treeview);
 
 	int itemHeight = NppParameters::getInstance()._dpiManager.scaleY(CY_ITEMHEIGHT);
@@ -205,8 +204,8 @@ void TreeView::removeItem(HTREEITEM hTreeItem)
 void TreeView::removeAllItems()
 {
 	for (HTREEITEM tvProj = getRoot();
-        tvProj != NULL;
-        tvProj = getNextSibling(tvProj))
+		tvProj != NULL;
+		tvProj = getNextSibling(tvProj))
 	{
 		cleanSubEntries(tvProj);
 	}
@@ -329,81 +328,81 @@ void TreeView::beginDrag(NMTREEVIEW* tv)
 	if (!canDragOut(tv->itemNew.hItem))
 		return;
 
-    // create dragging image for you using TVM_CREATEDRAGIMAGE
-    // You have to delete it after drop operation, so remember it.
-    _draggedItem = tv->itemNew.hItem;
+	// create dragging image for you using TVM_CREATEDRAGIMAGE
+	// You have to delete it after drop operation, so remember it.
+	_draggedItem = tv->itemNew.hItem;
 	_draggedImageList = reinterpret_cast<HIMAGELIST>(::SendMessage(_hSelf, TVM_CREATEDRAGIMAGE, 0, reinterpret_cast<LPARAM>(_draggedItem)));
 
-    // start dragging operation
-    // PARAMS: HIMAGELIST, imageIndex, xHotspot, yHotspot
-    ::ImageList_BeginDrag(_draggedImageList, 0, 0, 0);
-    ::ImageList_DragEnter(_hSelf, tv->ptDrag.x, tv->ptDrag.y);
+	// start dragging operation
+	// PARAMS: HIMAGELIST, imageIndex, xHotspot, yHotspot
+	::ImageList_BeginDrag(_draggedImageList, 0, 0, 0);
+	::ImageList_DragEnter(_hSelf, tv->ptDrag.x, tv->ptDrag.y);
 
-    // redirect mouse input to the parent window
-    ::SetCapture(::GetParent(_hSelf));
-    ::ShowCursor(false);          // hide the cursor
+	// redirect mouse input to the parent window
+	::SetCapture(::GetParent(_hSelf));
+	::ShowCursor(false);          // hide the cursor
 
-    _isItemDragged = true;
+	_isItemDragged = true;
 }
 
 void TreeView::dragItem(HWND parentHandle, int x, int y)
 {
-    // convert the dialog coords to control coords
-    POINT point;
-    point.x = (SHORT)x;
-    point.y = (SHORT)y;
-    ::ClientToScreen(parentHandle, &point);
-    ::ScreenToClient(_hSelf, &point);
+	// convert the dialog coords to control coords
+	POINT point;
+	point.x = (SHORT)x;
+	point.y = (SHORT)y;
+	::ClientToScreen(parentHandle, &point);
+	::ScreenToClient(_hSelf, &point);
 
-    // drag the item to the current the cursor position
-    ::ImageList_DragMove(point.x, point.y);
+	// drag the item to the current the cursor position
+	::ImageList_DragMove(point.x, point.y);
 
-    // hide the dragged image, so the background can be refreshed
-    ::ImageList_DragShowNolock(false);
+	// hide the dragged image, so the background can be refreshed
+	::ImageList_DragShowNolock(false);
 
-    // find out if the pointer is on an item
-    // If so, highlight the item as a drop target.
-    TVHITTESTINFO hitTestInfo;
-    hitTestInfo.pt.x = point.x;
-    hitTestInfo.pt.y = point.y;
+	// find out if the pointer is on an item
+	// If so, highlight the item as a drop target.
+	TVHITTESTINFO hitTestInfo;
+	hitTestInfo.pt.x = point.x;
+	hitTestInfo.pt.y = point.y;
 	HTREEITEM targetItem = reinterpret_cast<HTREEITEM>(::SendMessage(_hSelf, TVM_HITTEST, 0, reinterpret_cast<LPARAM>(&hitTestInfo)));
-    if (targetItem)
-    {
+	if (targetItem)
+	{
 		::SendMessage(_hSelf, TVM_SELECTITEM, TVGN_DROPHILITE, reinterpret_cast<LPARAM>(targetItem));
-    }
+	}
 
-    // show the dragged image
-    ::ImageList_DragShowNolock(true);
+	// show the dragged image
+	::ImageList_DragShowNolock(true);
 }
 
 bool TreeView::dropItem()
 {
 	bool isFilesMoved = false;
-    // get the target item
+	// get the target item
 	HTREEITEM targetItem = reinterpret_cast<HTREEITEM>(::SendMessage(_hSelf, TVM_GETNEXTITEM, TVGN_DROPHILITE, 0));
 
-    // make a copy of the dragged item and insert the clone under
-    // the target item, then, delete the original dragged item
-    // Note that the dragged item may have children. In this case,
-    // you have to move (copy and delete) for every child items, too.
+	// make a copy of the dragged item and insert the clone under
+	// the target item, then, delete the original dragged item
+	// Note that the dragged item may have children. In this case,
+	// you have to move (copy and delete) for every child items, too.
 	if (canBeDropped(_draggedItem, targetItem))
 	{
 		moveTreeViewItem(_draggedItem, targetItem);
 		isFilesMoved = true;
 	}
-    // finish drag-and-drop operation
-    ::ImageList_EndDrag();
-    ::ImageList_Destroy(_draggedImageList);
-    ::ReleaseCapture();
-    ::ShowCursor(true);
+	// finish drag-and-drop operation
+	::ImageList_EndDrag();
+	::ImageList_Destroy(_draggedImageList);
+	::ReleaseCapture();
+	::ShowCursor(true);
 
 	SendMessage(_hSelf, TVM_SELECTITEM, TVGN_CARET, reinterpret_cast<LPARAM>(targetItem));
-    SendMessage(_hSelf,TVM_SELECTITEM,TVGN_DROPHILITE,0);
+	SendMessage(_hSelf,TVM_SELECTITEM,TVGN_DROPHILITE,0);
 
-    // clear global variables
-    _draggedItem = 0;
-    _draggedImageList = 0;
-    _isItemDragged = false;
+	// clear global variables
+	_draggedItem = 0;
+	_draggedImageList = 0;
+	_isItemDragged = false;
 	return isFilesMoved;
 }
 
@@ -459,7 +458,7 @@ void TreeView::moveTreeViewItem(HTREEITEM draggedItem, HTREEITEM targetItem)
 	tvDraggingItem.hItem = draggedItem;
 	SendMessage(_hSelf, TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvDraggingItem));
 
-    TVINSERTSTRUCT tvInsertStruct;
+	TVINSERTSTRUCT tvInsertStruct;
 	tvInsertStruct.item = tvDraggingItem;
 	tvInsertStruct.hInsertAfter = (HTREEITEM)TVI_LAST;
 	tvInsertStruct.hParent = targetItem;
@@ -516,7 +515,7 @@ bool TreeView::swapTreeViewItem(HTREEITEM itemGoDown, HTREEITEM itemGoUp)
 	SendMessage(_hSelf, TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvDownItem));
 
 	// add 2 new items
-    TVINSERTSTRUCT tvInsertUp;
+	TVINSERTSTRUCT tvInsertUp;
 	tvInsertUp.item = tvUpItem;
 	tvInsertUp.hInsertAfter = itemTop;
 	tvInsertUp.hParent = parentGoUp;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -102,7 +102,7 @@ LRESULT VerticalFileSwitcherListView::runProc(HWND hwnd, UINT Message, WPARAM wP
 
 						case CDDS_ITEMPREPAINT:
 						{
-							bool isDarkModeSupported = NppDarkMode::isEnabled() && NppDarkMode::isExperimentalEnabled();
+							bool isDarkModeSupported = NppDarkMode::isEnabled() && NppDarkMode::isExperimentalSupported();
 							SetTextColor(nmcd->hdc, isDarkModeSupported ? NppDarkMode::getDarkerTextColor() : GetSysColor(COLOR_BTNTEXT));
 							return CDRF_DODEFAULT;
 						}


### PR DESCRIPTION
Make dark mode restartless.

Should work for everything, even treeview scrollbars.
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10121

@donho 
I have just noticed that Notepad++ still does not allow darkmode in Windows 11.
Should I do commit to allow it or wait for stable  Windows 11 build.