### PR TITLE
Apply dark mode on plugins admin

### DIFF
--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -258,6 +258,7 @@ void PluginsAdminDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	RECT rect;
 	getClientRect(rect);
 	_tab.init(_hInst, _hSelf, false, true);
+	NppDarkMode::subclassTabControl(_tab.getHSelf());
 	int tabDpiDynamicalHeight = NppParameters::getInstance()._dpiManager.scaleY(13);
 	_tab.setFont(TEXT("Tahoma"), tabDpiDynamicalHeight);
 
@@ -349,7 +350,15 @@ void PluginsAdminDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	//_availableList.addColumn(columnInfo(stabilityStr, nppParam._dpiManager.scaleX(70)));
 	_availableList.setViewStyleOption(LVS_EX_CHECKBOXES);
 
+	COLORREF fgColor = (NppParameters::getInstance()).getCurrentDefaultFgColor();
+	COLORREF bgColor = (NppParameters::getInstance()).getCurrentDefaultBgColor();
+
 	_availableList.initView(_hInst, _hSelf);
+
+	ListView_SetBkColor(_availableList.getViewHwnd(), bgColor);
+	ListView_SetTextBkColor(_availableList.getViewHwnd(), bgColor);
+	ListView_SetTextColor(_availableList.getViewHwnd(), fgColor);
+
 	_availableList.reSizeView(listRect);
 	
 	_updateList.addColumn(columnInfo(pluginStr, nppParam._dpiManager.scaleX(200)));
@@ -358,6 +367,11 @@ void PluginsAdminDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	_updateList.setViewStyleOption(LVS_EX_CHECKBOXES);
 
 	_updateList.initView(_hInst, _hSelf);
+
+	ListView_SetBkColor(_updateList.getViewHwnd(), bgColor);
+	ListView_SetTextBkColor(_updateList.getViewHwnd(), bgColor);
+	ListView_SetTextColor(_updateList.getViewHwnd(), fgColor);
+
 	_updateList.reSizeView(listRect);
 
 	_installedList.addColumn(columnInfo(pluginStr, nppParam._dpiManager.scaleX(200)));
@@ -366,6 +380,11 @@ void PluginsAdminDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	_installedList.setViewStyleOption(LVS_EX_CHECKBOXES);
 
 	_installedList.initView(_hInst, _hSelf);
+
+	ListView_SetBkColor(_installedList.getViewHwnd(), bgColor);
+	ListView_SetTextBkColor(_installedList.getViewHwnd(), bgColor);
+	ListView_SetTextColor(_installedList.getViewHwnd(), fgColor);
+
 	_installedList.reSizeView(listRect);
 
 	HWND hDesc = ::GetDlgItem(_hSelf, IDC_PLUGINADM_EDIT);
@@ -1102,6 +1121,62 @@ INT_PTR CALLBACK PluginsAdminDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 	{
         case WM_INITDIALOG :
 		{
+			NppDarkMode::autoSubclassAndThemeChildControls(_hSelf);
+			return TRUE;
+		}
+
+		case WM_CTLCOLOREDIT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return NppDarkMode::onCtlColorSofter(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_CTLCOLORDLG:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_CTLCOLORSTATIC:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				HWND hwnd = reinterpret_cast<HWND>(lParam);
+				if (hwnd == ::GetDlgItem(_hSelf, IDC_PLUGINADM_EDIT))
+				{
+					return NppDarkMode::onCtlColor(reinterpret_cast<HDC>(wParam));
+				}
+				else
+				{
+					return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+				}
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
+		case NPPM_INTERNAL_REFRESHDARKMODE:
+		{
+			NppDarkMode::autoThemeChildControls(_hSelf);
+
+			NppDarkMode::setDarkListView(_availableList.getViewHwnd());
+			NppDarkMode::setDarkListView(_updateList.getViewHwnd());
+			NppDarkMode::setDarkListView(_installedList.getViewHwnd());
+
 			return TRUE;
 		}
 
@@ -1220,4 +1295,3 @@ INT_PTR CALLBACK PluginsAdminDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 	}
 	return FALSE;
 }
-


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10287

![image](https://user-images.githubusercontent.com/55940305/127382784-88ad4294-7532-497e-a754-5215b19605ad.png)

Currently does not support dynamic change for  listview colors from style configurator, Notepad++ needs restart. 

@donho 
This may be last PR from me for while, I will be away.