### PR TITLE
Fix config files (XML) saving performance regression

### DIFF
--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -551,26 +551,20 @@ void TiXmlElement::SetAttribute( const TCHAR * name, const TCHAR * _value )
 	}
 }
 
-void TiXmlElement::Print( Win32_IO_File& cfile, int depth ) const
+void TiXmlElement::Print( FILE* cfile, int depth ) const
 {
 	int i;
 	for ( i=0; i<depth; i++ )
 	{
-		cfile.writeStr("    ");
-		//generic_fprintf( cfile, TEXT("    ") );
+		generic_fprintf( cfile, TEXT("    ") );
 	}
 
-	std::string tagOpenValue = "<";
-	tagOpenValue += wstring2string(value, CP_UTF8);
-	cfile.writeStr(tagOpenValue);
-	//generic_fprintf( cfile, TEXT("<%ls"), value.c_str() );
+	generic_fprintf( cfile, TEXT("<%s"), value.c_str() );
 
 	TiXmlAttribute* attrib;
 	for ( attrib = attributeSet.First(); attrib; attrib = attrib->Next() )
 	{
-		cfile.writeStr(" ");
-		//generic_fprintf(cfile, TEXT(" "));
-
+		generic_fprintf( cfile, TEXT(" ") );
 		attrib->Print( cfile, depth );
 	}
 
@@ -581,46 +575,30 @@ void TiXmlElement::Print( Win32_IO_File& cfile, int depth ) const
 	TiXmlNode* node;
 	if ( !firstChild )
 	{
-		cfile.writeStr(" />");
-		//generic_fprintf( cfile, TEXT(" />") );
+		generic_fprintf( cfile, TEXT(" />") );
 	}
 	else if ( firstChild == lastChild && firstChild->ToText() )
 	{
-		cfile.writeStr(">");
-		//generic_fprintf( cfile, TEXT(">") );
-
+		generic_fprintf( cfile, TEXT(">") );
 		firstChild->Print( cfile, depth + 1 );
-
-		std::string tagCloseWithValue = "</";
-		tagCloseWithValue += wstring2string(value, CP_UTF8) + ">";
-		cfile.writeStr(tagCloseWithValue);
-		//generic_fprintf( cfile, TEXT("</%ls>"), value.c_str() );
+		generic_fprintf( cfile, TEXT("</%s>"), value.c_str() );
 	}
 	else
 	{
-		cfile.writeStr(">");
-		//generic_fprintf( cfile, TEXT(">") );
+		generic_fprintf( cfile, TEXT(">") );
 
 		for ( node = firstChild; node; node=node->NextSibling() )
 		{
 			if ( !node->ToText() )
 			{
-				cfile.writeStr("\r\n");
-				//generic_fprintf( cfile, TEXT("\n") );
+				generic_fprintf( cfile, TEXT("\n") );
 			}
 			node->Print( cfile, depth+1 );
 		}
-		cfile.writeStr("\r\n");
-		//generic_fprintf( cfile, TEXT("\n") );
-
+		generic_fprintf( cfile, TEXT("\n") );
 		for( i=0; i<depth; ++i )
-			cfile.writeStr("    ");
-			// generic_fprintf( cfile, TEXT("    ") );
-
-		std::string tagCloseWithValue = "</";
-		tagCloseWithValue += wstring2string(value, CP_UTF8) + ">";
-		cfile.writeStr(tagCloseWithValue);
-		//generic_fprintf( cfile, TEXT("</%ls>"), value.c_str() );
+		generic_fprintf( cfile, TEXT("    ") );
+		generic_fprintf( cfile, TEXT("</%s>"), value.c_str() );
 	}
 }
 
@@ -736,7 +714,7 @@ bool TiXmlDocument::LoadFile( const TCHAR* filename )
 
 	if ( file )
 	{
-		// Get the file size, so we can pre-allocate the string. HUGE speed impact.
+		// Get the file size, so we can pre-allocate the generic_string. HUGE speed impact.
 		long length = 0;
 		fseek( file, 0, SEEK_END );
 		length = ftell( file );
@@ -776,7 +754,6 @@ bool TiXmlDocument::LoadFile( const TCHAR* filename )
 
 bool TiXmlDocument::SaveFile( const TCHAR * filename ) const
 {
-	/*
 	// The old c stuff lives on...
 	FILE* fp = generic_fopen( filename, TEXT("wc") );
 	if ( fp )
@@ -786,17 +763,6 @@ bool TiXmlDocument::SaveFile( const TCHAR * filename ) const
 		fclose( fp );
 		return true;
 	}
-	return false;
-	*/
-
-	Win32_IO_File file(filename, Win32_IO_File::Mode::WRITE);
-
-	if (file.isOpened())
-	{
-		Print(file, 0);
-		return true;
-	}
-
 	return false;
 }
 
@@ -820,15 +786,13 @@ TiXmlNode* TiXmlDocument::Clone() const
 }
 
 
-void TiXmlDocument::Print( Win32_IO_File& cfile, int depth ) const
+void TiXmlDocument::Print( FILE* cfile, int depth ) const
 {
 	TiXmlNode* node;
 	for ( node=FirstChild(); node; node=node->NextSibling() )
 	{
 		node->Print( cfile, depth );
-
-		cfile.writeStr("\r\n");
-		//generic_fprintf( cfile, TEXT("\n") );
+		generic_fprintf( cfile, TEXT("\n") );
 	}
 }
 
@@ -868,29 +832,17 @@ TiXmlAttribute* TiXmlAttribute::Previous() const
 }
 
 
-void TiXmlAttribute::Print( Win32_IO_File& cfile, int /*depth*/ ) const
+void TiXmlAttribute::Print( FILE* cfile, int /*depth*/ ) const
 {
 	TIXML_STRING n, v;
 
 	PutString( Name(), &n );
 	PutString( Value(), &v );
 
-	std::string attrVsValue = wstring2string(n, CP_UTF8);
-	if (value.find('\"') == TIXML_STRING::npos)
-	{
-		attrVsValue += "=\"";
-		attrVsValue += wstring2string(v, CP_UTF8);
-		attrVsValue += "\"";
-		//generic_fprintf(cfile, TEXT("%ls=\"%ls\""), n.c_str(), v.c_str());
-	}
+	if (value.find ('\"') == TIXML_STRING::npos)
+		generic_fprintf (cfile, TEXT("%s=\"%s\""), n.c_str(), v.c_str() );
 	else
-	{
-		attrVsValue += "='";
-		attrVsValue += wstring2string(v, CP_UTF8);
-		attrVsValue += "'";
-		//generic_fprintf(cfile, TEXT("%ls='%ls'"), n.c_str(), v.c_str());
-	}
-	cfile.writeStr(attrVsValue);
+		generic_fprintf (cfile, TEXT("%s='%s'"), n.c_str(), v.c_str() );
 }
 
 
@@ -950,19 +902,13 @@ const double  TiXmlAttribute::DoubleValue() const
 	return generic_atof (value.c_str ());
 }
 
-void TiXmlComment::Print( Win32_IO_File& cfile, int depth ) const
+void TiXmlComment::Print( FILE* cfile, int depth ) const
 {
 	for ( int i=0; i<depth; i++ )
 	{
-		cfile.writeStr("    ");
-		//generic_fprintf( cfile, TEXT("    ") );
+		fputs( "    ", cfile );
 	}
-
-	std::string comment = "<!--";
-	comment += wstring2string(value, CP_UTF8);
-	comment += "-->";
-	cfile.writeStr(comment);
-	//generic_fprintf( cfile, TEXT("<!--%ls-->"), value.c_str() );
+	generic_fprintf( cfile, TEXT("<!--%s-->"), value.c_str() );
 }
 
 void TiXmlComment::StreamOut( TIXML_OSTREAM * stream ) const
@@ -984,13 +930,11 @@ TiXmlNode* TiXmlComment::Clone() const
 }
 
 
-void TiXmlText::Print( Win32_IO_File& cfile, int /*depth*/ ) const
+void TiXmlText::Print( FILE* cfile, int /*depth*/ ) const
 {
 	TIXML_STRING buffer;
 	PutString( value, &buffer );
-
-	cfile.writeStr(wstring2string(buffer, CP_UTF8));
-	//generic_fprintf( cfile, TEXT("%ls"), buffer.c_str() );
+	generic_fprintf( cfile, TEXT("%s"), buffer.c_str() );
 }
 
 
@@ -1023,38 +967,18 @@ TiXmlDeclaration::TiXmlDeclaration( const TCHAR * _version,
 	standalone = _standalone;
 }
 
-void TiXmlDeclaration::Print( Win32_IO_File& cfile, int /*depth*/ ) const
+
+void TiXmlDeclaration::Print( FILE* cfile, int /*depth*/ ) const
 {
-	std::string xmlDcl = "<?xml ";
-	//generic_fprintf (cfile, TEXT("<?xml "));
+	generic_fprintf (cfile, TEXT("<?xml "));
 
-	if (!version.empty())
-	{
-		xmlDcl += "version=\"";
-		xmlDcl += wstring2string(version, CP_UTF8);
-		xmlDcl += "\" ";
-		//generic_fprintf(cfile, TEXT("version=\"%ls\" "), version.c_str());
-	}
-
-	if (!encoding.empty())
-	{
-		xmlDcl += "encoding=\"";
-		xmlDcl += wstring2string(encoding, CP_UTF8);
-		xmlDcl += "\" ";
-		//generic_fprintf(cfile, TEXT("encoding=\"%ls\" "), encoding.c_str());
-	}
-	if (!standalone.empty())
-	{
-		xmlDcl += "standalone=\"";
-		xmlDcl += wstring2string(standalone, CP_UTF8);
-		xmlDcl += "\" ";
-		//generic_fprintf(cfile, TEXT("standalone=\"%ls\" "), standalone.c_str());
-	}
-
-	xmlDcl += "?>";
-	//generic_fprintf (cfile, TEXT("?>"));
-
-	cfile.writeStr(xmlDcl);
+	if ( !version.empty() )
+		generic_fprintf (cfile, TEXT("version=\"%s\" "), version.c_str ());
+	if ( !encoding.empty() )
+		generic_fprintf (cfile, TEXT("encoding=\"%s\" "), encoding.c_str ());
+	if ( !standalone.empty() )
+		generic_fprintf (cfile, TEXT("standalone=\"%s\" "), standalone.c_str ());
+	generic_fprintf (cfile, TEXT("?>"));
 }
 
 void TiXmlDeclaration::StreamOut( TIXML_OSTREAM * stream ) const
@@ -1097,14 +1021,11 @@ TiXmlNode* TiXmlDeclaration::Clone() const
 }
 
 
-void TiXmlUnknown::Print( Win32_IO_File& cfile, int depth ) const
+void TiXmlUnknown::Print( FILE* cfile, int depth ) const
 {
 	for ( int i=0; i<depth; i++ )
-		cfile.writeStr("    ");
-		//generic_fprintf( cfile, TEXT("    ") );
-
-	cfile.writeStr(wstring2string(value, CP_UTF8));
-	//generic_fprintf( cfile, TEXT("%ls"), value.c_str() );
+		generic_fprintf( cfile, TEXT("    ") );
+	generic_fprintf( cfile, TEXT("%s"), value.c_str() );
 }
 
 void TiXmlUnknown::StreamOut( TIXML_OSTREAM * stream ) const

--- a/PowerEditor/src/TinyXml/tinyxml.h
+++ b/PowerEditor/src/TinyXml/tinyxml.h
@@ -62,7 +62,6 @@ distribution.
 #include <string>
 
 #include "Common.h"
-#include "FileInterface.h"
 
 class TiXmlDocument;
 class TiXmlElement;
@@ -132,7 +131,7 @@ public:
 		
 		(For an unformatted stream, use the << operator.)
 	*/
-	virtual void Print( Win32_IO_File& cfile, int depth ) const = 0;
+	virtual void Print( FILE* cfile, int depth ) const = 0;
 
 	/**	The world does not agree on whether white space should be kept or
 		not. In order to make everyone happy, these global, static functions
@@ -640,7 +639,7 @@ public:
 	virtual const TCHAR* Parse( const TCHAR* p, TiXmlParsingData* data );
 
 	// [internal use]
-	virtual void Print( Win32_IO_File& cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const;
 
 	virtual void StreamOut( TIXML_OSTREAM * out ) const;
 	// [internal use]
@@ -784,7 +783,7 @@ public:
 	virtual TiXmlNode* Clone() const;
 	// [internal use]
 
-	virtual void Print( Win32_IO_File& cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const;
 
 protected:
 
@@ -823,7 +822,7 @@ public:
 	// [internal use] Creates a new Element and returs it.
 	virtual TiXmlNode* Clone() const;
 	// [internal use]
-	virtual void Print( Win32_IO_File& cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const;
 protected:
 	// used to be public
 	#ifdef TIXML_USE_STL
@@ -860,7 +859,7 @@ public:
 	#endif
 
 	// [internal use]
-	virtual void Print( Win32_IO_File& cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const;
 
 protected :
 	// [internal use] Creates a new Element and returns it.
@@ -929,7 +928,7 @@ public:
 	// [internal use] Creates a new Element and returs it.
 	virtual TiXmlNode* Clone() const;
 	// [internal use]
-	virtual void Print( Win32_IO_File& cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const;
 
 protected:
 	// used to be public
@@ -964,7 +963,7 @@ public:
 	// [internal use]
 	virtual TiXmlNode* Clone() const;
 	// [internal use]
-	virtual void Print( Win32_IO_File& cfile, int depth ) const;
+	virtual void Print( FILE* cfile, int depth ) const;
 protected:
 	#ifdef TIXML_USE_STL
 	    virtual void StreamIn( TIXML_ISTREAM * in, TIXML_STRING * tag );
@@ -1098,10 +1097,10 @@ public:
 											}
 
 	/** Dump the document to standard out. */
-	void Print() const						{ /*Print(stdout, 0);*/ }
+	void Print() const						{ Print( stdout, 0 ); }
 
 	// [internal use]
-	virtual void Print( Win32_IO_File& cfile, int depth = 0 ) const;
+	virtual void Print( FILE* cfile, int depth = 0 ) const;
 	// [internal use]
 	void SetError( int err, const TCHAR* errorLocation, TiXmlParsingData* prevData );
 


### PR DESCRIPTION
Revert tinyxml saving modification from Win32 native functions back to POSIX IO functions, due to the performance issue.

Fix #10678, fix #10674