### PR TITLE
Fix White flash on Npp startup in darkmode

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -141,6 +141,16 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 		::SetWindowPlacement(_hSelf,&posInfo);
 	}
 
+	//when npp starts up in dark mode, draw dark background to client area temporarily.
+	if (NppDarkMode::isEnabled())
+	{
+		RECT windowClientArea;
+		HDC hdc = GetDCEx(_hSelf, NULL, DCX_CACHE | DCX_LOCKWINDOWUPDATE); //lock window update flag due to line 36 and 111 in this file
+		GetClientRect(_hSelf, &windowClientArea);
+		FillRect(hdc, &windowClientArea, CreateSolidBrush(NppDarkMode::getBackgroundColor()));
+		ReleaseDC(_hSelf, hdc);
+	}
+
 	if ((nppGUI._tabStatus & TAB_MULTILINE) != 0)
 		::SendMessage(_hSelf, WM_COMMAND, IDM_VIEW_DRAWTABBAR_MULTILINE, 0);
 


### PR DESCRIPTION
fix #3955 and fix #10601

This is currently set to work only on darkmode.
Btw @xomx, feel free to test it and let me know if its fine.

before fix on startup:

![backlight_fix_before2](https://user-images.githubusercontent.com/27722888/136656227-c2f2c1fa-5ba6-4c36-8a86-9abe139cc5f7.gif)

after fix on startup:

![backlight_fix_after1](https://user-images.githubusercontent.com/27722888/136656282-76e803da-6ed0-4f20-a337-f0d09504cc66.gif)
