### PR TITLE
Handle environment variables update at runtime

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -8153,7 +8153,7 @@ void Notepad_plus::handleEnvironmentSettingChange(LPARAM lParam)
 								strValue += *i;
 							}
 
-							DWORD dwRet = ::GetEnvironmentVariable(strName.c_str(), szBuf, BUFSIZE);
+							DWORD dwRet = ::GetEnvironmentVariable(strName.c_str(), szBuf, BUFMAXLEN + 1);
 							if (0 == dwRet)
 							{
 								if (ERROR_ENVVAR_NOT_FOUND == ::GetLastError())

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -636,4 +636,6 @@ private:
 
 	void monitoringStartOrStopAndUpdateUI(Buffer* pBuf, bool isStarting);
 	void updateCommandShortcuts();
+	
+	void handleEnvironmentSettingChange(LPARAM lParam);
 };

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -195,6 +195,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case WM_SETTINGCHANGE:
 		{
 			NppDarkMode::handleSettingChange(hwnd, lParam);
+			
+			handleEnvironmentSettingChange(lParam);
 
 			return ::DefWindowProc(hwnd, message, wParam, lParam);
 		}


### PR DESCRIPTION
Fixes #10749 .

Uses undocumented shell32!RegenerateUserEnvironment.

Keeps current environment variables of the running N++ process, updates the global ones (system & user profile variables).

In case of a conflict (RegenerateUserEnvironment updates a variable, which has been already updated by running N++ process somehow in the local N++ environment set), the global RegenerateUserEnvironment value wins.