### PR TITLE
Tweak themes for python and makefile

### DIFF
--- a/PowerEditor/installer/themes/Bespin.xml
+++ b/PowerEditor/installer/themes/Bespin.xml
@@ -152,7 +152,7 @@ Credits:
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
@@ -289,8 +289,8 @@ Credits:
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FF5555" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -340,17 +340,17 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="REGEX" styleID="17" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATASECTION" styleID="21" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGSUBST" styleID="18" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="20" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -359,10 +359,10 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORDS" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -390,14 +390,14 @@ Credits:
             <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="4" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -411,16 +411,16 @@ Credits:
             <WordsStyle name="FUNCTION" styleID="5" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="LABEL" styleID="7" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="SECTION" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VAR" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
@@ -447,19 +447,19 @@ Credits:
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -471,12 +471,12 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -488,24 +488,24 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="9" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
@@ -515,21 +515,21 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -541,26 +541,26 @@ Credits:
             <WordsStyle name="REGEX" styleID="12" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="13" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING Q" styleID="24" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="HEX STRING" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="BASE85 STRING" styleID="14" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -576,14 +576,14 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -591,27 +591,27 @@ Credits:
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="10" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TAGNAME" styleID="2" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">if else for while</WordsStyle>
-            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10">bool long int char</WordsStyle>
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">if else for while</WordsStyle>
+            <WordsStyle name="LINENUM" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10">bool long int char</WordsStyle>
             <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="8" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -635,7 +635,7 @@ Credits:
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
@@ -646,8 +646,8 @@ Credits:
             <WordsStyle name="STRING" styleID="2" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING2" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="VAR" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="FUNCTION" styleID="8" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="OPERATOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -659,29 +659,29 @@ Credits:
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="9" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SENT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="IDENTIFIER" styleID="2" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="10" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -702,12 +702,12 @@ Credits:
             <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CLASS" styleID="6" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="13" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
@@ -717,10 +717,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
@@ -735,13 +735,13 @@ Credits:
             <WordsStyle name="STRING L" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING R" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="7" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>

--- a/PowerEditor/installer/themes/Black board.xml
+++ b/PowerEditor/installer/themes/Black board.xml
@@ -154,7 +154,7 @@ Credits:
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
@@ -273,10 +273,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F8" bgColor="0C1021" fontSize="" fontStyle="0" />
@@ -287,8 +287,8 @@ Credits:
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="7F90AA" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FF8080" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -338,17 +338,17 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="REGEX" styleID="17" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATASECTION" styleID="21" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGSUBST" styleID="18" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="20" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -357,10 +357,10 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORDS" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="BECDE6" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -388,14 +388,14 @@ Credits:
             <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="4" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -409,16 +409,16 @@ Credits:
             <WordsStyle name="FUNCTION" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="LABEL" styleID="7" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="SECTION" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VAR" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
@@ -445,19 +445,19 @@ Credits:
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -469,12 +469,12 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -486,24 +486,24 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="9" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
@@ -513,21 +513,21 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -539,26 +539,26 @@ Credits:
             <WordsStyle name="REGEX" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="13" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING Q" styleID="24" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="HEX STRING" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="BASE85 STRING" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -574,14 +574,14 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -589,27 +589,27 @@ Credits:
             <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="10" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="1" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TAGNAME" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="8" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -633,7 +633,7 @@ Credits:
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
@@ -644,8 +644,8 @@ Credits:
             <WordsStyle name="STRING" styleID="2" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING2" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="VAR" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="FUNCTION" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="OPERATOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -657,29 +657,29 @@ Credits:
             <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="STRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="9" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SENT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="IDENTIFIER" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -700,12 +700,12 @@ Credits:
             <WordsStyle name="STRING" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CLASS" styleID="6" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
@@ -715,10 +715,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
@@ -733,13 +733,13 @@ Credits:
             <WordsStyle name="STRING L" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING R" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="7" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>

--- a/PowerEditor/installer/themes/Choco.xml
+++ b/PowerEditor/installer/themes/Choco.xml
@@ -154,7 +154,7 @@ Credits:
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
@@ -273,10 +273,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="C3BE98" bgColor="1A0F0B" fontSize="" fontStyle="0" />
@@ -287,8 +287,8 @@ Credits:
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FF8080" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -338,17 +338,17 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="REGEX" styleID="17" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATASECTION" styleID="21" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGSUBST" styleID="18" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="20" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -357,10 +357,10 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORDS" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -388,14 +388,14 @@ Credits:
             <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="4" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -409,16 +409,16 @@ Credits:
             <WordsStyle name="FUNCTION" styleID="5" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="VARIABLE" styleID="6" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="LABEL" styleID="7" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="SECTION" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VAR" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
@@ -445,19 +445,19 @@ Credits:
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -469,12 +469,12 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -486,24 +486,24 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="9" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
@@ -513,21 +513,21 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -539,26 +539,26 @@ Credits:
             <WordsStyle name="REGEX" styleID="12" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="13" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING Q" styleID="24" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="HEX STRING" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="BASE85 STRING" styleID="14" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -574,14 +574,14 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -589,27 +589,27 @@ Credits:
             <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="10" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TAGNAME" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">if else for while</WordsStyle>
-            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10">bool long int char</WordsStyle>
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">if else for while</WordsStyle>
+            <WordsStyle name="LINENUM" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10">bool long int char</WordsStyle>
             <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="8" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -633,7 +633,7 @@ Credits:
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
@@ -644,8 +644,8 @@ Credits:
             <WordsStyle name="STRING" styleID="2" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING2" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="VAR" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="FUNCTION" styleID="8" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="OPERATOR" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -657,29 +657,29 @@ Credits:
             <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="STRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="9" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SENT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="IDENTIFIER" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="10" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -700,12 +700,12 @@ Credits:
             <WordsStyle name="STRING" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CLASS" styleID="6" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="11" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="13" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
@@ -715,10 +715,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
@@ -733,13 +733,13 @@ Credits:
             <WordsStyle name="STRING L" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING R" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="7" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>

--- a/PowerEditor/installer/themes/Mono Industrial.xml
+++ b/PowerEditor/installer/themes/Mono Industrial.xml
@@ -154,7 +154,7 @@ Credits:
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
@@ -273,10 +273,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="FFFFFF" bgColor="222C28" />
@@ -287,8 +287,8 @@ Credits:
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -338,17 +338,17 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="REGEX" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATASECTION" styleID="21" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGSUBST" styleID="18" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="20" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -357,18 +357,18 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORDS" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="F STRING" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLE" styleID="18" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -392,14 +392,14 @@ Credits:
             <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="4" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -413,16 +413,16 @@ Credits:
             <WordsStyle name="FUNCTION" styleID="5" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="VARIABLE" styleID="6" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="LABEL" styleID="7" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="SECTION" styleID="9" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VAR" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
@@ -449,19 +449,19 @@ Credits:
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -473,12 +473,12 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -490,24 +490,24 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="9" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
@@ -517,21 +517,21 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -543,26 +543,26 @@ Credits:
             <WordsStyle name="REGEX" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="13" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING Q" styleID="24" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="6" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="HEX STRING" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="BASE85 STRING" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -578,14 +578,14 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="8" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -593,27 +593,27 @@ Credits:
             <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="10" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="1" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TAGNAME" styleID="2" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="8" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -637,7 +637,7 @@ Credits:
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
@@ -648,8 +648,8 @@ Credits:
             <WordsStyle name="STRING" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING2" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="VAR" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="FUNCTION" styleID="8" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="OPERATOR" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -661,29 +661,29 @@ Credits:
             <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="STRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="8" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="9" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SENT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="IDENTIFIER" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="9" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="10" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -704,12 +704,12 @@ Credits:
             <WordsStyle name="STRING" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CLASS" styleID="6" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="11" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="13" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
@@ -719,10 +719,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
@@ -737,13 +737,13 @@ Credits:
             <WordsStyle name="STRING L" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING R" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="7" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>

--- a/PowerEditor/installer/themes/Monokai.xml
+++ b/PowerEditor/installer/themes/Monokai.xml
@@ -154,7 +154,7 @@ Credits:
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
@@ -287,8 +287,8 @@ Credits:
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -338,17 +338,17 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="REGEX" styleID="17" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATASECTION" styleID="21" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGSUBST" styleID="18" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="20" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -357,18 +357,18 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="KEYWORDS" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="FF8080" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="F STRING" styleID="16" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="F TRIPLE" styleID="18" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -392,14 +392,14 @@ Credits:
             <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="TEXT" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -413,16 +413,16 @@ Credits:
             <WordsStyle name="FUNCTION" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="LABEL" styleID="7" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
             <WordsStyle name="SECTION" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING VAR" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
@@ -449,19 +449,19 @@ Credits:
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -473,12 +473,12 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -490,24 +490,24 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="9" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
@@ -517,21 +517,21 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
             <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -543,26 +543,26 @@ Credits:
             <WordsStyle name="REGEX" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING Q" styleID="24" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="TEXT" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="HEX STRING" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="BASE85 STRING" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -578,14 +578,14 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -593,27 +593,27 @@ Credits:
             <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="TAGNAME" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="8" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -637,19 +637,19 @@ Credits:
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         -->
             <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING2" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="FUNCTION" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="OPERATOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -661,29 +661,29 @@ Credits:
             <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="STRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="IDENTIFIER" styleID="2" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="LABEL" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="10" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -704,12 +704,12 @@ Credits:
             <WordsStyle name="STRING" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CLASS" styleID="6" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="13" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
@@ -719,10 +719,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
@@ -737,13 +737,13 @@ Credits:
             <WordsStyle name="STRING L" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING R" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
         </LexerType>

--- a/PowerEditor/installer/themes/Plastic Code Wrap.xml
+++ b/PowerEditor/installer/themes/Plastic Code Wrap.xml
@@ -154,7 +154,7 @@ Credits:
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
@@ -273,10 +273,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F8" bgColor="0B161D" />
@@ -287,8 +287,8 @@ Credits:
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -338,17 +338,17 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="REGEX" styleID="17" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATASECTION" styleID="21" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGSUBST" styleID="18" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="20" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PUNCTUATION" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATASECTION" styleID="21" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="REGSUBST" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="20" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="powershell" desc="PowerShell" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
@@ -369,18 +369,18 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORDS" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="F STRING" styleID="16" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLE" styleID="18" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -404,14 +404,14 @@ Credits:
             <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="4" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -425,16 +425,16 @@ Credits:
             <WordsStyle name="FUNCTION" styleID="5" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="LABEL" styleID="7" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="SECTION" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VAR" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
@@ -461,19 +461,19 @@ Credits:
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -485,12 +485,12 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -502,24 +502,24 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="9" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
@@ -529,21 +529,21 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -555,26 +555,26 @@ Credits:
             <WordsStyle name="REGEX" styleID="12" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="13" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING Q" styleID="24" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TEXT" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="HEX STRING" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="BASE85 STRING" styleID="14" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -590,14 +590,14 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -605,27 +605,27 @@ Credits:
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="10" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="TAGNAME" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="8" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -649,7 +649,7 @@ Credits:
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
@@ -660,8 +660,8 @@ Credits:
             <WordsStyle name="STRING" styleID="2" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING2" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="FUNCTION" styleID="8" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="OPERATOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -673,29 +673,29 @@ Credits:
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="9" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="IDENTIFIER" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="LABEL" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="10" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -716,12 +716,12 @@ Credits:
             <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="CLASS" styleID="6" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="13" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
@@ -731,10 +731,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
@@ -749,20 +749,20 @@ Credits:
             <WordsStyle name="STRING L" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING R" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="7" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="000000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="File Header" styleID="2" fgColor="008000" bgColor="D5FFD5" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="Line Number" styleID="3" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="File Header" styleID="2" fgColor="F8F8F8" bgColor="D5FFD5" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="Line Number" styleID="3" fgColor="F8F8F8" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="Hit Word" styleID="4" fgColor="FF0000" bgColor="FFFFBF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="Selected Line" styleID="5" fgColor="000080" bgColor="FFFF4F" fontName="" fontStyle="0" fontSize="">if else for while</WordsStyle>
             <WordsStyle name="Current line background colour" styleID="6" bgColor="E8E8FF" fgColor="0080FF" fontSize="" fontStyle="0">bool long int char</WordsStyle>


### PR DESCRIPTION
Fixes #10648

Tweak themes for python and makefile
Also apply default color to other items in need
Bespin.xml
Black board.xml
Choco.xml
Mono Industrial.xml
Monokai.xml
Plastic Code Wrap.xml

Before
![image](https://user-images.githubusercontent.com/190571/137026628-94092bed-050f-4fa0-a2a2-8b95ff3f6e01.png)

After
![image](https://user-images.githubusercontent.com/190571/137026751-fff728c0-11a4-4daa-94e6-d11ad5db7de5.png)

Objective C before in Blackboard
![image](https://user-images.githubusercontent.com/190571/137027653-ffed8ff3-2535-4a49-bb47-dee04b62a49d.png)

Objective C after (not explicitly tweaked)
![image](https://user-images.githubusercontent.com/190571/137027475-ba9e944b-a404-42de-a1fb-0ed7204d9d64.png)
