### PR TITLE
for #4795 "enhancement"

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1129,6 +1129,15 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 		}
 	}
 
+	// if we are attempting to close the application, close event received
+	// just proceed and close the docs, but if we aren't attempting to close the application, confirm the action
+	if(!_isAttemptingCloseOnQuit)
+	{
+		int doCloseAll = _nativeLangSpeaker.messageBox("CloseAllConfirmation", _pPublicInterface->getHSelf(), TEXT("Do you want to close all open tabs?"), TEXT("Close all confirmation"), MB_YESNOCANCEL);
+		if(doCloseAll != IDYES)
+			return false;
+	}
+
 	//Then start closing, inactive view first so the active is left open
     if (bothActive())
     {


### PR DESCRIPTION
for  Close All needs verification pop up #4795.

enhancement #4795 found that the Close All action didn't prompt the user to confirm the action. This will now prompt the user to confirm their intent to Close all files, but not if they are closing the application.

You can press the "ESC" key to cancel the action, in addtion to pressing the "no" and "cancel" buttons. Only clicking yes, will proceed and close all files.