### PR TITLE
Fix RTL inverse horizontal arrow key movement

### DIFF
--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -1548,6 +1548,14 @@ sptr_t ScintillaWin::KeyMessage(unsigned int iMessage, uptr_t wParam, sptr_t lPa
 			// KeyboardIsKeyDown(VK_CONTROL) ? 'C' : '-',
 			// KeyboardIsKeyDown(VK_MENU) ? 'A' : '-',
 			// wParam, lParam);
+			DWORD hwndExStyle = (DWORD)GetWindowLongPtr(MainHWND(), GWL_EXSTYLE);
+			if (hwndExStyle & WS_EX_LAYOUTRTL) //if RTL layout, swap arrow keys
+			{
+				if (wParam == VK_LEFT)
+					wParam = VK_RIGHT;
+				else if (wParam == VK_RIGHT)
+					wParam = VK_LEFT;
+			}
 			lastKeyDownConsumed = false;
 			const bool altDown = KeyboardIsKeyDown(VK_MENU);
 			if (altDown && KeyboardIsNumericKeypadFunction(wParam, lParam)) {


### PR DESCRIPTION

Fix #8553, Fix #7678 and Fix #9730


Before the fix:


![rtlArrowKeyFixbefore](https://user-images.githubusercontent.com/27722888/128285110-a255ea0e-2a89-4331-b9a9-6e564d3ef047.gif)


After the fix:


![rtlArrowKeyFixafter](https://user-images.githubusercontent.com/27722888/128285121-e05831d8-9d35-4733-a682-7c8bb2eb6ee7.gif)
