### PR TITLE
Fix boost REGEX performance issue

### DIFF
--- a/boostregex/BoostRegExSearch.cxx
+++ b/boostregex/BoostRegExSearch.cxx
@@ -417,9 +417,7 @@ void BoostRegexSearch::EncodingDependent<CharT, CharacterIterator>::compileRegex
 {
 	if (_lastCompileFlags != compileFlags || _lastRegexString != regex)
 	{
-		std::locale l = std::locale::global(std::locale(""));
 		_regex = Regex(CharTPtr(regex), static_cast<regex_constants::syntax_option_type>(compileFlags));
-		std::locale::global(l);
 		_lastRegexString = regex;
 		_lastCompileFlags = compileFlags;
 	}
@@ -449,11 +447,9 @@ bool BoostRegexSearch::SearchParameters::isLineEnd(Sci::Position position)
 
 const char *BoostRegexSearch::SubstituteByPosition(Document* doc, const char *text, Sci::Position *length) {
 	delete[] _substituted;
-	std::locale l = std::locale::global(std::locale(""));
 	_substituted = (doc->CodePage() == SC_CP_UTF8)
 		? _utf8.SubstituteByPosition(text, length)
 		: _ansi.SubstituteByPosition(text, length);
-	std::locale::global(l);
 	return _substituted;
 }
 


### PR DESCRIPTION
This commit revert 86c66bba90cc3f49323cdcae77173099122c75dc due to the boost REGEX performance issue.

Fix #10398, fix #10296, fix #10260