### PR TITLE
UDL: preserve DarkMode-ness upon saving

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -7242,6 +7242,8 @@ void NppParameters::insertUserLang2Tree(TiXmlNode *node, UserLangContainer *user
 
 	rootElement->SetAttribute(TEXT("name"), userLang->_name);
 	rootElement->SetAttribute(TEXT("ext"), userLang->_ext);
+	if (userLang->_isDarkModeTheme)
+		rootElement->SetAttribute(TEXT("darkModeTheme"), TEXT("yes"));
 	rootElement->SetAttribute(TEXT("udlVersion"), udlVersion.c_str());
 
 	TiXmlElement *settingsElement = (rootElement->InsertEndChild(TiXmlElement(TEXT("Settings"))))->ToElement();


### PR DESCRIPTION
Currently, after editing preinstalled MarkDown DarkMode UDL, its DarkMode-ness will be lost upon serializing into XML.

This PR may be too late for 8.1.5. That's why I made two PRs — so this one can be merged having no impact on translations and the other one can wait after 8.1.5 is released.

Fix #10583