### PR TITLE
Make menu folders on context menu translatable

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1506,6 +1506,10 @@ Find in all files but exclude all folders log or logs recursively:
             <IncrementalFind-FSNotFound value="Phrase not found" />
             <IncrementalFind-FSTopReached value="Reached top of page, continued from bottom" />
             <IncrementalFind-FSEndReached value="Reached end of page, continued from top" />
+            <contextMenu-styleAlloccurrencesOfToken value="Style all occurrences of token" />
+            <contextMenu-styleOneToken value="Style one token" />
+            <contextMenu-clearStyle value="Clear style" />
+            <contextMenu-PluginCommands value="Plugin commands" />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/french.xml
+++ b/PowerEditor/installer/nativeLang/french.xml
@@ -1460,6 +1460,10 @@ Rechercher dans tous les fichiers mais pas dans les dossiers log ou logs récurs
             <IncrementalFind-FSNotFound value="Expression introuvable" />
             <IncrementalFind-FSTopReached value="Haut de page atteint, continuer en partant du bas" />
             <IncrementalFind-FSEndReached value="Fin de page atteinte, continuer en partant du haut" />
+            <contextMenu-styleAlloccurrencesOfToken value="Appliquer le style à toutes les occurrences" />
+            <contextMenu-styleOneToken value="Appliquer le style à 1 seul occurrence" />
+            <contextMenu-clearStyle value="Dégager le style" />
+            <contextMenu-PluginCommands value="Modules d'extension" />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/taiwaneseMandarin.xml
+++ b/PowerEditor/installer/nativeLang/taiwaneseMandarin.xml
@@ -1453,6 +1453,10 @@
             <IncrementalFind-FSNotFound value="找不到相符字串" />
             <IncrementalFind-FSTopReached value="到達頁面頂部，從底部繼續" />
             <IncrementalFind-FSEndReached value="到達頁面末尾，從頂部繼續 " />
+            <contextMenu-styleAlloccurrencesOfToken value="樣式化所有相符的字串" />
+            <contextMenu-styleOneToken value="僅樣式化選擇的字串" />
+            <contextMenu-clearStyle value="清除樣式" />
+            <contextMenu-PluginCommands value="外掛模組" />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2018,6 +2018,7 @@ bool NppParameters::getContextMenuFromXmlTree(HMENU mainMenuHadle, HMENU plugins
 		return false;
 
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+	NativeLangSpeaker* pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 
 	TiXmlNodeA *contextMenuRoot = root->FirstChildElement("ScintillaContextMenu");
 	if (contextMenuRoot)
@@ -2026,13 +2027,19 @@ bool NppParameters::getContextMenuFromXmlTree(HMENU mainMenuHadle, HMENU plugins
 			childNode ;
 			childNode = childNode->NextSibling("Item") )
 		{
-			const char *folderNameA = (childNode->ToElement())->Attribute("FolderName");
+			const char *folderNameDefaultA = (childNode->ToElement())->Attribute("FolderName");
+			const char *folderNameTranslateID_A = (childNode->ToElement())->Attribute("TranslateID");
 			const char *displayAsA = (childNode->ToElement())->Attribute("ItemNameAs");
 
 			generic_string folderName;
 			generic_string displayAs;
-			folderName = folderNameA?wmc.char2wchar(folderNameA, SC_CP_UTF8):TEXT("");
-			displayAs = displayAsA?wmc.char2wchar(displayAsA, SC_CP_UTF8):TEXT("");
+			folderName = folderNameDefaultA ? wmc.char2wchar(folderNameDefaultA, SC_CP_UTF8) : TEXT("");
+			displayAs = displayAsA ? wmc.char2wchar(displayAsA, SC_CP_UTF8) : TEXT("");
+
+			if (folderNameTranslateID_A)
+			{
+				folderName = pNativeSpeaker->getLocalizedStrFromID(folderNameTranslateID_A, folderName);
+			}
 
 			int id;
 			const char *idStr = (childNode->ToElement())->Attribute("id", &id);

--- a/PowerEditor/src/contextMenu.xml
+++ b/PowerEditor/src/contextMenu.xml
@@ -29,38 +29,39 @@ https://npp-user-manual.org/docs/config-files/#the-context-menu-contextmenu-xml
 		
 		Use FolderName (optional) to create sub-menu. FolderName can be used in any type of item.
 		FolderName value can be in any language.
+		TranslateID is for translating FolderName's value. If you create your FolderName, don't add TranslateID.
 		-->
-        <Item FolderName="Style all occurrences of token" id="43022"/>
-        <Item FolderName="Style all occurrences of token" id="43024"/>
-        <Item FolderName="Style all occurrences of token" id="43026"/>
-        <Item FolderName="Style all occurrences of token" id="43028"/>
-        <Item FolderName="Style all occurrences of token" id="43030"/>
+        <Item FolderName="Style all occurrences of token" TranslateID="contextMenu-styleAlloccurrencesOfToken" id="43022"/>
+        <Item FolderName="Style all occurrences of token" TranslateID="contextMenu-styleAlloccurrencesOfToken" id="43024"/>
+        <Item FolderName="Style all occurrences of token" TranslateID="contextMenu-styleAlloccurrencesOfToken" id="43026"/>
+        <Item FolderName="Style all occurrences of token" TranslateID="contextMenu-styleAlloccurrencesOfToken" id="43028"/>
+        <Item FolderName="Style all occurrences of token" TranslateID="contextMenu-styleAlloccurrencesOfToken" id="43030"/>
 		
-        <Item FolderName="Style one token" id="43062"/>
-        <Item FolderName="Style one token" id="43063"/>
-        <Item FolderName="Style one token" id="43064"/>
-        <Item FolderName="Style one token" id="43065"/>
-        <Item FolderName="Style one token" id="43066"/>
+        <Item FolderName="Style one token"  TranslateID="contextMenu-styleOneToken" id="43062"/>
+        <Item FolderName="Style one token"  TranslateID="contextMenu-styleOneToken" id="43063"/>
+        <Item FolderName="Style one token"  TranslateID="contextMenu-styleOneToken" id="43064"/>
+        <Item FolderName="Style one token"  TranslateID="contextMenu-styleOneToken" id="43065"/>
+        <Item FolderName="Style one token"  TranslateID="contextMenu-styleOneToken" id="43066"/>
 		
-        <Item FolderName="Clear style" id="43023"/>
-        <Item FolderName="Clear style" id="43025"/>
-        <Item FolderName="Clear style" id="43027"/>
-        <Item FolderName="Clear style" id="43029"/>
-        <Item FolderName="Clear style" id="43031"/>
-        <Item FolderName="Clear style" id="43032"/>
+        <Item FolderName="Clear style"  TranslateID="contextMenu-clearStyle" id="43023"/>
+        <Item FolderName="Clear style"  TranslateID="contextMenu-clearStyle" id="43025"/>
+        <Item FolderName="Clear style"  TranslateID="contextMenu-clearStyle" id="43027"/>
+        <Item FolderName="Clear style"  TranslateID="contextMenu-clearStyle" id="43029"/>
+        <Item FolderName="Clear style"  TranslateID="contextMenu-clearStyle" id="43031"/>
+        <Item FolderName="Clear style"  TranslateID="contextMenu-clearStyle" id="43032"/>
         <Item id="0"/>
 		
 		<!--
 		To add plugin commands, you have to use PluginEntryName and PluginCommandItemName to localize the plugin commands
 		-->
-		<Item FolderName="Plugin commands" PluginEntryName="MIME Tools" PluginCommandItemName="Base64 Encode" />
-        <Item FolderName="Plugin commands" PluginEntryName="MIME Tools" PluginCommandItemName="Base64 Decode" />
+		<Item FolderName="Plugin commands" TranslateID="contextMenu-PluginCommands" PluginEntryName="MIME Tools" PluginCommandItemName="Base64 Encode" />
+        <Item FolderName="Plugin commands" TranslateID="contextMenu-PluginCommands" PluginEntryName="MIME Tools" PluginCommandItemName="Base64 Decode" />
 		
 		<!--
 		Use ItemNameAs (optional) to rename the menu item name in the context menu 
 		ItemNameAs can be used in any type of item. ItemNameAs value can be in any language.
 		-->
-        <Item FolderName="Plugin commands" PluginEntryName="NppExport" PluginCommandItemName="Copy all formats to clipboard" ItemNameAs="Copy Text with Syntax Highlighting" />
+        <Item FolderName="Plugin commands"  TranslateID="contextMenu-PluginCommands" PluginEntryName="NppExport" PluginCommandItemName="Copy all formats to clipboard" ItemNameAs="Copy Text with Syntax Highlighting" />
         <Item id="0"/>
         <Item MenuEntryName="Edit" MenuItemName="UPPERCASE"/>
         <Item MenuEntryName="Edit" MenuItemName="lowercase"/>


### PR DESCRIPTION
Make the following context menu items translatable:
1. "Style all occurrences of token"
2. "Style one token"
3. "Clear style"
4. "Plugin commands"

**Note for translators: to test your translation, you have to replace the old "contextMenu.xml" with the new one (modified in this commit).**

Fix partially #8972
Fix #9713