### PR TITLE
Document List icons now support darkmode icons and alternate icons

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6606,9 +6606,10 @@ void Notepad_plus::launchDocumentListPanel()
 	if (!_pDocumentListPanel)
 	{
 		NppParameters& nppParams = NppParameters::getInstance();
+		int tabBarStatus = nppParams.getNppGUI()._tabStatus;
 
 		_pDocumentListPanel = new VerticalFileSwitcher;
-		HIMAGELIST hImgLst = _docTabIconList.getHandle();
+		HIMAGELIST hImgLst = ((tabBarStatus & TAB_ALTICONS) ? _docTabIconListAlt.getHandle() : NppDarkMode::isEnabled() ? _docTabIconListDarkMode.getHandle() : _docTabIconList.getHandle());
 		_pDocumentListPanel->init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst);
 		NativeLangSpeaker *pNativeSpeaker = nppParams.getNativeLangSpeaker();
 		bool isRTL = pNativeSpeaker->isRTL();

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -740,6 +740,47 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		{
 			_mainDocTab.changeIcons(static_cast<unsigned char>(lParam));
 			_subDocTab.changeIcons(static_cast<unsigned char>(lParam));
+
+			//restart document list with the same icons as the DocTabs
+			if (_pDocumentListPanel && (!_pDocumentListPanel->isClosed())) // if doclist is open
+			{
+				//close the doclist
+				_pDocumentListPanel->display(false);
+				_pDocumentListPanel->setClosed(true);
+				checkMenuItem(IDM_VIEW_DOCLIST, false);
+				_toolBar.setCheck(IDM_VIEW_DOCLIST, false);
+
+				//clean doclist
+				_pDocumentListPanel->destroy();
+				_pDocumentListPanel = nullptr;
+
+				//relaunch with new icons
+				launchDocumentListPanel();
+				if (_pDocumentListPanel)
+				{
+					checkMenuItem(IDM_VIEW_DOCLIST, true);
+					_toolBar.setCheck(IDM_VIEW_DOCLIST, true);
+					_pDocumentListPanel->setClosed(false);
+				}
+
+			}
+			else if (_pDocumentListPanel && _pDocumentListPanel->isClosed()) //if doclist is closed
+			{
+				//clean doclist
+				_pDocumentListPanel->destroy();
+				_pDocumentListPanel = nullptr;
+
+				//relaunch doclist with new icons and close it
+				launchDocumentListPanel();
+				if (_pDocumentListPanel)
+				{
+					_pDocumentListPanel->display(false);
+					_pDocumentListPanel->setClosed(true);
+					checkMenuItem(IDM_VIEW_DOCLIST, false);
+					_toolBar.setCheck(IDM_VIEW_DOCLIST, false);
+				}
+			}
+
 			return TRUE;
 		}
 


### PR DESCRIPTION
fix  #10740

fix demo:

![DocListIconSupport_Fix](https://user-images.githubusercontent.com/27722888/147458824-0e87b4da-934e-4bbc-afcd-65047e181fb3.gif)

@thomassmith311, let me know if this fix is alright.
