### PR TITLE
Fix gcc build: xml writing, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,8 +152,7 @@ PowerEditor/bin/SourceCodePro-Regular.ttf
 # GNU GCC MinGW
 
 #-- Generated during makefile build
-PowerEditor/gcc/*release/
-PowerEditor/gcc/*debug/
+PowerEditor/gcc/*.build/
 PowerEditor/bin/NotepadPP*.exe
 scintilla/win32/*.o
 scintilla/bin/libscilexer.a

--- a/.gitignore
+++ b/.gitignore
@@ -100,11 +100,8 @@ PowerEditor/src/tools/NppShell/build_x64
 # scintilla - generated files
 scintilla/bin/SciLexer.*
 scintilla/bin/Scintilla.*
-scintilla/bin/libscilexer.a
-scintilla/bin/libscintilla.a
 scintilla/bin/libscintilla.lib
 scintilla/win32/*.lib
-scintilla/win32/Lexers.a
 scintilla/win32/ScintRes.res
 scintilla/win32/ARM64
 scintilla/win32/Unicode Release/
@@ -155,11 +152,11 @@ PowerEditor/bin/SourceCodePro-Regular.ttf
 # GNU GCC MinGW
 
 #-- Generated during makefile build
-*.d
-*.o
-/PowerEditor/gcc/resources.res
-/PowerEditor/bin/NotepadPP.exe
-/PowerEditor/bin/NotepadPP.exe_dynamic
+PowerEditor/gcc/*release/
+PowerEditor/gcc/*debug/
+PowerEditor/bin/NotepadPP*.exe
+scintilla/win32/*.o
+scintilla/bin/libscilexer.a
 
 #-- Generated manually to make Notepad++ execute properly on Linux using Wine
 /PowerEditor/bin/libgcc_s_sjlj-1.dll

--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -48,7 +48,7 @@ CXXFLAGS += -g -Wall -Wpedantic -Wconversion-null
 BUILD_TYPE := $(CROSS_COMPILE)debug
 endif
 
-BUILD_DIR := $(GCC_DIR)/$(BUILD_TYPE)
+BUILD_DIR := $(BUILD_TYPE).build
 TARGET_BINARY := $(TARGET_DIR)/$(TARGET_BASE)-$(BUILD_TYPE)$(TARGET_SUFFIX)
 
 # Preparations:

--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -559,7 +559,7 @@ void TiXmlElement::Print( FILE* cfile, int depth ) const
 		generic_fprintf( cfile, TEXT("    ") );
 	}
 
-	generic_fprintf( cfile, TEXT("<%s"), value.c_str() );
+	generic_fprintf( cfile, TEXT("<%ls"), value.c_str() );
 
 	TiXmlAttribute* attrib;
 	for ( attrib = attributeSet.First(); attrib; attrib = attrib->Next() )
@@ -581,7 +581,7 @@ void TiXmlElement::Print( FILE* cfile, int depth ) const
 	{
 		generic_fprintf( cfile, TEXT(">") );
 		firstChild->Print( cfile, depth + 1 );
-		generic_fprintf( cfile, TEXT("</%s>"), value.c_str() );
+		generic_fprintf( cfile, TEXT("</%ls>"), value.c_str() );
 	}
 	else
 	{
@@ -598,7 +598,7 @@ void TiXmlElement::Print( FILE* cfile, int depth ) const
 		generic_fprintf( cfile, TEXT("\n") );
 		for( i=0; i<depth; ++i )
 		generic_fprintf( cfile, TEXT("    ") );
-		generic_fprintf( cfile, TEXT("</%s>"), value.c_str() );
+		generic_fprintf( cfile, TEXT("</%ls>"), value.c_str() );
 	}
 }
 
@@ -840,9 +840,9 @@ void TiXmlAttribute::Print( FILE* cfile, int /*depth*/ ) const
 	PutString( Value(), &v );
 
 	if (value.find ('\"') == TIXML_STRING::npos)
-		generic_fprintf (cfile, TEXT("%s=\"%s\""), n.c_str(), v.c_str() );
+		generic_fprintf (cfile, TEXT("%ls=\"%ls\""), n.c_str(), v.c_str() );
 	else
-		generic_fprintf (cfile, TEXT("%s='%s'"), n.c_str(), v.c_str() );
+		generic_fprintf (cfile, TEXT("%ls='%ls'"), n.c_str(), v.c_str() );
 }
 
 
@@ -908,7 +908,7 @@ void TiXmlComment::Print( FILE* cfile, int depth ) const
 	{
 		fputs( "    ", cfile );
 	}
-	generic_fprintf( cfile, TEXT("<!--%s-->"), value.c_str() );
+	generic_fprintf( cfile, TEXT("<!--%ls-->"), value.c_str() );
 }
 
 void TiXmlComment::StreamOut( TIXML_OSTREAM * stream ) const
@@ -934,7 +934,7 @@ void TiXmlText::Print( FILE* cfile, int /*depth*/ ) const
 {
 	TIXML_STRING buffer;
 	PutString( value, &buffer );
-	generic_fprintf( cfile, TEXT("%s"), buffer.c_str() );
+	generic_fprintf( cfile, TEXT("%ls"), buffer.c_str() );
 }
 
 
@@ -973,11 +973,11 @@ void TiXmlDeclaration::Print( FILE* cfile, int /*depth*/ ) const
 	generic_fprintf (cfile, TEXT("<?xml "));
 
 	if ( !version.empty() )
-		generic_fprintf (cfile, TEXT("version=\"%s\" "), version.c_str ());
+		generic_fprintf (cfile, TEXT("version=\"%ls\" "), version.c_str ());
 	if ( !encoding.empty() )
-		generic_fprintf (cfile, TEXT("encoding=\"%s\" "), encoding.c_str ());
+		generic_fprintf (cfile, TEXT("encoding=\"%ls\" "), encoding.c_str ());
 	if ( !standalone.empty() )
-		generic_fprintf (cfile, TEXT("standalone=\"%s\" "), standalone.c_str ());
+		generic_fprintf (cfile, TEXT("standalone=\"%ls\" "), standalone.c_str ());
 	generic_fprintf (cfile, TEXT("?>"));
 }
 
@@ -1025,7 +1025,7 @@ void TiXmlUnknown::Print( FILE* cfile, int depth ) const
 {
 	for ( int i=0; i<depth; i++ )
 		generic_fprintf( cfile, TEXT("    ") );
-	generic_fprintf( cfile, TEXT("%s"), value.c_str() );
+	generic_fprintf( cfile, TEXT("%ls"), value.c_str() );
 }
 
 void TiXmlUnknown::StreamOut( TIXML_OSTREAM * stream ) const

--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -906,7 +906,7 @@ void TiXmlComment::Print( FILE* cfile, int depth ) const
 {
 	for ( int i=0; i<depth; i++ )
 	{
-		fputs( "    ", cfile );
+		generic_fprintf( cfile, TEXT("    ") );
 	}
 	generic_fprintf( cfile, TEXT("<!--%ls-->"), value.c_str() );
 }


### PR DESCRIPTION
As a non-unicode build is no longer possible, wide-char specifiers can be used.

Fixes #9163 and the second part of #10185.