### PR TITLE
Apply dark mode on rename tab dialog

### DIFF
--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -1437,6 +1437,8 @@ INT_PTR CALLBACK StringDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
     {
         case WM_INITDIALOG :
         {
+			NppDarkMode::autoSubclassAndThemeChildControls(_hSelf);
+
 			// Re-route to Subclassed the edit control's proc if needed
 			if (_restrictedChars.length())
 			{
@@ -1465,7 +1467,53 @@ INT_PTR CALLBACK StringDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 				goToCenter();
 
 			return TRUE;
-        }
+		}
+
+		case WM_CTLCOLOREDIT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return NppDarkMode::onCtlColorSofter(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_CTLCOLORDLG:
+		case WM_CTLCOLORSTATIC:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
+		case WM_ERASEBKGND:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				RECT rc = { 0 };
+				getClientRect(rc);
+				::FillRect(reinterpret_cast<HDC>(wParam), &rc, NppDarkMode::getDarkerBackgroundBrush());
+				return TRUE;
+			}
+			break;
+		}
+
+		case NPPM_INTERNAL_REFRESHDARKMODE:
+		{
+			NppDarkMode::autoThemeChildControls(_hSelf);
+			return TRUE;
+		}
 
         case WM_COMMAND :
         {
@@ -1492,6 +1540,7 @@ INT_PTR CALLBACK StringDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
         default :
             return FALSE;
     }
+	return FALSE;
 }
 
 LRESULT StringDlg::customEditProc(HWND hEdit, UINT msg, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10249

![image](https://user-images.githubusercontent.com/55940305/126905018-f798347a-709c-4733-8d02-94e81d7ab69b.png)

Does not support dynamic redraw, should not matter.