### PR TITLE
Document List: Additional path column feature

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1279,6 +1279,7 @@ Continue?"/>
             <PanelTitle name="Document List"/>
             <ColumnName name="Name"/>
             <ColumnExt name="Ext."/>
+            <ColumnPath name="Path"/>
         </DocList>
         <WindowsDlg>
             <ColumnName name="Name"/>

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -383,9 +383,13 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64 };
 	// INT NPPM_GETCURRENTVIEW(0, 0)
 	// Return: current edit view of Notepad++. Only 2 possible values: 0 = Main, 1 = Secondary
 
-	#define NPPM_DOCLISTDISABLECOLUMN    (NPPMSG + 89)
-	// VOID NPPM_DOCLISTDISABLECOLUMN(0, BOOL disableOrNot)
+	#define NPPM_DOCLISTDISABLEEXTCOLUMN    (NPPMSG + 89)
+	// VOID NPPM_DOCLISTDISABLEEXTCOLUMN(0, BOOL disableOrNot)
 	// Disable or enable extension column of Document List
+
+	#define NPPM_DOCLISTDISABLEPATHCOLUMN    (NPPMSG + 102)
+	// VOID NPPM_DOCLISTDISABLEPATHCOLUMN(0, BOOL disableOrNot)
+	// Disable or enable path column of Document List
 
 	#define NPPM_GETEDITORDEFAULTFOREGROUNDCOLOR    (NPPMSG + 90)
 	// INT NPPM_GETEDITORDEFAULTFOREGROUNDCOLOR(0, 0)

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2451,11 +2451,16 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return langDesc.length();
 		}
 
-		case NPPM_DOCLISTDISABLECOLUMN:
+		case NPPM_DOCLISTDISABLEPATHCOLUMN:
+		case NPPM_DOCLISTDISABLEEXTCOLUMN:
 		{
 			BOOL isOff = static_cast<BOOL>(lParam);
 			NppGUI & nppGUI = nppParam.getNppGUI();
-			nppGUI._fileSwitcherWithoutExtColumn = isOff == TRUE;
+
+			if(message == NPPM_DOCLISTDISABLEEXTCOLUMN)
+				nppGUI._fileSwitcherWithoutExtColumn = isOff == TRUE;
+			else
+				nppGUI._fileSwitcherWithoutPathColumn = isOff == TRUE;
 
 			if (_pDocumentListPanel)
 			{

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2457,7 +2457,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			BOOL isOff = static_cast<BOOL>(lParam);
 			NppGUI & nppGUI = nppParam.getNppGUI();
 
-			if(message == NPPM_DOCLISTDISABLEEXTCOLUMN)
+			if (message == NPPM_DOCLISTDISABLEEXTCOLUMN)
 				nppGUI._fileSwitcherWithoutExtColumn = isOff == TRUE;
 			else
 				nppGUI._fileSwitcherWithoutPathColumn = isOff == TRUE;

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5364,6 +5364,17 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			const TCHAR * optName = element->Attribute(TEXT("fileSwitcherWithoutExtColumn"));
 			if (optName)
 				_nppGUI._fileSwitcherWithoutExtColumn = (lstrcmp(optName, TEXT("yes")) == 0);
+			
+			int i;
+			if (element->Attribute(TEXT("fileSwitcherExtWidth"), &i))
+				_nppGUI._fileSwitcherExtWidth = i;
+
+			const TCHAR * optNamePath = element->Attribute(TEXT("fileSwitcherWithoutPathColumn"));
+			if (optNamePath)
+				_nppGUI._fileSwitcherWithoutPathColumn = (lstrcmp(optNamePath, TEXT("yes")) == 0);
+
+			if (element->Attribute(TEXT("fileSwitcherPathWidth"), &i))
+				_nppGUI._fileSwitcherPathWidth = i;
 
 			const TCHAR * optNameBackSlashEscape = element->Attribute(TEXT("backSlashIsEscapeCharacterForSql"));
 			if (optNameBackSlashEscape && !lstrcmp(optNameBackSlashEscape, TEXT("no")))
@@ -6428,6 +6439,9 @@ void NppParameters::createXmlTreeFromGUIParams()
 		GUIConfigElement->SetAttribute(TEXT("name"), TEXT("MISC"));
 
 		GUIConfigElement->SetAttribute(TEXT("fileSwitcherWithoutExtColumn"), _nppGUI._fileSwitcherWithoutExtColumn ? TEXT("yes") : TEXT("no"));
+		GUIConfigElement->SetAttribute(TEXT("fileSwitcherExtWidth"), _nppGUI._fileSwitcherExtWidth);
+		GUIConfigElement->SetAttribute(TEXT("fileSwitcherWithoutPathColumn"), _nppGUI._fileSwitcherWithoutPathColumn ? TEXT("yes") : TEXT("no"));
+		GUIConfigElement->SetAttribute(TEXT("fileSwitcherPathWidth"), _nppGUI._fileSwitcherPathWidth);
 		GUIConfigElement->SetAttribute(TEXT("backSlashIsEscapeCharacterForSql"), _nppGUI._backSlashIsEscapeCharacterForSql ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("writeTechnologyEngine"), _nppGUI._writeTechnologyEngine);
 		GUIConfigElement->SetAttribute(TEXT("isFolderDroppedOpenFiles"), _nppGUI._isFolderDroppedOpenFiles ? TEXT("yes") : TEXT("no"));

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5365,7 +5365,7 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			if (optName)
 				_nppGUI._fileSwitcherWithoutExtColumn = (lstrcmp(optName, TEXT("yes")) == 0);
 			
-			int i;
+			int i = 0;
 			if (element->Attribute(TEXT("fileSwitcherExtWidth"), &i))
 				_nppGUI._fileSwitcherExtWidth = i;
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -833,6 +833,9 @@ struct NppGUI final
 	generic_string _themeName;
 	MultiInstSetting _multiInstSetting = monoInst;
 	bool _fileSwitcherWithoutExtColumn = false;
+	int _fileSwitcherExtWidth = 50;
+	bool _fileSwitcherWithoutPathColumn = false;
+	int _fileSwitcherPathWidth = 50;
 	bool isSnapshotMode() const {return _isSnapshotMode && _rememberLastSession && !_isCmdlineNosessionActivated;};
 	bool _isSnapshotMode = true;
 	size_t _snapshotBackupTiming = 7000;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -832,9 +832,9 @@ struct NppGUI final
 	TCHAR _defaultDirExp[MAX_PATH];	//expanded environment variables
 	generic_string _themeName;
 	MultiInstSetting _multiInstSetting = monoInst;
-	bool _fileSwitcherWithoutExtColumn = false;
+	bool _fileSwitcherWithoutExtColumn = true;
 	int _fileSwitcherExtWidth = 50;
-	bool _fileSwitcherWithoutPathColumn = false;
+	bool _fileSwitcherWithoutPathColumn = true;
 	int _fileSwitcherPathWidth = 50;
 	bool isSnapshotMode() const {return _isSnapshotMode && _rememberLastSession && !_isCmdlineNosessionActivated;};
 	bool _isSnapshotMode = true;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -26,6 +26,7 @@
 #define GET_Y_LPARAM(lp) static_cast<short>(HIWORD(lp))
 
 #define CLMNEXT_ID     1
+#define CLMNPATH_ID    2
 
 int CALLBACK ListViewCompareProc(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort)
 {
@@ -195,6 +196,29 @@ INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, 
 					}
 					return TRUE;
 				}
+				case HDN_DIVIDERDBLCLICK:
+				case HDN_ENDTRACK:
+				{
+					NppParameters& nppParams = NppParameters::getInstance();
+					NativeLangSpeaker* pNativeSpeaker = nppParams.getNativeLangSpeaker();
+					
+					LPNMHEADER test = (LPNMHEADER)lParam;
+					HWND hwndHD = ListView_GetHeader(_fileListView.getHSelf());
+					TCHAR HDtext[MAX_PATH];
+					HDITEM hdi = { 0 };
+					hdi.mask = HDI_TEXT | HDI_WIDTH;
+					hdi.pszText = HDtext;
+					hdi.cchTextMax = MAX_PATH;
+					Header_GetItem(hwndHD, test->iItem, &hdi);
+
+					// storing column width data
+					if (hdi.pszText == pNativeSpeaker->getAttrNameStr(TEXT("Ext."), FS_ROOTNODE, FS_CLMNEXT))
+						nppParams.getNppGUI()._fileSwitcherExtWidth = hdi.cxy;
+					else if (hdi.pszText == pNativeSpeaker->getAttrNameStr(TEXT("Path"), FS_ROOTNODE, FS_CLMNPATH))
+						nppParams.getNppGUI()._fileSwitcherPathWidth = hdi.cxy;
+
+					return TRUE;
+				}
 				case LVN_KEYDOWN:
 				{
 					switch (((LPNMLVKEYDOWN)lParam)->wVKey)
@@ -227,7 +251,7 @@ INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, 
 
         case WM_SIZE:
         {
-            int width = LOWORD(lParam);
+			int width = LOWORD(lParam);
             int height = HIWORD(lParam);
 			::MoveWindow(_fileListView.getHSelf(), 0, 0, width, height, TRUE);
 			_fileListView.resizeColumns(width);
@@ -268,12 +292,16 @@ void VerticalFileSwitcher::initPopupMenus()
 	NativeLangSpeaker* pNativeSpeaker = NppParameters::getInstance().getNativeLangSpeaker();
 
 	generic_string extStr = pNativeSpeaker->getAttrNameStr(TEXT("Ext."), FS_ROOTNODE, FS_CLMNEXT);
+	generic_string pathStr = pNativeSpeaker->getAttrNameStr(TEXT("Path"), FS_ROOTNODE, FS_CLMNPATH);
 
 	_hGlobalMenu = ::CreatePopupMenu();
 	::InsertMenu(_hGlobalMenu, 0, MF_BYCOMMAND, CLMNEXT_ID, extStr.c_str());
+	::InsertMenu(_hGlobalMenu, 0, MF_BYCOMMAND, CLMNPATH_ID, pathStr.c_str());
 
 	bool isExtColumn = NppParameters::getInstance().getNppGUI()._fileSwitcherWithoutExtColumn;
 	::CheckMenuItem(_hGlobalMenu, CLMNEXT_ID, MF_BYCOMMAND | isExtColumn ? MF_UNCHECKED : MF_CHECKED);
+	bool isPathColumn = NppParameters::getInstance().getNppGUI()._fileSwitcherWithoutPathColumn;
+	::CheckMenuItem(_hGlobalMenu, CLMNPATH_ID, MF_BYCOMMAND | isPathColumn ? MF_UNCHECKED : MF_CHECKED);
 }
 
 void VerticalFileSwitcher::popupMenuCmd(int cmdID)
@@ -285,6 +313,14 @@ void VerticalFileSwitcher::popupMenuCmd(int cmdID)
 			bool& isExtColumn = NppParameters::getInstance().getNppGUI()._fileSwitcherWithoutExtColumn;
 			isExtColumn = !isExtColumn;
 			::CheckMenuItem(_hGlobalMenu, CLMNEXT_ID, MF_BYCOMMAND | isExtColumn ? MF_UNCHECKED : MF_CHECKED);
+			reload();
+		}
+		break;
+		case CLMNPATH_ID:
+		{
+			bool& isPathColumn = NppParameters::getInstance().getNppGUI()._fileSwitcherWithoutPathColumn;
+			isPathColumn = !isPathColumn;
+			::CheckMenuItem(_hGlobalMenu, CLMNPATH_ID, MF_BYCOMMAND | isPathColumn ? MF_UNCHECKED : MF_CHECKED);
 			reload();
 		}
 		break;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -290,6 +290,7 @@ INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, 
 void VerticalFileSwitcher::initPopupMenus()
 {
 	NativeLangSpeaker* pNativeSpeaker = NppParameters::getInstance().getNativeLangSpeaker();
+	NppGUI& nppGUI = NppParameters::getInstance().getNppGUI();
 
 	generic_string extStr = pNativeSpeaker->getAttrNameStr(TEXT("Ext."), FS_ROOTNODE, FS_CLMNEXT);
 	generic_string pathStr = pNativeSpeaker->getAttrNameStr(TEXT("Path"), FS_ROOTNODE, FS_CLMNPATH);
@@ -298,9 +299,9 @@ void VerticalFileSwitcher::initPopupMenus()
 	::InsertMenu(_hGlobalMenu, 0, MF_BYCOMMAND, CLMNEXT_ID, extStr.c_str());
 	::InsertMenu(_hGlobalMenu, 0, MF_BYCOMMAND, CLMNPATH_ID, pathStr.c_str());
 
-	bool isExtColumn = NppParameters::getInstance().getNppGUI()._fileSwitcherWithoutExtColumn;
+	bool isExtColumn = nppGUI._fileSwitcherWithoutExtColumn;
 	::CheckMenuItem(_hGlobalMenu, CLMNEXT_ID, MF_BYCOMMAND | isExtColumn ? MF_UNCHECKED : MF_CHECKED);
-	bool isPathColumn = NppParameters::getInstance().getNppGUI()._fileSwitcherWithoutPathColumn;
+	bool isPathColumn = nppGUI._fileSwitcherWithoutPathColumn;
 	::CheckMenuItem(_hGlobalMenu, CLMNPATH_ID, MF_BYCOMMAND | isPathColumn ? MF_UNCHECKED : MF_CHECKED);
 }
 

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -177,8 +177,10 @@ void VerticalFileSwitcherListView::initList()
 		}
 		if (isPathColumn)
 		{
-			wcscpy_s(fn, fileNameStatus._fn.c_str());
-			ListView_SetItemText(_hSelf, i, ++colIndex, fn);
+			TCHAR dir[MAX_PATH], drive[MAX_PATH];
+			_wsplitpath_s(fileNameStatus._fn.c_str(), drive, MAX_PATH, dir, MAX_PATH, NULL, 0, NULL, 0);
+			wcscat_s(drive, dir);
+			ListView_SetItemText(_hSelf, i, ++colIndex, drive);
 		}
 	}
 	ListView_SetItemState(_hSelf, taskListInfo._currentIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
@@ -188,6 +190,10 @@ void VerticalFileSwitcherListView::reload()
 {
 	removeAll();
 	initList();
+
+	RECT rc;
+	::GetClientRect(_hParent, &rc);
+	resizeColumns(rc.right - rc.left);
 }
 
 BufferID VerticalFileSwitcherListView::getBufferInfoFromIndex(int index, int & view) const
@@ -253,8 +259,10 @@ void VerticalFileSwitcherListView::setItemIconStatus(BufferID bufferID)
 			}
 			if (isPathColumn)
 			{
-				wcscpy_s(fn, buf->getFullPathName());
-				ListView_SetItemText(_hSelf, i, ++colIndex, (LPTSTR)fn);
+				TCHAR dir[MAX_PATH], drive[MAX_PATH];
+				_wsplitpath_s(buf->getFullPathName(), drive, MAX_PATH, dir, MAX_PATH, NULL, 0, NULL, 0);
+				wcscat_s(drive, dir);
+				ListView_SetItemText(_hSelf, i, ++colIndex, drive);
 			}
 		}
 	}
@@ -299,13 +307,13 @@ int VerticalFileSwitcherListView::add(BufferID bufferID, int iView)
 	int index = ListView_GetItemCount(_hSelf);
 	Buffer *buf = static_cast<Buffer *>(bufferID);
 	const TCHAR *fileName = buf->getFileName();
-
+	NppGUI& nppGUI = NppParameters::getInstance().getNppGUI();
 	TaskLstFnStatus *tl = new TaskLstFnStatus(iView, 0, buf->getFullPathName(), 0, (void *)bufferID);
 
 	TCHAR fn[MAX_PATH];
 	wcscpy_s(fn, ::PathFindFileName(fileName));
-	bool isExtColumn = !(NppParameters::getInstance()).getNppGUI()._fileSwitcherWithoutExtColumn;
-	bool isPathColumn = !(NppParameters::getInstance()).getNppGUI()._fileSwitcherWithoutPathColumn;
+	bool isExtColumn = !nppGUI._fileSwitcherWithoutExtColumn;
+	bool isPathColumn = !nppGUI._fileSwitcherWithoutPathColumn;
 	if (isExtColumn)
 	{
 		::PathRemoveExtension(fn);
@@ -326,8 +334,10 @@ int VerticalFileSwitcherListView::add(BufferID bufferID, int iView)
 	}
 	if (isPathColumn)
 	{
-		wcscpy_s(fn, buf->getFullPathName());
-		ListView_SetItemText(_hSelf, index, ++colIndex, fn);
+		TCHAR dir[MAX_PATH], drive[MAX_PATH];
+		_wsplitpath_s(buf->getFullPathName(), drive, MAX_PATH, dir, MAX_PATH, NULL, 0, NULL, 0);
+		wcscat_s(drive, dir);
+		ListView_SetItemText(_hSelf, index, ++colIndex, drive);
 	}
 	ListView_SetItemState(_hSelf, index, LVIS_FOCUSED|LVIS_SELECTED, LVIS_FOCUSED|LVIS_SELECTED);
 	

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -115,52 +115,35 @@ LRESULT VerticalFileSwitcherListView::runProc(HWND hwnd, UINT Message, WPARAM wP
 
 void VerticalFileSwitcherListView::initList()
 {
-	HWND colHeader = reinterpret_cast<HWND>(SendMessage(_hSelf, LVM_GETHEADER, 0, 0));
-	int columnCount = static_cast<int32_t>(SendMessage(colHeader, HDM_GETITEMCOUNT, 0, 0));
-	
 	NppParameters& nppParams = NppParameters::getInstance();
 	NativeLangSpeaker *pNativeSpeaker = nppParams.getNativeLangSpeaker();
 	
 	bool isExtColumn = !nppParams.getNppGUI()._fileSwitcherWithoutExtColumn;
-	
-	// check if columns need to be added
-	if (columnCount <= 1)
-	{
-		RECT rc;
-		::GetClientRect(_hParent, &rc);
-		int totalWidth = rc.right - rc.left;
-		const int extColWidth =80;
+	bool isPathColumn = !nppParams.getNppGUI()._fileSwitcherWithoutPathColumn;
 
-		if (columnCount == 0)
-		{
-			generic_string nameStr = pNativeSpeaker->getAttrNameStr(TEXT("Name"), FS_ROOTNODE, FS_CLMNNAME);
-			insertColumn(nameStr.c_str(), (isExtColumn ? totalWidth - extColWidth : totalWidth), 1);
-		}
-		
-		if (isExtColumn)
-		{
-			// resize "Name" column when "exts" won't fit
-			LVCOLUMN lvc;
-			lvc.mask = LVCF_WIDTH;
-			SendMessage(_hSelf, LVM_GETCOLUMN, 0, reinterpret_cast<LPARAM>(&lvc));
-			
-			if (lvc.cx + extColWidth > totalWidth)
-			{
-				lvc.cx = totalWidth - extColWidth;
-				SendMessage(_hSelf, LVM_SETCOLUMN, 0, reinterpret_cast<LPARAM>(&lvc));
-			}
-			
-			generic_string extStr = pNativeSpeaker->getAttrNameStr(TEXT("Ext."), FS_ROOTNODE, FS_CLMNEXT);
-			insertColumn(extStr.c_str(), extColWidth, 2);
-		}
-	}
-	
-	// "exts" was disabled
-	if (columnCount >= 2 && !isExtColumn)
+	RECT rc;
+	::GetClientRect(_hParent, &rc);
+	int nameWidth = rc.right - rc.left;
+	int colIndex = 0;
+	if (isExtColumn)
+		nameWidth -= nppParams._dpiManager.scaleX(nppParams.getNppGUI()._fileSwitcherExtWidth);
+	if (isPathColumn)
+		nameWidth -= nppParams._dpiManager.scaleX(nppParams.getNppGUI()._fileSwitcherPathWidth);
+
+	//add columns
+	generic_string nameStr = pNativeSpeaker->getAttrNameStr(TEXT("Name"), FS_ROOTNODE, FS_CLMNNAME);
+	insertColumn(nameStr.c_str(), nameWidth, ++colIndex);
+	if (isExtColumn)
 	{
-		ListView_DeleteColumn(_hSelf, 1);
+		generic_string extStr = pNativeSpeaker->getAttrNameStr(TEXT("Ext."), FS_ROOTNODE, FS_CLMNEXT);
+		insertColumn(extStr.c_str(), nppParams._dpiManager.scaleX(nppParams.getNppGUI()._fileSwitcherExtWidth), ++colIndex); //2nd column
 	}
-	
+	if (isPathColumn)
+	{
+		generic_string pathStr = pNativeSpeaker->getAttrNameStr(TEXT("Path"), FS_ROOTNODE, FS_CLMNPATH);
+		insertColumn(pathStr.c_str(), nppParams._dpiManager.scaleX(nppParams.getNppGUI()._fileSwitcherPathWidth), ++colIndex); //2nd column if .ext is off
+	}
+
 	TaskListInfo taskListInfo;
 	static HWND nppHwnd = ::GetParent(_hParent);
 	::SendMessage(nppHwnd, WM_GETTASKLISTINFO, reinterpret_cast<WPARAM>(&taskListInfo), TRUE);
@@ -187,9 +170,15 @@ void VerticalFileSwitcherListView::initList()
 		item.iImage = fileNameStatus._status;
 		item.lParam = reinterpret_cast<LPARAM>(tl);
 		ListView_InsertItem(_hSelf, &item);
+		int colIndex = 0;
 		if (isExtColumn)
 		{
-			ListView_SetItemText(_hSelf, i, 1, ::PathFindExtension(fileNameStatus._fn.c_str()));
+			ListView_SetItemText(_hSelf, i, ++colIndex, ::PathFindExtension(fileNameStatus._fn.c_str()));
+		}
+		if (isPathColumn)
+		{
+			wcscpy_s(fn, fileNameStatus._fn.c_str());
+			ListView_SetItemText(_hSelf, i, ++colIndex, fn);
 		}
 	}
 	ListView_SetItemState(_hSelf, taskListInfo._currentIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
@@ -234,6 +223,7 @@ void VerticalFileSwitcherListView::setItemIconStatus(BufferID bufferID)
 	TCHAR fn[MAX_PATH];
 	wcscpy_s(fn, ::PathFindFileName(buf->getFileName()));
 	bool isExtColumn = !(NppParameters::getInstance()).getNppGUI()._fileSwitcherWithoutExtColumn;
+	bool isPathColumn = !(NppParameters::getInstance()).getNppGUI()._fileSwitcherWithoutPathColumn;
 	if (isExtColumn)
 	{
 		::PathRemoveExtension(fn);
@@ -256,10 +246,15 @@ void VerticalFileSwitcherListView::setItemIconStatus(BufferID bufferID)
 			tlfs->_fn = buf->getFullPathName();
 			item.mask = LVIF_TEXT | LVIF_IMAGE;
 			ListView_SetItem(_hSelf, &item);
-
+			int colIndex = 0;
 			if (isExtColumn)
 			{
-				ListView_SetItemText(_hSelf, i, 1, (LPTSTR)::PathFindExtension(buf->getFileName()));
+				ListView_SetItemText(_hSelf, i, ++colIndex, (LPTSTR)::PathFindExtension(buf->getFileName()));
+			}
+			if (isPathColumn)
+			{
+				wcscpy_s(fn, buf->getFullPathName());
+				ListView_SetItemText(_hSelf, i, ++colIndex, (LPTSTR)fn);
 			}
 		}
 	}
@@ -310,6 +305,7 @@ int VerticalFileSwitcherListView::add(BufferID bufferID, int iView)
 	TCHAR fn[MAX_PATH];
 	wcscpy_s(fn, ::PathFindFileName(fileName));
 	bool isExtColumn = !(NppParameters::getInstance()).getNppGUI()._fileSwitcherWithoutExtColumn;
+	bool isPathColumn = !(NppParameters::getInstance()).getNppGUI()._fileSwitcherWithoutPathColumn;
 	if (isExtColumn)
 	{
 		::PathRemoveExtension(fn);
@@ -323,10 +319,15 @@ int VerticalFileSwitcherListView::add(BufferID bufferID, int iView)
 	item.iImage = buf->isMonitoringOn()?3:(buf->isReadOnly()?2:(buf->isDirty()?1:0));
 	item.lParam = reinterpret_cast<LPARAM>(tl);
 	ListView_InsertItem(_hSelf, &item);
-
+	int colIndex = 0;
 	if (isExtColumn)
 	{
-		ListView_SetItemText(_hSelf, index, 1, ::PathFindExtension(fileName));
+		ListView_SetItemText(_hSelf, index, ++colIndex, ::PathFindExtension(fileName));
+	}
+	if (isPathColumn)
+	{
+		wcscpy_s(fn, buf->getFullPathName());
+		ListView_SetItemText(_hSelf, index, ++colIndex, fn);
 	}
 	ListView_SetItemState(_hSelf, index, LVIS_FOCUSED|LVIS_SELECTED, LVIS_FOCUSED|LVIS_SELECTED);
 	
@@ -352,6 +353,14 @@ void VerticalFileSwitcherListView::removeAll()
 	for (int i = nbItem - 1; i >= 0 ; --i)
 	{
 		remove(i);
+	}
+
+	HWND colHeader = reinterpret_cast<HWND>(SendMessage(_hSelf, LVM_GETHEADER, 0, 0));
+	int columnCount = static_cast<int32_t>(SendMessage(colHeader, HDM_GETITEMCOUNT, 0, 0));
+
+	for (int i = 0; i < columnCount; ++i)
+	{
+		ListView_DeleteColumn(_hSelf, 0);
 	}
 }
 
@@ -390,16 +399,25 @@ void VerticalFileSwitcherListView::resizeColumns(int totalWidth)
 {
 	NppParameters& nppParams = NppParameters::getInstance();
 	bool isExtColumn = !nppParams.getNppGUI()._fileSwitcherWithoutExtColumn;
+	bool isPathColumn = !nppParams.getNppGUI()._fileSwitcherWithoutPathColumn;
+
+	const int extWidthDyn = nppParams._dpiManager.scaleX(nppParams.getNppGUI()._fileSwitcherExtWidth);
+	const int pathWidthDyn = nppParams._dpiManager.scaleX(nppParams.getNppGUI()._fileSwitcherPathWidth);
+	int totalColWidthDynExceptName = 0;
+	int colIndex = 0;
+
 	if (isExtColumn)
 	{
-		int extWidthDyn = nppParams._dpiManager.scaleX(50);
-		ListView_SetColumnWidth(_hSelf, 0, totalWidth - extWidthDyn);
-		ListView_SetColumnWidth(_hSelf, 1, extWidthDyn);
+		totalColWidthDynExceptName += extWidthDyn;
+		ListView_SetColumnWidth(_hSelf, ++colIndex, extWidthDyn);
 	}
-	else
+	if (isPathColumn)
 	{
-		ListView_SetColumnWidth(_hSelf, 0, totalWidth);
+		totalColWidthDynExceptName += pathWidthDyn;
+		ListView_SetColumnWidth(_hSelf, ++colIndex, pathWidthDyn);
 	}
+		
+	ListView_SetColumnWidth(_hSelf, 0, totalWidth - totalColWidthDynExceptName);
 }
 
 std::vector<SwitcherFileInfo> VerticalFileSwitcherListView::getSelectedFiles(bool reverse) const

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
@@ -30,6 +30,7 @@ typedef Buffer * BufferID;	//each buffer has unique ID by which it can be retrie
 #define FS_ROOTNODE					"DocList"
 #define FS_CLMNNAME					"ColumnName"
 #define FS_CLMNEXT					"ColumnExt"
+#define FS_CLMNPATH					"ColumnPath"
 
 struct SwitcherFileInfo {
 	BufferID _bufID;


### PR DESCRIPTION
fix #9679

![DocListPath_Fix](https://user-images.githubusercontent.com/27722888/132945457-6ebde442-5c38-47bc-9587-d84e2afb2879.gif)

The column widths are stored in the config file to retain the widths when closing and reopening Npp.