### PR TITLE
Add VHDL unresolved numeric_std types highlighting

### DIFF
--- a/scintilla/lexers/LexVHDL.cxx
+++ b/scintilla/lexers/LexVHDL.cxx
@@ -580,6 +580,6 @@ LexerModule lmVHDL(SCLEX_VHDL, ColouriseVHDLDoc, "vhdl", FoldVHDLDoc, VHDLWordLi
 // Std Types:
 //    boolean bit character severity_level integer real time delay_length natural positive string bit_vector
 //    file_open_kind file_open_status line text side width std_ulogic std_ulogic_vector std_logic
-//    std_logic_vector X01 X01Z UX01 UX01Z unsigned signed unresolved_unsigned unresolved_signed u_unsigned u_signed
+//    std_logic_vector X01 X01Z UX01 UX01Z unsigned signed
 //
 


### PR DESCRIPTION
New unresolved types were added into numeric_std library in VHDL-2008.  So it seems reasonable to highlight them correctly like it's done with other std types.