### PR TITLE
Document List icons now support darkmode icons and alternate icons (Fix 2)

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6606,9 +6606,10 @@ void Notepad_plus::launchDocumentListPanel()
 	if (!_pDocumentListPanel)
 	{
 		NppParameters& nppParams = NppParameters::getInstance();
+		int tabBarStatus = nppParams.getNppGUI()._tabStatus;
 
 		_pDocumentListPanel = new VerticalFileSwitcher;
-		HIMAGELIST hImgLst = _docTabIconList.getHandle();
+		HIMAGELIST hImgLst = ((tabBarStatus & TAB_ALTICONS) ? _docTabIconListAlt.getHandle() : NppDarkMode::isEnabled() ? _docTabIconListDarkMode.getHandle() : _docTabIconList.getHandle());
 		_pDocumentListPanel->init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), hImgLst);
 		NativeLangSpeaker *pNativeSpeaker = nppParams.getNativeLangSpeaker();
 		bool isRTL = pNativeSpeaker->isRTL();

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -742,42 +742,35 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			_subDocTab.changeIcons(static_cast<unsigned char>(lParam));
 
 			//restart document list with the same icons as the DocTabs
-			if (_pDocumentListPanel && (!_pDocumentListPanel->isClosed())) // if doclist is open
+			if (_pDocumentListPanel)
 			{
-				//close the doclist
-				_pDocumentListPanel->display(false);
-				_pDocumentListPanel->setClosed(true);
-				checkMenuItem(IDM_VIEW_DOCLIST, false);
-				_toolBar.setCheck(IDM_VIEW_DOCLIST, false);
-
-				//clean doclist
-				_pDocumentListPanel->destroy();
-				_pDocumentListPanel = nullptr;
-
-				//relaunch with new icons
-				launchDocumentListPanel();
-				if (_pDocumentListPanel)
+				if (!_pDocumentListPanel->isClosed()) // if doclist is open
 				{
-					checkMenuItem(IDM_VIEW_DOCLIST, true);
-					_toolBar.setCheck(IDM_VIEW_DOCLIST, true);
-					_pDocumentListPanel->setClosed(false);
-				}
-
-			}
-			else if (_pDocumentListPanel && _pDocumentListPanel->isClosed()) //if doclist is closed
-			{
-				//clean doclist
-				_pDocumentListPanel->destroy();
-				_pDocumentListPanel = nullptr;
-
-				//relaunch doclist with new icons and close it
-				launchDocumentListPanel();
-				if (_pDocumentListPanel)
-				{
+					//close the doclist
 					_pDocumentListPanel->display(false);
-					_pDocumentListPanel->setClosed(true);
-					checkMenuItem(IDM_VIEW_DOCLIST, false);
-					_toolBar.setCheck(IDM_VIEW_DOCLIST, false);
+
+					//clean doclist
+					_pDocumentListPanel->destroy();
+					_pDocumentListPanel = nullptr;
+
+					//relaunch with new icons
+					launchDocumentListPanel();
+				}
+				else //if doclist is closed
+				{
+					//clean doclist
+					_pDocumentListPanel->destroy();
+					_pDocumentListPanel = nullptr;
+
+					//relaunch doclist with new icons and close it
+					launchDocumentListPanel();
+					if (_pDocumentListPanel)
+					{
+						_pDocumentListPanel->display(false);
+						_pDocumentListPanel->setClosed(true);
+						checkMenuItem(IDM_VIEW_DOCLIST, false);
+						_toolBar.setCheck(IDM_VIEW_DOCLIST, false);
+					}
 				}
 			}
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -740,6 +740,47 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		{
 			_mainDocTab.changeIcons(static_cast<unsigned char>(lParam));
 			_subDocTab.changeIcons(static_cast<unsigned char>(lParam));
+
+			//restart document list with the same icons as the DocTabs
+			if (_pDocumentListPanel && (!_pDocumentListPanel->isClosed())) // if doclist is open
+			{
+				//close the doclist
+				_pDocumentListPanel->display(false);
+				_pDocumentListPanel->setClosed(true);
+				checkMenuItem(IDM_VIEW_DOCLIST, false);
+				_toolBar.setCheck(IDM_VIEW_DOCLIST, false);
+
+				//clean doclist
+				_pDocumentListPanel->destroy();
+				_pDocumentListPanel = nullptr;
+
+				//relaunch with new icons
+				launchDocumentListPanel();
+				if (_pDocumentListPanel)
+				{
+					checkMenuItem(IDM_VIEW_DOCLIST, true);
+					_toolBar.setCheck(IDM_VIEW_DOCLIST, true);
+					_pDocumentListPanel->setClosed(false);
+				}
+
+			}
+			else if (_pDocumentListPanel && _pDocumentListPanel->isClosed()) //if doclist is closed
+			{
+				//clean doclist
+				_pDocumentListPanel->destroy();
+				_pDocumentListPanel = nullptr;
+
+				//relaunch doclist with new icons and close it
+				launchDocumentListPanel();
+				if (_pDocumentListPanel)
+				{
+					_pDocumentListPanel->display(false);
+					_pDocumentListPanel->setClosed(true);
+					checkMenuItem(IDM_VIEW_DOCLIST, false);
+					_toolBar.setCheck(IDM_VIEW_DOCLIST, false);
+				}
+			}
+
 			return TRUE;
 		}
 

--- a/PowerEditor/src/WinControls/DockingWnd/DockingDlgInterface.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingDlgInterface.h
@@ -63,7 +63,9 @@ public:
 		::SendMessage(_hParent, NPPM_DMMUPDATEDISPINFO, 0, reinterpret_cast<LPARAM>(_hSelf));
 	}
 
-    virtual void destroy() {}
+    virtual void destroy() {
+		StaticDialog::destroy();
+	}
 
 	virtual void setBackgroundColor(COLORREF) {}
 	virtual void setForegroundColor(COLORREF) {}


### PR DESCRIPTION
fix #10740

fix demo:
![DocListIconSupport_Fix](https://user-images.githubusercontent.com/27722888/147484699-24ed7e62-9679-4aac-9a9e-625f41e72754.gif)

Note: when you toggle the app to dark mode or toggle alternate icons, the document list docking panel will reset back to the left side of notepad++. So if the panel was floating or docked to the right, it'll go back to its default position (left). This is due to it restarting.