### PR TITLE
Restore edit zone border in dark mode

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -284,16 +284,8 @@ LRESULT Notepad_plus::init(HWND hwnd)
 		_subEditView.execute(SCI_SETFONTQUALITY, SC_EFF_QUALITY_LCD_OPTIMIZED);
 	}
 
-	if (NppDarkMode::isEnabled())
-	{
-		_mainEditView.setBorderEdge(false);
-		_subEditView.setBorderEdge(false);
-	}
-	else
-	{
-		_mainEditView.setBorderEdge(svp._showBorderEdge);
-		_subEditView.setBorderEdge(svp._showBorderEdge);
-	}
+	_mainEditView.setBorderEdge(svp._showBorderEdge);
+	_subEditView.setBorderEdge(svp._showBorderEdge);
 
 	_mainEditView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
 	_subEditView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1511,16 +1511,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_SETEDITORBORDEREDGE:
 		{
 			bool withBorderEdge = (lParam == 1);
-			if (NppDarkMode::isEnabled()) 
-			{
-				_mainEditView.setBorderEdge(false);
-				_subEditView.setBorderEdge(false);
-			}
-			else
-			{
-				_mainEditView.setBorderEdge(withBorderEdge);
-				_subEditView.setBorderEdge(withBorderEdge);
-			}
+			_mainEditView.setBorderEdge(withBorderEdge);
+			_subEditView.setBorderEdge(withBorderEdge);
 			return TRUE;
 		}
 
@@ -2746,4 +2738,3 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 	_pluginsManager.relayNppMessages(message, wParam, lParam);
 	return result;
 }
-

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -3705,13 +3705,29 @@ generic_string ScintillaEditView::getEOLString()
 
 void ScintillaEditView::setBorderEdge(bool doWithBorderEdge)
 {
+	long style = static_cast<long>(::GetWindowLongPtr(_hSelf, GWL_STYLE));
 	long exStyle = static_cast<long>(::GetWindowLongPtr(_hSelf, GWL_EXSTYLE));
 
-	if (doWithBorderEdge)
-		exStyle |= WS_EX_CLIENTEDGE;
-	else
+	if (NppDarkMode::isEnabled())
+	{
 		exStyle &= ~WS_EX_CLIENTEDGE;
 
+		if (doWithBorderEdge)
+			style |= WS_BORDER;
+		else
+			style &= ~WS_BORDER;
+	}
+	else
+	{
+		style &= ~WS_BORDER;
+
+		if (doWithBorderEdge)
+			exStyle |= WS_EX_CLIENTEDGE;
+		else
+			exStyle &= ~WS_EX_CLIENTEDGE;
+	}
+
+	::SetWindowLongPtr(_hSelf, GWL_STYLE, style);
 	::SetWindowLongPtr(_hSelf, GWL_EXSTYLE, exStyle);
 	::SetWindowPos(_hSelf, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
 }


### PR DESCRIPTION
Restore functionality for option `No edge` in preference when using dark mode.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10205

I did not run tabify on "Notepad_plus.cpp" and "ScintillaEditView.cpp", because both of them contain nearly same amount of tab and space lines.