### PR TITLE
Apply dark mode on Windows dialog

### DIFF
--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
@@ -78,6 +78,9 @@ protected :
 	void putItemsToClipboard(bool isFullPath);
 	Buffer* getBuffer(int index) const;
 
+	static LONG_PTR originalListViewProc;
+	static LRESULT CALLBACK listViewProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
+
 	HWND _hList = nullptr;
 	static RECT _lastKnownLocation;
 	SIZE _szMinButton;
@@ -104,4 +107,3 @@ public:
 private:
 	HMENU _hMenu = nullptr;
 };
-


### PR DESCRIPTION
Use background and text colors from style theme in listview.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10230

Currently does not support dynamic redraw, dialog needs to be closed and reopened to apply new settings.

![image](https://user-images.githubusercontent.com/55940305/126814036-04956e13-44af-4fd2-b2c8-a713160be007.png)
![image](https://user-images.githubusercontent.com/55940305/126814314-62418e37-e8f0-4a41-9edd-2c590404a44c.png)
![image](https://user-images.githubusercontent.com/55940305/126814665-b8601010-6927-4b9d-8a2e-872a0b45e0af.png)

