### PR TITLE
Fixed NPP RTL: wrong path in tooltip and File Drag and Drop Bug

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3795,8 +3795,10 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 	{
 		// Determinate in which view the file(s) is (are) dropped
 		POINT p;
-		::DragQueryPoint(hdrop, &p);
-		HWND hWin = ::RealChildWindowFromPoint(_pPublicInterface->getHSelf(), p);
+		::GetCursorPos(&p);
+		HWND hWnd = WindowFromPoint(p);
+		::MapWindowPoints(NULL, hWnd, &p, 1);
+		HWND hWin = ::RealChildWindowFromPoint(hWnd, p);
 		if (!hWin) return;
 
 		if ((_subEditView.getHSelf() == hWin) || (_subDocTab.getHSelf() == hWin))

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -907,8 +907,9 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 				POINT p;
 				::GetCursorPos(&p);
-				::ScreenToClient(_pPublicInterface->getHSelf(), &p);
-				HWND hWin = ::RealChildWindowFromPoint(_pPublicInterface->getHSelf(), p);
+				HWND hWnd = WindowFromPoint(p);
+				::MapWindowPoints(NULL, hWnd, &p, 1);
+				HWND hWin = ::RealChildWindowFromPoint(hWnd, p);
 				const int tipMaxLen = 1024;
 				static TCHAR docTip[tipMaxLen];
 				docTip[0] = '\0';


### PR DESCRIPTION
Fix #8520, Fixed first 2 problems mentioned in this Issue.

Fix #8730, Fixed the file drag and drop bug, now can drag and drop to the exact view.

(Reverting back to LTR (English) Layout works as usual). 
Btw @Yaron10, test it and let me know if this fix is fine. 


First 2 issue fix gifs.

![rtlFix1](https://user-images.githubusercontent.com/27722888/128589820-b8be8540-6c6c-461b-9162-14e01659a053.gif)



![rtlFix2](https://user-images.githubusercontent.com/27722888/128589862-30e465d1-2038-41a6-94c9-ee3fb43243d2.gif)


Drag and Drop Fix gif;

![rtlFix3](https://user-images.githubusercontent.com/27722888/128589881-ca3e8226-2993-4b35-874f-39aff543306a.gif)

