### PR TITLE
Clipboard text memory overrun fix

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2456,11 +2456,11 @@ void Notepad_plus::pasteToMarkedLines()
 
 	::OpenClipboard(_pPublicInterface->getHSelf());
 	HANDLE clipboardData = ::GetClipboardData(clipFormat);
-	::GlobalSize(clipboardData);
+	SIZE_T clipboardDataSize = ::GlobalSize(clipboardData);
 	LPVOID clipboardDataPtr = ::GlobalLock(clipboardData);
 	if (!clipboardDataPtr) return;
 
-	generic_string clipboardStr = (const TCHAR *)clipboardDataPtr;
+	const generic_string clipboardStr((const TCHAR *)clipboardDataPtr, clipboardDataSize/sizeof(wchar_t));
 
 	::GlobalUnlock(clipboardData);
 	::CloseClipboard();

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -1683,12 +1683,14 @@ void StringDlg::HandlePaste(HWND hEdit)
 		HANDLE hClipboardData = GetClipboardData(CF_UNICODETEXT);
 		if (NULL != hClipboardData)
 		{
-			LPTSTR pszText = reinterpret_cast<LPTSTR>(GlobalLock(hClipboardData));
-			if (NULL != pszText && isAllowed(pszText))
+			if (LPTSTR pszText = reinterpret_cast<LPTSTR>(GlobalLock(hClipboardData)))
 			{
-				SendMessage(hEdit, EM_REPLACESEL, TRUE, reinterpret_cast<LPARAM>(pszText));
+				const generic_string text(pszText,GlobalSize(hClipboardData)/sizeof(wchar_t));
+				if (isAllowed(pszText))
+				{
+					SendMessage(hEdit, EM_REPLACESEL, TRUE, reinterpret_cast<LPARAM>(text.c_str()));
+				}
 			}
-
 			GlobalUnlock(hClipboardData);
 		}
 

--- a/scintilla/win32/ScintillaWin.cxx
+++ b/scintilla/win32/ScintillaWin.cxx
@@ -2561,7 +2561,7 @@ void ScintillaWin::Paste() {
 	// Use CF_UNICODETEXT if available
 	GlobalMemory memUSelection(::GetClipboardData(CF_UNICODETEXT));
 	if (const wchar_t *uptr = static_cast<const wchar_t *>(memUSelection.ptr)) {
-		const std::string putf = EncodeWString(uptr);
+		const std::string putf = EncodeWString(std::wstring_view(uptr,memUSelection.Size()/sizeof(wchar_t)));
 		InsertPasteShape(putf.c_str(), putf.length(), pasteShape);
 		memUSelection.Unlock();
 	}


### PR DESCRIPTION
Fixed the memory overrun of the clipboard text copy operation caused by missed zero terminator at the end of data induced by some ill-behavior programs.

Fix for: #10590

Signed-off-by: raspopov <raspopov@cherubicsoft.com>