### PR TITLE
run macros until the last line, with option "run until the end of file"

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1319,7 +1319,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 						currLine += deltaCurrLine;
 
 						// eof?
-						if ((currLine >= lastLine) || (currLine < 0)
+						if ((currLine > lastLine) || (currLine < 0)
 							|| ((deltaCurrLine == 0) && (currLine == 0) && ((deltaLastLine >= 0) || cursorMovedUp)))
 						{
 							break;


### PR DESCRIPTION
Macros are run until the last line, if they are run by playback-icon, or if they are "Run X times", but were not, if they were "Run until the end of file". With this change, it will also run on the last line with the option "run until the end of file" . This fixes #10441.