### PR TITLE
Update Bulgarian lоcalization

### DIFF
--- a/PowerEditor/installer/nativeLang/bulgarian.xml
+++ b/PowerEditor/installer/nativeLang/bulgarian.xml
@@ -3,7 +3,7 @@
 |
 |   Translators:.....: 2014–yyyy – Rusi Dimitrov;
 |                      2007–2012 – Milen Metev (Tragedy);
-|   Last revision:...: 26.12.2021 by Rusi Dimitrov <npp[at]rdd.anonaddy.com>
+|   Last revision:...: 15.01.2022 by Rusi Dimitrov <npp[at]rdd.anonaddy.com>
 |
 \=========================================================================== -->
 <NotepadPlus>
@@ -138,9 +138,11 @@
 					<Item id="42085" name="Час и дата (дълго)"/>
 					<Item id="42086" name="Час и дата (персонализирано)"/>
 						<!-- Подменю "Копиране в системния буфер -->
-					<Item id="42029" name="Текущият път на файла"/>
-					<Item id="42030" name="Текущото име на файла"/>
-					<Item id="42031" name="Текущият път на папката"/>
+					<Item id="42029" name="Пътя на текущият файл"/>
+					<Item id="42030" name="Името на текущият файл"/>
+					<Item id="42031" name="Пътя на текущата папка"/>
+					<Item id="42087" name="Имената на всички файлове"/>
+					<Item id="42088" name="Пътищата на всички файлове"/>
 						<!-- Подменю "Табулация" -->
 					<Item id="42008" name="Увеличаване на отстъпа"/>
 					<Item id="42009" name="Намаляване на отстъпа"/>
@@ -427,6 +429,13 @@
 					<Item id="47012" name="Инфо за отстраняване на грешки..."/>
 					<Item id="47000" name="Относно Notepad++"/>
 				<!-- Меню "?" край -->
+				<!-- Контекстно меню - начало -->
+						<!-- Списък с документи -->
+					<Item id="43501" name="Затваряне на избраните"/>
+					<Item id="43502" name="Затваряне на другите"/>
+					<Item id="43503" name="Копиране имената на избраните"/>
+					<Item id="43504" name="Копиране пътищата на избраните"/>
+				<!-- Контекстно меню - край -->
 				</Commands>
 			</Main>
 			<Splitter>
@@ -835,6 +844,7 @@
 					<Item id="7122" name="По-тъмен текст"/>
 					<Item id="7123" name="Неактивна опция"/>
 					<Item id="7124" name="Разделител"/>
+					<Item id="7125" name="Връзка"/>
 					<Item id="7130" name="Нулиране"/>
 				</DarkMode>
 					<!-- Полета/Граница/Ръб -->
@@ -985,16 +995,18 @@
 				</Backup>
 					<!-- Автоматично завършване -->
 				<AutoCompletion title="Авто-завършване">
-					<Item id="6115" name="Автоматичен отстъп"/>
 					<Item id="6807" name="Автоматично завършване"/>
 					<Item id="6808" name="Включено"/>
 					<Item id="6809" name="Завършване на функции"/>
 					<Item id="6810" name="Завършване на думи"/>
 					<Item id="6816" name="Завършване на функции и думи"/>
+					<Item id="6815" name="Подсказка при въвеждане на функции"/>
 					<Item id="6811" name="при"/>
 					<Item id="6813" name="знак(а)"/>
 					<Item id="6814" name="(стойност от 1 до 9)"/>
-					<Item id="6815" name="Подсказка при въвеждане на функции"/>
+					<Item id="6869" name="Вмъкване на избрано"/>
+					<Item id="6870" name="Клавиш Tab"/>
+					<Item id="6871" name="Клавиш Enter"/>
 					<Item id="6824" name="Игнориране на числа"/>
 					<Item id="6851" name="Автоматично вмъкване"/>
 					<Item id="6857" name=" html/xml затваряне"/>
@@ -1003,6 +1015,7 @@
 					<Item id="6860" name="Двойка #1:"/>
 					<Item id="6863" name="Двойка #2:"/>
 					<Item id="6866" name="Двойка #3:"/>
+					<Item id="6115" name="Автоматичен отстъп"/>
 				</AutoCompletion>
 					<!-- Прозорци и дата -->
 				<MultiInstance title="Прозорци и дата">
@@ -1380,7 +1393,8 @@
 			<session-save-folder-as-workspace value="&amp;Запис на &quot;Директория като работно място&quot;"/>
 			<file-save-assign-type value="&amp;Добавяне на разширение"/>
 			<file-rename-title value="Преименуване"/>
-				<!-- Меню "Търсене" - "Търсене", "Замяна", "Търсене във файлове", "Търсене в проекти", "Маркиране" -->
+				<!-- Меню "Търсене" -->
+					<!-- "Търсене", "Замяна", "Търсене във файлове", "Търсене в проекти", "Маркиране" -->
 			<shift-change-direction-tip value="Търсене в обратна посока чрез Shift+Enter"/>
 			<two-find-buttons-tip value="Режим за търсене с два бутона"/>
 			<find-status-top-reached value="Търсене: Намерено е първото повторение от краят. Началото на документа е достигнато."/>
@@ -1430,8 +1444,16 @@
 *.cpp *.cxx *.h *.hxx *.hpp
 
 Търсене във всички файлове с изключение на exe, obj и log:
-*.* !*.exe !*.obj !*.log"/>
-				<!-- Меню "Търсене" - "Търсене във файлове" - "Намиране на всички" -->
+*.* !*.exe !*.obj !*.log
+
+Търсене във всички файлове, но с изключване на папки tests, bin и bin64:
+*.* !\tests !\bin*
+
+Търсене във всички файлове, но с изключване на всички папки log или logs рекурсивно:
+*.* !+\log*"/>
+					<!-- "Търсене във файлове" -->
+			<find-in-files-select-folder value="Избиране на папка, от която да се търси"/>
+						<!-- "Намиране на всички" -->
 			<find-result-caption value="Намерени резултати"/>
 			<find-result-title value="Търсене на"/>
 			<find-result-title-info value="($INT_REPLACE1$ повторения в $INT_REPLACE2$ файл(а) от $INT_REPLACE3$ претърсен(и))"/>
@@ -1441,15 +1463,15 @@
 			<find-result-line-prefix value="Ред"/>
 			<find-regex-zero-length-match value="повторение с нулева дължина"/>
 			<find-in-files-progress-title value="Намиране във файлове..."/>
-				<!-- Меню "Търсене" - "Замяна" - "Замяна на всичко във всички отворени" -->
-			<replace-in-open-docs-confirm-title value="Сигурни ли сте?"/>
-			<replace-in-open-docs-confirm-message value="Сигурни ли сте, че искате да бъдат заменени всички повторения във всички отворени документи?"/>
-				<!-- Меню "Търсене" - "Търсене във файлове" - "Замяна във файловете" -->
+						<!-- "Замяна във файловете" -->
 			<replace-in-files-confirm-title value="Сигурни ли сте?"/>
 			<replace-in-files-confirm-directory value="Сигурни ли сте, че искате да бъдат заменени всички повторения в:"/>
 			<replace-in-files-confirm-filetype value="За типа файл:"/>
 			<replace-in-files-progress-title value="Замяна във файлове..."/>
-				<!-- Меню "Търсене" - "Търсене в проекти" - "Замяна в проектите" -->
+					<!-- "Замяна" - "Замяна на всичко във всички отворени" -->
+			<replace-in-open-docs-confirm-title value="Сигурни ли сте?"/>
+			<replace-in-open-docs-confirm-message value="Сигурни ли сте, че искате да бъдат заменени всички повторения във всички отворени документи?"/>
+					<!-- "Търсене в проекти" - "Замяна в проектите" -->
 			<replace-in-projects-confirm-title value="Сигурни ли сте?"/>
 			<replace-in-projects-confirm-message value="Сигурни ли сте, че искате да бъдат заменени всички повторения във всички документи в избраните проектни панели?"/>
 				<!-- Меню "Изглед" - "Информация за файла..." -->
@@ -1469,19 +1491,26 @@
 			<userdefined-title-save value="Запазване на синтаксиса като..."/>
 			<userdefined-title-rename value="Преименуване на синтаксиса"/>
 			<common-name value="Име:"/>
-				<!-- Меню "Настройки" - "Предпочитания..." - "Разделител" -->
+				<!-- Меню "Настройки" - "Предпочитания..." -->
+					<!-- "Път по подразбиране" -->
+			<default-open-save-select-folder value="Избиране на папка като директория по подразбиране"/>
+					<!-- "Резервно копие" -->
+			<backup-select-folder value="Избиране на папка като директория за архивиране"/>
+					<!-- "Разделител" -->
 			<word-chars-list-tip value="Позволява добавяне на допълнителни символи към дума, чрез двойно щракане върху нея или при включена опция за търсене на &quot;Само цели думи&quot;"/>
 			<word-chars-list-warning-begin value="Бъдете внимателни: "/>
 			<word-chars-list-space-warning value="$INT_REPLACE$ интервал(а)"/>
 			<word-chars-list-tab-warning value="$INT_REPLACE$ отстъп(а)"/>
 			<word-chars-list-warning-end value=" в списъкa със символи."/>
-				<!-- Меню "Настройки" - "Предпочитания..." - "Облак и връзка" -->
+					<!-- "Облак и връзка" -->
 			<cloud-invalid-warning value="Невалиден път"/>
 			<cloud-restart-warning value="Изисква се рестартиране на Notepad++"/>
 			<cloud-select-folder value="Избор на папка, от/в която Notepad++ ще чете/пише настройките си"/>
-				<!-- Меню "Настройки" - "Предпочитания..." -->
+					<!-- "История на отваряния" -->
 			<recent-file-history-maxfile value="Макс. файла:"/>
+					<!-- "Синтаксис" -->
 			<language-tabsize value="Размер:"/>
+					<!-- "Авто-завършване" -->
 			<autocomplete-nb-char value="Брой знаци:"/>
 				<!-- Дясно щракане върху раздел - "Преименуване..." -->
 			<tabrename-title value="Преименуване на раздела"/>
@@ -1493,6 +1522,11 @@
 			<IncrementalFind-FSNotFound value="Фразата не е намерена"/>
 			<IncrementalFind-FSTopReached value="Достигнато е началото, продължава отдолу"/>
 			<IncrementalFind-FSEndReached value="Достигнат е краят, продължава отгоре"/>
+				<!-- Контекстно меню -->
+			<contextMenu-styleAlloccurrencesOfToken value="Открояване на всички избрани"/>
+			<contextMenu-styleOneToken value="Открояване само на еднo избранo"/>
+			<contextMenu-clearStyle value="Изчистване на открояването"/>
+			<contextMenu-PluginCommands value="Команди от добавки"/>
 				<!-- Други -->
 			<splitter-rotate-left value="Завъртане наляво"/>
 			<splitter-rotate-right value="Завъртане надясно"/>


### PR DESCRIPTION
* Add exclude folder(s) capacity in Find in Files · notepad-plus-plus/notepad-plus-plus@b5d646b
* Add link text color in customized dark colors of Preferences dialog · notepad-plus-plus/notepad-plus-plus@50dfdb2
* Add copy name/path commands to DocList and Edit menu · notepad-plus-plus/notepad-plus-plus@9be4eeb
* Add missing translation for folder browser title · notepad-plus-plus/notepad-plus-plus@78c6554
* Auto-completion currently use both ENTER and TAB to insert the selected item · notepad-plus-plus/notepad-plus-plus@68d339d
* Make menu folders on context menu translatable · notepad-plus-plus/notepad-plus-plus@e048f83