### PR TITLE
Updated to also filter by shortcut key combination

### DIFF
--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -141,18 +141,15 @@ generic_string ShortcutMapper::getTextFromCombo(HWND hCombo)
 
 bool ShortcutMapper::isFilterValid(Shortcut sc)
 {
-	bool match = false;
-	generic_string shortcut_name = stringToLower(generic_string(sc.getName()));
 	if (_shortcutFilter.empty())
-	{
 		return true;
-	}
-	// test the filter on the shortcut name
-	size_t match_pos = shortcut_name.find(_shortcutFilter);
-	if (match_pos != std::string::npos){
-		match = true;
-	}
-	return match;
+
+	generic_string shortcut_name = stringToLower(generic_string(sc.getName()));
+	generic_string shortcut_value = stringToLower(sc.toString());
+
+	// test the filter on the shortcut name and value
+	return (shortcut_name.find(_shortcutFilter) != std::string::npos) || 
+		(shortcut_value.find(_shortcutFilter) != std::string::npos);
 }
 
 bool ShortcutMapper::isFilterValid(PluginCmdShortcut sc)


### PR DESCRIPTION
Fixes #5616, #9316
This allows to filter shortcuts in Shortcut mapper not only by name but also by key combination text.


![image](https://user-images.githubusercontent.com/7416072/126162123-a0af8a11-d5dc-43ed-929e-044571efb674.png)
