### PR TITLE
Add copy name/path commands to Doc. List and Edit menu

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -252,9 +252,9 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="43049" name="&amp;Select and Find Previous"/>
                     <Item id="43054" name="Mar&amp;k..."/>
                     <Item id="43501" name="Close Selected"/>
-										<Item id="43502" name="Close Others"/>
-										<Item id="43503" name="Copy Selected Names"/>
-										<Item id="43504" name="Copy Selected Pathnames"/>
+                    <Item id="43502" name="Close Others"/>
+                    <Item id="43503" name="Copy Selected Names"/>
+                    <Item id="43504" name="Copy Selected Pathnames"/>
                     <Item id="44009" name="Post-It"/>
                     <Item id="44010" name="Fold All"/>
                     <Item id="44011" name="Distraction Free Mode"/>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -178,6 +178,8 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="42029" name="Current File Path to Clipboard"/>
                     <Item id="42030" name="Current Filename to Clipboard"/>
                     <Item id="42031" name="Current Dir. Path to Clipboard"/>
+                    <Item id="42087" name="All Filenames to Clipboard"/>
+                    <Item id="42088" name="All File Paths to Clipboard"/>
                     <Item id="42032" name="&amp;Run a Macro Multiple Times..."/>
                     <Item id="42033" name="Clear Read-Only Flag"/>
                     <Item id="42035" name="Single Line Comment"/>
@@ -249,6 +251,10 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="43048" name="&amp;Select and Find Next"/>
                     <Item id="43049" name="&amp;Select and Find Previous"/>
                     <Item id="43054" name="Mar&amp;k..."/>
+                    <Item id="43501" name="Close Selected"/>
+										<Item id="43502" name="Close Others"/>
+										<Item id="43503" name="Copy Selected Names"/>
+										<Item id="43504" name="Copy Selected Pathnames"/>
                     <Item id="44009" name="Post-It"/>
                     <Item id="44010" name="Fold All"/>
                     <Item id="44011" name="Distraction Free Mode"/>

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -27,6 +27,7 @@
 #include "Common.h"
 #include "Utf8.h"
 #include <Parameters.h>
+#include "Buffer.h"
 
 void printInt(int int2print)
 {
@@ -934,6 +935,26 @@ bool str2Clipboard(const generic_string &str2cpy, HWND hwnd)
 		return false;
 	}
 	return true;
+}
+
+bool buf2Clipborad(const std::vector<Buffer*>& buffers, bool isFullPath, HWND hwnd)
+{
+	const generic_string crlf = _T("\r\n");
+	generic_string selection;
+	for (auto&& buf : buffers)
+	{
+		if (buf)
+		{
+			const TCHAR* fileName = isFullPath ? buf->getFullPathName() : buf->getFileName();
+			if (fileName)
+				selection += fileName;
+		}
+		if (!selection.empty() && !endsWith(selection, crlf))
+			selection += crlf;
+	}
+	if (!selection.empty())
+		return str2Clipboard(selection, hwnd);
+	return false;
 }
 
 bool matchInList(const TCHAR *fileName, const std::vector<generic_string> & patterns)

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -180,6 +180,8 @@ double stodLocale(const generic_string& str, _locale_t loc, size_t* idx = NULL);
 int OrdinalIgnoreCaseCompareStrings(LPCTSTR sz1, LPCTSTR sz2);
 
 bool str2Clipboard(const generic_string &str2cpy, HWND hwnd);
+class Buffer;
+bool buf2Clipborad(const std::vector<Buffer*>& buffers, bool isFullPath, HWND hwnd);
 
 generic_string GetLastErrorAsString(DWORD errorCode = 0);
 

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -439,6 +439,7 @@ BEGIN
                 MENUITEM "Current Full File path to Clipboard",    IDM_EDIT_FULLPATHTOCLIP
                 MENUITEM "Current Filename to Clipboard",          IDM_EDIT_FILENAMETOCLIP
                 MENUITEM "Current Dir. Path to Clipboard",         IDM_EDIT_CURRENTDIRTOCLIP
+                MENUITEM SEPARATOR
                 MENUITEM "All Filenames to Clipboard",             IDM_EDIT_COPY_ALL_NAMES
                 MENUITEM "All File Paths to Clipboard",            IDM_EDIT_COPY_ALL_PATHS
         END

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -439,6 +439,8 @@ BEGIN
                 MENUITEM "Current Full File path to Clipboard",    IDM_EDIT_FULLPATHTOCLIP
                 MENUITEM "Current Filename to Clipboard",          IDM_EDIT_FILENAMETOCLIP
                 MENUITEM "Current Dir. Path to Clipboard",         IDM_EDIT_CURRENTDIRTOCLIP
+                MENUITEM "All Filenames to Clipboard",             IDM_EDIT_COPY_ALL_NAMES
+                MENUITEM "All File Paths to Clipboard",            IDM_EDIT_COPY_ALL_PATHS
         END
         POPUP "&Indent"
         BEGIN

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -236,6 +236,18 @@ void Notepad_plus::command(int id)
 			}
 			break;
 
+		case IDM_DOCLIST_COPYNAMES:
+		case IDM_DOCLIST_COPYPATHS:
+			if (_pDocumentListPanel)
+			{
+				std::vector<Buffer*> buffers;
+				auto files = _pDocumentListPanel->getSelectedFiles(false);
+				for (auto&& sel : files)
+					buffers.push_back(MainFileManager.getBufferByID(sel._bufID));
+				buf2Clipborad(buffers, id == IDM_DOCLIST_COPYPATHS, _pDocumentListPanel->getHSelf());
+			}
+			break;
+
 		case IDM_FILE_CLOSE:
 			if (fileClose())
                 checkDocState();
@@ -1156,6 +1168,30 @@ void Notepad_plus::command(int id)
 			}
 		}
 		break;
+
+		case IDM_EDIT_COPY_ALL_NAMES:
+		case IDM_EDIT_COPY_ALL_PATHS:
+			{
+				std::vector<DocTabView*> docTabs;
+				if (viewVisible(MAIN_VIEW))
+					docTabs.push_back(&_mainDocTab);
+				if (viewVisible(SUB_VIEW))
+					docTabs.push_back(&_subDocTab);
+				std::vector<Buffer*> buffers;
+				for (auto&& docTab : docTabs)
+				{
+					for (size_t i = 0, len = docTab->nbItem(); i < len; ++i)
+					{
+						BufferID bufID = docTab->getBufferByIndex(i);
+						Buffer* buf = MainFileManager.getBufferByID(bufID);
+						// Don't add duplicates because a buffer might be cloned in other view.
+						if (docTabs.size() < 2 || std::find(buffers.begin(), buffers.end(), buf) == buffers.end())
+							buffers.push_back(buf);
+					}
+				}
+				buf2Clipborad({ buffers.begin(), buffers.end() }, id == IDM_EDIT_COPY_ALL_PATHS, _pPublicInterface->getHSelf());
+			}
+			break;
 
 		case IDM_SEARCH_FIND :
 		case IDM_SEARCH_REPLACE :

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3923,6 +3923,8 @@ void Notepad_plus::command(int id)
 			case IDM_VIEW_IN_CHROME  :
 			case IDM_VIEW_IN_EDGE    :
 			case IDM_VIEW_IN_IE      :
+			case IDM_EDIT_COPY_ALL_NAMES:
+			case IDM_EDIT_COPY_ALL_PATHS:
 				_macro.push_back(recordedMacroStep(id));
 				break;
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -499,7 +499,9 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 						for (auto&& x : itemUnitArray)
 						{
-							x._itemName = _nativeLangSpeaker.getNativeLangMenuString(x._cmdID);
+							const generic_string menuItem = _nativeLangSpeaker.getNativeLangMenuString(x._cmdID);
+							if (!menuItem.empty())
+								x._itemName = menuItem;
 						}
 
 						_fileSwitcherMultiFilePopupMenu.create(_pPublicInterface->getHSelf(), itemUnitArray);

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -493,10 +493,16 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					{
 						vector<MenuItemUnit> itemUnitArray;
 						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSE, TEXT("Close Selected files")));
-						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSEOTHERS, TEXT("Close others files")));
+						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSEOTHERS, TEXT("Close Other files")));
+						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_COPYNAMES, TEXT("Copy Selected Names")));
+						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_COPYPATHS, TEXT("Copy Selected Pathnames")));
+
+						for (auto&& x : itemUnitArray)
+						{
+							x._itemName = _nativeLangSpeaker.getNativeLangMenuString(x._cmdID);
+						}
 
 						_fileSwitcherMultiFilePopupMenu.create(_pPublicInterface->getHSelf(), itemUnitArray);
-						_nativeLangSpeaker.changeLangTabContextMenu(_fileSwitcherMultiFilePopupMenu.getMenuHandle());
 					}
 					_fileSwitcherMultiFilePopupMenu.display(p);
 					return TRUE;

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -105,6 +105,9 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{ VK_NULL,    IDM_EDIT_FULLPATHTOCLIP,                      false, false, false, nullptr },
 	{ VK_NULL,    IDM_EDIT_FILENAMETOCLIP,                      false, false, false, nullptr },
 	{ VK_NULL,    IDM_EDIT_CURRENTDIRTOCLIP,                    false, false, false, nullptr },
+	{ VK_NULL,    IDM_EDIT_COPY_ALL_NAMES,                      false, false, false, nullptr },
+	{ VK_NULL,    IDM_EDIT_COPY_ALL_PATHS,                      false, false, false, nullptr },
+
 	{ VK_NULL,    IDM_EDIT_INS_TAB,                             false, false, false, nullptr },
 	{ VK_NULL,    IDM_EDIT_RMV_TAB,                             false, false, false, nullptr },
 	{ VK_U,       IDM_EDIT_UPPERCASE,                           true,  false, true,  nullptr },

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -980,39 +980,18 @@ void WindowsDlg::doSortToTabs()
 
 void WindowsDlg::putItemsToClipboard(bool isFullPath)
 {
-	constexpr int pathColumn = 1;
-
-	TCHAR str[MAX_PATH] = {};
-	const generic_string crlf = _T("\r\n");
-
-	generic_string selection;
+	std::vector<Buffer*> buffers;
 	for (int i = -1, j = 0; ; ++j)
 	{
 		i = ListView_GetNextItem(_hList, i, LVNI_SELECTED);
 		if (i < 0)
 			break;
-		if (isFullPath)
-		{
-			// Get the directory path (2nd column).
-			ListView_GetItemText(_hList, i, pathColumn, str, sizeof(str));
-			if (str[0])
-				selection += str;
-		}
-
 		// Get the file name.
 		// Do not use ListView_GetItemText() because 1st column may contain "*" or "[Read Only]".
-		Buffer* buf = getBuffer(i);
-		if (buf)
-		{
-			const TCHAR* fileName = buf->getFileName();
-			if (fileName)
-				selection += fileName;
-		}
-		if (!selection.empty() && !endsWith(selection, crlf))
-			selection += crlf;
+		buffers.push_back(getBuffer(i));
 	}
-	if (!selection.empty())
-		str2Clipboard(selection, _hList);
+
+	buf2Clipborad(buffers, isFullPath, _hList);
 }
 
 Buffer* WindowsDlg::getBuffer(int index) const

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -168,6 +168,8 @@
     #define    IDM_EDIT_INSERT_DATETIME_SHORT                   (IDM_EDIT + 84)
     #define    IDM_EDIT_INSERT_DATETIME_LONG                    (IDM_EDIT + 85)
     #define    IDM_EDIT_INSERT_DATETIME_CUSTOMIZED              (IDM_EDIT + 86)
+    #define    IDM_EDIT_COPY_ALL_NAMES                          (IDM_EDIT + 87)
+    #define    IDM_EDIT_COPY_ALL_PATHS                          (IDM_EDIT + 88)
 
     #define    IDM_EDIT_AUTOCOMPLETE                            (50000 + 0)
     #define    IDM_EDIT_AUTOCOMPLETE_CURRENTFILE                (50000 + 1)
@@ -249,6 +251,8 @@
 #define    IDM_MISC    (IDM + 3500)
     #define    IDM_DOCLIST_FILESCLOSE             (IDM_MISC + 1)
     #define    IDM_DOCLIST_FILESCLOSEOTHERS       (IDM_MISC + 2)
+    #define    IDM_DOCLIST_COPYNAMES              (IDM_MISC + 3)
+    #define    IDM_DOCLIST_COPYPATHS              (IDM_MISC + 4)
 
 
 #define IDM_VIEW    (IDM + 4000)                


### PR DESCRIPTION
Add new commands to copy selected files name/path into multi-selection
context menu in Document List.
Add new commands to copy all files name/path into Edit > Copy to Clipboard.
Create a new function buf2Clipborad() to be used in all similar commands.
Add new translation strings.
Also, fix the translation of the Document List multi-selection context menu.

Fix #10394