### PR TITLE
Added reloading of the language list when the styler is reloaded

### DIFF
--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -290,6 +290,7 @@ INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 							{
 								generic_string str(nppParamInst.getNppGUI()._themeName);
 								nppParamInst.reloadStylers(str.c_str());
+								loadLangListFromNppParam();
 							}
 
 							LexerStylerArray & lsArray = nppParamInst.getLStylerArray();


### PR DESCRIPTION
Pressing Cancel in the Style Configurator after changing the style didn't reset the language list. This could lead to crashes, as described in #9512. This PR reloads the language list after the styler is reloaded, preventing those crashes.

Fixes #9512