### PR TITLE
NPP RTL: dockable panels docking fix

### DIFF
--- a/PowerEditor/src/WinControls/DockingWnd/Gripper.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/Gripper.cpp
@@ -792,13 +792,13 @@ DockingCont* Gripper::workHitTest(POINT pt, RECT *rc)
 				default:
 					break;
 			}
-			ClientRectToScreenRect(_dockData.hWnd, &rcCont);
+			::MapWindowPoints(_dockData.hWnd, NULL, (LPPOINT)(&rcCont), 2);
 
 			if (::PtInRect(&rcCont, pt) == TRUE)
 			{
 				if (rc != NULL)
 				{
-					ClientRectToScreenRect(_dockData.hWnd, rc);
+					::MapWindowPoints(_dockData.hWnd, NULL, (LPPOINT)(rc), 2);
 					rc->right  -= rc->left;
 					rc->bottom -= rc->top;
 				}


### PR DESCRIPTION
fix #10641
Can now dock the dockable panels in LTR and RTL layouts.
@Yaron10, test this and let me know if its working as intended.
