### PR TITLE
Failed to compile with VS 2022

### DIFF
--- a/PowerEditor/src/WinControls/DockingWnd/Docking.h
+++ b/PowerEditor/src/WinControls/DockingWnd/Docking.h
@@ -46,7 +46,7 @@
 #define DWS_DF_FLOATING		0x80000000			// default state is floating
 
 
-typedef struct {
+struct tTbData {
 	HWND hClient = nullptr;                // client Window Handle
 	const TCHAR* pszName = nullptr;        // name of plugin (shown in window)
 	int dlgID = 0;                         // a funcItem provides the function pointer to start a dialog. Please parse here these ID
@@ -60,13 +60,13 @@ typedef struct {
 	RECT rcFloat = {0};                    // floating position
 	int iPrevCont = 0;                     // stores the privious container (toggling between float and dock)
 	const TCHAR* pszModuleName = nullptr;  // it's the plugin file name. It's used to identify the plugin
-} tTbData;
+};
 
 
-typedef struct {
+struct tDockMgr {
 	HWND hWnd = nullptr;                   // the docking manager wnd
 	RECT rcRegion[DOCKCONT_MAX] = {{0}};   // position of docked dialogs
-} tDockMgr;
+};
 
 
 #define	HIT_TEST_THICKNESS		20

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -980,7 +980,6 @@ void WindowsDlg::doSortToTabs()
 
 void WindowsDlg::putItemsToClipboard(bool isFullPath)
 {
-	constexpr int nameColumn = 0;
 	constexpr int pathColumn = 1;
 
 	TCHAR str[MAX_PATH] = {};


### PR DESCRIPTION
Compiled npp after a long time and compilation failed in VS 2022, it may fail in VS2019 as well. See if below makes sense. Thanks!

> typedef struct

It results into error (`error C7626: unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes`). 

https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=msvc-160
As per above link, this warning (becomes error due to treat warning as error) is new to VS 2019 16.6 onwards.


> constexpr int nameColumn = 0;

`warning C4189: 'nameColumn': local variable is initialized but not referenced`
This warning got converted into error.
