### PR TITLE
Try to fix Find dialog glitch

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -398,7 +398,7 @@ private:
 	ScintillaCtrls _scintillaCtrls4Plugins;
 
 	std::vector<std::pair<int, int> > _hideLinesMarks;
-	StyleArray _hotspotStyles;
+	StyleArray* _hotspotStyles = new StyleArray;
 
 	AnsiCharPanel* _pAnsiCharPanel = nullptr;
 	ClipboardHistoryPanel* _pClipboardHistoryPanel = nullptr;

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -927,7 +927,7 @@ bool NppParameters::reloadStylers(const TCHAR* stylePath)
 		return false;
 	}
 	_lexerStylerVect.clear();
-	_widgetStyleArray.clear();
+	_widgetStyleArray->clear();
 
 	getUserStylersFromXmlTree();
 
@@ -1594,7 +1594,7 @@ UserLangContainer* NppParameters::getULCFromName(const TCHAR *userLangName)
 
 COLORREF NppParameters::getCurLineHilitingColour()
 {
-	const Style * pStyle = _widgetStyleArray.findByName(TEXT("Current line background colour"));
+	const Style * pStyle = _widgetStyleArray->findByName(TEXT("Current line background colour"));
 	if (!pStyle)
 		return COLORREF(-1);
 	return pStyle->_bgColor;
@@ -1603,7 +1603,7 @@ COLORREF NppParameters::getCurLineHilitingColour()
 
 void NppParameters::setCurLineHilitingColour(COLORREF colour2Set)
 {
-	Style * pStyle = _widgetStyleArray.findByName(TEXT("Current line background colour"));
+	Style * pStyle = _widgetStyleArray->findByName(TEXT("Current line background colour"));
 	if (!pStyle)
 		return;
 	pStyle->_bgColor = colour2Set;
@@ -2773,9 +2773,9 @@ std::pair<unsigned char, unsigned char> NppParameters::feedUserLang(TiXmlNode *n
 			// styles that were not read from xml file should get default values
 			for (int i = 0 ; i < SCE_USER_STYLE_TOTAL_STYLES ; ++i)
 			{
-				const Style * pStyle = _userLangArray[_nbUserLang - 1]->_styles.findByID(i);
+				const Style * pStyle = _userLangArray[_nbUserLang - 1]->_styles->findByID(i);
 				if (!pStyle)
-					_userLangArray[_nbUserLang - 1]->_styles.addStyler(i, globalMappper().styleNameMapper[i]);
+					_userLangArray[_nbUserLang - 1]->_styles->addStyler(i, globalMappper().styleNameMapper[i]);
 			}
 
 		}
@@ -3547,7 +3547,7 @@ void NppParameters::feedUserStyles(TiXmlNode *node)
 			if (globalMappper().styleIdMapper.find(styleName) != globalMappper().styleIdMapper.end())
 			{
 				id = globalMappper().styleIdMapper[styleName];
-				_userLangArray[_nbUserLang - 1]->_styles.addStyler((id | L_USER << 16), childNode);
+				_userLangArray[_nbUserLang - 1]->_styles->addStyler((id | L_USER << 16), childNode);
 			}
 		}
 	}
@@ -3594,7 +3594,7 @@ bool NppParameters::feedStylerArray(TiXmlNode *node)
 		int styleID = -1;
 		if ((styleID = decStrVal(styleIDStr)) != -1)
 		{
-			_widgetStyleArray.addStyler(styleID, childNode);
+			_widgetStyleArray->addStyler(styleID, childNode);
 		}
 	}
 	return true;
@@ -7116,7 +7116,7 @@ generic_string NppParameters::writeStyles(LexerStylerArray & lexersStylers, Styl
 	{
 		TiXmlElement *pElement = childNode->ToElement();
 		const TCHAR *styleName = pElement->Attribute(TEXT("name"));
-		const Style * pStyle = _widgetStyleArray.findByName(styleName);
+		const Style * pStyle = _widgetStyleArray->findByName(styleName);
 		Style * pStyle2Sync = globalStylers.findByName(styleName);
 		if (pStyle && pStyle2Sync)
 		{
@@ -7255,7 +7255,7 @@ void NppParameters::insertUserLang2Tree(TiXmlNode *node, UserLangContainer *user
 
 	TiXmlElement *styleRootElement = (rootElement->InsertEndChild(TiXmlElement(TEXT("Styles"))))->ToElement();
 
-	for (const Style & style2Write : userLang->_styles)
+	for (const Style & style2Write : *(userLang->_styles))
 	{
 		TiXmlElement *styleElement = (styleRootElement->InsertEndChild(TiXmlElement(TEXT("WordsStyle"))))->ToElement();
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1014,7 +1014,7 @@ public:
 			this->_forcePureLC = ulc._forcePureLC;
 			this->_decimalSeparator = ulc._decimalSeparator;
 			this->_foldCompact = ulc._foldCompact;
-			for (Style & st : this->_styles)
+			for (Style & st : *(this->_styles))
 			{
 				if (st._bgColor == COLORREF(-1))
 					st._bgColor = white;
@@ -1036,7 +1036,7 @@ public:
 	const TCHAR * getUdlVersion() {return _udlVersion.c_str();};
 
 private:
-	StyleArray _styles;
+	StyleArray* _styles = new StyleArray;
 	generic_string _name;
 	generic_string _ext;
 	generic_string _udlVersion;
@@ -1404,9 +1404,9 @@ public:
 	bool insertTabInfo(const TCHAR *langName, int tabInfo);
 
 	LexerStylerArray & getLStylerArray() {return _lexerStylerVect;};
-	StyleArray & getGlobalStylers() {return _widgetStyleArray;};
+	StyleArray & getGlobalStylers() {return *_widgetStyleArray;};
 
-	StyleArray & getMiscStylerArray() {return _widgetStyleArray;};
+	StyleArray & getMiscStylerArray() {return *_widgetStyleArray;};
 	GlobalOverride & getGlobalOverrideStyle() {return _nppGUI._globalOverride;};
 
 	COLORREF getCurLineHilitingColour();
@@ -1712,7 +1712,7 @@ private:
 
 	FindHistory _findHistory;
 
-	UserLangContainer *_userLangArray[NB_MAX_USER_LANG];
+	UserLangContainer* _userLangArray[NB_MAX_USER_LANG];
 	unsigned char _nbUserLang = 0; // won't be exceeded to 255;
 	generic_string _userDefineLangsFolderPath;
 	generic_string _userDefineLangPath;
@@ -1726,7 +1726,7 @@ private:
 
 	// All Styles (colours & fonts)
 	LexerStylerArray _lexerStylerVect;
-	StyleArray _widgetStyleArray;
+	StyleArray* _widgetStyleArray = new StyleArray;
 
 	std::vector<generic_string> _fontlist;
 	std::vector<generic_string> _blacklist;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -859,7 +859,7 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 	sprintf(intBuffer, "%" PRIuPTR, reinterpret_cast<uintptr_t>(_currentBufferID)); // use numeric value of BufferID pointer
     execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("userDefine.currentBufferID"), reinterpret_cast<LPARAM>(intBuffer));
 
-	for (const Style & style : userLangContainer->_styles)
+	for (const Style & style : *(userLangContainer->_styles))
 	{
 		if (style._styleID == STYLE_NOT_USED)
 			continue;

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -865,30 +865,30 @@ UserDefineDialog::UserDefineDialog(): SharedParametersDialog()
 {
     _pCurrentUserLang = new UserLangContainer();
 
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DEFAULT,              globalMappper().styleNameMapper[SCE_USER_STYLE_DEFAULT].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_COMMENT,              globalMappper().styleNameMapper[SCE_USER_STYLE_COMMENT].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_COMMENTLINE,          globalMappper().styleNameMapper[SCE_USER_STYLE_COMMENTLINE].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_NUMBER,               globalMappper().styleNameMapper[SCE_USER_STYLE_NUMBER].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD1,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD1].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD2,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD2].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD3,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD3].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD4,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD4].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD5,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD5].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD6,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD6].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD7,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD7].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_KEYWORD8,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD8].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_OPERATOR,             globalMappper().styleNameMapper[SCE_USER_STYLE_OPERATOR].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_FOLDER_IN_CODE1,      globalMappper().styleNameMapper[SCE_USER_STYLE_FOLDER_IN_CODE1].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_FOLDER_IN_CODE2,      globalMappper().styleNameMapper[SCE_USER_STYLE_FOLDER_IN_CODE2].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_FOLDER_IN_COMMENT,    globalMappper().styleNameMapper[SCE_USER_STYLE_FOLDER_IN_COMMENT].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER1,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER1].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER2,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER2].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER3,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER3].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER4,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER4].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER5,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER5].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER6,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER6].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER7,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER7].c_str());
-    _pCurrentUserLang->_styles.addStyler(SCE_USER_STYLE_DELIMITER8,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER8].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DEFAULT,              globalMappper().styleNameMapper[SCE_USER_STYLE_DEFAULT].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_COMMENT,              globalMappper().styleNameMapper[SCE_USER_STYLE_COMMENT].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_COMMENTLINE,          globalMappper().styleNameMapper[SCE_USER_STYLE_COMMENTLINE].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_NUMBER,               globalMappper().styleNameMapper[SCE_USER_STYLE_NUMBER].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD1,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD1].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD2,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD2].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD3,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD3].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD4,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD4].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD5,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD5].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD6,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD6].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD7,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD7].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_KEYWORD8,             globalMappper().styleNameMapper[SCE_USER_STYLE_KEYWORD8].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_OPERATOR,             globalMappper().styleNameMapper[SCE_USER_STYLE_OPERATOR].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_FOLDER_IN_CODE1,      globalMappper().styleNameMapper[SCE_USER_STYLE_FOLDER_IN_CODE1].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_FOLDER_IN_CODE2,      globalMappper().styleNameMapper[SCE_USER_STYLE_FOLDER_IN_CODE2].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_FOLDER_IN_COMMENT,    globalMappper().styleNameMapper[SCE_USER_STYLE_FOLDER_IN_COMMENT].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER1,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER1].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER2,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER2].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER3,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER3].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER4,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER4].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER5,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER5].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER6,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER6].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER7,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER7].c_str());
+    _pCurrentUserLang->_styles->addStyler(SCE_USER_STYLE_DELIMITER8,           globalMappper().styleNameMapper[SCE_USER_STYLE_DELIMITER8].c_str());
 }
 
 UserDefineDialog::~UserDefineDialog()
@@ -1726,7 +1726,7 @@ INT_PTR CALLBACK StylerDlg::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPAR
 
             ::SetProp(hwnd, TEXT("Styler dialog prop"), (HANDLE)lParam);
             dlg = (StylerDlg *)::GetProp(hwnd, TEXT("Styler dialog prop"));
-            Style & style = SharedParametersDialog::_pUserLang->_styles.getStyler(dlg->_stylerIndex);
+            Style & style = SharedParametersDialog::_pUserLang->_styles->getStyler(dlg->_stylerIndex);
 
             // move dialog over UDL GUI (position 0,0 of UDL window) so it wouldn't cover the code
             RECT wrc;
@@ -1848,7 +1848,7 @@ INT_PTR CALLBACK StylerDlg::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPAR
 			if (dlg == nullptr)
 				return FALSE;
 
-            Style & style = SharedParametersDialog::_pUserLang->_styles.getStyler(dlg->_stylerIndex);
+            Style & style = SharedParametersDialog::_pUserLang->_styles->getStyler(dlg->_stylerIndex);
             if (HIWORD(wParam) == CBN_SELCHANGE)
             {
                 auto i = ::SendDlgItemMessage(hwnd, LOWORD(wParam), CB_GETCURSEL, 0, 0);

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.h
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.h
@@ -433,7 +433,7 @@ public:
         _hInst(hInst), _parent(parent), _stylerIndex(stylerIndex), _enabledNesters(enabledNesters) {
         _pFgColour = new ColourPicker;
         _pBgColour = new ColourPicker;
-        _initialStyle = SharedParametersDialog::_pUserLang->_styles.getStyler(stylerIndex);
+        _initialStyle = SharedParametersDialog::_pUserLang->_styles->getStyler(stylerIndex);
     };
 
     ~StylerDlg() {

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -298,11 +298,13 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 							if (_restoreInvalid)
 							{
 								_lsArray = _styles2restored = lsArray;
-								_globalStyles = _gstyles2restored = globalStyles;
+								*_globalStyles = globalStyles;
+								*_gstyles2restored =  globalStyles;
 							}
 							else
 							{
-								globalStyles = _globalStyles = _gstyles2restored;
+								globalStyles = *_gstyles2restored;
+								*_globalStyles = *_gstyles2restored;
 								lsArray = _lsArray = _styles2restored;
 							}
 
@@ -331,7 +333,7 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 							StyleArray & globalStyles = (NppParameters::getInstance()).getGlobalStylers();
 
 							_lsArray = lsa;
-							_globalStyles = globalStyles;
+							*_globalStyles = globalStyles;
 							updateThemeName(_themeName);
 							_restoreInvalid = false;
 
@@ -340,7 +342,7 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 							_isDirty = false;
 						}
 						_isThemeDirty = false;
-						auto newSavedFilePath = (NppParameters::getInstance()).writeStyles(_lsArray, _globalStyles);
+						auto newSavedFilePath = (NppParameters::getInstance()).writeStyles(_lsArray, *_globalStyles);
 						if (!newSavedFilePath.empty())
 							updateThemeName(newSavedFilePath);
 
@@ -538,7 +540,7 @@ void WordStyleDlg::loadLangListFromNppParam()
 {
 	NppParameters& nppParamInst = NppParameters::getInstance();
 	_lsArray = nppParamInst.getLStylerArray();
-	_globalStyles = nppParamInst.getGlobalStylers();
+	*_globalStyles = nppParamInst.getGlobalStylers();
 
 	// Clean up Language List
 	::SendDlgItemMessage(_hSelf, IDC_LANGUAGES_LIST, LB_RESETCONTENT, 0, 0);
@@ -743,7 +745,7 @@ void WordStyleDlg::switchToTheme()
 				themeFileName,
 				MB_ICONWARNING | MB_YESNO | MB_APPLMODAL | MB_SETFOREGROUND );
 		if ( mb_response == IDYES )
-			(NppParameters::getInstance()).writeStyles(_lsArray, _globalStyles);
+			(NppParameters::getInstance()).writeStyles(_lsArray, *_globalStyles);
 	}
 	nppParamInst.reloadStylers(_themeName.c_str());
 
@@ -806,7 +808,7 @@ void WordStyleDlg::setStyleListFromLexer(int index)
 	::ShowWindow(::GetDlgItem(_hSelf, IDC_USER_EXT_STATIC), index?SW_SHOW:SW_HIDE);
 	::ShowWindow(::GetDlgItem(_hSelf, IDC_PLUSSYMBOL2_STATIC), index?SW_SHOW:SW_HIDE);
 
-	StyleArray & lexerStyler = index?_lsArray.getLexerFromIndex(index-1):_globalStyles;
+	StyleArray & lexerStyler = index?_lsArray.getLexerFromIndex(index-1):*_globalStyles;
 
 	for (const Style & style : lexerStyler)
 	{
@@ -1001,7 +1003,7 @@ void WordStyleDlg::apply()
 	StyleArray & globalStyles = (NppParameters::getInstance()).getGlobalStylers();
 
 	lsa = _lsArray;
-	globalStyles = _globalStyles;
+	globalStyles = *_globalStyles;
 
 	::EnableWindow(::GetDlgItem(_hSelf, IDOK), FALSE);
 	::SendMessage(_hParent, WM_UPDATESCINTILLAS, 0, 0);

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
@@ -82,7 +82,7 @@ public :
 
 	void prepare2Cancel() {
 		_styles2restored = (NppParameters::getInstance()).getLStylerArray();
-		_gstyles2restored = (NppParameters::getInstance()).getGlobalStylers();
+		*_gstyles2restored = (NppParameters::getInstance()).getGlobalStylers();
 		_gOverride2restored = (NppParameters::getInstance()).getGlobalOverrideStyle();
 	};
 
@@ -130,11 +130,11 @@ private :
 	HWND _hStyleInfoStaticText = nullptr;
 
 	LexerStylerArray _lsArray;
-    StyleArray _globalStyles;
+    StyleArray* _globalStyles = new StyleArray;
 	generic_string _themeName;
 
 	LexerStylerArray _styles2restored;
-	StyleArray _gstyles2restored;
+	StyleArray* _gstyles2restored = new StyleArray;
 	GlobalOverride _gOverride2restored;
 	bool _restoreInvalid = false;
 
@@ -154,7 +154,7 @@ private :
 
         if (_currentLexerIndex == 0)
 		{
-            return _globalStyles.getStyler(styleIndex);
+            return _globalStyles->getStyler(styleIndex);
 		}
         else
         {


### PR DESCRIPTION
The issue #10511 could be due to stack corrupted because all StylerArray objects are in stack.
This PR allocate all StylerArray objects dynamically.
However, as comment said (https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10511#issuecomment-914617113), it doesn't fix the problem.