### PR TITLE
Fix crash when several instances of the file dialog are shown

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -743,10 +743,16 @@ public:
 
 	bool show()
 	{
+		// Allow only one instance of the dialog to be active at a time.
+		static bool isActive = false;
+		if (isActive)
+			return false;
+
 		assert(_dialog);
 		if (!_dialog)
 			return false;
 
+		isActive = true;
 		HRESULT hr = S_OK;
 		DWORD dwCookie = 0;
 		com_ptr<IFileDialogEvents> dialogEvents = _events;
@@ -774,6 +780,8 @@ public:
 
 		if (dialogEvents)
 			_dialog->Unadvise(dwCookie);
+
+		isActive = false;
 
 		return okPressed;
 	}


### PR DESCRIPTION
Pass a pointer to FileDialogEventHandler instance via GWLP_USERDATA
instead of using static variable. This way each window can have its
own pointer.

Fix #10290