### PR TITLE
Fix undoing a modification make deleted file from outside undirty

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -123,8 +123,15 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 			if (isSnapshotMode && !isDirty)
 			{
+				DocFileStatus status = buf->getStatus();
+				bool isDocDeleted = status == DOC_DELETED;
+				bool isDocModified = status == DOC_MODIFIED;
+				bool isDocRegular = status == DOC_REGULAR;
+
 				bool canUndo = _pEditView->execute(SCI_CANUNDO) == TRUE;
 				if (!canUndo && buf->isLoadedDirty() && buf->isDirty())
+					isDirty = true;
+				else if(canUndo && (isDocDeleted || isDocModified) && !isDocRegular && buf->isDirty())
 					isDirty = true;
 			}
 			buf->setDirty(isDirty);

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -207,6 +207,10 @@ void Buffer::setFileName(const TCHAR *fn, LangType defaultLang)
 	doNotify(BufferChangeFilename | BufferChangeTimestamp);
 }
 
+bool Buffer::isDocDeleted() const 
+{
+	return getStatus() == DocFileStatus::DOC_DELETED;
+}
 
 bool Buffer::checkFileState() // returns true if the status has been changed (it can change into DOC_REGULAR too). false otherwise
 {

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -177,6 +177,8 @@ public:
 
 	long getRecentTag() const { return _recentTag; }
 
+	bool isDocDeleted() const;
+
 	bool checkFileState();
 
 	bool isDirty() const {

--- a/PowerEditor/src/ScintillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.cpp
@@ -133,7 +133,7 @@ void DocTabView::bufferUpdated(Buffer * buffer, int mask)
 	if (mask & BufferChangeReadonly || mask & BufferChangeDirty)
 	{
 		tie.mask |= TCIF_IMAGE;
-		tie.iImage = buffer->isDirty() || buffer->isDocDeleted() ? UNSAVED_IMG_INDEX : SAVED_IMG_INDEX;
+		tie.iImage = buffer->isDirty()?UNSAVED_IMG_INDEX:SAVED_IMG_INDEX;
 		if (buffer->isMonitoringOn())
 		{
 			tie.iImage = MONITORING_IMG_INDEX;

--- a/PowerEditor/src/ScintillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.cpp
@@ -133,7 +133,7 @@ void DocTabView::bufferUpdated(Buffer * buffer, int mask)
 	if (mask & BufferChangeReadonly || mask & BufferChangeDirty)
 	{
 		tie.mask |= TCIF_IMAGE;
-		tie.iImage = buffer->isDirty()?UNSAVED_IMG_INDEX:SAVED_IMG_INDEX;
+		tie.iImage = buffer->isDirty() || buffer->isDocDeleted() ? UNSAVED_IMG_INDEX : SAVED_IMG_INDEX;
 		if (buffer->isMonitoringOn())
 		{
 			tie.iImage = MONITORING_IMG_INDEX;


### PR DESCRIPTION
for issue #10401. _mainDocTab saved status isn't being updated correctly when a external file delete of the currently opened buffer happens. Initially, if there is text in the buffer it will display as unsaved. But after a undo, and redo operation, the _mainDocTab displays the incorrect saved status. If the file has been deleted externally, and the user opts to keep the file open and there is text in the buffer it should be displayed as unsaved until the file is saved.

problem may also be in NppNotification.cpp (starting line 122). because if a SCN_SAVEPOINTREACHED the code says you can no longer undo, which results isDirty being set to false. and when bufferUpdated is called _mainDocTab will see that the buffer isn't dirty and not display the correct saved status

Fix #10401