### PR TITLE
Retains tree state of function tree during Sort/Unsort and Save/Reload actions

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1300,7 +1300,7 @@ bool FileBrowser::addToTree(FilesToChange & group, HTREEITEM node)
 				_treeView.addItem(file.c_str(), node, INDEX_LEAF, reinterpret_cast<LPARAM>(customData));
 			}
 		}
-		_treeView.customSorting(node, categorySortFunc, 0);
+		_treeView.customSorting(node, categorySortFunc, 0, false);
 		return true;
 	}
 	else
@@ -1491,7 +1491,7 @@ bool FileBrowser::renameInTree(const generic_string& rootPath, HTREEITEM node, c
 	_treeView.renameItem(foundItem, renameTo.c_str());
 	SortingData4lParam* compareData = reinterpret_cast<SortingData4lParam*>(_treeView.getItemParam(foundItem));
 	compareData->_label = renameTo;
-	_treeView.customSorting(_treeView.getParent(foundItem), categorySortFunc, 0);
+	_treeView.customSorting(_treeView.getParent(foundItem), categorySortFunc, 0, false);
 
 	return true;
 }

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -53,7 +53,7 @@ void FunctionListPanel::addEntry(const TCHAR *nodeName, const TCHAR *displayText
 		itemParent = _treeView.searchSubItemByName(nodeName, root);
 		if (!itemParent)
 		{
-			generic_string* invalidValueStr = new generic_string(TEXT("-1"));
+			generic_string* invalidValueStr = new generic_string(posStr);
 			posStrs.push_back(invalidValueStr);
 			LPARAM lParamInvalidPosStr = reinterpret_cast<LPARAM>(invalidValueStr);
 
@@ -213,7 +213,7 @@ void FunctionListPanel::sortOrUnsort()
 
 		if (text2search[0] == '\0') // main view
 		{
-			reload();
+			_pTreeView->customSorting(_pTreeView->getRoot(), categorySortFunc, 0, true);
 		}
 		else // aux view
 		{
@@ -239,6 +239,18 @@ void FunctionListPanel::sortOrUnsort()
 	}
 }
 
+int CALLBACK FunctionListPanel::categorySortFunc(LPARAM lParam1, LPARAM lParam2, LPARAM /*lParamSort*/)
+{
+	generic_string* posString1 = reinterpret_cast<generic_string*>(lParam1);
+	generic_string* posString2 = reinterpret_cast<generic_string*>(lParam2);
+	
+	size_t pos1 = generic_atoi(posString1->c_str());
+	size_t pos2 = generic_atoi(posString2->c_str());
+	if (pos1 > pos2)
+		return 1;
+	else 
+		return -1;
+}
 
 bool FunctionListPanel::serialize(const generic_string & outputFilename)
 {
@@ -392,12 +404,12 @@ void FunctionListPanel::reload()
 		{
 			::SendMessage(_hSearchEdit, WM_SETTEXT, 0, reinterpret_cast<LPARAM>((previousParams->_searchParameters)._text2Find.c_str()));
 
-			_treeView.restoreFoldingStateFrom(previousParams->_treeState, root);
-
 			bool isSort = (previousParams->_searchParameters)._doSort;
 			setSort(isSort);
 			if (isSort)
 				_pTreeView->sort(_pTreeView->getRoot(), true);
+
+			_treeView.restoreFoldingStateFrom(previousParams->_treeState, root);
 		}
 	}
 

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -90,6 +90,7 @@ public:
     };
 	
 	// functionalities
+	static int CALLBACK categorySortFunc(LPARAM lParam1, LPARAM lParam2, LPARAM /*lParamSort*/);
 	void sortOrUnsort();
 	void reload();
 	void markEntry();

--- a/PowerEditor/src/WinControls/TreeView/TreeView.cpp
+++ b/PowerEditor/src/WinControls/TreeView/TreeView.cpp
@@ -677,7 +677,7 @@ bool TreeView::restoreFoldingStateFrom(const TreeStateNode & treeState2Compare, 
 
 	if (treeState2Compare._isSelected) //= (tvItem.state & TVIS_SELECTED) != 0;
 		selectItem(treeviewNode);
-	
+
 	size_t i = 0;
 	bool isOk = true;
 	for (HTREEITEM hItem = getChildFrom(treeviewNode); hItem != NULL; hItem = getNextSibling(hItem))

--- a/PowerEditor/src/WinControls/TreeView/TreeView.cpp
+++ b/PowerEditor/src/WinControls/TreeView/TreeView.cpp
@@ -670,23 +670,6 @@ bool TreeView::restoreFoldingStateFrom(const TreeStateNode & treeState2Compare, 
 	if (!treeviewNode)
 		return false;
 
-	TCHAR textBuffer[MAX_PATH];
-	TVITEM tvItem;
-	tvItem.hItem = treeviewNode;
-	tvItem.pszText = textBuffer;
-	tvItem.cchTextMax = MAX_PATH;
-	tvItem.mask = TVIF_TEXT | TVIF_PARAM | TVIF_STATE;
-	SendMessage(_hSelf, TVM_GETITEM, 0, reinterpret_cast<LPARAM>(&tvItem));
-
-	if (treeState2Compare._label != textBuffer)
-		return false;
-
-	if (tvItem.lParam)
-	{
-		if (treeState2Compare._extraData != *(reinterpret_cast<generic_string *>(tvItem.lParam)))
-			return false;
-	}
-
 	if (treeState2Compare._isExpanded) //= (tvItem.state & TVIS_EXPANDED) != 0;
 		expand(treeviewNode);
 	else
@@ -694,7 +677,7 @@ bool TreeView::restoreFoldingStateFrom(const TreeStateNode & treeState2Compare, 
 
 	if (treeState2Compare._isSelected) //= (tvItem.state & TVIS_SELECTED) != 0;
 		selectItem(treeviewNode);
-
+	
 	size_t i = 0;
 	bool isOk = true;
 	for (HTREEITEM hItem = getChildFrom(treeviewNode); hItem != NULL; hItem = getNextSibling(hItem))
@@ -720,7 +703,7 @@ void TreeView::sort(HTREEITEM hTreeItem, bool isRecusive)
 }
 
 
-void TreeView::customSorting(HTREEITEM hTreeItem, PFNTVCOMPARE sortingCallbackFunc, LPARAM lParam)
+void TreeView::customSorting(HTREEITEM hTreeItem, PFNTVCOMPARE sortingCallbackFunc, LPARAM lParam, bool isRecusive)
 {
 	TVSORTCB treeViewSortCB;
 	treeViewSortCB.hParent = hTreeItem;
@@ -728,4 +711,9 @@ void TreeView::customSorting(HTREEITEM hTreeItem, PFNTVCOMPARE sortingCallbackFu
 	treeViewSortCB.lParam = lParam;
 
 	::SendMessage(_hSelf, TVM_SORTCHILDRENCB, 0, reinterpret_cast<LPARAM>(&treeViewSortCB));
+	if (!isRecusive)
+		return;
+
+	for (HTREEITEM hItem = getChildFrom(hTreeItem); hItem != NULL; hItem = getNextSibling(hItem))
+		customSorting(hItem, sortingCallbackFunc, lParam, isRecusive);
 }

--- a/PowerEditor/src/WinControls/TreeView/TreeView.h
+++ b/PowerEditor/src/WinControls/TreeView/TreeView.h
@@ -115,7 +115,7 @@ public:
 	bool retrieveFoldingStateTo(TreeStateNode & treeState2Construct, HTREEITEM treeviewNode);
 	bool searchLeafAndBuildTree(TreeView & tree2Build, const generic_string & text2Search, int index2Search);
 	void sort(HTREEITEM hTreeItem, bool isRecusive);
-	void customSorting(HTREEITEM hTreeItem, PFNTVCOMPARE sortingCallbackFunc, LPARAM lParam);
+	void customSorting(HTREEITEM hTreeItem, PFNTVCOMPARE sortingCallbackFunc, LPARAM lParam, bool isRecursive);
 
 protected:
 	WNDPROC _defaultProc;


### PR DESCRIPTION
### fix #10280, fix #10294 and fix #8819

below 2 gifs for fix #10280 







STR1 fix:
![funcListTreeSortProb-Str1](https://user-images.githubusercontent.com/27722888/128066782-122cc5c4-ea66-4006-87c0-cd3d957a90f1.gif)







STR2 fix:
![funcListTreeSortProb-Str2](https://user-images.githubusercontent.com/27722888/128066817-8e20eb8a-b053-4802-adc1-a7b6459f78b1.gif)







below gif for fix #10294








![funcListTreeSortProb-Str3](https://user-images.githubusercontent.com/27722888/128066976-7c4431ca-0ef9-477b-9ed2-7e7620a2dc5c.gif)


 