### PR TITLE
Use `!` instead of `not` as per guideline # 13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ In short: The easier the code review is, the better the chance your pull request
 
   * ###### Good:
     ```cpp
-    if (not string.empty())
+    if (!string.empty())
     ...
     ```
 


### PR DESCRIPTION
Contradicts guideline # 13 "Use `!` instead of `not`"