### PR TITLE
Fix security flaw issue

### DIFF
--- a/PowerEditor/Test/FunctionList/nsis/unitTest
+++ b/PowerEditor/Test/FunctionList/nsis/unitTest
@@ -30,7 +30,7 @@
 !define VERSION_MAJOR 6
 !define VERSION_MINOR 9
 
-!define APPWEBSITE "http://notepad-plus-plus.org/"
+!define APPWEBSITE "https://notepad-plus-plus.org/"
 
 !define UNINSTALL_REG_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 !define MEMENTO_REGISTRY_ROOT HKLM
@@ -344,15 +344,15 @@ Function .onInit
 	${GetWindowsVersion} $WinVer
 	
 	StrCmp $WinVer "95" 0 +3
-		MessageBox MB_OK "This version of Notepad++ does not support your OS.$\nPlease download zipped package of version 5.9 and use ANSI version. You can find v5.9 here:$\nhttp://notepad-plus-plus.org/release/5.9"
+		MessageBox MB_OK "This version of Notepad++ does not support your OS.$\nPlease download zipped package of version 5.9 and use ANSI version. You can find v5.9 here:$\nhttps://notepad-plus-plus.org/release/5.9"
 		Abort
 		
 	StrCmp $WinVer "98" 0 +3
-		MessageBox MB_OK "This version of Notepad++ does not support your OS.$\nPlease download zipped package of version 5.9 and use ANSI version. You can find v5.9 here:$\nhttp://notepad-plus-plus.org/release/5.9"
+		MessageBox MB_OK "This version of Notepad++ does not support your OS.$\nPlease download zipped package of version 5.9 and use ANSI version. You can find v5.9 here:$\nhttps://notepad-plus-plus.org/release/5.9"
 		Abort
 		
 	StrCmp $WinVer "ME" 0 +3
-		MessageBox MB_OK "This version of Notepad++ does not support your OS.$\nPlease download zipped package of version 5.9 and use ANSI version. You can find v5.9 here:$\nhttp://notepad-plus-plus.org/release/5.9"
+		MessageBox MB_OK "This version of Notepad++ does not support your OS.$\nPlease download zipped package of version 5.9 and use ANSI version. You can find v5.9 here:$\nhttps://notepad-plus-plus.org/release/5.9"
 		Abort
 
   !insertmacro MUI_LANGDLL_DISPLAY

--- a/PowerEditor/installer/nsisInclude/globalDef.nsh
+++ b/PowerEditor/installer/nsisInclude/globalDef.nsh
@@ -58,7 +58,7 @@
 !define ProdVer		"${VERSION_MAJOR}.${VERSION_MINOR}"
 !define LegalCopyright		"Copyleft 1998-2017 by Don HO"
 
-!define APPWEBSITE "http://notepad-plus-plus.org/"
+!define APPWEBSITE "https://notepad-plus-plus.org/"
 
 !define UNINSTALL_REG_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 !define MEMENTO_REGISTRY_ROOT HKLM

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -171,7 +171,7 @@ Function writeInstallInfoInRegistry
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "Publisher" "Notepad++ Team"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "MajorVersion" "${VERSION_MAJOR}"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "MinorVersion" "${VERSION_MINOR}"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "UninstallString" "$INSTDIR\uninstall.exe"
+	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "UninstallString" '"$INSTDIR\uninstall.exe"'
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayIcon" "$INSTDIR\notepad++.exe"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayVersion" "${APPVERSION}"
 	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "URLInfoAbout" "${APPWEBSITE}"


### PR DESCRIPTION
There's a security flaw for the un-installation of Notepad++ in Windows Register, the string without quotes:
`C:\Program Files\Notepad++\uninstall.exe`, whereas it should be `"C:\Program Files\Notepad++\uninstall.exe"`.
The reason is, hacker can create a file called `c:\program.exe`, then Windows could interpret  `Files\Notepad++\uninstall.exe` as the argument, so the system could run `c:\program.exe`. Ref:
https://isc.sans.edu/diary/Help+eliminate+unquoted+path+vulnerabilities/14464

Fixed by @ozone10:
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10191#issuecomment-894811688

Fix #10191, fix #6165