### PR TITLE
invalid save status displayed when an undo and redo op is done on a modified or deleted document

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4372,7 +4372,7 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne)
 	}
 	Buffer * pBuf = MainFileManager.getBufferByID(id);
 	bool reload = pBuf->getNeedReload();
-	if (reload)
+	if (reload && pBuf->getUserReloadDecision())
 	{
 		MainFileManager.reloadBuffer(id);
 		pBuf->setNeedReload(false);
@@ -5873,6 +5873,8 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 					{
 						// Since the file content has changed but the user doesn't want to reload it, set state to dirty
 						buffer->setDirty(true);
+						buffer->setNeedReload(true);
+						buffer->setUserReloadDecision(false);
 
 						break;	//abort
 					}

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -120,6 +120,22 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			}
 
 			bool isDirty = notification->nmhdr.code == SCN_SAVEPOINTLEFT;
+
+			const DocFileStatus status = buf->getStatus();
+			const bool deleted = status == DocFileStatus::DOC_DELETED;
+			const bool modified = status == DocFileStatus::DOC_MODIFIED;
+
+			if(!isDirty && buf->isDirty())
+			{
+				if(modified)
+				{
+					if(buf->getNeedReload())
+						isDirty = true;
+				}
+				else if(deleted)
+					isDirty = true;
+			}
+
 			bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 			if (isSnapshotMode && !isDirty)
 			{

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -678,6 +678,14 @@ bool FileManager::reloadBuffer(BufferID id)
 
 	if (res)
 	{
+		// file has been successfully reloaded, we can now unset the reload flag
+		if(buf->getNeedReload())
+		{
+			buf->setNeedReload(false);
+			buf->setUserReloadDecision(true);
+			_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, doc);
+			_pscratchTilla->execute(SCI_SETSAVEPOINT);
+		}
 		setLoadedBufferEncodingAndEol(buf, UnicodeConvertor, loadedFileFormat._encoding, loadedFileFormat._eolFormat);
 	}
 	return res;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1066,6 +1066,8 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 		buffer->setDirty(false);
 		buffer->setStatus(DOC_REGULAR);
 		buffer->checkFileState();
+		buffer->setUserReloadDecision(true);
+		buffer->setNeedReload(false);
 		_pscratchTilla->execute(SCI_SETSAVEPOINT);
 		_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, _scratchDocDefault);
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -209,6 +209,18 @@ public:
 		doNotify(BufferChangeReadonly);
 	}
 
+	bool getUserReloadDecision() const
+	{
+		return _userReloadDecision;
+	}
+
+	void setUserReloadDecision(bool userReloadDecision)
+	{
+		// if the user's reload decision is true, reload the document
+		// otherwise, if its false, dont reload.
+		_userReloadDecision = userReloadDecision;
+	}
+
 	EolType getEolFormat() const {
 		return _eolFormat;
 	}
@@ -396,6 +408,9 @@ private:
 	UniMode _unicodeMode = uniUTF8;
 	int _encoding = -1;
 	bool _isUserReadOnly = false;
+
+	bool _userReloadDecision = true;
+
 	bool _needLexer = false; // new buffers do not need lexing, Scintilla takes care of that
 	//these properties have to be duplicated because of multiple references
 	//All the vectors must have the same size at all times


### PR DESCRIPTION
fix #10401 

invalid save status being displayed when an undo and redo op is done on a modified or deleted doc (modification or deletion done outside of npp).

