### PR TITLE
Fix dirty status of reloaded files (isUnsync true)

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -721,7 +721,18 @@ bool FileManager::reloadBuffer(BufferID id)
 	buf->setLoadedDirty(false);	// Since the buffer will be reloaded from the disk, and it will be clean (not dirty), we can set _isLoadedDirty false safetly.
 								// Set _isLoadedDirty false before calling "_pscratchTilla->execute(SCI_CLEARALL);" in loadFileData() to avoid setDirty in SCN_SAVEPOINTREACHED / SCN_SAVEPOINTLEFT
 
+	bool bUnsyncStateBeforeReload = buf->isUnsync(); // store for a possible unsync state restoration later 
+	buf->setUnsync(false);	// we have to ensure that isUnsync is false before we try to call the loadFileData below for the reloading
+							// - after a successful reload, the source file and its filebuffer in N++ are the same, so the isDirty should be false (and the isUnsync too)
+							// - but when the isUnsync is true at this point, any successfully reloaded filebuffer later will end up marked as dirty!
+							//   (similar reason as in the above setLoadedDirty(false), but now it is the "_pscratchTilla->execute(SCI_SETSAVEPOINT)" in loadFileData(),
+							//    which ends up in the Notepad_plus::notify(), case SCN_SAVEPOINTLEFT, where is logic "if (buf->isUnsync()) isDirty = true")
+
 	bool res = loadFileData(doc, buf->getFullPathName(), data, &UnicodeConvertor, loadedFileFormat);
+
+	if (!res)
+		buf->setUnsync(bUnsyncStateBeforeReload);
+
 	buf->_canNotify = true;
 
 	if (res)

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -722,11 +722,7 @@ bool FileManager::reloadBuffer(BufferID id)
 								// Set _isLoadedDirty false before calling "_pscratchTilla->execute(SCI_CLEARALL);" in loadFileData() to avoid setDirty in SCN_SAVEPOINTREACHED / SCN_SAVEPOINTLEFT
 
 	bool bUnsyncStateBeforeReload = buf->isUnsync(); // store for a possible unsync state restoration later 
-	buf->setUnsync(false);	// we have to ensure that isUnsync is false before we try to call the loadFileData below for the reloading
-							// - after a successful reload, the source file and its filebuffer in N++ are the same, so the isDirty should be false (and the isUnsync too)
-							// - but when the isUnsync is true at this point, any successfully reloaded filebuffer later will end up marked as dirty!
-							//   (similar reason as in the above setLoadedDirty(false), but now it is the "_pscratchTilla->execute(SCI_SETSAVEPOINT)" in loadFileData(),
-							//    which ends up in the Notepad_plus::notify(), case SCN_SAVEPOINTLEFT, where is logic "if (buf->isUnsync()) isDirty = true")
+	buf->setUnsync(false);	// ensure that isUnsync is false before calling the loadFileData, otherwise isDirty and isUnsync will not be false after a successful reload (issue fixed: #10796)
 
 	bool res = loadFileData(doc, buf->getFullPathName(), data, &UnicodeConvertor, loadedFileFormat);
 


### PR DESCRIPTION
Fixes #10796 .

After a successful reload, the N++ filebuffer should be marked as not dirty, because of now it is the same as its file source on disk. But that was not true, when the filebufer had been marked as unsynced before the reloading. Steps to reproduce the previous incorrect behavior:

1. Open a file in N++.
2. Switch to another editor, edit the same file there and save it.
3. Switch back to N++, there will be the changed-file messagebox with options to reload / not reload, choose 'No'.
4. The N++ filebufer is now marked as dirty (this is ok).
5. Then initiate the same reloading manually (eg via Ctrl+R), this time choose 'Yes'.
6. After a successful reload, the filebuffer in N++ is now incorrectly marked as dirty.