### PR TITLE
Retain Functions list scrollbar position on reload

### DIFF
--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -315,6 +315,13 @@ bool FunctionListPanel::serialize(const generic_string & outputFilename)
 
 void FunctionListPanel::reload()
 {
+	bool isScrollBarOn = GetWindowLongPtr(_treeView.getHSelf(), GWL_STYLE) & WS_VSCROLL;
+	//get scroll position
+	if (isScrollBarOn)
+	{
+		GetScrollInfo(_treeView.getHSelf(), SB_VERT, &si);
+	}
+
 	// clean up
 	_findLine = -1;
 	_findEndLine = -1;
@@ -396,6 +403,12 @@ void FunctionListPanel::reload()
 
 	// invalidate the editor rect
 	::InvalidateRect(_hSearchEdit, NULL, TRUE);
+
+	//set scroll position
+	if (isScrollBarOn)
+	{
+		SetScrollInfo(_treeView.getHSelf(), SB_VERT, &si, TRUE);
+	}
 }
 
 void FunctionListPanel::markEntry()
@@ -498,6 +511,11 @@ void FunctionListPanel::init(HINSTANCE hInst, HWND hPere, ScintillaEditView **pp
 			_funcParserMgr.init(funcListDefaultXmlPath, funcListDefaultXmlPath, ppEditView);
 		}
 	}
+
+	//init scrollinfo structure
+	ZeroMemory(&si, sizeof(si));
+	si.cbSize = sizeof(si);
+	si.fMask = SIF_POS;
 }
 
 bool FunctionListPanel::openSelection(const TreeView & treeView)

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -109,6 +109,7 @@ private:
 	TreeView _treeView;
 	TreeView _treeViewSearchResult;
 
+	SCROLLINFO si;
 	long _findLine = -1;
 	long _findEndLine = -1;
 	HTREEITEM _findItem;


### PR DESCRIPTION
fix #9659

Saving the file before fix does not retain scroll bar position:

![funcListSaveFix_before](https://user-images.githubusercontent.com/27722888/126068246-92e47ec1-29f1-4232-b963-5be5b5378ab2.gif)

Saving the file after fix retains scroll bar position:

![funcListSaveFix_after](https://user-images.githubusercontent.com/27722888/126068262-31ffa2bb-cde5-4e33-89ef-392268bef16e.gif)
