### PR TITLE
Fixed memory leak when toggling to and from Dark Mode.

### DIFF
--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
@@ -99,6 +99,11 @@ void ToolBarIcons::reInit(int size)
 	ImageList_SetIconSize(getDefaultLstSetDM2(), size, size);
 	ImageList_SetIconSize(getDisableLstSetDM2(), size, size);
 
+	for (size_t i = 0; i < _iconListVector.size(); ++i)
+	{
+		_iconListVector[i].removeAll();
+	}
+
 	for (size_t i = 0, len = _tbiis.size(); i < len; ++i)
 	{
 		if (_tbiis[i]._defaultIcon != -1)

--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
@@ -33,6 +33,11 @@ public :
 	void destroy() {
 		ImageList_Destroy(_hImglst);
 	};
+
+	void removeAll() {
+		ImageList_RemoveAll(_hImglst);
+	};
+
 	HIMAGELIST getHandle() const {return _hImglst;};
 	void addIcon(int iconID) const;
 	void addIcon(HICON hIcon) const;


### PR DESCRIPTION
fix #10957

The problem was in the following function

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/4a7a33f010b6e95d1480db93bb348840d4b82bf3/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp#L88-L117

The for loop keeps adding icons without clearing the old ones for every re-initialization of the toolbar icons.

@donho , @xomx and @mshingote, let me know if this fix is working in your PCs.