### PR TITLE
Make number of languages and styles unlimited and independent

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -681,13 +681,11 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	// Initialize the default foreground & background color
 	//
 	{
-		StyleArray & globalStyles = nppParam.getGlobalStylers();
-		int i = globalStyles.getStylerIndexByID(STYLE_DEFAULT);
-		if (i != -1)
+		const Style * pStyle = nppParam.getGlobalStylers().findByID(STYLE_DEFAULT);
+		if (pStyle)
 		{
-			Style & style = globalStyles.getStyler(i);
-			nppParam.setCurrentDefaultFgColor(style._fgColor);
-			nppParam.setCurrentDefaultBgColor(style._bgColor);
+			nppParam.setCurrentDefaultFgColor(pStyle->_fgColor);
+			nppParam.setCurrentDefaultBgColor(pStyle->_bgColor);
 		}
 	}
 
@@ -2259,12 +2257,9 @@ void Notepad_plus::setupColorSampleBitmapsOnMainMenuItems()
 
 	for (int j = 0; j < sizeof(bitmapOnStyleMenuItemsInfo) / sizeof(bitmapOnStyleMenuItemsInfo[0]); ++j)
 	{
-		StyleArray& stylers = NppParameters::getInstance().getMiscStylerArray();
-		int iFind = stylers.getStylerIndexByID(bitmapOnStyleMenuItemsInfo[j].styleIndic);
-		
-		if (iFind != -1)
+		const Style * pStyle = NppParameters::getInstance().getMiscStylerArray().findByID(bitmapOnStyleMenuItemsInfo[j].styleIndic);
+		if (pStyle)
 		{
-			Style const* pStyle = &(stylers.getStyler(iFind));
 
 			HDC hDC = GetDC(NULL);
 			const int bitmapXYsize = 16;
@@ -6369,16 +6364,7 @@ generic_string Notepad_plus::getLangFromMenu(const Buffer * buf)
 
 Style * Notepad_plus::getStyleFromName(const TCHAR *styleName)
 {
-	StyleArray & stylers = (NppParameters::getInstance()).getMiscStylerArray();
-
-	int i = stylers.getStylerIndexByName(styleName);
-	Style * st = NULL;
-	if (i != -1)
-	{
-		Style & style = stylers.getStyler(i);
-		st = &style;
-	}
-	return st;
+	return NppParameters::getInstance().getMiscStylerArray().findByName(styleName);
 }
 
 bool Notepad_plus::noOpenedDoc() const

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1796,67 +1796,68 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			drawDocumentMapColoursFromStylerArray();
 
 			// Update default fg/bg colors in Parameters for both internal/plugins docking dialog
-			StyleArray & globalStyles = (NppParameters::getInstance()).getGlobalStylers();
-			int i = globalStyles.getStylerIndexByID(STYLE_DEFAULT);
-			Style & style = globalStyles.getStyler(i);
-			(NppParameters::getInstance()).setCurrentDefaultFgColor(style._fgColor);
-			(NppParameters::getInstance()).setCurrentDefaultBgColor(style._bgColor);
+			const Style * pStyle = NppParameters::getInstance().getGlobalStylers().findByID(STYLE_DEFAULT);
+			if (pStyle)
+			{
+				NppParameters::getInstance().setCurrentDefaultFgColor(pStyle->_fgColor);
+				NppParameters::getInstance().setCurrentDefaultBgColor(pStyle->_bgColor);
+			}
 
 			NppDarkMode::calculateTreeViewStyle();
 			auto refreshOnlyTreeView = static_cast<LPARAM>(TRUE);
 
 			// Set default fg/bg colors on internal docking dialog
-			if (_pFuncList)
+			if (pStyle && _pFuncList)
 			{
-				_pFuncList->setBackgroundColor(style._bgColor);
-				_pFuncList->setForegroundColor(style._fgColor);
+				_pFuncList->setBackgroundColor(pStyle->_bgColor);
+				_pFuncList->setForegroundColor(pStyle->_fgColor);
 				::SendMessage(_pFuncList->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
-			if (_pAnsiCharPanel)
+			if (pStyle && _pAnsiCharPanel)
 			{
-				_pAnsiCharPanel->setBackgroundColor(style._bgColor);
-				_pAnsiCharPanel->setForegroundColor(style._fgColor);
+				_pAnsiCharPanel->setBackgroundColor(pStyle->_bgColor);
+				_pAnsiCharPanel->setForegroundColor(pStyle->_fgColor);
 			}
 
-			if (_pDocumentListPanel)
+			if (pStyle && _pDocumentListPanel)
 			{
-				_pDocumentListPanel->setBackgroundColor(style._bgColor);
-				_pDocumentListPanel->setForegroundColor(style._fgColor);
+				_pDocumentListPanel->setBackgroundColor(pStyle->_bgColor);
+				_pDocumentListPanel->setForegroundColor(pStyle->_fgColor);
 			}
 
-			if (_pClipboardHistoryPanel)
+			if (pStyle && _pClipboardHistoryPanel)
 			{
-				_pClipboardHistoryPanel->setBackgroundColor(style._bgColor);
-				_pClipboardHistoryPanel->setForegroundColor(style._fgColor);
+				_pClipboardHistoryPanel->setBackgroundColor(pStyle->_bgColor);
+				_pClipboardHistoryPanel->setForegroundColor(pStyle->_fgColor);
 				_pClipboardHistoryPanel->redraw(true);
 			}
 
-			if (_pProjectPanel_1)
+			if (pStyle && _pProjectPanel_1)
 			{
-				_pProjectPanel_1->setBackgroundColor(style._bgColor);
-				_pProjectPanel_1->setForegroundColor(style._fgColor);
+				_pProjectPanel_1->setBackgroundColor(pStyle->_bgColor);
+				_pProjectPanel_1->setForegroundColor(pStyle->_fgColor);
 				::SendMessage(_pProjectPanel_1->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
-			if (_pProjectPanel_2)
+			if (pStyle && _pProjectPanel_2)
 			{
-				_pProjectPanel_2->setBackgroundColor(style._bgColor);
-				_pProjectPanel_2->setForegroundColor(style._fgColor);
+				_pProjectPanel_2->setBackgroundColor(pStyle->_bgColor);
+				_pProjectPanel_2->setForegroundColor(pStyle->_fgColor);
 				::SendMessage(_pProjectPanel_2->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
-			if (_pProjectPanel_3)
+			if (pStyle && _pProjectPanel_3)
 			{
-				_pProjectPanel_3->setBackgroundColor(style._bgColor);
-				_pProjectPanel_3->setForegroundColor(style._fgColor);
+				_pProjectPanel_3->setBackgroundColor(pStyle->_bgColor);
+				_pProjectPanel_3->setForegroundColor(pStyle->_fgColor);
 				::SendMessage(_pProjectPanel_3->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
-			if (_pFileBrowser)
+			if (pStyle && _pFileBrowser)
 			{
-				_pFileBrowser->setBackgroundColor(style._bgColor);
-				_pFileBrowser->setForegroundColor(style._fgColor);
+				_pFileBrowser->setBackgroundColor(pStyle->_bgColor);
+				_pFileBrowser->setForegroundColor(pStyle->_fgColor);
 				::SendMessage(_pFileBrowser->getHSelf(), NPPM_INTERNAL_REFRESHDARKMODE, 0, refreshOnlyTreeView);
 			}
 
@@ -2534,13 +2535,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 			ScintillaViewParams &svp = const_cast<ScintillaViewParams &>(nppParam.getSVP());
 
-			StyleArray & stylers = NppParameters::getInstance().getMiscStylerArray();
 			COLORREF multiEdgeColor = liteGrey;
-			int i = stylers.getStylerIndexByName(TEXT("Edge colour"));
-			if (i != -1)
+			const Style * pStyle = NppParameters::getInstance().getMiscStylerArray().findByName(TEXT("Edge colour"));
+			if (pStyle)
 			{
-				Style & style = stylers.getStyler(i);
-				multiEdgeColor = style._fgColor;
+				multiEdgeColor = pStyle->_fgColor;
 			}
 
 			const size_t twoPower13 = 8192;

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -926,8 +926,8 @@ bool NppParameters::reloadStylers(const TCHAR* stylePath)
 		_pXmlUserStylerDoc = NULL;
 		return false;
 	}
-	_lexerStylerVect.eraseAll();
-	_widgetStyleArray.setNbStyler( 0 );
+	_lexerStylerVect.clear();
+	_widgetStyleArray.clear();
 
 	getUserStylersFromXmlTree();
 
@@ -1594,22 +1594,19 @@ UserLangContainer* NppParameters::getULCFromName(const TCHAR *userLangName)
 
 COLORREF NppParameters::getCurLineHilitingColour()
 {
-	int i = _widgetStyleArray.getStylerIndexByName(TEXT("Current line background colour"));
-	if (i == -1)
-		return i;
-	Style & style = _widgetStyleArray.getStyler(i);
-	return style._bgColor;
+	const Style * pStyle = _widgetStyleArray.findByName(TEXT("Current line background colour"));
+	if (!pStyle)
+		return COLORREF(-1);
+	return pStyle->_bgColor;
 }
 
 
 void NppParameters::setCurLineHilitingColour(COLORREF colour2Set)
 {
-	int i = _widgetStyleArray.getStylerIndexByName(TEXT("Current line background colour"));
-	if (i == -1)
+	Style * pStyle = _widgetStyleArray.findByName(TEXT("Current line background colour"));
+	if (!pStyle)
 		return;
-
-	Style& style = _widgetStyleArray.getStyler(i);
-	style._bgColor = colour2Set;
+	pStyle->_bgColor = colour2Set;
 }
 
 
@@ -2774,11 +2771,11 @@ std::pair<unsigned char, unsigned char> NppParameters::feedUserLang(TiXmlNode *n
 			feedUserStyles(stylesRoot);
 
 			// styles that were not read from xml file should get default values
-			for (int i=0; i<SCE_USER_STYLE_TOTAL_STYLES; ++i)
+			for (int i = 0 ; i < SCE_USER_STYLE_TOTAL_STYLES ; ++i)
 			{
-				Style & style = _userLangArray[_nbUserLang - 1]->_styles.getStyler(i);
-				if (style._styleID == -1)
-					_userLangArray[_nbUserLang - 1]->_styles.addStyler(i, globalMappper().styleNameMapper[i].c_str());
+				const Style * pStyle = _userLangArray[_nbUserLang - 1]->_styles.findByID(i);
+				if (!pStyle)
+					_userLangArray[_nbUserLang - 1]->_styles.addStyler(i, globalMappper().styleNameMapper[i]);
 			}
 
 		}
@@ -3098,12 +3095,8 @@ void NppParameters::writeNonDefaultUDL()
 
 void NppParameters::writeNeed2SaveUDL()
 {
-	stylerStrOp(DUP);
-
 	writeDefaultUDL();
 	writeNonDefaultUDL();
-	
-	stylerStrOp(FREE);
 }
 
 
@@ -3570,8 +3563,6 @@ bool NppParameters::feedStylerArray(TiXmlNode *node)
 		 childNode ;
 		 childNode = childNode->NextSibling(TEXT("LexerType")) )
 	{
-	 	if (!_lexerStylerVect.hasEnoughSpace()) return false;
-
 		TiXmlElement *element = childNode->ToElement();
 		const TCHAR *lexerName = element->Attribute(TEXT("name"));
 		const TCHAR *lexerDesc = element->Attribute(TEXT("desc"));
@@ -3597,8 +3588,6 @@ bool NppParameters::feedStylerArray(TiXmlNode *node)
 		 childNode ;
 		 childNode = childNode->NextSibling(TEXT("WidgetStyle")) )
 	{
-	 	if (!_widgetStyleArray.hasEnoughSpace()) return false;
-
 		TiXmlElement *element = childNode->ToElement();
 		const TCHAR *styleIDStr = element->Attribute(TEXT("styleID"));
 
@@ -3613,7 +3602,8 @@ bool NppParameters::feedStylerArray(TiXmlNode *node)
 
 void LexerStylerArray::addLexerStyler(const TCHAR *lexerName, const TCHAR *lexerDesc, const TCHAR *lexerUserExt , TiXmlNode *lexerNode)
 {
-	LexerStyler & ls = _lexerStylerVect[_nbLexerStyler++];
+	_lexerStylerVect.emplace_back();
+	LexerStyler & ls = _lexerStylerVect.back();
 	ls.setLexerName(lexerName);
 	if (lexerDesc)
 		ls.setLexerDesc(lexerDesc);
@@ -3625,9 +3615,6 @@ void LexerStylerArray::addLexerStyler(const TCHAR *lexerName, const TCHAR *lexer
 		 childNode ;
 		 childNode = childNode->NextSibling(TEXT("WordsStyle")) )
 	{
-		if (!ls.hasEnoughSpace())
-			return;
-
 		TiXmlElement *element = childNode->ToElement();
 		const TCHAR *styleIDStr = element->Attribute(TEXT("styleID"));
 
@@ -3642,35 +3629,19 @@ void LexerStylerArray::addLexerStyler(const TCHAR *lexerName, const TCHAR *lexer
 	}
 }
 
-void LexerStylerArray::eraseAll()
-{
-
-	for (int i = 0 ; i < _nbLexerStyler ; ++i)
-	{
-		_lexerStylerVect[i].setNbStyler( 0 );
-	}
-
-	_nbLexerStyler = 0;
-}
-
 void StyleArray::addStyler(int styleID, TiXmlNode *styleNode)
 {
-	int index = _nbStyler;
 	bool isUser = styleID >> 16 == L_USER;
 	if (isUser)
 	{
 		styleID = (styleID & 0xFFFF);
-		index = styleID;
-		if (index >= SCE_USER_STYLE_TOTAL_STYLES || _styleVect[index]._styleID != -1)
-			return;
-	}
-	else
-	{
-		if (index >= STYLE_ARR_MAX_SIZE)
+		if (styleID >= SCE_USER_STYLE_TOTAL_STYLES || findByID(styleID))
 			return;
 	}
 
-	_styleVect[index]._styleID = styleID;
+	_styleVect.emplace_back();
+	Style & s = _styleVect.back();
+	s._styleID = styleID;
 
 	if (styleNode)
 	{
@@ -3684,16 +3655,16 @@ void StyleArray::addStyler(int styleID, TiXmlNode *styleNode)
 		if (str)
 		{
 			if (isUser)
-				_styleVect[index]._styleDesc = globalMappper().styleNameMapper[index].c_str();
+				s._styleDesc = globalMappper().styleNameMapper[styleID];
 			else
-				_styleVect[index]._styleDesc = str;
+				s._styleDesc = str;
 		}
 
 		str = element->Attribute(TEXT("fgColor"));
 		if (str)
 		{
 			unsigned long result = hexStrVal(str);
-			_styleVect[index]._fgColor = (RGB((result >> 16) & 0xFF, (result >> 8) & 0xFF, result & 0xFF)) | (result & 0xFF000000);
+			s._fgColor = (RGB((result >> 16) & 0xFF, (result >> 8) & 0xFF, result & 0xFF)) | (result & 0xFF000000);
 
 		}
 
@@ -3701,49 +3672,51 @@ void StyleArray::addStyler(int styleID, TiXmlNode *styleNode)
 		if (str)
 		{
 			unsigned long result = hexStrVal(str);
-			_styleVect[index]._bgColor = (RGB((result >> 16) & 0xFF, (result >> 8) & 0xFF, result & 0xFF)) | (result & 0xFF000000);
+			s._bgColor = (RGB((result >> 16) & 0xFF, (result >> 8) & 0xFF, result & 0xFF)) | (result & 0xFF000000);
 		}
 
 		str = element->Attribute(TEXT("colorStyle"));
 		if (str)
 		{
-			_styleVect[index]._colorStyle = decStrVal(str);
+			s._colorStyle = decStrVal(str);
 		}
 
 		str = element->Attribute(TEXT("fontName"));
-		_styleVect[index]._fontName = str;
+		if (str)
+		{
+			s._fontName = str;
+		}
 
 		str = element->Attribute(TEXT("fontStyle"));
 		if (str)
 		{
-			_styleVect[index]._fontStyle = decStrVal(str);
+			s._fontStyle = decStrVal(str);
 		}
 
 		str = element->Attribute(TEXT("fontSize"));
 		if (str)
 		{
-			_styleVect[index]._fontSize = decStrVal(str);
+			s._fontSize = decStrVal(str);
 		}
 		str = element->Attribute(TEXT("nesting"));
 
 		if (str)
 		{
-			_styleVect[index]._nesting = decStrVal(str);
+			s._nesting = decStrVal(str);
 		}
 
 		str = element->Attribute(TEXT("keywordClass"));
 		if (str)
 		{
-			_styleVect[index]._keywordClass = getKwClassFromName(str);
+			s._keywordClass = getKwClassFromName(str);
 		}
 
 		TiXmlNode *v = styleNode->FirstChild();
 		if (v)
 		{
-			_styleVect[index]._keywords = new generic_string(v->Value());
+			s._keywords = v->Value();
 		}
 	}
-	++_nbStyler;
 }
 
 bool NppParameters::writeRecentFileHistorySettings(int nbMaxFile) const
@@ -7089,14 +7062,11 @@ generic_string NppParameters::writeStyles(LexerStylerArray & lexersStylers, Styl
 			{
 				TiXmlElement *grElement = grChildNode->ToElement();
 				const TCHAR *styleName = grElement->Attribute(TEXT("name"));
-
-				int i = pLs->getStylerIndexByName(styleName);
-				if (i != -1)
+				const Style * pStyle = pLs->findByName(styleName);
+				Style * pStyle2Sync = pLs2 ? pLs2->findByName(styleName) : nullptr;
+				if (pStyle && pStyle2Sync)
 				{
-					Style & style = pLs->getStyler(i);
-					Style & style2Sync = pLs2->getStyler(i);
-
-					writeStyle2Element(style, style2Sync, grElement);
+					writeStyle2Element(*pStyle, *pStyle2Sync, grElement);
 				}
 			}
 		}
@@ -7126,14 +7096,11 @@ generic_string NppParameters::writeStyles(LexerStylerArray & lexersStylers, Styl
 				{
 					TiXmlElement *grElement = grChildNode->ToElement();
 					const TCHAR *styleName = grElement->Attribute(TEXT("name"));
-
-					int i = pLs->getStylerIndexByName(styleName);
-					if (i != -1)
+					const Style * pStyle = pLs->findByName(styleName);
+					Style * pStyle2Sync = pLs2 ? pLs2->findByName(styleName) : nullptr;
+					if (pStyle && pStyle2Sync)
 					{
-						Style & style = pLs->getStyler(i);
-						Style & style2Sync = pLs2->getStyler(i);
-
-						writeStyle2Element(style, style2Sync, grElement);
+						writeStyle2Element(*pStyle, *pStyle2Sync, grElement);
 					}
 				}
 			}
@@ -7149,14 +7116,11 @@ generic_string NppParameters::writeStyles(LexerStylerArray & lexersStylers, Styl
 	{
 		TiXmlElement *pElement = childNode->ToElement();
 		const TCHAR *styleName = pElement->Attribute(TEXT("name"));
-		int i = _widgetStyleArray.getStylerIndexByName(styleName);
-
-		if (i != -1)
+		const Style * pStyle = _widgetStyleArray.findByName(styleName);
+		Style * pStyle2Sync = globalStylers.findByName(styleName);
+		if (pStyle && pStyle2Sync)
 		{
-			Style & style = _widgetStyleArray.getStyler(i);
-			Style & style2Sync = globalStylers.getStyler(i);
-
-			writeStyle2Element(style, style2Sync, pElement);
+			writeStyle2Element(*pStyle, *pStyle2Sync, pElement);
 		}
 	}
 
@@ -7194,7 +7158,7 @@ bool NppParameters::insertTabInfo(const TCHAR *langName, int tabInfo)
 	return false;
 }
 
-void NppParameters::writeStyle2Element(Style & style2Write, Style & style2Sync, TiXmlElement *element)
+void NppParameters::writeStyle2Element(const Style & style2Write, Style & style2Sync, TiXmlElement *element)
 {
 	if (HIBYTE(HIWORD(style2Write._fgColor)) != 0xFF)
 	{
@@ -7217,13 +7181,13 @@ void NppParameters::writeStyle2Element(Style & style2Write, Style & style2Sync, 
 		element->SetAttribute(TEXT("colorStyle"), style2Write._colorStyle);
 	}
 
-	if (style2Write._fontName)
+	if (!style2Write._fontName.empty())
 	{
-		const TCHAR *oldFontName = element->Attribute(TEXT("fontName"));
-		if (lstrcmp(oldFontName, style2Write._fontName))
+		const TCHAR * oldFontName = element->Attribute(TEXT("fontName"));
+		if (oldFontName && oldFontName != style2Write._fontName)
 		{
 			element->SetAttribute(TEXT("fontName"), style2Write._fontName);
-			style2Sync._fontName = style2Write._fontName = element->Attribute(TEXT("fontName"));
+			style2Sync._fontName = style2Write._fontName;
 		}
 	}
 
@@ -7241,14 +7205,14 @@ void NppParameters::writeStyle2Element(Style & style2Write, Style & style2Sync, 
 	}
 
 
-	if (style2Write._keywords)
+	if (!style2Write._keywords.empty())
 	{
 		TiXmlNode *teteDeNoeud = element->LastChild();
 
 		if (teteDeNoeud)
-			teteDeNoeud->SetValue(style2Write._keywords->c_str());
+			teteDeNoeud->SetValue(style2Write._keywords.c_str());
 		else
-			element->InsertEndChild(TiXmlText(style2Write._keywords->c_str()));
+			element->InsertEndChild(TiXmlText(style2Write._keywords.c_str()));
 	}
 }
 
@@ -7291,10 +7255,9 @@ void NppParameters::insertUserLang2Tree(TiXmlNode *node, UserLangContainer *user
 
 	TiXmlElement *styleRootElement = (rootElement->InsertEndChild(TiXmlElement(TEXT("Styles"))))->ToElement();
 
-	for (int i = 0 ; i < SCE_USER_STYLE_TOTAL_STYLES ; ++i)
+	for (const Style & style2Write : userLang->_styles)
 	{
 		TiXmlElement *styleElement = (styleRootElement->InsertEndChild(TiXmlElement(TEXT("WordsStyle"))))->ToElement();
-		Style style2Write = userLang->_styles.getStyler(i);
 
 		if (style2Write._styleID == -1)
 			continue;
@@ -7322,7 +7285,7 @@ void NppParameters::insertUserLang2Tree(TiXmlNode *node, UserLangContainer *user
 			styleElement->SetAttribute(TEXT("colorStyle"), style2Write._colorStyle);
 		}
 
-		if (style2Write._fontName)
+		if (!style2Write._fontName.empty())
 		{
 			styleElement->SetAttribute(TEXT("fontName"), style2Write._fontName);
 		}
@@ -7345,43 +7308,6 @@ void NppParameters::insertUserLang2Tree(TiXmlNode *node, UserLangContainer *user
 		}
 
 		styleElement->SetAttribute(TEXT("nesting"), style2Write._nesting);
-	}
-}
-
-void NppParameters::stylerStrOp(bool op)
-{
-	for (int i = 0 ; i < _nbUserLang ; ++i)
-	{
-		for (int j = 0 ; j < SCE_USER_STYLE_TOTAL_STYLES ; ++j)
-		{
-			Style & style = _userLangArray[i]->_styles.getStyler(j);
-
-			if (op == DUP)
-			{
-				const size_t strLen = lstrlen(style._styleDesc) + 1;
-				TCHAR *str = new TCHAR[strLen];
-				wcscpy_s(str, strLen, style._styleDesc);
-				style._styleDesc = str;
-				if (style._fontName)
-				{
-					const size_t strLen2 = lstrlen(style._fontName) + 1;
-					str = new TCHAR[strLen2];
-					wcscpy_s(str, strLen2, style._fontName);
-					style._fontName = str;
-				}
-				else
-				{
-					str = new TCHAR[2];
-					str[0] = str[1] = '\0';
-					style._fontName = str;
-				}
-			}
-			else
-			{
-				delete [] style._styleDesc;
-				delete [] style._fontName;
-			}
-		}
 	}
 }
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4259,43 +4259,40 @@ void Finder::setFinderStyle()
 	LexerStyler *pStyler = (NppParameters::getInstance().getLStylerArray()).getLexerStylerByName(lexerName);
 	if (pStyler)
 	{
-		int i = pStyler->getStylerIndexByID(SCE_SEARCHRESULT_CURRENT_LINE);
-		if (i != -1)
+		const Style * pStyle = pStyler->findByID(SCE_SEARCHRESULT_CURRENT_LINE);
+		if (pStyle)
 		{
-			Style & style = pStyler->getStyler(i);
-			_scintView.execute(SCI_SETCARETLINEBACK, style._bgColor);
+			_scintView.execute(SCI_SETCARETLINEBACK, pStyle->_bgColor);
 		}
 	}
 	_scintView.setSearchResultLexer();
 
 	// Override foreground & background colour by default foreground & background coulour
 	StyleArray & stylers = NppParameters::getInstance().getMiscStylerArray();
-	int iStyleDefault = stylers.getStylerIndexByID(STYLE_DEFAULT);
-	if (iStyleDefault != -1)
+	Style * pStyleDefault = stylers.findByID(STYLE_DEFAULT);
+	if (pStyleDefault)
 	{
-		Style & styleDefault = stylers.getStyler(iStyleDefault);
-		_scintView.setStyle(styleDefault);
+		_scintView.setStyle(*pStyleDefault);
 
 		GlobalOverride & go = NppParameters::getInstance().getGlobalOverrideStyle();
 		if (go.isEnable())
 		{
-			int iGlobalOverride = stylers.getStylerIndexByName(TEXT("Global override"));
-			if (iGlobalOverride != -1)
+			const Style * pStyleGlobalOverride = stylers.findByName(TEXT("Global override"));
+			if (pStyleGlobalOverride)
 			{
-				Style & styleGlobalOverride = stylers.getStyler(iGlobalOverride);
 				if (go.enableFg)
 				{
-					styleDefault._fgColor = styleGlobalOverride._fgColor;
+					pStyleDefault->_fgColor = pStyleGlobalOverride->_fgColor;
 				}
 				if (go.enableBg)
 				{
-					styleDefault._bgColor = styleGlobalOverride._bgColor;
+					pStyleDefault->_bgColor = pStyleGlobalOverride->_bgColor;
 				}
 			}
 		}
 
-		_scintView.execute(SCI_STYLESETFORE, SCE_SEARCHRESULT_DEFAULT, styleDefault._fgColor);
-		_scintView.execute(SCI_STYLESETBACK, SCE_SEARCHRESULT_DEFAULT, styleDefault._bgColor);
+		_scintView.execute(SCI_STYLESETFORE, SCE_SEARCHRESULT_DEFAULT, pStyleDefault->_fgColor);
+		_scintView.execute(SCI_STYLESETBACK, SCE_SEARCHRESULT_DEFAULT, pStyleDefault->_bgColor);
 	}
 
 	_scintView.execute(SCI_COLOURISE, 0, -1);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -199,10 +199,6 @@ public:
 
 			for (BufferStyleMap::iterator it(_hotspotStyles.begin()); it != _hotspotStyles.end(); ++it )
 			{
-				for (StyleMap::iterator it2(it->second->begin()) ; it2 != it->second->end() ; ++it2)
-				{
-					delete [] it2->second._fontName;
-				}
 				delete it->second;
 			}
 		}

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -1763,7 +1763,7 @@ INT_PTR CALLBACK StylerDlg::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPAR
 				::SendMessage(hFontNameCombo, CB_SETITEMDATA, k, reinterpret_cast<LPARAM>(fontlist[j].c_str()));
             }
 
-			i = ::SendMessage(hFontNameCombo, CB_FINDSTRINGEXACT, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(style._fontName));
+			i = ::SendMessage(hFontNameCombo, CB_FINDSTRINGEXACT, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(style._fontName.c_str()));
             if (i == CB_ERR)
                 i = 0;
             ::SendMessage(hFontNameCombo, CB_SETCURSEL, i, 0);

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -146,11 +146,11 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 			::EnableWindow(::GetDlgItem(_hSelf, IDOK), _isDirty);
 			::EnableWindow(::GetDlgItem(_hSelf, IDC_SAVECLOSE_BUTTON), FALSE/*!_isSync*/);
 
+			loadLangListFromNppParam();
 			updateGlobalOverrideCtrls();
 			setVisualFromStyleList();
 			goToCenter();
 
-			loadLangListFromNppParam();
 			return TRUE;
 		}
 
@@ -545,7 +545,7 @@ void WordStyleDlg::loadLangListFromNppParam()
 
 	::SendDlgItemMessage(_hSelf, IDC_LANGUAGES_LIST, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(TEXT("Global Styles")));
 	// All the lexers
-	for (int i = 0, nb = _lsArray.getNbLexer() ; i < nb ; ++i)
+	for (size_t i = 0, nb = _lsArray.getNbLexer() ; i < nb ; ++i)
 	{
 		::SendDlgItemMessage(_hSelf, IDC_LANGUAGES_LIST, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(_lsArray.getLexerDescFromIndex(i)));
 	}
@@ -675,7 +675,7 @@ void WordStyleDlg::updateUserKeywords()
 	len += 1;
 	TCHAR *kw = new TCHAR[len];
 	::SendDlgItemMessage(_hSelf, IDC_USER_KEYWORDS_EDIT, WM_GETTEXT, len, reinterpret_cast<LPARAM>(kw));
-	style.setKeywords(kw);
+	style._keywords = kw;
 
 	delete [] kw;
 }
@@ -808,10 +808,9 @@ void WordStyleDlg::setStyleListFromLexer(int index)
 
 	StyleArray & lexerStyler = index?_lsArray.getLexerFromIndex(index-1):_globalStyles;
 
-	for (int i = 0, nb = lexerStyler.getNbStyler(); i < nb ; ++i)
+	for (const Style & style : lexerStyler)
 	{
-		Style & style = lexerStyler.getStyler(i);
-		::SendDlgItemMessage(_hSelf, IDC_STYLES_LIST, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(style._styleDesc));
+		::SendDlgItemMessage(_hSelf, IDC_STYLES_LIST, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(style._styleDesc.c_str()));
 	}
 	::SendDlgItemMessage(_hSelf, IDC_STYLES_LIST, LB_SETCURSEL, 0, 0);
 	setVisualFromStyleList();
@@ -824,7 +823,7 @@ void WordStyleDlg::setVisualFromStyleList()
 	Style & style = getCurrentStyler();
 
 	// Global override style
-	if (style._styleDesc && lstrcmp(style._styleDesc, TEXT("Global override")) == 0)
+	if (style._styleDesc == TEXT("Global override"))
 	{
 		showGlobalOverrideCtrls(true);
 	}
@@ -874,7 +873,7 @@ void WordStyleDlg::setVisualFromStyleList()
 	}
 
 	// Selected text colour style
-	if (style._styleDesc && lstrcmp(style._styleDesc, TEXT("Selected text colour")) == 0)
+	if (style._styleDesc == TEXT("Selected text colour"))
 	{
 		isEnable = false; // disable by default for "Selected text colour" style
 
@@ -895,9 +894,9 @@ void WordStyleDlg::setVisualFromStyleList()
 	//-- font name
 	isEnable = false;
 	LRESULT iFontName;
-	if (style._fontName != NULL)
+	if (!style._fontName.empty())
 	{
-		iFontName = ::SendMessage(_hFontNameCombo, CB_FINDSTRING, 1, reinterpret_cast<LPARAM>(style._fontName));
+		iFontName = ::SendMessage(_hFontNameCombo, CB_FINDSTRING, 1, reinterpret_cast<LPARAM>(style._fontName.c_str()));
 		if (iFontName == CB_ERR)
 			iFontName = 0;
 		isEnable = true;
@@ -964,7 +963,7 @@ void WordStyleDlg::setVisualFromStyleList()
 			kws = TEXT("");
 		::SendDlgItemMessage(_hSelf, IDC_DEF_KEYWORDS_EDIT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(kws));
 
-		const TCHAR *ckwStr = (style._keywords)?style._keywords->c_str():TEXT("");
+		const TCHAR *ckwStr = style._keywords.c_str();
 		::SendDlgItemMessage(_hSelf, IDC_USER_KEYWORDS_EDIT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(ckwStr));
 	}
 


### PR DESCRIPTION
_A clean version of https://github.com/notepad-plus-plus/notepad-plus-plus/pull/10483 thanks to @ozone10 and @chcg._

The proper fix for #10206 without any compile-time limits.

Now there may be any number of languages and styles. Here is the showcase:
![showcase](https://user-images.githubusercontent.com/81974034/131647770-b21d0d8f-52b3-4f5d-9e00-0872f2d54a08.png)

@donho This is the version to review, if you please.