### PR TITLE
Edit Control Enhancement

### DIFF
--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -31,7 +31,7 @@ namespace NppDarkMode
 		bool enable = false;
 		bool enableMenubar = false;
 	};
-	
+
 	enum class ToolTipsType
 	{
 		tooltip,
@@ -118,6 +118,7 @@ namespace NppDarkMode
 	void subclassGroupboxControl(HWND hwnd);
 	void subclassToolbarControl(HWND hwnd);
 	void subclassTabControl(HWND hwnd);
+	void subclassComboBoxControl(HWND hwnd);
 
 	void autoSubclassAndThemeChildControls(HWND hwndParent, bool subclass = true, bool theme = true);
 	void autoThemeChildControls(HWND hwndParent);
@@ -131,4 +132,8 @@ namespace NppDarkMode
 
 	void disableVisualStyle(HWND hwnd, bool doDisable);
 	void setTreeViewStyle(HWND hwnd);
+
+	LRESULT onCtlColor(HDC hdc);
+	LRESULT onCtlColorSofter(HDC hdc);
+	LRESULT onCtlColorError(HDC hdc);
 }

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -76,7 +76,7 @@ void delLeftWordInEdit(HWND hEdit)
 	}
 };
 
-int Searching::convertExtendedToString(const TCHAR * query, TCHAR * result, int length) 
+int Searching::convertExtendedToString(const TCHAR * query, TCHAR * result, int length)
 {	//query may equal to result, since it always gets smaller
 	int i = 0, j = 0;
 	int charLeft = length;
@@ -111,7 +111,7 @@ int Searching::convertExtendedToString(const TCHAR * query, TCHAR * result, int 
 				case 'd':
 				case 'o':
 				case 'x':
-				case 'u': 
+				case 'u':
 				{
 					int size = 0, base = 0;
 					if (current == 'b')
@@ -134,8 +134,8 @@ int Searching::convertExtendedToString(const TCHAR * query, TCHAR * result, int 
 					{	//0xCDCD
 						size = 4, base = 16;
 					}
-					
-					if (charLeft >= size) 
+
+					if (charLeft >= size)
 					{
 						int res = 0;
 						if (Searching::readBase(query+(i+1), &res, base, size))
@@ -147,8 +147,8 @@ int Searching::convertExtendedToString(const TCHAR * query, TCHAR * result, int 
 					}
 					//not enough chars to make parameter, use default method as fallback
 				}
-				
-				default: 
+
+				default:
 				{	//unknown sequence, treat as regular text
 					result[j] = '\\';
 					++j;
@@ -177,7 +177,7 @@ bool Searching::readBase(const TCHAR * str, int * value, int base, int size)
 	while (i < size)
 	{
 		current = str[i];
-		if (current >= 'A') 
+		if (current >= 'A')
 		{
 			current &= 0xdf;
 			current -= ('A' - '0' - 10);
@@ -200,7 +200,7 @@ bool Searching::readBase(const TCHAR * str, int * value, int base, int size)
 	return true;
 }
 
-void Searching::displaySectionCentered(int posStart, int posEnd, ScintillaEditView * pEditView, bool isDownwards) 
+void Searching::displaySectionCentered(int posStart, int posEnd, ScintillaEditView * pEditView, bool isDownwards)
 {
 	// Make sure target lines are unfolded
 	pEditView->execute(SCI_ENSUREVISIBLE, pEditView->execute(SCI_LINEFROMPOSITION, posStart));
@@ -264,7 +264,7 @@ void FindReplaceDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	fillFindHistory();
 	_currentStatus = REPLACE_DLG;
 	initOptionsFromDlg();
-	
+
 	_statusBar.init(GetModuleHandle(NULL), _hSelf, 0);
 	_statusBar.display();
 
@@ -275,7 +275,7 @@ void FindReplaceDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	NppDarkMode::subclassTabControl(_tab.getHSelf());
 	int tabDpiDynamicalHeight = NppParameters::getInstance()._dpiManager.scaleY(13);
 	_tab.setFont(TEXT("Tahoma"), tabDpiDynamicalHeight);
-	
+
 	const TCHAR *find = TEXT("Find");
 	const TCHAR *replace = TEXT("Replace");
 	const TCHAR *findInFiles = TEXT("Find in Files");
@@ -292,13 +292,13 @@ void FindReplaceDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	_tab.display();
 
 	_initialClientWidth = rect.right - rect.left;
-	
+
 	//fill min dialog size info
 	this->getWindowRect(_initialWindowRect);
 	_initialWindowRect.right = _initialWindowRect.right - _initialWindowRect.left;
 	_initialWindowRect.left = 0;
 	_initialWindowRect.bottom = _initialWindowRect.bottom - _initialWindowRect.top;
-	_initialWindowRect.top = 0;	
+	_initialWindowRect.top = 0;
 
 	ETDTProc enableDlgTheme = (ETDTProc)::SendMessage(_hParent, NPPM_GETENABLETHEMETEXTUREFUNC, 0, 0);
 	if (enableDlgTheme)
@@ -325,7 +325,7 @@ void FindReplaceDlg::fillFindHistory()
 	fillComboHistory(IDFINDWHAT, findHistory._findHistoryFinds);
 	fillComboHistory(IDREPLACEWITH, findHistory._findHistoryReplaces);
 	fillComboHistory(IDD_FINDINFILES_FILTERS_COMBO, findHistory._findHistoryFilters);
-    fillComboHistory(IDD_FINDINFILES_DIR_COMBO, findHistory._findHistoryPaths);
+	fillComboHistory(IDD_FINDINFILES_DIR_COMBO, findHistory._findHistoryPaths);
 
 	::SendDlgItemMessage(_hSelf, IDWRAP, BM_SETCHECK, findHistory._isWrap, 0);
 	::SendDlgItemMessage(_hSelf, IDWHOLEWORD, BM_SETCHECK, findHistory._isMatchWord, 0);
@@ -334,7 +334,7 @@ void FindReplaceDlg::fillFindHistory()
 
 	::SendDlgItemMessage(_hSelf, IDD_FINDINFILES_INHIDDENDIR_CHECK, BM_SETCHECK, findHistory._isFifInHiddenFolder, 0);
 	::SendDlgItemMessage(_hSelf, IDD_FINDINFILES_RECURSIVE_CHECK, BM_SETCHECK, findHistory._isFifRecuisive, 0);
-    ::SendDlgItemMessage(_hSelf, IDD_FINDINFILES_FOLDERFOLLOWSDOC_CHECK, BM_SETCHECK, findHistory._isFolderFollowDoc, 0);
+	::SendDlgItemMessage(_hSelf, IDD_FINDINFILES_FOLDERFOLLOWSDOC_CHECK, BM_SETCHECK, findHistory._isFolderFollowDoc, 0);
 
 	::SendDlgItemMessage(_hSelf, IDD_FINDINFILES_PROJECT1_CHECK, BM_SETCHECK, findHistory._isFifProjectPanel_1, 0);
 	::SendDlgItemMessage(_hSelf, IDD_FINDINFILES_PROJECT2_CHECK, BM_SETCHECK, findHistory._isFifProjectPanel_2, 0);
@@ -357,11 +357,11 @@ void FindReplaceDlg::fillFindHistory()
 		::SendDlgItemMessage(_hSelf, IDC_BACKWARDDIRECTION, BM_SETCHECK, BST_UNCHECKED, 0);
 		enableFindDlgItem(IDC_BACKWARDDIRECTION, nppParams.regexBackward4PowerUser());
 		enableFindDlgItem(IDC_FINDPREV, nppParams.regexBackward4PowerUser());
-		
+
 		// If the search mode from history is regExp then enable the checkbox (. matches newline)
 		enableFindDlgItem(IDREDOTMATCHNL);
 	}
-	
+
 	if (nppParams.isTransparentAvailable())
 	{
 		showFindDlgItem(IDC_TRANSPARENT_CHECK);
@@ -369,10 +369,10 @@ void FindReplaceDlg::fillFindHistory()
 		showFindDlgItem(IDC_TRANSPARENT_LOSSFOCUS_RADIO);
 		showFindDlgItem(IDC_TRANSPARENT_ALWAYS_RADIO);
 		showFindDlgItem(IDC_PERCENTAGE_SLIDER);
-		
+
 		::SendDlgItemMessage(_hSelf, IDC_PERCENTAGE_SLIDER, TBM_SETRANGE, FALSE, MAKELONG(20, 200));
 		::SendDlgItemMessage(_hSelf, IDC_PERCENTAGE_SLIDER, TBM_SETPOS, TRUE, findHistory._transparency);
-		
+
 		if (findHistory._transparencyMode == FindHistory::none)
 		{
 			enableFindDlgItem(IDC_TRANSPARENT_GRPBOX, false);
@@ -383,7 +383,7 @@ void FindReplaceDlg::fillFindHistory()
 		else
 		{
 			::SendDlgItemMessage(_hSelf, IDC_TRANSPARENT_CHECK, BM_SETCHECK, TRUE, 0);
-			
+
 			int id;
 			if (findHistory._transparencyMode == FindHistory::onLossingFocus)
 			{
@@ -618,7 +618,7 @@ bool Finder::canFind(const TCHAR *fileName, size_t lineNumber) const
 				return true;
 		}
 	}
-	return false; 
+	return false;
 }
 
 void Finder::gotoNextFoundResult(int direction)
@@ -628,7 +628,7 @@ void Finder::gotoNextFoundResult(int direction)
 	auto lno = _scintView.execute(SCI_LINEFROMPOSITION, currentPos);
 	auto total_lines = _scintView.execute(SCI_GETLINECOUNT);
 	if (total_lines <= 1) return;
-	
+
 	if (lno == total_lines - 1) lno--; // last line doesn't belong to any search, use last search
 
 	auto init_lno = lno;
@@ -650,7 +650,7 @@ void Finder::gotoNextFoundResult(int direction)
 	assert(min_lno <= max_lno);
 
 	lno += increment;
-	
+
 	if      (lno > max_lno) lno = min_lno;
 	else if (lno < min_lno) lno = max_lno;
 
@@ -682,7 +682,7 @@ void FindInFinderDlg::initFromOptions()
 
 	setChecked(IDWHOLEWORD_FIFOLDER, _options._searchType != FindRegex && _options._isWholeWord);
 	::EnableWindow(::GetDlgItem(_hSelf, IDWHOLEWORD_FIFOLDER), _options._searchType != FindRegex);
-	
+
 	setChecked(IDMATCHCASE_FIFOLDER, _options._isMatchCase);
 
 	setChecked(IDNORMAL_FIFOLDER, _options._searchType == FindNormal);
@@ -759,7 +759,7 @@ INT_PTR CALLBACK FindInFinderDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 						::EnableWindow(GetDlgItem(_hSelf, IDREDOTMATCHNL_FIFOLDER), false);
 					}
 
-					return TRUE; 
+					return TRUE;
 				}
 			}
 			return FALSE;
@@ -832,7 +832,7 @@ std::mutex findOps_mutex;
 
 INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
-	switch (message) 
+	switch (message)
 	{
 		case WM_GETMINMAXINFO:
 		{
@@ -850,30 +850,44 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 		}
 
 		case WM_CTLCOLOREDIT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return NppDarkMode::onCtlColorSofter(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
+		case WM_CTLCOLORLISTBOX:
 		{
-			if (!NppDarkMode::isEnabled())
+			if (NppDarkMode::isEnabled())
 			{
-				break;
+				return NppDarkMode::onCtlColor(reinterpret_cast<HDC>(wParam));
 			}
-
-			SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
-			SetBkColor((HDC)wParam, NppDarkMode::getBackgroundColor());
-			return (LRESULT)NppDarkMode::getBackgroundBrush();
+			break;
 		}
+
 		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case WM_ERASEBKGND:
 		{
-			if (!NppDarkMode::isEnabled())
+			if (NppDarkMode::isEnabled())
 			{
-				break;
+				RECT rc = { 0 };
+				getClientRect(rc);
+				FillRect(reinterpret_cast<HDC>(wParam), &rc, NppDarkMode::getBackgroundBrush());
+				return TRUE;
 			}
-			RECT rc = { 0 };
-			getClientRect(rc);
-			FillRect((HDC)wParam, &rc, NppDarkMode::getBackgroundBrush());
-			SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, TRUE);
-			return TRUE;
+			break;
 		}
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
@@ -1053,7 +1067,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 
 				_options._isInSelection = isCheckedOrNot(IDC_IN_SELECTION_CHECK)?1:0;
 				int checkVal = _options._isInSelection?BST_CHECKED:BST_UNCHECKED;
-				
+
 				if (!_options._isInSelection)
 				{
 					if (nbSelected <= 1024)
@@ -1067,7 +1081,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						_options._isInSelection = true;
 					}
 				}
-				// Searching/replacing in multiple selections or column selection is not allowed 
+				// Searching/replacing in multiple selections or column selection is not allowed
 				if (((*_ppEditView)->execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE) || ((*_ppEditView)->execute(SCI_GETSELECTIONS) > 1))
 				{
 					checkVal = BST_UNCHECKED;
@@ -1083,7 +1097,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				}
 				::SendDlgItemMessage(_hSelf, IDC_IN_SELECTION_CHECK, BM_SETCHECK, checkVal, 0);
 			}
-			
+
 			if (isCheckedOrNot(IDC_TRANSPARENT_LOSSFOCUS_RADIO))
 			{
 				if (LOWORD(wParam) == WA_INACTIVE && isVisible())
@@ -1114,7 +1128,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 		case NPPM_MODELESSDIALOG :
 			return ::SendMessage(_hParent, NPPM_MODELESSDIALOG, wParam, lParam);
 
-		case WM_COMMAND : 
+		case WM_COMMAND :
 		{
 			bool isMacroRecording = (::SendMessage(_hParent, WM_GETCURRENTMACROSTATUS,0,0) == MACRO_RECORDING_IN_PROGRESS);
 			NppParameters& nppParamInst = NppParameters::getInstance();
@@ -1236,8 +1250,8 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 					if (_currentStatus == FIND_DLG)
 					{
 						setStatusbarMessage(TEXT(""), FSNoMessage);
- 						HWND hFindCombo = ::GetDlgItem(_hSelf, IDFINDWHAT);
-                        combo2ExtendedMode(IDFINDWHAT);
+						HWND hFindCombo = ::GetDlgItem(_hSelf, IDFINDWHAT);
+						combo2ExtendedMode(IDFINDWHAT);
 						_options._str2Search = getTextFromCombo(hFindCombo);
 						updateCombo(IDFINDWHAT);
 
@@ -1253,7 +1267,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				{
 					setStatusbarMessage(TEXT(""), FSNoMessage);
 					HWND hFindCombo = ::GetDlgItem(_hSelf, IDFINDWHAT);
-                    combo2ExtendedMode(IDFINDWHAT);
+					combo2ExtendedMode(IDFINDWHAT);
 					_options._str2Search = getTextFromCombo(hFindCombo);
 					updateCombo(IDFINDWHAT);
 
@@ -1402,7 +1416,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 							nppParamInst._isFindReplacing = false;
 						}
 					}
-				}			
+				}
 				return TRUE;
 
 				case IDREPLACEALL :
@@ -1511,7 +1525,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						nppParamInst._isFindReplacing = true;
 						int nbMarked = processAll(ProcessMarkAll, &_options);
 						nppParamInst._isFindReplacing = false;
-						
+
 						generic_string result;
 						NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 						if (nbMarked < 0)
@@ -1569,7 +1583,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 
 				case IDNORMAL:
 				case IDEXTENDED:
-				case IDREGEXP : 
+				case IDREGEXP :
 				{
 					if (isCheckedOrNot(IDREGEXP))
 					{
@@ -1591,8 +1605,8 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 					}
 
 					bool isRegex = (_options._searchType == FindRegex);
-					if (isRegex) 
-					{	
+					if (isRegex)
+					{
 						//regex doesn't allow whole word
 						_options._isWholeWord = false;
 						::SendDlgItemMessage(_hSelf, IDWHOLEWORD, BM_SETCHECK, _options._isWholeWord?BST_CHECKED:BST_UNCHECKED, 0);
@@ -1616,7 +1630,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 					enableFindDlgItem(IDC_BACKWARDDIRECTION, doEnable);
 					enableFindDlgItem(IDC_FINDPREV, doEnable);
 
-					return TRUE; 
+					return TRUE;
 				}
 
 				case IDWRAP :
@@ -1696,7 +1710,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				{
 					if (_currentStatus == FINDINFILES_DLG)
 						findHistory._isFifRecuisive = _options._isRecursive = isCheckedOrNot(IDD_FINDINFILES_RECURSIVE_CHECK);
-					
+
 				}
 				return TRUE;
 
@@ -1706,7 +1720,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 						findHistory._isFifInHiddenFolder = _options._isInHiddenDir = isCheckedOrNot(IDD_FINDINFILES_INHIDDENDIR_CHECK);
 				}
 				return TRUE;
-					
+
 				case IDD_FINDINFILES_PROJECT1_CHECK:
 				case IDD_FINDINFILES_PROJECT2_CHECK:
 				case IDD_FINDINFILES_PROJECT3_CHECK:
@@ -1732,18 +1746,18 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 				}
 				return TRUE;
 
-                case IDD_FINDINFILES_FOLDERFOLLOWSDOC_CHECK :
+				case IDD_FINDINFILES_FOLDERFOLLOWSDOC_CHECK :
 				{
 					if (_currentStatus == FINDINFILES_DLG)
-                        findHistory._isFolderFollowDoc = isCheckedOrNot(IDD_FINDINFILES_FOLDERFOLLOWSDOC_CHECK);
+						findHistory._isFolderFollowDoc = isCheckedOrNot(IDD_FINDINFILES_FOLDERFOLLOWSDOC_CHECK);
 
-                    if (findHistory._isFolderFollowDoc)
-                    {
-                        NppParameters& nppParam = NppParameters::getInstance();
-                        const TCHAR * dir = nppParam.getWorkingDir();
-                        ::SetDlgItemText(_hSelf, IDD_FINDINFILES_DIR_COMBO, dir);
-                    }
-					
+					if (findHistory._isFolderFollowDoc)
+					{
+						NppParameters& nppParam = NppParameters::getInstance();
+						const TCHAR * dir = nppParam.getWorkingDir();
+						::SetDlgItemText(_hSelf, IDD_FINDINFILES_DIR_COMBO, dir);
+					}
+
 				}
 				return TRUE;
 
@@ -1782,7 +1796,7 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 	int stringSizeFind = lstrlen(txt2find);
 	TCHAR *pText = new TCHAR[stringSizeFind + 1];
 	wcscpy_s(pText, stringSizeFind + 1, txt2find);
-	
+
 	if (pOptions->_searchType == FindExtended)
 	{
 		stringSizeFind = Searching::convertExtendedToString(txt2find, pText, stringSizeFind);
@@ -1796,7 +1810,7 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 	int startPosition = cr.cpMax;
 	int endPosition = docLength;
 
-	
+
 	if (pOptions->_whichDirection == DIR_UP)
 	{
 		//When searching upwards, start is the lower part, end the upper, for backwards search
@@ -1821,7 +1835,7 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 	{
 		// text to find is not modified, so use current position +1
 		startPosition = cr.cpMin + 1;
-		endPosition = docLength;	
+		endPosition = docLength;
 
 		if (pOptions->_whichDirection == DIR_UP)
 		{
@@ -1852,7 +1866,7 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 
 	// Never allow a zero length match in the middle of a line end marker
 	if ((*_ppEditView)->execute(SCI_GETCHARAT, startPosition - 1) == '\r'
-		&& (*_ppEditView)->execute(SCI_GETCHARAT, startPosition) == '\n') 
+		&& (*_ppEditView)->execute(SCI_GETCHARAT, startPosition) == '\n')
 	{
 		flags = (flags & ~SCFIND_REGEXP_EMPTYMATCH_MASK) | SCFIND_REGEXP_EMPTYMATCH_NONE;
 	}
@@ -1863,7 +1877,7 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 	posFind = (*_ppEditView)->searchInTarget(pText, stringSizeFind, startPosition, endPosition);
 	if (posFind == -1) //no match found in target, check if a new target should be used
 	{
-		if (pOptions->_isWrapAround) 
+		if (pOptions->_isWrapAround)
 		{
 			//when wrapping, use the rest of the document (entire document is usable)
 			if (pOptions->_whichDirection == DIR_DOWN)
@@ -1891,13 +1905,13 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 				*oFindStatus = FSNotFound;
 			//failed, or failed twice with wrap
 			if (NotIncremental == pOptions->_incrementalType) //incremental search doesnt trigger messages
-			{	
+			{
 				generic_string newTxt2find = stringReplace(txt2find, TEXT("&"), TEXT("&&"));
 				NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 				generic_string msg = pNativeSpeaker->getLocalizedStrFromID("find-status-cannot-find", TEXT("Find: Can't find the text \"$STR_REPLACE$\""));
 				msg = stringReplace(msg, TEXT("$STR_REPLACE$"), newTxt2find);
 				setStatusbarMessage(msg, FSNotFound);
-				
+
 				// if the dialog is not shown, pass the focus to his parent(ie. Notepad++)
 				if (!::IsWindowVisible(_hSelf))
 				{
@@ -1912,7 +1926,7 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 			return false;
 		}
 	}
-	else if (posFind < -1) 
+	else if (posFind < -1)
 	{ // error
 		NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 		generic_string  msgGeneral;
@@ -1934,14 +1948,14 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 	start =	posFind;
 	end = int((*_ppEditView)->execute(SCI_GETTARGETEND));
 
-	setStatusbarMessage(TEXT(""), FSNoMessage);	
+	setStatusbarMessage(TEXT(""), FSNoMessage);
 
 	// to make sure the found result is visible:
 	// prevent recording of absolute positioning commands issued in the process
 	(*_ppEditView)->execute(SCI_STOPRECORD);
 	Searching::displaySectionCentered(start, end, *_ppEditView, pOptions->_whichDirection == DIR_DOWN);
 	// Show a calltip for a zero length match
-	if (start == end) 
+	if (start == end)
 	{
 		NativeLangSpeaker* pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 		generic_string msg = pNativeSpeaker->getLocalizedStrFromID("find-regex-zero-length-match", TEXT("zero length match"));
@@ -1982,10 +1996,10 @@ bool FindReplaceDlg::processReplace(const TCHAR *txt2find, const TCHAR *txt2repl
 	FindStatus status;
 	moreMatches = processFindNext(txt2find, &replaceOptions, &status, FINDNEXTTYPE_FINDNEXTFORREPLACE);
 
-	if (moreMatches) 
+	if (moreMatches)
 	{
 		Sci_CharacterRange nextFind = (*_ppEditView)->getSelection();
-		
+
 		// If the next find is the same as the last, then perform the replacement
 		if (nextFind.cpMin == currentSelection.cpMin && nextFind.cpMax == currentSelection.cpMax)
 		{
@@ -2061,7 +2075,7 @@ bool FindReplaceDlg::processReplace(const TCHAR *txt2find, const TCHAR *txt2repl
 		setStatusbarMessage(msg, FSNotFound);
 	}
 
-	return moreMatches;	
+	return moreMatches;
 }
 
 
@@ -2103,7 +2117,7 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 	Sci_CharacterRange cr = (*_ppEditView)->getSelection();
 	int docLength = int((*_ppEditView)->execute(SCI_GETLENGTH));
 
-	// Default : 
+	// Default :
 	//        direction : down
 	//        begin at : 0
 	//        end at : end of doc
@@ -2113,7 +2127,7 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 	bool direction = pOptions->_whichDirection;
 
 	//first try limiting scope by direction
-	if (direction == DIR_UP)	
+	if (direction == DIR_UP)
 	{
 		startPosition = 0;
 		endPosition = cr.cpMax;
@@ -2135,7 +2149,7 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 		startPosition = 0;
 		endPosition = docLength;
 	}
-	
+
 	//then readjust scope if the selection override is active and allowed
 	if ((pOptions->_isInSelection) && ((op == ProcessMarkAll) || ((op == ProcessReplaceAll || op == ProcessFindAll) && (!isEntire))))
 		//if selection limiter and either mark all or replace all or find all w/o entire document override
@@ -2177,7 +2191,7 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findReplaceInfo, const FindersInfo * pFindersInfo, const FindOption *opt, int colourStyleID, ScintillaEditView *view2Process)
 {
 	int nbProcessed = 0;
-	
+
 	if (!isCreated() && !findReplaceInfo._txt2find)
 		return nbProcessed;
 
@@ -2212,7 +2226,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		wcscpy_s(pTextFind, stringSizeFind + 1, findReplaceInfo._txt2find);
 	}
 
-	if (!pTextFind[0]) 
+	if (!pTextFind[0])
 	{
 		delete [] pTextFind;
 		return nbProcessed;
@@ -2235,7 +2249,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 			pTextReplace = new TCHAR[stringSizeReplace + 1];
 			wcscpy_s(pTextReplace, stringSizeReplace + 1, findReplaceInfo._txt2replace);
 		}
-	}	
+	}
 
 	if (pOptions->_searchType == FindExtended)
 	{
@@ -2245,14 +2259,14 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 	}
 
 	bool isRegExp = pOptions->_searchType == FindRegex;
-	int flags = Searching::buildSearchFlags(pOptions) | SCFIND_REGEXP_SKIPCRLFASONE; 
+	int flags = Searching::buildSearchFlags(pOptions) | SCFIND_REGEXP_SKIPCRLFASONE;
 
 	// Allow empty matches, but not immediately after previous match for replace all or find all.
 	// Other search types should ignore empty matches completely.
 	if (op == ProcessReplaceAll || op == ProcessFindAll)
 		flags |= SCFIND_REGEXP_EMPTYMATCH_NOTAFTERMATCH;
-	
-	
+
+
 
 	if (op == ProcessMarkAll && colourStyleID == -1)	//if marking, check if purging is needed
 	{
@@ -2267,8 +2281,8 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 
 	//Initial range for searching
 	pEditView->execute(SCI_SETSEARCHFLAGS, flags);
-	
-	
+
+
 	bool findAllFileNameAdded = false;
 
 	while (targetStart >= 0)
@@ -2290,10 +2304,10 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		int foundTextLen = targetEnd - targetStart;
 		int replaceDelta = 0;
 		bool processed = true;
-				
+
 		switch (op)
 		{
-			case ProcessFindAll: 
+			case ProcessFindAll:
 			{
 				const TCHAR *pFileName = TEXT("");
 				if (pFindersInfo && pFindersInfo->_pFileName)
@@ -2328,7 +2342,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				srm._end = end_mark;
 				_pFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str());
 
-				break; 
+				break;
 			}
 
 			case ProcessFindInFinder:
@@ -2345,7 +2359,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 
 				// use the static buffer
 				TCHAR lineBuf[SC_SEARCHRESULT_LINEBUFFERMAXLENGTH];
-				
+
 				if (nbChar > SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 3)
 					lend = lstart + SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 4;
 
@@ -2372,7 +2386,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				break;
 			}
 
-			case ProcessReplaceAll: 
+			case ProcessReplaceAll:
 			{
 				int replacedLength;
 				if (isRegExp)
@@ -2381,16 +2395,16 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 					replacedLength = pEditView->replaceTarget(pTextReplace);
 
 				replaceDelta = replacedLength - foundTextLen;
-				break; 
+				break;
 			}
 
-			case ProcessMarkAll: 
+			case ProcessMarkAll:
 			{
-				// In theory, we can't have empty matches for a ProcessMarkAll, but because scintilla 
+				// In theory, we can't have empty matches for a ProcessMarkAll, but because scintilla
 				// gets upset if we call INDICATORFILLRANGE with a length of 0, we protect against it here.
-				// At least in version 2.27, after calling INDICATORFILLRANGE with length 0, further indicators 
+				// At least in version 2.27, after calling INDICATORFILLRANGE with length 0, further indicators
 				// on the same line would simply not be shown.  This may have been fixed in later version of Scintilla.
-				if (foundTextLen > 0)  
+				if (foundTextLen > 0)
 				{
 					pEditView->execute(SCI_SETINDICATORCURRENT, SCE_UNIVERSAL_FOUND_STYLE);
 					pEditView->execute(SCI_INDICATORFILLRANGE,  targetStart, foundTextLen);
@@ -2409,9 +2423,9 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 							pEditView->execute(SCI_MARKERADD, i, MARK_BOOKMARK);
 					}
 				}
-				break; 
+				break;
 			}
-			
+
 			case ProcessMarkAllExt:
 			{
 				// See comment by ProcessMarkAll
@@ -2445,7 +2459,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				break;
 			}
 
-			case ProcessCountAll: 
+			case ProcessCountAll:
 			{
 				//Nothing to do
 				break;
@@ -2457,15 +2471,15 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				delete [] pTextReplace;
 				return nbProcessed;
 			}
-			
-		}	
+
+		}
 		if (processed) ++nbProcessed;
 
-        // After the processing of the last string occurrence the search loop should be stopped
-        // This helps to avoid the endless replacement during the EOL ("$") searching
+		// After the processing of the last string occurrence the search loop should be stopped
+		// This helps to avoid the endless replacement during the EOL ("$") searching
 		if (targetStart + foundTextLen == findReplaceInfo._endRange)
-            break;
-		
+			break;
+
 		findReplaceInfo._startRange = targetStart + foundTextLen + replaceDelta;		//search from result onwards
 		findReplaceInfo._endRange += replaceDelta;									//adjust end of range in case of replace
 	}
@@ -2588,11 +2602,11 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		char ptrword[sizeof(void*)*2+1];
 		sprintf(ptrword, "%p", &_pFinder->_markingsStruct);
 		_pFinder->_scintView.execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("@MarkingsStruct"), reinterpret_cast<LPARAM>(ptrword));
-		
-		//enable "Search Results Window" under Search Menu 
+
+		//enable "Search Results Window" under Search Menu
 		::EnableMenuItem(::GetMenu(_hParent), IDM_FOCUS_ON_FOUND_RESULTS, MF_ENABLED | MF_BYCOMMAND);
 	}
-	
+
 	::SendMessage(_pFinder->getHSelf(), WM_SIZE, 0, 0);
 
 	int cmdid = 0;
@@ -2616,7 +2630,7 @@ void FindReplaceDlg::findAllIn(InWhat op)
 
 		bool isRTL = (*_ppEditView)->isTextDirectionRTL();
 		_pFinder->_scintView.changeTextDirection(isRTL);
-		if (_findAllResult) 
+		if (_findAllResult)
 		{
 			focusOnFinder();
 		}
@@ -2698,7 +2712,7 @@ Finder * FindReplaceDlg::createFinder()
 
 	pFinder->_scintView.display();
 	::UpdateWindow(_hParent);
-	
+
 	pFinder->setFinderStyle();
 
 	// Send the address of _MarkingsStruct to the lexer
@@ -2758,7 +2772,7 @@ void FindReplaceDlg::showFindDlgItem(int dlgItemID, bool isShow /* = true*/)
 {
 	HWND h = ::GetDlgItem(_hSelf, dlgItemID);
 	if (!h) return;
-	
+
 	::ShowWindow(h, isShow ? SW_SHOW : SW_HIDE);
 
 	// when hiding a control to make it user-inaccessible, it can still be manipulated via a keyboard accelerator!
@@ -3445,7 +3459,7 @@ void FindReplaceDlg::initOptionsFromDlg()
 	_options._doMarkLine = isCheckedOrNot(IDC_MARKLINE_CHECK);
 
 	_options._whichDirection = isCheckedOrNot(IDC_BACKWARDDIRECTION) ? DIR_UP : DIR_DOWN;
-	
+
 	_options._isRecursive = isCheckedOrNot(IDD_FINDINFILES_RECURSIVE_CHECK);
 	_options._isInHiddenDir = isCheckedOrNot(IDD_FINDINFILES_INHIDDENDIR_CHECK);
 	_options._isProjectPanel_1 =  isCheckedOrNot(IDD_FINDINFILES_PROJECT1_CHECK);
@@ -3465,7 +3479,7 @@ void FindInFinderDlg::doDialog(Finder *launcher, bool isRTL)
 	}
 	else
 		::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_FINDINFINDER_DLG), _hParent, dlgProc, reinterpret_cast<LPARAM>(this));
-	
+
 }
 
 void FindReplaceDlg::doDialog(DIALOG_TYPE whichType, bool isRTL, bool toShow)
@@ -3486,7 +3500,7 @@ void FindReplaceDlg::doDialog(DIALOG_TYPE whichType, bool isRTL, bool toShow)
 		enableReplaceFunc(whichType == REPLACE_DLG);
 
 	::SetFocus(::GetDlgItem(_hSelf, IDFINDWHAT));
-    display(toShow, true);
+	display(toShow, true);
 }
 
 LRESULT FAR PASCAL FindReplaceDlg::finderProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
@@ -3608,43 +3622,43 @@ void FindReplaceDlg::combo2ExtendedMode(int comboID)
 {
 	HWND hFindCombo = ::GetDlgItem(_hSelf, comboID);
 	if (!hFindCombo) return;
-	
-	generic_string str2transform = getTextFromCombo(hFindCombo);
-		
-    // Count the number of character '\n' and '\r'
-    size_t nbEOL = 0;
-    size_t str2transformLen = lstrlen(str2transform.c_str());
-    for (size_t i = 0 ; i < str2transformLen ; ++i)
-    {
-        if (str2transform[i] == '\r' || str2transform[i] == '\n')
-            ++nbEOL;
-    }
 
-    if (nbEOL)
-    {
+	generic_string str2transform = getTextFromCombo(hFindCombo);
+
+	// Count the number of character '\n' and '\r'
+	size_t nbEOL = 0;
+	size_t str2transformLen = lstrlen(str2transform.c_str());
+	for (size_t i = 0 ; i < str2transformLen ; ++i)
+	{
+		if (str2transform[i] == '\r' || str2transform[i] == '\n')
+			++nbEOL;
+	}
+
+	if (nbEOL)
+	{
 		TCHAR * newBuffer = new TCHAR[str2transformLen + nbEOL*2 + 1];
-        int j = 0;
-        for (size_t i = 0 ; i < str2transformLen ; ++i)
-        {
-            if (str2transform[i] == '\r')
-            {
-                newBuffer[j++] = '\\';
-                newBuffer[j++] = 'r';
-            }
-            else if (str2transform[i] == '\n')
-            {
-                newBuffer[j++] = '\\';
-                newBuffer[j++] = 'n';
-            }
-            else
-            {
-                newBuffer[j++] = str2transform[i];
-            }
-        }
-        newBuffer[j++] = '\0';
+		int j = 0;
+		for (size_t i = 0 ; i < str2transformLen ; ++i)
+		{
+			if (str2transform[i] == '\r')
+			{
+				newBuffer[j++] = '\\';
+				newBuffer[j++] = 'r';
+			}
+			else if (str2transform[i] == '\n')
+			{
+				newBuffer[j++] = '\\';
+				newBuffer[j++] = 'n';
+			}
+			else
+			{
+				newBuffer[j++] = str2transform[i];
+			}
+		}
+		newBuffer[j++] = '\0';
 		setSearchText(newBuffer);
 
-        _options._searchType = FindExtended;
+		_options._searchType = FindExtended;
 		::SendDlgItemMessage(_hSelf, IDNORMAL, BM_SETCHECK, FALSE, 0);
 		::SendDlgItemMessage(_hSelf, IDEXTENDED, BM_SETCHECK, TRUE, 0);
 		::SendDlgItemMessage(_hSelf, IDREGEXP, BM_SETCHECK, FALSE, 0);
@@ -3693,7 +3707,7 @@ void FindReplaceDlg::drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 			fgColor = RGB(0x50, 0xFF, 0x50); // green
 		}
 	}
-	
+
 	SetTextColor(lpDrawItemStruct->hDC, fgColor);
 
 	COLORREF bgColor;
@@ -3916,7 +3930,7 @@ void Finder::addSearchHitCount(int count, int countSearched, bool isMatchLines, 
 			fileOrSelection += TEXT("s");
 		}
 
-		text = TEXT("(") + nbResStr + TEXT(" ") + hitsIn + TEXT(" in ") + nbFoundFilesStr + TEXT(" ") + 
+		text = TEXT("(") + nbResStr + TEXT(" ") + hitsIn + TEXT(" in ") + nbFoundFilesStr + TEXT(" ") +
 			fileOrSelection + TEXT(" of ") + nbSearchedFilesStr + TEXT(" searched") TEXT(")");
 	}
 	else
@@ -3976,7 +3990,7 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
 	_pMainMarkings->push_back(mi);
 }
 
-void Finder::removeAll() 
+void Finder::removeAll()
 {
 	_pMainFoundInfos->clear();
 	_pMainMarkings->clear();
@@ -4116,7 +4130,7 @@ void Finder::beginNewFilesSearch()
 	NativeLangSpeaker* pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 	_prefixLineStr = pNativeSpeaker->getLocalizedStrFromID("find-result-line-prefix", TEXT("Line"));
 
-	// Use SCI_SETSEL(0, 0) instead of SCI_SETCURRENTPOS(0) to workaround 
+	// Use SCI_SETSEL(0, 0) instead of SCI_SETCURRENTPOS(0) to workaround
 	// an eventual regression or a change of behaviour in Scintilla 4.4.6
 	// ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9595#issuecomment-789824579
 	//
@@ -4137,14 +4151,14 @@ void Finder::finishFilesSearch(int count, int searchedCount, bool isMatchLines, 
 	std::vector<SearchResultMarking>* _pOldMarkings;
 	_pOldFoundInfos = _pMainFoundInfos == &_foundInfos1 ? &_foundInfos2 : &_foundInfos1;
 	_pOldMarkings = _pMainMarkings == &_markings1 ? &_markings2 : &_markings1;
-	
+
 	_pOldFoundInfos->insert(_pOldFoundInfos->begin(), _pMainFoundInfos->begin(), _pMainFoundInfos->end());
 	_pOldMarkings->insert(_pOldMarkings->begin(), _pMainMarkings->begin(), _pMainMarkings->end());
 	_pMainFoundInfos->clear();
 	_pMainMarkings->clear();
 	_pMainFoundInfos = _pOldFoundInfos;
 	_pMainMarkings = _pOldMarkings;
-	
+
 	_markingsStruct._length = static_cast<long>(_pMainMarkings->size());
 	if (_pMainMarkings->size() > 0)
 		_markingsStruct._markings = &((*_pMainMarkings)[0]);
@@ -4161,7 +4175,7 @@ void Finder::setFinderStyle()
 {
 	// Set global styles for the finder
 	_scintView.performGlobalStyles();
-	
+
 	// Set current line background color for the finder
 	const TCHAR * lexerName = ScintillaEditView::langNames[L_SEARCHRESULT].lexerName;
 	LexerStyler *pStyler = (NppParameters::getInstance().getLStylerArray()).getLexerStylerByName(lexerName);
@@ -4175,14 +4189,14 @@ void Finder::setFinderStyle()
 		}
 	}
 	_scintView.setSearchResultLexer();
-	
+
 	// Override foreground & background colour by default foreground & background coulour
 	StyleArray & stylers = NppParameters::getInstance().getMiscStylerArray();
-    int iStyleDefault = stylers.getStylerIndexByID(STYLE_DEFAULT);
-    if (iStyleDefault != -1)
-    {
-        Style & styleDefault = stylers.getStyler(iStyleDefault);
-	    _scintView.setStyle(styleDefault);
+	int iStyleDefault = stylers.getStylerIndexByID(STYLE_DEFAULT);
+	if (iStyleDefault != -1)
+	{
+		Style & styleDefault = stylers.getStyler(iStyleDefault);
+		_scintView.setStyle(styleDefault);
 
 		GlobalOverride & go = NppParameters::getInstance().getGlobalOverrideStyle();
 		if (go.isEnable())
@@ -4204,7 +4218,7 @@ void Finder::setFinderStyle()
 
 		_scintView.execute(SCI_STYLESETFORE, SCE_SEARCHRESULT_DEFAULT, styleDefault._fgColor);
 		_scintView.execute(SCI_STYLESETBACK, SCE_SEARCHRESULT_DEFAULT, styleDefault._bgColor);
-    }
+	}
 
 	_scintView.execute(SCI_COLOURISE, 0, -1);
 
@@ -4215,9 +4229,9 @@ void Finder::setFinderStyle()
 
 INT_PTR CALLBACK Finder::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
-	switch (message) 
+	switch (message)
 	{
-		case WM_COMMAND : 
+		case WM_COMMAND :
 		{
 			switch (wParam)
 			{
@@ -4304,7 +4318,7 @@ INT_PTR CALLBACK Finder::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				}
 			}
 		}
-		
+
 		case WM_CONTEXTMENU :
 		{
 			if (HWND(wParam) == _scintView.getHSelf())
@@ -4356,7 +4370,7 @@ INT_PTR CALLBACK Finder::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				scintillaContextmenu.enableItem(NPPM_INTERNAL_SCINTILLAFINDERCOPYVERBATIM, hasSomeSelectedText);
 
 				scintillaContextmenu.enableItem(NPPM_INTERNAL_SCINTILLAFINDERCLEARALL, !_canBeVolatiled);
-				
+
 				scintillaContextmenu.enableItem(NPPM_INTERNAL_SCINTILLAFINDERPURGE, !_canBeVolatiled);
 				scintillaContextmenu.checkItem(NPPM_INTERNAL_SCINTILLAFINDERPURGE, _purgeBeforeEverySearch && !_canBeVolatiled);
 
@@ -4400,7 +4414,7 @@ void FindIncrementDlg::init(HINSTANCE hInst, HWND hPere, FindReplaceDlg *pFRDlg,
 
 void FindIncrementDlg::destroy()
 {
-	if (_pRebar) 
+	if (_pRebar)
 	{
 		_pRebar->removeBand(_rbBand.wID);
 		_pRebar = NULL;
@@ -4430,19 +4444,17 @@ INT_PTR CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 		// Make edit field red if not found
 		case WM_CTLCOLOREDIT :
 		{
+			auto hdc = reinterpret_cast<HDC>(wParam);
+
 			if (NppDarkMode::isEnabled())
 			{
 				if (FSNotFound != getFindStatus())
 				{
-					SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
-					SetBkColor((HDC)wParam, NppDarkMode::getBackgroundColor());
-					return (LRESULT)NppDarkMode::getBackgroundBrush();
+					return NppDarkMode::onCtlColorSofter(hdc);
 				}
 				else // text not found
 				{
-					SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
-					SetBkColor((HDC)wParam, NppDarkMode::getErrorBackgroundColor());
-					return (LRESULT)NppDarkMode::getErrorBackgroundBrush();
+					return NppDarkMode::onCtlColorError(hdc);
 				}
 			}
 
@@ -4453,9 +4465,9 @@ INT_PTR CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 				return FALSE; // text found, use the default color
 
 			// text not found
-			SetTextColor((HDC)wParam, TXT_COLOR);
-			SetBkColor((HDC)wParam, BCKGRD_COLOR);
-			return (LRESULT)hBrushBackground;
+			SetTextColor(hdc, TXT_COLOR);
+			SetBkColor(hdc, BCKGRD_COLOR);
+			return reinterpret_cast<LRESULT>(hBrushBackground);
 		}
 
 		case WM_CTLCOLORDLG:
@@ -4466,9 +4478,7 @@ INT_PTR CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 				return DefWindowProc(getHSelf(), message, wParam, lParam);
 			}
 
-			SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
-			SetBkColor((HDC)wParam, NppDarkMode::getBackgroundColor());
-			return (LRESULT)NppDarkMode::getBackgroundBrush();
+			return NppDarkMode::onCtlColor(reinterpret_cast<HDC>(wParam));
 		}
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
@@ -4485,7 +4495,7 @@ INT_PTR CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 			return lr;
 		}
 
-		case WM_COMMAND : 
+		case WM_COMMAND :
 		{
 			bool updateSearch = false;
 			bool forward = true;
@@ -4556,7 +4566,7 @@ INT_PTR CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 			{
 				FindStatus findStatus = FSFound;
 				bool isFound = _pFRDlg->processFindNext(str2Search.c_str(), &fo, &findStatus);
-				
+
 				fo._str2Search = str2Search;
 				int nbCounted = _pFRDlg->processAll(ProcessCountAll, &fo);
 				setFindStatus(findStatus, nbCounted);
@@ -4582,7 +4592,7 @@ INT_PTR CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 
 		case WM_ERASEBKGND:
 		{
-			if (NppDarkMode::isEnabled()) 
+			if (NppDarkMode::isEnabled())
 			{
 				RECT rcClient = { 0 };
 				GetClientRect(_hSelf, &rcClient);
@@ -4630,9 +4640,9 @@ void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted)
 {
 	static TCHAR findCount[128] = TEXT("");
 	static const TCHAR * const findStatus[] = { findCount, // FSFound
-	                               TEXT("Phrase not found"), //FSNotFound
-	                               TEXT("Reached top of page, continued from bottom"), // FSTopReached
-	                               TEXT("Reached end of page, continued from top")}; // FSEndReached
+		TEXT("Phrase not found"), //FSNotFound
+		TEXT("Reached top of page, continued from bottom"), // FSTopReached
+		TEXT("Reached end of page, continued from top")}; // FSEndReached
 	if (nbCounted <= 0)
 		findCount[0] = '\0';
 	else if (nbCounted == 1)
@@ -4653,7 +4663,7 @@ void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted)
 	::SendDlgItemMessage(_hSelf, IDC_INCFINDSTATUS, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(findStatus[iStatus]));
 }
 
-void FindIncrementDlg::addToRebar(ReBar * rebar) 
+void FindIncrementDlg::addToRebar(ReBar * rebar)
 {
 	if (_pRebar)
 		return;

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -250,7 +250,7 @@ bool FunctionListPanel::serialize(const generic_string & outputFilename)
 	{
 		const TCHAR *fullFilePath = currentBuf->getFullPathName();
 
-		// Export function list from an existing file 
+		// Export function list from an existing file
 		bool exportFuncntionList = (NppParameters::getInstance()).doFunctionListExport();
 		if (exportFuncntionList && ::PathFileExists(fullFilePath))
 		{
@@ -363,7 +363,7 @@ void FunctionListPanel::reload()
 	}
 
 	HTREEITEM root = _treeView.getRoot();
-	
+
 	if (root)
 	{
 		currentBuf = (*_ppEditView)->getCurrentBuffer();
@@ -465,7 +465,7 @@ void FunctionListPanel::init(HINSTANCE hInst, HWND hPere, ScintillaEditView **pp
 {
 	DockingDlgInterface::init(hInst, hPere);
 	_ppEditView = ppEditView;
-	
+
 	generic_string funcListXmlPath = (NppParameters::getInstance()).getUserPath();
 	PathAppend(funcListXmlPath, TEXT("functionList"));
 
@@ -477,7 +477,7 @@ void FunctionListPanel::init(HINSTANCE hInst, HWND hPere, ScintillaEditView **pp
 	if (!doLocalConf)
 	{
 		if (!PathFileExists(funcListXmlPath.c_str()))
-		{	
+		{
 			if (PathFileExists(funcListDefaultXmlPath.c_str()))
 			{
 				::CopyFile(funcListDefaultXmlPath.c_str(), funcListXmlPath.c_str(), TRUE);
@@ -769,24 +769,31 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 				}
 			}
 
+			auto hdc = reinterpret_cast<HDC>(wParam);
+
+			if (NppDarkMode::isEnabled())
+			{
+				if (textFound)
+				{
+					return NppDarkMode::onCtlColorSofter(hdc);
+				}
+				else // text not found
+				{
+					return NppDarkMode::onCtlColorError(hdc);
+				}
+			}
+
 			if (textFound)
 			{
-				if (NppDarkMode::isEnabled())
-				{
-					SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
-					SetBkColor((HDC)wParam, NppDarkMode::getBackgroundColor());
-					return (LRESULT)NppDarkMode::getBackgroundBrush();
-				}
-				else
-					return FALSE;
+				return FALSE;
 			}
 
 			// text not found
 			// if the text not found modify the background color of the editor
 			static HBRUSH hBrushBackground = CreateSolidBrush(BCKGRD_COLOR);
-			SetTextColor((HDC)wParam, TXT_COLOR);
-			SetBkColor((HDC)wParam, BCKGRD_COLOR);
-			return (LRESULT)hBrushBackground;
+			SetTextColor(hdc, TXT_COLOR);
+			SetBkColor(hdc, BCKGRD_COLOR);
+			return reinterpret_cast<LRESULT>(hBrushBackground);
 		}
 
 		case WM_INITDIALOG :
@@ -798,7 +805,7 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			// Create toolbar menu
 			int style = WS_CHILD | WS_VISIBLE | CCS_ADJUSTABLE | TBSTYLE_AUTOSIZE | TBSTYLE_FLAT | TBSTYLE_LIST | TBSTYLE_TRANSPARENT | BTNS_AUTOSIZE | BTNS_SEP | TBSTYLE_TOOLTIPS;
 			_hToolbarMenu = CreateWindowEx(0,TOOLBARCLASSNAME,NULL, style,
-								   0,0,0,0,_hSelf,nullptr, _hInst, NULL);
+								0,0,0,0,_hSelf,nullptr, _hInst, NULL);
 
 			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
 			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
@@ -845,9 +852,9 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			_reloadTipStr = pNativeSpeaker->getAttrNameStr(_reloadTipStr.c_str(), FL_FUCTIONLISTROOTNODE, FL_RELOADLOCALNODENAME);
 
 			_hSearchEdit = CreateWindowEx(0, L"Edit", NULL,
-                                   WS_CHILD | WS_BORDER | WS_VISIBLE | ES_AUTOVSCROLL,
-                                   2, 2, editWidth, editHeight,
-                                   _hToolbarMenu, reinterpret_cast<HMENU>(IDC_SEARCHFIELD_FUNCLIST), _hInst, 0 );
+								WS_CHILD | WS_BORDER | WS_VISIBLE | ES_AUTOVSCROLL,
+								2, 2, editWidth, editHeight,
+								_hToolbarMenu, reinterpret_cast<HMENU>(IDC_SEARCHFIELD_FUNCLIST), _hInst, 0 );
 
 			oldFunclstSearchEditProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(_hSearchEdit, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(funclstSearchEditProc)));
 


### PR DESCRIPTION
Allow function list search to use dark mode error background.
Make combobox more dark and allow to use custom colors (borders,
arrow head and background).
Use dark listbox in combobox.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10178

![image](https://user-images.githubusercontent.com/55940305/126001563-2bb815c8-0503-48f7-8989-eeb73d6ee25d.png)
![image](https://user-images.githubusercontent.com/55940305/126000911-13d85b59-f755-4db1-8603-42a29d998b70.png)