### PR TITLE
Make dark colors consistent

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -181,7 +181,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			{
 				RECT rc = { 0 };
 				GetClientRect(hwnd, &rc);
-				FillRect((HDC)wParam, &rc, NppDarkMode::getBackgroundBrush());
+				::FillRect(reinterpret_cast<HDC>(wParam), &rc, NppDarkMode::getDarkerBackgroundBrush());
 				return 0;
 			}
 			else

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -191,11 +191,27 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 
 		case WM_CTLCOLORLISTBOX:
 		case WM_CTLCOLORDLG:
-		case WM_CTLCOLORSTATIC:
 		{
 			if (NppDarkMode::isEnabled())
 			{
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_CTLCOLORSTATIC:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				HWND hwnd = reinterpret_cast<HWND>(lParam);
+				if (hwnd == ::GetDlgItem(_hSelf, IDC_DEF_EXT_EDIT) || hwnd == ::GetDlgItem(_hSelf, IDC_DEF_KEYWORDS_EDIT))
+				{
+					return NppDarkMode::onCtlColor(reinterpret_cast<HDC>(wParam));
+				}
+				else
+				{
+					return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+				}
 			}
 			break;
 		}

--- a/PowerEditor/src/WinControls/DockingWnd/DockingDlgInterface.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingDlgInterface.h
@@ -104,8 +104,8 @@ protected :
 
 				RECT rc = { 0 };
 				getClientRect(rc);
-				FillRect((HDC)wParam, &rc, NppDarkMode::getBackgroundBrush());
-				return 1;
+				::FillRect(reinterpret_cast<HDC>(wParam), &rc, NppDarkMode::getDarkerBackgroundBrush());
+				return TRUE;
 			}
 			case WM_NOTIFY: 
 			{

--- a/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingSplitter.cpp
@@ -152,10 +152,8 @@ LRESULT DockingSplitter::runProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM 
 
 			RECT rc = { 0 };
 			getClientRect(rc);
-
-			FillRect((HDC)wParam, &rc, NppDarkMode::getSofterBackgroundBrush());
-
-			return 1;
+			::FillRect(reinterpret_cast<HDC>(wParam), &rc, NppDarkMode::getBackgroundBrush());
+			return TRUE;
 		}
 		default :
 			break;

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -721,7 +721,7 @@ void FileBrowser::notified(LPNMHDR notification)
 		if (NppDarkMode::isEnabled())
 		{
 			auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(notification);
-			FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
+			::FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getDarkerBackgroundBrush());
 		}
 	}
 }

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -618,7 +618,7 @@ void FunctionListPanel::notified(LPNMHDR notification)
 		if (NppDarkMode::isEnabled())
 		{
 			auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(notification);
-			FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
+			::FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getDarkerBackgroundBrush());
 		}
 	}
 }

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -818,7 +818,7 @@ void ProjectPanel::notified(LPNMHDR notification)
 		if (NppDarkMode::isEnabled())
 		{
 			auto nmtbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(notification);
-			FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getBackgroundBrush());
+			::FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, NppDarkMode::getDarkerBackgroundBrush());
 			nmtbcd->clrText = NppDarkMode::getTextColor();
 			nmtbcd->clrHighlightHotTrack = NppDarkMode::getHotBackgroundColor();
 			SetWindowLongPtr(_hSelf, DWLP_MSGRESULT, CDRF_NOTIFYITEMDRAW | TBCDRF_HILITEHOTTRACK);


### PR DESCRIPTION
Make dark colors consistent for panel toolbars.
Make dark colors consistent style configurator edit controls.
Make dark colors consistent for docking elements.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10242

-  `BackgroundColor()`, `BackgroundBrush()` – should be used for items which have some interactions, or need to be different from Darker variant.
-  `DarkerBackgroundColor()`,  `DarkerBackgroundBrush()` – should be used for static/top backgrounds.
-  `SofterBackgroundColor()`,  `SofterBackgroundBrush()` – should be used for items , which have interactions, or have focus.
