### PR TITLE
fix #10454 (open crash) properly

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -57,11 +57,6 @@ filePath : file or folder name to open (absolute or relative path name)\r\
 class Notepad_plus_Window : public Window
 {
 public:
-	static Notepad_plus_Window & getInstance() {
-		static Notepad_plus_Window * instance = new Notepad_plus_Window;
-		return *instance;
-	}
-
 	void init(HINSTANCE, HWND, const TCHAR *cmdLine, CmdLineParams *cmdLineParams);
 
 	bool isDlgsMsg(MSG *msg) const;

--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -57,6 +57,11 @@ filePath : file or folder name to open (absolute or relative path name)\r\
 class Notepad_plus_Window : public Window
 {
 public:
+	static Notepad_plus_Window & getInstance() {
+		static Notepad_plus_Window * instance = new Notepad_plus_Window;
+		return *instance;
+	}
+
 	void init(HINSTANCE, HWND, const TCHAR *cmdLine, CmdLineParams *cmdLineParams);
 
 	bool isDlgsMsg(MSG *msg) const;

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -20,6 +20,7 @@
 #include "MiniDumper.h"			//Write dump files
 #include "verifySignedfile.h"
 #include "NppDarkMode.h"
+#include <memory>
 
 typedef std::vector<generic_string> ParamVector;
 
@@ -609,7 +610,8 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
         }
 	}
 
-	Notepad_plus_Window & notepad_plus_plus = Notepad_plus_Window::getInstance();
+	auto upNotepadWindow = std::make_unique<Notepad_plus_Window>();
+	Notepad_plus_Window & notepad_plus_plus = *upNotepadWindow.get();
 
 	generic_string updaterDir = nppParameters.getNppPath();
 	updaterDir += TEXT("\\updater\\");

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -609,7 +609,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
         }
 	}
 
-	Notepad_plus_Window notepad_plus_plus;
+	Notepad_plus_Window & notepad_plus_plus = Notepad_plus_Window::getInstance();
 
 	generic_string updaterDir = nppParameters.getNppPath();
 	updaterDir += TEXT("\\updater\\");


### PR DESCRIPTION
`Notepad_plus_Window` was rather huge (megabytes). Now it's small (tens of kilobytes), but to safeguard against future size increase move its allocation from the stack into the heap.

fix #10454 (open crash)