### PR TITLE
Allow CtrlTab to switch tabs in Find dialog

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -3579,7 +3579,9 @@ LRESULT FAR PASCAL FindReplaceDlg::comboEditProc(HWND hwndEdit, UINT message, WP
 	{
 		// find the associated combobox for the edit control that triggered this
 
-		static HWND hwndCombo = 0;
+		static HWND hwndCombo;
+
+		hwndCombo = 0;
 
 		EnumChildWindows(pFindReplaceDlg->_hSelf, [](HWND hwnd, LPARAM lParam) {
 			HWND hwndEdit = reinterpret_cast<HWND>(lParam);

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -353,8 +353,12 @@ protected :
 	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	static LONG_PTR originalFinderProc;
 	static LONG_PTR originalComboEditProc;
+	static LONG_PTR originalCheckOrRadioButtonProc;
+	static LONG_PTR originalPushButtonProc;
 
-	static LRESULT FAR PASCAL comboEditProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT FAR PASCAL comboEditProc(HWND hwndEdit, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT FAR PASCAL checkOrRadioButtonProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+	static LRESULT FAR PASCAL pushButtonProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 	// Window procedure for the finder
 	static LRESULT FAR PASCAL finderProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
@@ -412,6 +416,8 @@ private :
 	void enableFindInProjectsFunc();
 	void enableMarkAllControls(bool isEnable);
 	void enableMarkFunc();
+
+	bool ctrlTabPressProcessed(MSG* pMsg);
 
 	void setDefaultButton(int nID) {
 		SendMessage(_hSelf, DM_SETDEFID, nID, 0L);


### PR DESCRIPTION
Fix #10019

Doesn't implement exactly what the requester wanted, but implements a way to switch tabs once _Find_ dialog is focused that was impossible before.

Ctrl+Tab will switch to the right one tab.
Ctrl+Shift+Tab (awkward so maybe rarely used) will switch to the left one tab.

A lot of code for a simple thing (runs high risk of rejection), but it is easily validated to not break existing functionality:
* test Delete key functionality to delete an entry when a combobox is dropped down (still works)
* test Ctrl+Backspace functionality to delete a word in an edit box (still works)

Additionally, the groundwork is now put down for easily implementing new behaviors for more control types.