### PR TITLE
Fix loaded session being empty on exit

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5703,7 +5703,7 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includUntitledD
 		for (size_t i = 0, len = docTab[k]->nbItem(); i < len ; ++i)
 		{
 			BufferID bufID = docTab[k]->getBufferByIndex(i);
-			ScintillaEditView *editView = k == 0?&_mainEditView:&_subEditView;
+			ScintillaEditView *editView = k == 0 ? &_mainEditView : &_subEditView;
 			size_t activeIndex = k == 0 ? session._activeMainIndex : session._activeSubIndex;
 			vector<sessionFileInfo> *viewFiles = (vector<sessionFileInfo> *)(k == 0?&(session._mainViewFiles):&(session._subViewFiles));
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1964,9 +1964,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				}
 
 				Session currentSession;
+				getCurrentOpenedFiles(currentSession, true);
+
 				if (nppgui._rememberLastSession)
 				{
-					getCurrentOpenedFiles(currentSession, true);
 					//Lock the recent file list so it isnt populated with opened files
 					//Causing them to show on restart even though they are loaded by session
 					_lastRecentFileList.setLock(true);	//only lock when the session is remembered
@@ -2032,7 +2033,6 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				//
 				// saving session.xml into loaded session if a saved session is loaded and saveLoadedSessionOnExit option is enabled
 				//
-				
 				generic_string loadedSessionFilePath = nppParam.getLoadedSessionFilePath();
 				if (!loadedSessionFilePath.empty() && PathFileExists(loadedSessionFilePath.c_str()))
 					nppParam.writeSession(currentSession, loadedSessionFilePath.c_str());


### PR DESCRIPTION
In the following configuration loaded session will be empty on exit
* Remember current session for next launch: OFF
* Open session in a new instance: ON

This commit fix the issue.

Fix #10986