### PR TITLE
fix #10511 (Find dialog glitch) caused by unintialized member variable

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -363,8 +363,8 @@ protected :
 
 private :
 	RECT _initialWindowRect;
-	LONG _deltaWidth;
-	LONG _initialClientWidth;
+	LONG _deltaWidth = 0;
+	LONG _initialClientWidth = 0;
 
 	DIALOG_TYPE _currentStatus;
 	RECT _findClosePos, _replaceClosePos, _findInFilesClosePos, _markClosePos;


### PR DESCRIPTION
fix #10511 (Find dialog glitch) caused by uninitialized member variable in `FindReplaceDlg`