### PR TITLE
update in nppnotification invalid save state when undo redo on a deleted or modified document

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -120,6 +120,14 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			}
 
 			bool isDirty = notification->nmhdr.code == SCN_SAVEPOINTLEFT;
+
+			const DocFileStatus status = buf->getStatus();
+			const bool deleted	= (status == DOC_DELETED);
+			const bool modified = (status == DOC_MODIFIED);
+
+			if(deleted || modified)
+				isDirty = true;
+
 			bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 			if (isSnapshotMode && !isDirty)
 			{


### PR DESCRIPTION
invalid saved state displayed on the main doc tab when undo and redo is done on a deleted or modified doc. isDirty was being determined by nmhdr.code being equal SCN_SAVEPOINTLEFT. Any document that is modified or deleted has a dirty buffer, and the undo redo op would call setDirty(false), changing the dirty buffer (true) to false when ever a savepoint was reached. which is why the saved icon would show on the main doc tab when the buffer was dirty because of a deleted or modified document.

fix #10401 
