### PR TITLE
Fix a regression of saving problem

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -121,18 +121,17 @@ bool Win32_IO_File::write(const void *wbuf, unsigned long buf_size)
 void Win32_IO_File::fillCreateParams(DWORD &access, DWORD &share, DWORD &disp, DWORD &attrib)
 {
 	access	= GENERIC_READ;
+	share = FILE_SHARE_READ;
 	attrib	= FILE_ATTRIBUTE_NORMAL | FILE_FLAG_POSIX_SEMANTICS; // Distinguish between upper/lower case in name
 
 	if (_hMode == Mode::READ)
 	{
-		share	=	FILE_SHARE_READ;
 		disp	=	OPEN_EXISTING; // Open only if file exists and is not locked by other process
 
 		attrib	|=	FILE_FLAG_SEQUENTIAL_SCAN; // Optimize caching for sequential read
 	}
 	else
 	{
-		share	=	0;
 		disp	=	OPEN_ALWAYS; // Open existing file for writing without destroying it or create new
 
 		access	|=	GENERIC_WRITE;


### PR DESCRIPTION
Some users encounter the issue that files cannot be saved sometimes.
It's due to the share parameter in CreateFile() set as 0, which makes sense for preventing other process from accessing to the file being written. However, when Notepad++ tries to write the file, it opens the file for writing. If at that moment the file is already opened by other program and the share flag is zero, then the system is instructed to deny opening the file on share conflict and the open fails.
Setting share parameter to "FILE_SHARE_READ" instead of 0 solve this problem.

Fix #10751