### PR TITLE
Apply dark mode on run dialog

### DIFF
--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
@@ -247,6 +247,53 @@ INT_PTR CALLBACK RunDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 			return ::SendMessage(_hParent, message, wParam, lParam);
 		}
 
+		case WM_CTLCOLOREDIT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return NppDarkMode::onCtlColorSofter(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_CTLCOLORLISTBOX:
+		case WM_CTLCOLORDLG:
+		case WM_CTLCOLORSTATIC:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
+		case WM_ERASEBKGND:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				RECT rc = { 0 };
+				getClientRect(rc);
+				::FillRect(reinterpret_cast<HDC>(wParam), &rc, NppDarkMode::getDarkerBackgroundBrush());
+				return TRUE;
+			}
+			break;
+		}
+
+		case NPPM_INTERNAL_REFRESHDARKMODE:
+		{
+			NppDarkMode::autoThemeChildControls(_hSelf);
+			return TRUE;
+		}
+
 		case WM_COMMAND : 
 		{
 			switch (wParam)
@@ -368,6 +415,8 @@ void RunDlg::doDialog(bool isRTL)
 {
 	if (!isCreated())
 		create(IDD_RUN_DLG, isRTL);
+
+	NppDarkMode::autoSubclassAndThemeChildControls(_hSelf);
 
     // Adjust the position in the center
 	goToCenter();


### PR DESCRIPTION
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10251

![image](https://user-images.githubusercontent.com/55940305/126905086-e7cfff13-862e-491d-b8ea-c8db7931490f.png)

text "The Program to Run" should be in center, fixed in PR https://github.com/notepad-plus-plus/notepad-plus-plus/pull/10237
