### PR TITLE
Apply explorer style on treeview

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -162,6 +162,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			{
 				NppDarkMode::drawUAHMenuNCBottomLine(hwnd);
 			}
+
+			NppDarkMode::calculateTreeViewStyle();
 			return result;
 		}
 
@@ -1798,11 +1800,15 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			(NppParameters::getInstance()).setCurrentDefaultFgColor(style._fgColor);
 			(NppParameters::getInstance()).setCurrentDefaultBgColor(style._bgColor);
 
+			NppDarkMode::calculateTreeViewStyle();
+			auto refreshOnlyTreeView = static_cast<LPARAM>(TRUE);
+
 			// Set default fg/bg colors on internal docking dialog
 			if (_pFuncList)
 			{
 				_pFuncList->setBackgroundColor(style._bgColor);
 				_pFuncList->setForegroundColor(style._fgColor);
+				::SendMessage(_pFuncList->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
 			if (_pAnsiCharPanel)
@@ -1828,24 +1834,28 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			{
 				_pProjectPanel_1->setBackgroundColor(style._bgColor);
 				_pProjectPanel_1->setForegroundColor(style._fgColor);
+				::SendMessage(_pProjectPanel_1->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
 			if (_pProjectPanel_2)
 			{
 				_pProjectPanel_2->setBackgroundColor(style._bgColor);
 				_pProjectPanel_2->setForegroundColor(style._fgColor);
+				::SendMessage(_pProjectPanel_2->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
 			if (_pProjectPanel_3)
 			{
 				_pProjectPanel_3->setBackgroundColor(style._bgColor);
 				_pProjectPanel_3->setForegroundColor(style._fgColor);
+				::SendMessage(_pProjectPanel_3->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
 			if (_pFileBrowser)
 			{
 				_pFileBrowser->setBackgroundColor(style._bgColor);
 				_pFileBrowser->setForegroundColor(style._fgColor);
+				::SendMessage(_pFileBrowser->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
 			if (_pDocMap)

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -385,6 +385,31 @@ namespace NppDarkMode
 		return invert_c;
 	}
 
+	TreeViewStyle treeViewStyle = TreeViewStyle::classic;
+	COLORREF treeViewBg = NppParameters::getInstance().getCurrentDefaultBgColor();
+	double lighnessTreeView = 50.0;
+
+	// adapted from https://stackoverflow.com/a/56678483
+	double calculatePerceivedLighness(COLORREF c)
+	{
+		auto linearValue = [](double colorChannel) -> double
+		{
+			colorChannel /= 255.0;
+			if (colorChannel <= 0.04045)
+				return colorChannel / 12.92;
+			return pow(((colorChannel + 0.055) / 1.055), 2.4);
+		};
+
+		double r = linearValue(static_cast<double>(GetRValue(c)));
+		double g = linearValue(static_cast<double>(GetGValue(c)));
+		double b = linearValue(static_cast<double>(GetBValue(c)));
+
+		double luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+		double lighness = (luminance <= 216.0 / 24389.0) ? (luminance * 24389.0 / 27.0) : (pow(luminance, (1.0 / 3.0)) * 116.0 - 16.0);
+		return lighness;
+	}
+
 	COLORREF getBackgroundColor()         { return getTheme()._colors.background; }
 	COLORREF getSofterBackgroundColor()   { return getTheme()._colors.softerBackground; }
 	COLORREF getHotBackgroundColor()      { return getTheme()._colors.hotBackground; }
@@ -1596,10 +1621,76 @@ namespace NppDarkMode
 		}
 	}
 
-	// force scrollbar redraw
+	// range to determine when it should be better to use classic style
+	constexpr double middleGrayRange = 2.0;
+
+	void calculateTreeViewStyle()
+	{
+		COLORREF bgColor = NppParameters::getInstance().getCurrentDefaultBgColor();
+
+		if (treeViewBg != bgColor || lighnessTreeView == 50.0)
+		{
+			lighnessTreeView = calculatePerceivedLighness(bgColor);
+			treeViewBg = bgColor;
+		}
+
+		if (lighnessTreeView < (50.0 - middleGrayRange))
+		{
+			treeViewStyle = TreeViewStyle::dark;
+		}
+		else if (lighnessTreeView > (50.0 + middleGrayRange))
+		{
+			treeViewStyle = TreeViewStyle::light;
+		}
+		else
+		{
+			treeViewStyle = TreeViewStyle::classic;
+		}
+	}
+
 	void setTreeViewStyle(HWND hwnd)
 	{
-		SetWindowTheme(hwnd, nullptr, nullptr);
+		auto style = static_cast<long>(::GetWindowLongPtr(hwnd, GWL_STYLE));
+		bool hasHotStyle = (style & TVS_TRACKSELECT) == TVS_TRACKSELECT;
+		bool change = false;
+		switch (treeViewStyle)
+		{
+			case TreeViewStyle::light:
+			{
+				if (!hasHotStyle)
+				{
+					style |= TVS_TRACKSELECT;
+					change = true;
+				}
+				SetWindowTheme(hwnd, L"Explorer", nullptr);
+				break;
+			}
+			case TreeViewStyle::dark:
+			{
+				if (!hasHotStyle)
+				{
+					style |= TVS_TRACKSELECT;
+					change = true;
+				}
+				SetWindowTheme(hwnd, L"DarkMode_Explorer", nullptr);
+				break;
+			}
+			default:
+			{
+				if (hasHotStyle)
+				{
+					style &= ~TVS_TRACKSELECT;
+					change = true;
+				}
+				SetWindowTheme(hwnd, nullptr, nullptr);
+				break;
+			}
+		}
+
+		if (change)
+		{
+			::SetWindowLongPtr(hwnd, GWL_STYLE, style);
+		}
 	}
 
 	void setBorder(HWND hwnd, bool border)

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -28,6 +28,10 @@
 
 #include <Shlwapi.h>
 
+#ifdef __MINGW32__
+#include <cmath>
+#endif
+
 #pragma comment(lib, "uxtheme.lib")
 
 namespace NppDarkMode
@@ -397,7 +401,7 @@ namespace NppDarkMode
 			colorChannel /= 255.0;
 			if (colorChannel <= 0.04045)
 				return colorChannel / 12.92;
-			return pow(((colorChannel + 0.055) / 1.055), 2.4);
+			return std::pow(((colorChannel + 0.055) / 1.055), 2.4);
 		};
 
 		double r = linearValue(static_cast<double>(GetRValue(c)));
@@ -406,7 +410,7 @@ namespace NppDarkMode
 
 		double luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
 
-		double lighness = (luminance <= 216.0 / 24389.0) ? (luminance * 24389.0 / 27.0) : (pow(luminance, (1.0 / 3.0)) * 116.0 - 16.0);
+		double lighness = (luminance <= 216.0 / 24389.0) ? (luminance * 24389.0 / 27.0) : (std::pow(luminance, (1.0 / 3.0)) * 116.0 - 16.0);
 		return lighness;
 	}
 

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -69,6 +69,13 @@ namespace NppDarkMode
 		customizedTone = 32
 	};
 
+	enum class TreeViewStyle
+	{
+		classic = 0,
+		light = 1,
+		dark = 2
+	};
+
 	void initDarkMode();				// pulls options from NppParameters
 	void refreshDarkMode(HWND hwnd, bool forceRefresh = false);	// attempts to apply new options from NppParameters, sends NPPM_INTERNAL_REFRESHDARKMODE to hwnd's top level parent
 
@@ -78,6 +85,7 @@ namespace NppDarkMode
 
 	COLORREF invertLightness(COLORREF c);
 	COLORREF invertLightnessSofter(COLORREF c);
+	double calculatePerceivedLighness(COLORREF c);
 
 	void setDarkTone(ColorTone colorToneChoice);
 
@@ -152,6 +160,7 @@ namespace NppDarkMode
 	void setDarkListView(HWND hwnd);
 
 	void disableVisualStyle(HWND hwnd, bool doDisable);
+	void calculateTreeViewStyle();
 	void setTreeViewStyle(HWND hwnd);
 	void setBorder(HWND hwnd, bool border = true);
 

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -181,10 +181,13 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
-			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
-			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+			if (static_cast<BOOL>(lParam) != TRUE)
+			{
+				NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
+				NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
-			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+				NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+			}
 			NppDarkMode::setTreeViewStyle(_treeView.getHSelf());
 			return TRUE;
 		}

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -904,10 +904,13 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
-			NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
-			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+			if (static_cast<BOOL>(lParam) != TRUE)
+			{
+				NppDarkMode::setDarkTooltips(_hToolbarMenu, NppDarkMode::ToolTipsType::toolbar);
+				NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
 
-			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+				NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+			}
 			NppDarkMode::setTreeViewStyle(_treeView.getHSelf());
 			return TRUE;
 		}

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -100,10 +100,13 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
-			NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
-			NppDarkMode::disableVisualStyle(_hToolbarMenu, NppDarkMode::isEnabled());
+			if (static_cast<BOOL>(lParam) != TRUE)
+			{
+				NppDarkMode::setDarkLineAbovePanelToolbar(_hToolbarMenu);
+				NppDarkMode::disableVisualStyle(_hToolbarMenu, NppDarkMode::isEnabled());
 
-			NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+				NppDarkMode::setDarkTooltips(_treeView.getHSelf(), NppDarkMode::ToolTipsType::treeview);
+			}
 			NppDarkMode::setTreeViewStyle(_treeView.getHSelf());
 			return TRUE;
 		}

--- a/PowerEditor/src/WinControls/TreeView/TreeView.cpp
+++ b/PowerEditor/src/WinControls/TreeView/TreeView.cpp
@@ -43,6 +43,7 @@ void TreeView::init(HINSTANCE hInst, HWND parent, int treeViewID)
 							_hInst,
 							nullptr);
 
+	NppDarkMode::setTreeViewStyle(_hSelf);
 	NppDarkMode::setDarkTooltips(_hSelf, NppDarkMode::ToolTipsType::treeview);
 
 	int itemHeight = NppParameters::getInstance()._dpiManager.scaleY(CY_ITEMHEIGHT);


### PR DESCRIPTION
Enable hottracking for explorer style.
Allow dynamic change based on treeview background.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10061