### PR TITLE
Avoid crash on broken non ascii regex

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1223,7 +1223,7 @@ bool isAssoCommandExisting(LPCTSTR FullPathName)
 std::wstring s2ws(const std::string& str)
 {
 	using convert_typeX = std::codecvt_utf8<wchar_t>;
-	std::wstring_convert<convert_typeX, wchar_t> converterX;
+	std::wstring_convert<convert_typeX, wchar_t> converterX("Error in N++ string conversion s2ws!", L"Error in N++ string conversion s2ws!");
 
 	return converterX.from_bytes(str);
 }
@@ -1231,7 +1231,7 @@ std::wstring s2ws(const std::string& str)
 std::string ws2s(const std::wstring& wstr)
 {
 	using convert_typeX = std::codecvt_utf8<wchar_t>;
-	std::wstring_convert<convert_typeX, wchar_t> converterX;
+	std::wstring_convert<convert_typeX, wchar_t> converterX("Error in N++ string conversion ws2s!", L"Error in N++ string conversion ws2s!");
 
 	return converterX.to_bytes(wstr);
 }


### PR DESCRIPTION
fix #10773

avoid unhandled std::range_error exceptions in case of an text input issue by providing an user-supplied byte-error string

see https://en.cppreference.com/w/cpp/locale/wstring_convert/from_bytes and https://en.cppreference.com/w/cpp/locale/wstring_convert/to_bytes

Another option would be to add exception handling for these two methods.

Currently I don't fully understand why https://en.cppreference.com/w/cpp/error/exception/what is returning a string which contains é in a not usable encoding. Maybe that should be clarified to get the actual error string

`"Found a closing ) with no corresponding opening parenthesis. The error occurred while parsing the regular expression: '[a-é>>>HERE>>>'."`

in the tooltip.