### PR TITLE
Activate dark mode in Windows 11

### DIFF
--- a/PowerEditor/src/DarkMode/DarkMode.cpp
+++ b/PowerEditor/src/DarkMode/DarkMode.cpp
@@ -246,7 +246,8 @@ constexpr bool CheckBuildNumber(DWORD buildNumber)
 		buildNumber == 18363 || // 1909
 		buildNumber == 19041 || // 2004
 		buildNumber == 19042 || // 20H2
-		buildNumber == 19043);  // 21H1
+		buildNumber == 19043 || // 21H1
+		buildNumber >= 22000);  // Windows 11 insider builds
 }
 
 void InitDarkMode()


### PR DESCRIPTION
Allow dark mode in Windows 11 insider build 22000 and later.


Per this comment https://github.com/notepad-plus-plus/notepad-plus-plus/pull/10122#issuecomment-877082580
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10136

There is issue with toolbar button highlight, but I don't think we should fix it now.
![image](https://user-images.githubusercontent.com/55940305/125109561-0f0a8100-e0d3-11eb-8054-ea970ba0b8f8.png)

![image](https://user-images.githubusercontent.com/55940305/125109650-28133200-e0d3-11eb-85cd-1bee1b588f61.png)