### PR TITLE
Document List context menu now appears only when files are selected

### DIFF
--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -147,12 +147,16 @@ INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, 
 
 						activateDoc(tlfs);
 					}
-					// Redirect NM_RCLICK message to Notepad_plus handle
-					NMHDR	nmhdr;
-					nmhdr.code = NM_RCLICK;
-					nmhdr.hwndFrom = _hSelf;
-					nmhdr.idFrom = ::GetDlgCtrlID(nmhdr.hwndFrom);
-					::SendMessage(_hParent, WM_NOTIFY, nmhdr.idFrom, reinterpret_cast<LPARAM>(&nmhdr));
+
+					if (nbSelectedFiles() >= 1)
+					{
+						// Redirect NM_RCLICK message to Notepad_plus handle
+						NMHDR	nmhdr;
+						nmhdr.code = NM_RCLICK;
+						nmhdr.hwndFrom = _hSelf;
+						nmhdr.idFrom = ::GetDlgCtrlID(nmhdr.hwndFrom);
+						::SendMessage(_hParent, WM_NOTIFY, nmhdr.idFrom, reinterpret_cast<LPARAM>(&nmhdr));
+					}
 					return TRUE;
 				}
 


### PR DESCRIPTION
Fix #10463

Context menu now appears only when files are selected.

![DocListpopup_Fixv1 1](https://user-images.githubusercontent.com/27722888/131309100-2d144f3e-ad2b-441c-a728-9a2f330350b5.gif)
