### PR TITLE
Fix inconsistent spacing in notepad++.exe.manifest

### DIFF
--- a/PowerEditor/src/notepad++.exe.manifest
+++ b/PowerEditor/src/notepad++.exe.manifest
@@ -22,7 +22,7 @@
 </dependency>
  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
     <application> 
-		<!-- Windows 10 --> 
+        <!-- Windows 10 --> 
         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
         <!-- Windows 8.1 -->
         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>


### PR DESCRIPTION
Changed comment line for Windows 11 to use tabs instead of spaces for consistency with the rest of the file.