### PR TITLE
Fix empty file with non-Unicode encoding cannot be saved issue

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1010,21 +1010,26 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 		else
 		{
 			WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-			int grabSize;
-			for (int i = 0; i < lengthDoc; i += grabSize)
-			{
-				grabSize = lengthDoc - i;
-				if (grabSize > blockSize)
-					grabSize = blockSize;
-
-				int newDataLen = 0;
-				int incompleteMultibyteChar = 0;
-				const char *newData = wmc.encode(SC_CP_UTF8, encoding, buf+i, grabSize, &newDataLen, &incompleteMultibyteChar);
-				grabSize -= incompleteMultibyteChar;
-				isWrittenSuccessful = UnicodeConvertor.writeFile(newData, static_cast<unsigned long>(newDataLen));
-			}
 			if (lengthDoc == 0)
-				isWrittenSuccessful = true;
+			{
+				isWrittenSuccessful = UnicodeConvertor.writeFile(buf, 0);
+			}
+			else
+			{
+				int grabSize;
+				for (int i = 0; i < lengthDoc; i += grabSize)
+				{
+					grabSize = lengthDoc - i;
+					if (grabSize > blockSize)
+						grabSize = blockSize;
+
+					int newDataLen = 0;
+					int incompleteMultibyteChar = 0;
+					const char* newData = wmc.encode(SC_CP_UTF8, encoding, buf + i, grabSize, &newDataLen, &incompleteMultibyteChar);
+					grabSize -= incompleteMultibyteChar;
+					isWrittenSuccessful = UnicodeConvertor.writeFile(newData, static_cast<unsigned long>(newDataLen));
+				}
+			}
 		}
 
 		// check the language du fichier


### PR DESCRIPTION
The PR fixes the regression due to the saving file API being changecd from POSIX functions to Win32 native API:
The old used function "fopen" using "wbc" as argument, according Microsoft document:
```
"w" 	Opens an empty file for writing. If the given file exists, its contents are destroyed.
```
(https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-160)

so to save a 0 length document, it was unecessary to "write nothing" explicitely on disk, since fopen did it for you.
Whereas our new implementation which uses Win32 native API passes "OPEN_ALWAYS" - that needs to "write nothing" explicitely.

Fix #10699