### PR TITLE
Fix for phantom docked panels after using systray

### DIFF
--- a/PowerEditor/src/WinControls/DockingWnd/DockingManager.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingManager.cpp
@@ -205,7 +205,10 @@ void DockingManager::showFloatingContainers(bool show)
 	{
 		size_t iElementCnt = _vContainer[i]->getElementCnt();
 		if (iElementCnt > 0)
-			_vContainer[i]->display(show);
+		{
+			if (0 < ::SendMessage(_vContainer[i]->getTabWnd(), TCM_GETITEMCOUNT, 0, 0)) // any real item(s)?
+				_vContainer[i]->display(show);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes visual bug and potential crash in the #10512 .

During testing I have found another (independent) issue with minimizing to systray - when I have enabled Document Map and minimize the N++ to systray, some portion of the Document Map remains on the desktop screen. When systray is not used for the minimization, everything is ok.