### PR TITLE
Remove 2GB file open restriction for x64 binary

### DIFF
--- a/PowerEditor/src/DarkMode/DarkMode.cpp
+++ b/PowerEditor/src/DarkMode/DarkMode.cpp
@@ -134,7 +134,7 @@ bool IsHighContrast()
 void SetTitleBarThemeColor(HWND hWnd, BOOL dark)
 {
 	if (g_buildNumber < 18362)
-		SetPropW(hWnd, L"UseImmersiveDarkModeColors", reinterpret_cast<HANDLE>(static_cast<INT_PTR>(dark)));
+		SetPropW(hWnd, L"UseImmersiveDarkModeColors", reinterpret_cast<HANDLE>(static_cast<intptr_t>(dark)));
 	else if (_SetWindowCompositionAttribute)
 	{
 		WINDOWCOMPOSITIONATTRIBDATA data = { WCA_USEDARKMODECOLORS, &dark, sizeof(dark) };

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -397,7 +397,7 @@ const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t
 
 // "mstart" and "mend" are pointers to indexes in mbcs2Convert,
 // which are converted to the corresponding indexes in the returned wchar_t string.
-const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t codepage, INT_PTR* mstart, INT_PTR* mend)
+const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t codepage, intptr_t* mstart, intptr_t* mend)
 {
 	// Do not process NULL pointer
 	if (!mbcs2Convert) return NULL;

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -325,7 +325,7 @@ generic_string purgeMenuItemString(const TCHAR * menuItemStr, bool keepAmpersand
 }
 
 
-const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t codepage, int lenMbcs, int *pLenWc, int *pBytesNotProcessed)
+const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t codepage, int lenMbcs, int* pLenWc, int* pBytesNotProcessed)
 {
 	// Do not process NULL pointer
 	if (!mbcs2Convert)
@@ -429,7 +429,7 @@ const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t
 }
 
 
-const char* WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, size_t codepage, int lenWc, int *pLenMbcs)
+const char* WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, size_t codepage, int lenWc, int* pLenMbcs)
 {
 	if (nullptr == wcharStr2Convert)
 		return nullptr;
@@ -449,7 +449,7 @@ const char* WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, siz
 }
 
 
-const char * WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, size_t codepage, long *mstart, long *mend)
+const char * WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, size_t codepage, long* mstart, long* mend)
 {
 	if (nullptr == wcharStr2Convert)
 		return nullptr;

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -325,7 +325,7 @@ generic_string purgeMenuItemString(const TCHAR * menuItemStr, bool keepAmpersand
 }
 
 
-const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, UINT codepage, int lenMbcs, int *pLenWc, int *pBytesNotProcessed)
+const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t codepage, int lenMbcs, int *pLenWc, int *pBytesNotProcessed)
 {
 	// Do not process NULL pointer
 	if (!mbcs2Convert)
@@ -338,36 +338,37 @@ const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, UINT c
 		return _wideCharStr;
 	}
 
+	UINT cp = static_cast<UINT>(codepage);
 	int bytesNotProcessed = 0;
 	int lenWc = 0;
 
 	// If length not specified, simply convert without checking
 	if (lenMbcs == -1)
 	{
-		lenWc = MultiByteToWideChar(codepage, 0, mbcs2Convert, lenMbcs, NULL, 0);
+		lenWc = MultiByteToWideChar(cp, 0, mbcs2Convert, lenMbcs, NULL, 0);
 	}
 	// Otherwise, test if we are cutting a multi-byte character at end of buffer
-	else if (lenMbcs != -1 && codepage == CP_UTF8) // For UTF-8, we know how to test it
+	else if (lenMbcs != -1 && cp == CP_UTF8) // For UTF-8, we know how to test it
 	{
 		int indexOfLastChar = Utf8::characterStart(mbcs2Convert, lenMbcs-1); // get index of last character
 		if (indexOfLastChar != 0 && !Utf8::isValid(mbcs2Convert+indexOfLastChar, lenMbcs-indexOfLastChar)) // if it is not valid we do not process it right now (unless its the only character in string, to ensure that we always progress, e.g. that bytesNotProcessed < lenMbcs)
 		{
 			bytesNotProcessed = lenMbcs-indexOfLastChar;
 		}
-		lenWc = MultiByteToWideChar(codepage, 0, mbcs2Convert, lenMbcs-bytesNotProcessed, NULL, 0);
+		lenWc = MultiByteToWideChar(cp, 0, mbcs2Convert, lenMbcs-bytesNotProcessed, NULL, 0);
 	}
 	else // For other encodings, ask system if there are any invalid characters; note that it will not correctly know if last character is cut when there are invalid characters inside the text
 	{
-		lenWc = MultiByteToWideChar(codepage, (lenMbcs == -1) ? 0 : MB_ERR_INVALID_CHARS, mbcs2Convert, lenMbcs, NULL, 0);
+		lenWc = MultiByteToWideChar(cp, (lenMbcs == -1) ? 0 : MB_ERR_INVALID_CHARS, mbcs2Convert, lenMbcs, NULL, 0);
 		if (lenWc == 0 && GetLastError() == ERROR_NO_UNICODE_TRANSLATION)
 		{
 			// Test without last byte
-			if (lenMbcs > 1) lenWc = MultiByteToWideChar(codepage, MB_ERR_INVALID_CHARS, mbcs2Convert, lenMbcs-1, NULL, 0);
+			if (lenMbcs > 1) lenWc = MultiByteToWideChar(cp, MB_ERR_INVALID_CHARS, mbcs2Convert, lenMbcs-1, NULL, 0);
 			if (lenWc == 0) // don't have to check that the error is still ERROR_NO_UNICODE_TRANSLATION, since only the length parameter changed
 			{
 				// TODO: should warn user about incorrect loading due to invalid characters
 				// We still load the file, but the system will either strip or replace invalid characters (including the last character, if cut in half)
-				lenWc = MultiByteToWideChar(codepage, 0, mbcs2Convert, lenMbcs, NULL, 0);
+				lenWc = MultiByteToWideChar(cp, 0, mbcs2Convert, lenMbcs, NULL, 0);
 			}
 			else
 			{
@@ -380,7 +381,7 @@ const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, UINT c
 	if (lenWc > 0)
 	{
 		_wideCharStr.sizeTo(lenWc);
-		MultiByteToWideChar(codepage, 0, mbcs2Convert, lenMbcs-bytesNotProcessed, _wideCharStr, lenWc);
+		MultiByteToWideChar(cp, 0, mbcs2Convert, lenMbcs-bytesNotProcessed, _wideCharStr, lenWc);
 	}
 	else
 		_wideCharStr.empty();
@@ -396,21 +397,21 @@ const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, UINT c
 
 // "mstart" and "mend" are pointers to indexes in mbcs2Convert,
 // which are converted to the corresponding indexes in the returned wchar_t string.
-const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, UINT codepage, int *mstart, int *mend)
+const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, size_t codepage, INT_PTR* mstart, INT_PTR* mend)
 {
 	// Do not process NULL pointer
 	if (!mbcs2Convert) return NULL;
-
-	int len = MultiByteToWideChar(codepage, 0, mbcs2Convert, -1, NULL, 0);
+	UINT cp = static_cast<UINT>(codepage);
+	int len = MultiByteToWideChar(cp, 0, mbcs2Convert, -1, NULL, 0);
 	if (len > 0)
 	{
 		_wideCharStr.sizeTo(len);
-		len = MultiByteToWideChar(codepage, 0, mbcs2Convert, -1, _wideCharStr, len);
+		len = MultiByteToWideChar(cp, 0, mbcs2Convert, -1, _wideCharStr, len);
 
 		if ((size_t)*mstart < strlen(mbcs2Convert) && (size_t)*mend <= strlen(mbcs2Convert))
 		{
-			*mstart = MultiByteToWideChar(codepage, 0, mbcs2Convert, *mstart, _wideCharStr, 0);
-			*mend   = MultiByteToWideChar(codepage, 0, mbcs2Convert, *mend, _wideCharStr, 0);
+			*mstart = MultiByteToWideChar(cp, 0, mbcs2Convert, static_cast<int>(*mstart), _wideCharStr, 0);
+			*mend   = MultiByteToWideChar(cp, 0, mbcs2Convert, static_cast<int>(*mend), _wideCharStr, 0);
 			if (*mstart >= len || *mend >= len)
 			{
 				*mstart = 0;
@@ -428,16 +429,16 @@ const wchar_t * WcharMbcsConvertor::char2wchar(const char * mbcs2Convert, UINT c
 }
 
 
-const char* WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, UINT codepage, int lenWc, int *pLenMbcs)
+const char* WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, size_t codepage, int lenWc, int *pLenMbcs)
 {
 	if (nullptr == wcharStr2Convert)
 		return nullptr;
-
-	int lenMbcs = WideCharToMultiByte(codepage, 0, wcharStr2Convert, lenWc, NULL, 0, NULL, NULL);
+	UINT cp = static_cast<UINT>(codepage);
+	int lenMbcs = WideCharToMultiByte(cp, 0, wcharStr2Convert, lenWc, NULL, 0, NULL, NULL);
 	if (lenMbcs > 0)
 	{
 		_multiByteStr.sizeTo(lenMbcs);
-		WideCharToMultiByte(codepage, 0, wcharStr2Convert, lenWc, _multiByteStr, lenMbcs, NULL, NULL);
+		WideCharToMultiByte(cp, 0, wcharStr2Convert, lenWc, _multiByteStr, lenMbcs, NULL, NULL);
 	}
 	else
 		_multiByteStr.empty();
@@ -448,21 +449,21 @@ const char* WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, UIN
 }
 
 
-const char * WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, UINT codepage, long *mstart, long *mend)
+const char * WcharMbcsConvertor::wchar2char(const wchar_t * wcharStr2Convert, size_t codepage, long *mstart, long *mend)
 {
 	if (nullptr == wcharStr2Convert)
 		return nullptr;
-
-	int len = WideCharToMultiByte(codepage, 0, wcharStr2Convert, -1, NULL, 0, NULL, NULL);
+	UINT cp = static_cast<UINT>(codepage);
+	int len = WideCharToMultiByte(cp, 0, wcharStr2Convert, -1, NULL, 0, NULL, NULL);
 	if (len > 0)
 	{
 		_multiByteStr.sizeTo(len);
-		len = WideCharToMultiByte(codepage, 0, wcharStr2Convert, -1, _multiByteStr, len, NULL, NULL); // not needed?
+		len = WideCharToMultiByte(cp, 0, wcharStr2Convert, -1, _multiByteStr, len, NULL, NULL); // not needed?
 
         if (*mstart < lstrlenW(wcharStr2Convert) && *mend < lstrlenW(wcharStr2Convert))
         {
-			*mstart = WideCharToMultiByte(codepage, 0, wcharStr2Convert, *mstart, NULL, 0, NULL, NULL);
-			*mend = WideCharToMultiByte(codepage, 0, wcharStr2Convert, *mend, NULL, 0, NULL, NULL);
+			*mstart = WideCharToMultiByte(cp, 0, wcharStr2Convert, *mstart, NULL, 0, NULL, NULL);
+			*mend = WideCharToMultiByte(cp, 0, wcharStr2Convert, *mend, NULL, 0, NULL, NULL);
 			if (*mstart >= len || *mend >= len)
 			{
 				*mstart = 0;

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -95,7 +95,7 @@ public:
 	}
 
 	const wchar_t * char2wchar(const char *mbStr, size_t codepage, int lenMbcs =-1, int* pLenOut=NULL, int* pBytesNotProcessed=NULL);
-	const wchar_t * char2wchar(const char *mbcs2Convert, size_t codepage, INT_PTR* mstart, INT_PTR* mend);
+	const wchar_t * char2wchar(const char *mbcs2Convert, size_t codepage, intptr_t* mstart, intptr_t* mend);
 	const char * wchar2char(const wchar_t *wcStr, size_t codepage, int lenIn = -1, int* pLenOut = NULL);
 	const char * wchar2char(const wchar_t *wcStr, size_t codepage, long* mstart, long* mend);
 

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -94,12 +94,12 @@ public:
 		return instance;
 	}
 
-	const wchar_t * char2wchar(const char *mbStr, UINT codepage, int lenIn=-1, int *pLenOut=NULL, int *pBytesNotProcessed=NULL);
-	const wchar_t * char2wchar(const char *mbcs2Convert, UINT codepage, int *mstart, int *mend);
-	const char * wchar2char(const wchar_t *wcStr, UINT codepage, int lenIn = -1, int *pLenOut = NULL);
-	const char * wchar2char(const wchar_t *wcStr, UINT codepage, long *mstart, long *mend);
+	const wchar_t * char2wchar(const char *mbStr, size_t codepage, int lenIn=-1, int *pLenOut=NULL, int *pBytesNotProcessed=NULL);
+	const wchar_t * char2wchar(const char *mbcs2Convert, size_t codepage, INT_PTR* mstart, INT_PTR* mend);
+	const char * wchar2char(const wchar_t *wcStr, size_t codepage, int lenIn = -1, int *pLenOut = NULL);
+	const char * wchar2char(const wchar_t *wcStr, size_t codepage, long *mstart, long *mend);
 
-	const char * encode(UINT fromCodepage, UINT toCodepage, const char *txt2Encode, int lenIn=-1, int *pLenOut=NULL, int *pBytesNotProcessed=NULL)
+	const char * encode(UINT fromCodepage, UINT toCodepage, const char *txt2Encode, int lenIn = -1, int *pLenOut=NULL, int *pBytesNotProcessed=NULL)
 	{
 		int lenWc = 0;
         const wchar_t * strW = char2wchar(txt2Encode, fromCodepage, lenIn, &lenWc, pBytesNotProcessed);

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -94,12 +94,12 @@ public:
 		return instance;
 	}
 
-	const wchar_t * char2wchar(const char *mbStr, size_t codepage, int lenIn=-1, int *pLenOut=NULL, int *pBytesNotProcessed=NULL);
+	const wchar_t * char2wchar(const char *mbStr, size_t codepage, int lenMbcs =-1, int* pLenOut=NULL, int* pBytesNotProcessed=NULL);
 	const wchar_t * char2wchar(const char *mbcs2Convert, size_t codepage, INT_PTR* mstart, INT_PTR* mend);
-	const char * wchar2char(const wchar_t *wcStr, size_t codepage, int lenIn = -1, int *pLenOut = NULL);
-	const char * wchar2char(const wchar_t *wcStr, size_t codepage, long *mstart, long *mend);
+	const char * wchar2char(const wchar_t *wcStr, size_t codepage, int lenIn = -1, int* pLenOut = NULL);
+	const char * wchar2char(const wchar_t *wcStr, size_t codepage, long* mstart, long* mend);
 
-	const char * encode(UINT fromCodepage, UINT toCodepage, const char *txt2Encode, int lenIn = -1, int *pLenOut=NULL, int *pBytesNotProcessed=NULL)
+	const char * encode(UINT fromCodepage, UINT toCodepage, const char *txt2Encode, int lenIn = -1, int* pLenOut=NULL, int* pBytesNotProcessed=NULL)
 	{
 		int lenWc = 0;
         const wchar_t * strW = char2wchar(txt2Encode, fromCodepage, lenIn, &lenWc, pBytesNotProcessed);

--- a/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
@@ -81,7 +81,7 @@ void RegExtDlg::doDialog(bool isRTL)
 		::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_REGEXT_BOX), _hParent, dlgProc, reinterpret_cast<LPARAM>(this));
 }
 
-INT_PTR CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
 	switch (Message)
 	{

--- a/PowerEditor/src/MISC/RegExt/regExtDlg.h
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.h
@@ -33,7 +33,7 @@ public :
 private :
 	bool _isCustomize = false;
 
-	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
 
 	void getRegisteredExts();
 	void getDefSupportedExts();

--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -167,7 +167,7 @@ INT_PTR CALLBACK HashFromFilesDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 					int len = static_cast<int>(::SendMessage(::GetDlgItem(_hSelf, IDC_HASH_RESULT_EDIT), WM_GETTEXTLENGTH, 0, 0));
 					if (len)
 					{
-						wchar_t *rStr = new wchar_t[len+1];
+						wchar_t* rStr = new wchar_t[len+1];
 						::GetDlgItemText(_hSelf, IDC_HASH_RESULT_EDIT, rStr, len + 1);
 						str2Clipboard(rStr, _hSelf);
 						delete[] rStr;
@@ -243,7 +243,7 @@ void HashFromTextDlg::generateHash()
 	{
 		// it's important to get text from UNICODE then convert it to UTF8
 		// So we get the result of UTF8 text (tested with Chinese).
-		wchar_t *text = new wchar_t[len + 1];
+		wchar_t* text = new wchar_t[len + 1];
 		::GetDlgItemText(_hSelf, IDC_HASH_TEXT_EDIT, text, len + 1);
 		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 		const char *newText = wmc.wchar2char(text, SC_CP_UTF8);
@@ -277,7 +277,7 @@ void HashFromTextDlg::generateHashPerLine()
 	int len = static_cast<int>(::SendMessage(::GetDlgItem(_hSelf, IDC_HASH_TEXT_EDIT), WM_GETTEXTLENGTH, 0, 0));
 	if (len)
 	{
-		wchar_t *text = new wchar_t[len + 1];
+		wchar_t* text = new wchar_t[len + 1];
 		::GetDlgItemText(_hSelf, IDC_HASH_TEXT_EDIT, text, len + 1);
 
 		std::wstringstream ss(text);
@@ -455,7 +455,7 @@ INT_PTR CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 					int len = static_cast<int>(::SendMessage(::GetDlgItem(_hSelf, IDC_HASH_RESULT_FOMTEXT_EDIT), WM_GETTEXTLENGTH, 0, 0));
 					if (len)
 					{
-						wchar_t *rStr = new wchar_t[len+1];
+						wchar_t* rStr = new wchar_t[len+1];
 						::GetDlgItemText(_hSelf, IDC_HASH_RESULT_FOMTEXT_EDIT, rStr, len + 1);
 						str2Clipboard(rStr, _hSelf);
 						delete[] rStr;

--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -24,7 +24,7 @@
 #include <shlwapi.h>
 #include "resource.h"
 
-INT_PTR CALLBACK HashFromFilesDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK HashFromFilesDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) 
 	{
@@ -327,7 +327,7 @@ void HashFromTextDlg::generateHashPerLine()
 	}
 }
 
-INT_PTR CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) 
 	{

--- a/PowerEditor/src/MISC/md5/md5Dlgs.h
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.h
@@ -32,7 +32,7 @@ public :
 	void setHashType(hashType hashType2set);
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	hashType _ht = hash_md5;
 
 	static LRESULT CALLBACK HashPathEditStaticProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
@@ -62,7 +62,7 @@ public :
 	void setHashType(hashType hashType2set);
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	hashType _ht = hash_md5;
 
 	static LRESULT CALLBACK HashTextEditStaticProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -308,7 +308,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.performGlobalStyles();
 	_subEditView.performGlobalStyles();
 
-	_zoomOriginalValue = static_cast<int32_t>(_pEditView->execute(SCI_GETZOOM));
+	_zoomOriginalValue = _pEditView->execute(SCI_GETZOOM);
 	_mainEditView.execute(SCI_SETZOOM, svp._zoom);
 	_subEditView.execute(SCI_SETZOOM, svp._zoom2);
 
@@ -1061,11 +1061,11 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 
 		_invisibleEditView.execute(SCI_SETTARGETRANGE, startPos, endPos);
 
-		int posFound = static_cast<int32_t>(_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(htmlHeaderRegExpr), reinterpret_cast<LPARAM>(htmlHeaderRegExpr)));
+		auto posFound = _invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(htmlHeaderRegExpr), reinterpret_cast<LPARAM>(htmlHeaderRegExpr));
 
 		if (posFound < 0)
 		{
-			posFound = static_cast<int32_t>(_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(htmlHeaderRegExpr2), reinterpret_cast<LPARAM>(htmlHeaderRegExpr2)));
+			posFound = _invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(htmlHeaderRegExpr2), reinterpret_cast<LPARAM>(htmlHeaderRegExpr2));
 			if (posFound < 0)
 				return -1;
 		}
@@ -1093,8 +1093,8 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 
 void Notepad_plus::setCodePageForInvisibleView(Buffer const *pBuffer)
 {
-	int detectedCp = static_cast<int>(_invisibleEditView.execute(SCI_GETCODEPAGE));
-	int cp2set = SC_CP_UTF8;
+	INT_PTR detectedCp = _invisibleEditView.execute(SCI_GETCODEPAGE);
+	INT_PTR cp2set = SC_CP_UTF8;
 	if (pBuffer->getUnicodeMode() == uni8Bit)
 	{
 		cp2set = (detectedCp == SC_CP_UTF8 ? CP_ACP : detectedCp);
@@ -1186,17 +1186,17 @@ bool Notepad_plus::replaceInOpenedFiles()
 
 void Notepad_plus::wsTabConvert(spaceTab whichWay)
 {
-	int tabWidth = static_cast<int32_t>(_pEditView->execute(SCI_GETTABWIDTH));
-	int currentPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
-    int lastLine = _pEditView->lastZeroBasedLineNumber();
-	int docLength = static_cast<int32_t>(_pEditView->execute(SCI_GETLENGTH) + 1);
+	INT_PTR tabWidth = _pEditView->execute(SCI_GETTABWIDTH);
+	INT_PTR currentPos = _pEditView->execute(SCI_GETCURRENTPOS);
+    INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
+	INT_PTR docLength = _pEditView->execute(SCI_GETLENGTH) + 1;
     if (docLength < 2)
         return;
 
-    int count = 0;
-    int column = 0;
-    int newCurrentPos = 0;
-	int tabStop = static_cast<int32_t>(tabWidth - 1);   // remember, counting from zero !
+    INT_PTR count = 0;
+    INT_PTR column = 0;
+    INT_PTR newCurrentPos = 0;
+	INT_PTR tabStop = static_cast<int32_t>(tabWidth - 1);   // remember, counting from zero !
     bool onlyLeading = false;
     vector<int> bookmarks;
     vector<int> folding;
@@ -1249,7 +1249,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
             {
                 if (source[i] == '\t')
                 {
-                    int insertTabs = tabWidth - (column % tabWidth);
+                    INT_PTR insertTabs = tabWidth - (column % tabWidth);
                     for (int j = 0; j < insertTabs; ++j)
                     {
                         *dest++ = ' ';
@@ -2399,9 +2399,9 @@ generic_string Notepad_plus::getLangDesc(LangType langType, bool getName)
 
 void Notepad_plus::copyMarkedLines()
 {
-	int lastLine = _pEditView->lastZeroBasedLineNumber();
+	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
 	generic_string globalStr = TEXT("");
-	for (int i = lastLine ; i >= 0 ; i--)
+	for (INT_PTR i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
 		{
@@ -2418,11 +2418,11 @@ void Notepad_plus::cutMarkedLines()
 {
 	std::lock_guard<std::mutex> lock(mark_mutex);
 
-	int lastLine = _pEditView->lastZeroBasedLineNumber();
+	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
 	generic_string globalStr = TEXT("");
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
-	for (int i = lastLine ; i >= 0 ; i--)
+	for (INT_PTR i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
 		{
@@ -2440,10 +2440,10 @@ void Notepad_plus::deleteMarkedLines(bool isMarked)
 {
 	std::lock_guard<std::mutex> lock(mark_mutex);
 
-	int lastLine = _pEditView->lastZeroBasedLineNumber();
+	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
-	for (int i = lastLine ; i >= 0 ; i--)
+	for (INT_PTR i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i) == isMarked)
 			deleteMarkedline(i);
@@ -2461,7 +2461,7 @@ void Notepad_plus::pasteToMarkedLines()
 	BOOL canPaste = ::IsClipboardFormatAvailable(clipFormat);
 	if (!canPaste)
 		return;
-	int lastLine = _pEditView->lastZeroBasedLineNumber();
+	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
 
 	::OpenClipboard(_pPublicInterface->getHSelf());
 	HANDLE clipboardData = ::GetClipboardData(clipFormat);
@@ -2475,7 +2475,7 @@ void Notepad_plus::pasteToMarkedLines()
 	::CloseClipboard();
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
-	for (int i = lastLine ; i >= 0 ; i--)
+	for (INT_PTR i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
 		{
@@ -2485,7 +2485,7 @@ void Notepad_plus::pasteToMarkedLines()
 	_pEditView->execute(SCI_ENDUNDOACTION);
 }
 
-void Notepad_plus::deleteMarkedline(int ln)
+void Notepad_plus::deleteMarkedline(size_t ln)
 {
 	int lineLen = static_cast<int32_t>(_pEditView->execute(SCI_LINELENGTH, ln));
 	int lineBegin = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, ln));
@@ -2497,7 +2497,7 @@ void Notepad_plus::deleteMarkedline(int ln)
 
 void Notepad_plus::inverseMarks()
 {
-	int lastLine = _pEditView->lastZeroBasedLineNumber();
+	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
 	for (int i = 0 ; i <= lastLine  ; ++i)
 	{
 		if (bookmarkPresent(i))
@@ -2511,7 +2511,7 @@ void Notepad_plus::inverseMarks()
 	}
 }
 
-void Notepad_plus::replaceMarkedline(int ln, const TCHAR *str)
+void Notepad_plus::replaceMarkedline(size_t ln, const TCHAR *str)
 {
 	int lineBegin = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, ln));
 	int lineEnd = static_cast<int32_t>(_pEditView->execute(SCI_GETLINEENDPOSITION, ln));
@@ -2519,7 +2519,7 @@ void Notepad_plus::replaceMarkedline(int ln, const TCHAR *str)
 	_pEditView->replaceTarget(str, lineBegin, lineEnd);
 }
 
-generic_string Notepad_plus::getMarkedLine(int ln)
+generic_string Notepad_plus::getMarkedLine(size_t ln)
 {
 	auto lineLen = _pEditView->execute(SCI_LINELENGTH, ln);
 	auto lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
@@ -2993,8 +2993,8 @@ void Notepad_plus::addHotSpot(ScintillaEditView* view)
 		pView->execute(SCI_INDICSETFLAGS, URL_INDIC, SC_INDICFLAG_VALUEFORE);
 	}
 
-	int startPos = 0;
-	int endPos = -1;
+	INT_PTR startPos = 0;
+	INT_PTR endPos = -1;
 	pView->getVisibleStartAndEndPosition(&startPos, &endPos);
 	if (startPos >= endPos) return;
 	pView->execute(SCI_SETINDICATORCURRENT, URL_INDIC);
@@ -3011,7 +3011,7 @@ void Notepad_plus::addHotSpot(ScintillaEditView* view)
 	char *encodedText = new char[endPos - startPos + 1];
 	pView->getText(encodedText, startPos, endPos);
 	TCHAR *wideText = new TCHAR[endPos - startPos + 1];
-	int wideTextLen = MultiByteToWideChar(cp, 0, encodedText, endPos - startPos + 1, (LPWSTR) wideText, endPos - startPos + 1) - 1;
+	int wideTextLen = MultiByteToWideChar(cp, 0, encodedText, static_cast<int>(endPos - startPos + 1), (LPWSTR) wideText, static_cast<int>(endPos - startPos + 1)) - 1;
 	delete[] encodedText;
 	if (wideTextLen > 0)
 	{
@@ -3098,7 +3098,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 	int eolMode = static_cast<int32_t>((_pEditView->execute(SCI_GETEOLMODE)));
 	int curLine = static_cast<int32_t>((_pEditView->getCurrentLineNumber()));
 	int prevLine = curLine - 1;
-	int indentAmountPrevLine = 0;
+	INT_PTR indentAmountPrevLine = 0;
 	int tabWidth = static_cast<int32_t>(_pEditView->execute(SCI_GETTABWIDTH));
 
 	LangType type = _pEditView->getCurrentBuffer()->getLangType();
@@ -3747,17 +3747,17 @@ void Notepad_plus::updateStatusBar()
 
 	TCHAR strSel[64];
 
-	int numSelections = static_cast<int>(_pEditView->execute(SCI_GETSELECTIONS));
+	size_t numSelections = _pEditView->execute(SCI_GETSELECTIONS);
 	if (numSelections == 1)
 	{
 		if (_pEditView->execute(SCI_GETSELECTIONEMPTY))
 		{
-			int currPos = static_cast<int>(_pEditView->execute(SCI_GETCURRENTPOS));
+			size_t currPos = _pEditView->execute(SCI_GETCURRENTPOS);
 			wsprintf(strSel, TEXT("Pos : %s"), commafyInt(currPos + 1).c_str());
 		}
 		else
 		{
-			const std::pair<int, int> oneSelCharsAndLines = _pEditView->getSelectedCharsAndLinesCount();
+			const std::pair<size_t, size_t> oneSelCharsAndLines = _pEditView->getSelectedCharsAndLinesCount();
 			wsprintf(strSel, TEXT("Sel : %s | %s"),
 				commafyInt(oneSelCharsAndLines.first).c_str(),
 				commafyInt(oneSelCharsAndLines.second).c_str());
@@ -3765,16 +3765,16 @@ void Notepad_plus::updateStatusBar()
 	}
 	else if (_pEditView->execute(SCI_SELECTIONISRECTANGLE))
 	{
-		const std::pair<int, int> rectSelCharsAndLines = _pEditView->getSelectedCharsAndLinesCount();
+		const std::pair<size_t, size_t> rectSelCharsAndLines = _pEditView->getSelectedCharsAndLinesCount();
 
 		bool sameCharCountOnEveryLine = true;
-		int maxLineCharCount = 0;
+		size_t maxLineCharCount = 0;
 
-		for (int sel = 0; sel < numSelections; ++sel)
+		for (size_t sel = 0; sel < numSelections; ++sel)
 		{
-			int start = static_cast<int>(_pEditView->execute(SCI_GETSELECTIONNSTART, sel));
-			int end = static_cast<int>(_pEditView->execute(SCI_GETSELECTIONNEND, sel));
-			int lineCharCount = static_cast<int>(_pEditView->execute(SCI_COUNTCHARACTERS, start, end));
+			size_t start = _pEditView->execute(SCI_GETSELECTIONNSTART, sel);
+			size_t end = _pEditView->execute(SCI_GETSELECTIONNEND, sel);
+			size_t lineCharCount = _pEditView->execute(SCI_COUNTCHARACTERS, start, end);
 
 			if (sel == 0)
 			{
@@ -3802,7 +3802,7 @@ void Notepad_plus::updateStatusBar()
 	else  // multiple stream selections
 	{
 		const int maxSelsToProcessLineCount = 99;  // limit the number of selections to process, for performance reasons
-		const std::pair<int, int> multipleSelCharsAndLines = _pEditView->getSelectedCharsAndLinesCount(maxSelsToProcessLineCount);
+		const std::pair<size_t, size_t> multipleSelCharsAndLines = _pEditView->getSelectedCharsAndLinesCount(maxSelsToProcessLineCount);
 
 		wsprintf(strSel, TEXT("Sel %s : %s | %s"),
 			commafyInt(numSelections).c_str(),
@@ -5042,8 +5042,8 @@ void Notepad_plus::saveScintillasZoom()
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	ScintillaViewParams & svp = (ScintillaViewParams &)nppParam.getSVP();
-	svp._zoom = static_cast<int>(_mainEditView.execute(SCI_GETZOOM));
-	svp._zoom2 = static_cast<int>(_subEditView.execute(SCI_GETZOOM));
+	svp._zoom = _mainEditView.execute(SCI_GETZOOM);
+	svp._zoom2 = _subEditView.execute(SCI_GETZOOM);
 }
 
 bool Notepad_plus::addCurrentMacro()
@@ -5147,8 +5147,8 @@ bool Notepad_plus::goToPreviousIndicator(int indicID2Search, bool isWrap) const
 	auto docLen = _pEditView->getCurrentDocLen();
 
     bool isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  position) != 0;
-    auto posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
-    auto posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search,  position);
+    size_t posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
+    size_t posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search,  position);
 
 	// pre-condition
 	if ((posStart == 0) && (posEnd == docLen - 1))
@@ -5196,12 +5196,12 @@ bool Notepad_plus::goToPreviousIndicator(int indicID2Search, bool isWrap) const
 
 bool Notepad_plus::goToNextIndicator(int indicID2Search, bool isWrap) const
 {
-    auto position = _pEditView->execute(SCI_GETCURRENTPOS);
-	int docLen = _pEditView->getCurrentDocLen();
+    size_t position = _pEditView->execute(SCI_GETCURRENTPOS);
+	size_t docLen = _pEditView->getCurrentDocLen();
 
     bool isInIndicator = _pEditView->execute(SCI_INDICATORVALUEAT, indicID2Search,  position) != 0;
-    auto posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
-    auto posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search,  position);
+    size_t posStart = _pEditView->execute(SCI_INDICATORSTART, indicID2Search,  position);
+    size_t posEnd = _pEditView->execute(SCI_INDICATOREND, indicID2Search,  position);
 
 	// pre-condition
 	if ((posStart == 0) && (posEnd == docLen - 1))
@@ -6113,7 +6113,7 @@ std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * co
 	generic_string udl = pCmdParams->_udlName;
 	int lineNumber =  pCmdParams->_line2go;
 	int columnNumber = pCmdParams->_column2go;
-	int positionNumber = pCmdParams->_pos2go;
+	size_t positionNumber = pCmdParams->_pos2go;
 	bool recursive = pCmdParams->_isRecursive;
 	bool readOnly = pCmdParams->_isReadOnly;
 	bool openFoldersAsWorkspace = pCmdParams->_openFoldersAsWorkspace;
@@ -6160,7 +6160,7 @@ std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * co
 					// make sure not jumping into the middle of a multibyte character
 					// or into the middle of a CR/LF pair for Windows files
 					auto before = _pEditView->execute(SCI_POSITIONBEFORE, positionNumber);
-					positionNumber = static_cast<int>(_pEditView->execute(SCI_POSITIONAFTER, before));
+					positionNumber = _pEditView->execute(SCI_POSITIONAFTER, before);
 				}
 				_pEditView->execute(SCI_GOTOPOS, positionNumber);
 			}
@@ -7901,10 +7901,10 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		//-- First, search all start_comment and end_comment before and after the selectionStart and selectionEnd position.
 		const int iSelStart=0, iSelEnd=1;
 		const size_t N_CMNT = 2;
-		int posStartCommentBefore[N_CMNT], posEndCommentBefore[N_CMNT], posStartCommentAfter[N_CMNT], posEndCommentAfter[N_CMNT];
+		INT_PTR posStartCommentBefore[N_CMNT], posEndCommentBefore[N_CMNT], posStartCommentAfter[N_CMNT], posEndCommentAfter[N_CMNT];
 		bool blnStartCommentBefore[N_CMNT], blnEndCommentBefore[N_CMNT], blnStartCommentAfter[N_CMNT], blnEndCommentAfter[N_CMNT];
-		int posStartComment, posEndComment;
-		int selectionStartMove, selectionEndMove;
+		INT_PTR posStartComment, posEndComment;
+		INT_PTR selectionStartMove, selectionEndMove;
 		int flags;
 
 		//-- Directly use Scintilla-Functions
@@ -7973,8 +7973,8 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		//-- Ok, there are valid start-comment and valid end-comment around the caret-position.
 		//   Now, un-comment stream-comment:
 		retVal = true;
-		int startCommentLength = static_cast<int32_t>(start_comment_length);
-		int endCommentLength = static_cast<int32_t>(end_comment_length);
+		INT_PTR startCommentLength = start_comment_length;
+		INT_PTR endCommentLength = end_comment_length;
 
 		//-- First delete end-comment, so that posStartCommentBefore does not change!
 		//-- Get character before end-comment to decide, if there is a white character before the end-comment, which will be removed too!
@@ -8005,20 +8005,20 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		if (selectionStart > posStartComment)
 		{
 			if (selectionStart >= posStartComment+startCommentLength)
-				selectionStartMove = -static_cast<int>(startCommentLength);
+				selectionStartMove = -startCommentLength;
 			else
-				selectionStartMove = -static_cast<int>(selectionStart - posStartComment);
+				selectionStartMove = -selectionStart - posStartComment;
 		}
 		else
 			selectionStartMove = 0;
 
 		//   selectionEnd
 		if (selectionEnd >= posEndComment+endCommentLength)
-			selectionEndMove = -static_cast<int>(startCommentLength+endCommentLength);
+			selectionEndMove = -startCommentLength+endCommentLength;
 		else if (selectionEnd <= posEndComment)
-			selectionEndMove = -static_cast<int>(startCommentLength);
+			selectionEndMove = -startCommentLength;
 		else
-			selectionEndMove = -static_cast<int>(startCommentLength + (selectionEnd - posEndComment));
+			selectionEndMove = -startCommentLength + (selectionEnd - posEndComment);
 
 		//-- Reset selection of text without deleted stream-comment-string
 		if (move_caret)

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3740,9 +3740,11 @@ void Notepad_plus::updateStatusBar()
 	// STATUSBAR_DOC_TYPE , STATUSBAR_EOF_FORMAT , STATUSBAR_UNICODE_TYPE
 
 	TCHAR strDocLen[256];
+	size_t docLen = _pEditView->getCurrentDocLen();
+	INT_PTR nbLine = _pEditView->execute(SCI_GETLINECOUNT);
 	wsprintf(strDocLen, TEXT("length : %s    lines : %s"),
-		commafyInt(_pEditView->getCurrentDocLen()).c_str(),
-		commafyInt(_pEditView->execute(SCI_GETLINECOUNT)).c_str());
+		commafyInt(docLen).c_str(),
+		commafyInt(nbLine).c_str());
 	_statusBar.setText(strDocLen, STATUSBAR_DOC_SIZE);
 
 	TCHAR strSel[64];
@@ -3813,9 +3815,11 @@ void Notepad_plus::updateStatusBar()
 	}
 
 	TCHAR strLnColSel[128];
+	INT_PTR curLN = _pEditView->getCurrentLineNumber();
+	INT_PTR curCN = _pEditView->getCurrentColumnNumber();
 	wsprintf(strLnColSel, TEXT("Ln : %s    Col : %s    %s"),
-		commafyInt(_pEditView->getCurrentLineNumber() + 1).c_str(),
-		commafyInt(_pEditView->getCurrentColumnNumber() + 1).c_str(),
+		commafyInt(curLN + 1).c_str(),
+		commafyInt(curCN + 1).c_str(),
 		strSel);
 	_statusBar.setText(strLnColSel, STATUSBAR_CUR_POS);
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3609,7 +3609,7 @@ size_t Notepad_plus::getSelectedCharNumber(UniMode u)
 	}
 	else
 	{
-		for (int i=0; i < numSel; ++i)
+		for (size_t i = 0; i < numSel; ++i)
 		{
 			size_t stpos = _pEditView->execute(SCI_GETSELECTIONNSTART, i);
 			size_t endpos = _pEditView->execute(SCI_GETSELECTIONNEND, i);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2582,8 +2582,8 @@ bool Notepad_plus::braceMatch()
 
 		if (_pEditView->isShownIndentGuide())
         {
-            int columnAtCaret = int(_pEditView->execute(SCI_GETCOLUMN, braceAtCaret));
-		    int columnOpposite = int(_pEditView->execute(SCI_GETCOLUMN, braceOpposite));
+            INT_PTR columnAtCaret = _pEditView->execute(SCI_GETCOLUMN, braceAtCaret);
+		    INT_PTR columnOpposite = _pEditView->execute(SCI_GETCOLUMN, braceOpposite);
 			_pEditView->execute(SCI_SETHIGHLIGHTGUIDE, (columnAtCaret < columnOpposite)?columnAtCaret:columnOpposite);
         }
     }

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1029,7 +1029,7 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 
 			_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(encodingAliasRegExpr), reinterpret_cast<LPARAM>(encodingAliasRegExpr));
 
-            startPos = int(_invisibleEditView.execute(SCI_GETTARGETSTART));
+            startPos = _invisibleEditView.execute(SCI_GETTARGETSTART);
 			endPos = _invisibleEditView.execute(SCI_GETTARGETEND);
 			
 			size_t len = endPos - startPos;
@@ -1055,7 +1055,7 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 		const char *intermediaire = "=[ \\t]*.+";
 		const char *encodingStrRE = "[^ \\t=]+";
 
-        int startPos = 0;
+		INT_PTR startPos = 0;
 		auto endPos = lenFile - 1;
 		_invisibleEditView.execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
 
@@ -1073,7 +1073,7 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 		_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(intermediaire), reinterpret_cast<LPARAM>(intermediaire));
 		_invisibleEditView.execute(SCI_SEARCHINTARGET, strlen(encodingStrRE), reinterpret_cast<LPARAM>(encodingStrRE));
 
-        startPos = int(_invisibleEditView.execute(SCI_GETTARGETSTART));
+        startPos = _invisibleEditView.execute(SCI_GETTARGETSTART);
 		endPos = _invisibleEditView.execute(SCI_GETTARGETEND);
 
 		size_t len = endPos - startPos;
@@ -1196,7 +1196,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
     INT_PTR count = 0;
     INT_PTR column = 0;
     INT_PTR newCurrentPos = 0;
-	INT_PTR tabStop = static_cast<int32_t>(tabWidth - 1);   // remember, counting from zero !
+	INT_PTR tabStop = tabWidth - 1;   // remember, counting from zero !
     bool onlyLeading = false;
     vector<int> bookmarks;
     vector<int> folding;
@@ -2011,10 +2011,10 @@ void Notepad_plus::filePrint(bool showDialog)
 {
 	Printer printer;
 
-	int startPos = int(_pEditView->execute(SCI_GETSELECTIONSTART));
-	int endPos = int(_pEditView->execute(SCI_GETSELECTIONEND));
+	INT_PTR startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
+	INT_PTR endPos = _pEditView->execute(SCI_GETSELECTIONEND);
 
-	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, startPos, endPos, _nativeLangSpeaker.isRTL());
+	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, int(startPos), int(endPos), _nativeLangSpeaker.isRTL());
 	printer.doPrint();
 }
 
@@ -2487,8 +2487,8 @@ void Notepad_plus::pasteToMarkedLines()
 
 void Notepad_plus::deleteMarkedline(size_t ln)
 {
-	int lineLen = static_cast<int32_t>(_pEditView->execute(SCI_LINELENGTH, ln));
-	int lineBegin = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, ln));
+	INT_PTR lineLen = _pEditView->execute(SCI_LINELENGTH, ln);
+	INT_PTR lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
 
 	bookmarkDelete(ln);
 	TCHAR emptyString[2] = TEXT("");
@@ -2513,8 +2513,8 @@ void Notepad_plus::inverseMarks()
 
 void Notepad_plus::replaceMarkedline(size_t ln, const TCHAR *str)
 {
-	int lineBegin = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, ln));
-	int lineEnd = static_cast<int32_t>(_pEditView->execute(SCI_GETLINEENDPOSITION, ln));
+	INT_PTR lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
+	INT_PTR lineEnd = _pEditView->execute(SCI_GETLINEENDPOSITION, ln);
 
 	_pEditView->replaceTarget(str, lineBegin, lineEnd);
 }
@@ -2532,14 +2532,14 @@ generic_string Notepad_plus::getMarkedLine(size_t ln)
 	return line;
 }
 
-void Notepad_plus::findMatchingBracePos(int & braceAtCaret, int & braceOpposite)
+void Notepad_plus::findMatchingBracePos(INT_PTR& braceAtCaret, INT_PTR& braceOpposite)
 {
-	int caretPos = int(_pEditView->execute(SCI_GETCURRENTPOS));
+	INT_PTR caretPos = _pEditView->execute(SCI_GETCURRENTPOS);
 	braceAtCaret = -1;
 	braceOpposite = -1;
 	TCHAR charBefore = '\0';
 
-	int lengthDoc = int(_pEditView->execute(SCI_GETLENGTH));
+	INT_PTR lengthDoc = _pEditView->execute(SCI_GETLENGTH);
 
 	if ((lengthDoc > 0) && (caretPos > 0))
     {
@@ -2561,14 +2561,14 @@ void Notepad_plus::findMatchingBracePos(int & braceAtCaret, int & braceOpposite)
 		}
 	}
 	if (braceAtCaret >= 0)
-		braceOpposite = int(_pEditView->execute(SCI_BRACEMATCH, braceAtCaret, 0));
+		braceOpposite = _pEditView->execute(SCI_BRACEMATCH, braceAtCaret, 0);
 }
 
 // return true if 1 or 2 (matched) brace(s) is found
 bool Notepad_plus::braceMatch()
 {
-	int braceAtCaret = -1;
-	int braceOpposite = -1;
+	INT_PTR braceAtCaret = -1;
+	INT_PTR braceOpposite = -1;
 	findMatchingBracePos(braceAtCaret, braceOpposite);
 
 	if ((braceAtCaret != -1) && (braceOpposite == -1))
@@ -3041,7 +3041,7 @@ void Notepad_plus::addHotSpot(ScintillaEditView* view)
 	delete[] wideText;
 }
 
-bool Notepad_plus::isConditionExprLine(int lineNumber)
+bool Notepad_plus::isConditionExprLine(INT_PTR lineNumber)
 {
 	if (lineNumber < 0 || lineNumber > _pEditView->execute(SCI_GETLINECOUNT))
 		return false;
@@ -3064,7 +3064,7 @@ bool Notepad_plus::isConditionExprLine(int lineNumber)
 	return false;
 }
 
-int Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol)
+INT_PTR Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol)
 {
 	if (startPos == endPos)
 		return -1;
@@ -3072,7 +3072,7 @@ int Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char target
 	if (startPos > endPos) // backward
 	{
 		int balance = 0;
-		for (int i = int(startPos); i >= int(endPos); --i)
+		for (INT_PTR i = startPos; i >= static_cast<INT_PTR>(endPos); --i)
 		{
 			char aChar = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, i));
 			if (aChar == targetSymbol)
@@ -3095,11 +3095,11 @@ int Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char target
 
 void Notepad_plus::maintainIndentation(TCHAR ch)
 {
-	int eolMode = static_cast<int32_t>((_pEditView->execute(SCI_GETEOLMODE)));
-	int curLine = static_cast<int32_t>((_pEditView->getCurrentLineNumber()));
-	int prevLine = curLine - 1;
+	INT_PTR eolMode = _pEditView->execute(SCI_GETEOLMODE);
+	INT_PTR curLine = _pEditView->getCurrentLineNumber();
+	INT_PTR prevLine = curLine - 1;
 	INT_PTR indentAmountPrevLine = 0;
-	int tabWidth = static_cast<int32_t>(_pEditView->execute(SCI_GETTABWIDTH));
+	INT_PTR tabWidth = _pEditView->execute(SCI_GETTABWIDTH);
 
 	LangType type = _pEditView->getCurrentBuffer()->getLangType();
 
@@ -3125,7 +3125,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 			}
 
 			// get previous char from current line
-			int prevPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS)) - (eolMode == SC_EOL_CRLF ? 3 : 2);
+			INT_PTR prevPos = _pEditView->execute(SCI_GETCURRENTPOS) - (eolMode == SC_EOL_CRLF ? 3 : 2);
 			UCHAR prevChar = (UCHAR)_pEditView->execute(SCI_GETCHARAT, prevPos);
 			auto curPos = _pEditView->execute(SCI_GETCURRENTPOS);
 			UCHAR nextChar = (UCHAR)_pEditView->execute(SCI_GETCHARAT, curPos);
@@ -3200,10 +3200,10 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 
 				const char braceExpr[] = "[ \t]*\\{.*";
 
-				int posFound = static_cast<int32_t>(_pEditView->execute(SCI_SEARCHINTARGET, strlen(braceExpr), reinterpret_cast<LPARAM>(braceExpr)));
+				INT_PTR posFound = _pEditView->execute(SCI_SEARCHINTARGET, strlen(braceExpr), reinterpret_cast<LPARAM>(braceExpr));
 				if (posFound >= 0)
 				{
-					int end = int(_pEditView->execute(SCI_GETTARGETEND));
+					auto end = _pEditView->execute(SCI_GETTARGETEND);
 					if (end == endPos2)
 						indentAmountPrevLine += tabWidth;
 				}
@@ -3215,17 +3215,17 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 		else if (ch == '}')
 		{
 			// Look backward for the pair {
-			int startPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+			INT_PTR startPos = _pEditView->execute(SCI_GETCURRENTPOS);
 			if (startPos != 0)
 				startPos -= 1;
-			int posFound = findMachedBracePos(startPos - 1, 0, '{', '}');
+			INT_PTR posFound = findMachedBracePos(startPos - 1, 0, '{', '}');
 
 			// if no { found, do nothing
 			if (posFound == -1)
 				return;
 
 			// if { is in the same line, do nothing
-			int matchedPairLine = static_cast<int32_t>(_pEditView->execute(SCI_LINEFROMPOSITION, posFound));
+			INT_PTR matchedPairLine = _pEditView->execute(SCI_LINEFROMPOSITION, posFound);
 			if (matchedPairLine == curLine)
 				return;
 
@@ -3583,10 +3583,10 @@ static const char utflen[] = {1,1,2,3};
 size_t Notepad_plus::getSelectedCharNumber(UniMode u)
 {
 	size_t result = 0;
-	int numSel = static_cast<int32_t>(_pEditView->execute(SCI_GETSELECTIONS));
+	size_t numSel = _pEditView->execute(SCI_GETSELECTIONS);
 	if (u == uniUTF8 || u == uniCookie)
 	{
-		for (int i=0; i < numSel; ++i)
+		for (size_t i = 0; i < numSel; ++i)
 		{
 			size_t line1 = _pEditView->execute(SCI_LINEFROMPOSITION, _pEditView->execute(SCI_GETSELECTIONNSTART, i));
 			size_t line2 = _pEditView->execute(SCI_LINEFROMPOSITION, _pEditView->execute(SCI_GETSELECTIONNEND, i));
@@ -4450,16 +4450,16 @@ void Notepad_plus::bookmarkNext(bool forwardScan)
 	size_t lineno = _pEditView->getCurrentLineNumber();
 	int sci_marker = SCI_MARKERNEXT;
 	size_t lineStart = lineno + 1;	//Scan starting from next line
-	int lineRetry = 0;				//If not found, try from the beginning
+	INT_PTR lineRetry = 0;				//If not found, try from the beginning
 	if (!forwardScan)
     {
 		lineStart = lineno - 1;		//Scan starting from previous line
-		lineRetry = int(_pEditView->execute(SCI_GETLINECOUNT));	//If not found, try from the end
+		lineRetry = _pEditView->execute(SCI_GETLINECOUNT);	//If not found, try from the end
 		sci_marker = SCI_MARKERPREVIOUS;
 	}
-	int nextLine = int(_pEditView->execute(sci_marker, lineStart, 1 << MARK_BOOKMARK));
+	INT_PTR nextLine = _pEditView->execute(sci_marker, lineStart, 1 << MARK_BOOKMARK);
 	if (nextLine < 0)
-		nextLine = int(_pEditView->execute(sci_marker, lineRetry, 1 << MARK_BOOKMARK));
+		nextLine = _pEditView->execute(sci_marker, lineRetry, 1 << MARK_BOOKMARK);
 
 	if (nextLine < 0)
 		return;
@@ -4758,9 +4758,9 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
     size_t caretPosition = _pEditView->execute(SCI_GETCURRENTPOS);
     // checking if caret is located in _beginning_ of selected block
     bool move_caret = caretPosition < selectionEnd;
-	int selStartLine = static_cast<int32_t>(_pEditView->execute(SCI_LINEFROMPOSITION, selectionStart));
-	int selEndLine = static_cast<int32_t>(_pEditView->execute(SCI_LINEFROMPOSITION, selectionEnd));
-    int lines = selEndLine - selStartLine;
+	INT_PTR selStartLine = _pEditView->execute(SCI_LINEFROMPOSITION, selectionStart);
+	INT_PTR selEndLine = _pEditView->execute(SCI_LINEFROMPOSITION, selectionEnd);
+	INT_PTR lines = selEndLine - selStartLine;
     // "caret return" is part of the last selected line
     if ((lines > 0) && (selectionEnd == static_cast<size_t>(_pEditView->execute(SCI_POSITIONFROMLINE, selEndLine))))
 		selEndLine--;
@@ -4773,7 +4773,7 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 
     _pEditView->execute(SCI_BEGINUNDOACTION);
 
-    for (int i = selStartLine; i <= selEndLine; ++i)
+    for (INT_PTR i = selStartLine; i <= selEndLine; ++i)
 	{
 		size_t lineStart = _pEditView->execute(SCI_POSITIONFROMLINE, i);
 		size_t lineIndent = _pEditView->execute(SCI_GETLINEINDENTPOSITION, i);
@@ -5592,36 +5592,36 @@ void Notepad_plus::distractionFreeToggle()
 
 void Notepad_plus::doSynScorll(HWND whichView)
 {
-	int column = 0;
-	int line = 0;
+	INT_PTR column = 0;
+	INT_PTR line = 0;
 	ScintillaEditView *pView;
 
 	// var for Line
-	int mainCurrentLine, subCurrentLine;
+	INT_PTR mainCurrentLine, subCurrentLine;
 
 	// var for Column
-	int mxoffset, sxoffset;
-	int pixel;
-	int mainColumn, subColumn;
+	INT_PTR mxoffset, sxoffset;
+	INT_PTR pixel;
+	INT_PTR mainColumn, subColumn;
 
     if (whichView == _mainEditView.getHSelf())
 	{
 		if (_syncInfo._isSynScollV)
 		{
 			// Compute for Line
-			mainCurrentLine = static_cast<int32_t>(_mainEditView.execute(SCI_GETFIRSTVISIBLELINE));
-			subCurrentLine = static_cast<int32_t>(_subEditView.execute(SCI_GETFIRSTVISIBLELINE));
+			mainCurrentLine = _mainEditView.execute(SCI_GETFIRSTVISIBLELINE);
+			subCurrentLine = _subEditView.execute(SCI_GETFIRSTVISIBLELINE);
 			line = mainCurrentLine - _syncInfo._line - subCurrentLine;
 		}
 		if (_syncInfo._isSynScollH)
 		{
 			// Compute for Column
-			mxoffset = static_cast<int32_t>(_mainEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			mxoffset = _mainEditView.execute(SCI_GETXOFFSET);
+			pixel = _mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
 			mainColumn = mxoffset/pixel;
 
-			sxoffset = static_cast<int32_t>(_subEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			sxoffset = _subEditView.execute(SCI_GETXOFFSET);
+			pixel = _subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
 			subColumn = sxoffset/pixel;
 			column = mainColumn - _syncInfo._column - subColumn;
 		}
@@ -5632,19 +5632,19 @@ void Notepad_plus::doSynScorll(HWND whichView)
 		if (_syncInfo._isSynScollV)
 		{
 			// Compute for Line
-			mainCurrentLine = static_cast<int32_t>(_mainEditView.execute(SCI_GETFIRSTVISIBLELINE));
-			subCurrentLine = static_cast<int32_t>(_subEditView.execute(SCI_GETFIRSTVISIBLELINE));
+			mainCurrentLine = _mainEditView.execute(SCI_GETFIRSTVISIBLELINE);
+			subCurrentLine = _subEditView.execute(SCI_GETFIRSTVISIBLELINE);
 			line = subCurrentLine + _syncInfo._line - mainCurrentLine;
 		}
 		if (_syncInfo._isSynScollH)
 		{
 			// Compute for Column
-			mxoffset = static_cast<int32_t>(_mainEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			mxoffset = _mainEditView.execute(SCI_GETXOFFSET);
+			pixel = _mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
 			mainColumn = mxoffset/pixel;
 
-			sxoffset = static_cast<int32_t>(_subEditView.execute(SCI_GETXOFFSET));
-			pixel = static_cast<int32_t>(_subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+			sxoffset = _subEditView.execute(SCI_GETXOFFSET);
+			pixel = _subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
 			subColumn = sxoffset/pixel;
 			column = subColumn + _syncInfo._column - mainColumn;
 		}

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1055,7 +1055,7 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 		const char *intermediaire = "=[ \\t]*.+";
 		const char *encodingStrRE = "[^ \\t=]+";
 
-		INT_PTR startPos = 0;
+		intptr_t startPos = 0;
 		auto endPos = lenFile - 1;
 		_invisibleEditView.execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
 
@@ -1093,8 +1093,8 @@ int Notepad_plus::getHtmlXmlEncoding(const TCHAR *fileName) const
 
 void Notepad_plus::setCodePageForInvisibleView(Buffer const *pBuffer)
 {
-	INT_PTR detectedCp = _invisibleEditView.execute(SCI_GETCODEPAGE);
-	INT_PTR cp2set = SC_CP_UTF8;
+	intptr_t detectedCp = _invisibleEditView.execute(SCI_GETCODEPAGE);
+	intptr_t cp2set = SC_CP_UTF8;
 	if (pBuffer->getUnicodeMode() == uni8Bit)
 	{
 		cp2set = (detectedCp == SC_CP_UTF8 ? CP_ACP : detectedCp);
@@ -1186,17 +1186,17 @@ bool Notepad_plus::replaceInOpenedFiles()
 
 void Notepad_plus::wsTabConvert(spaceTab whichWay)
 {
-	INT_PTR tabWidth = _pEditView->execute(SCI_GETTABWIDTH);
-	INT_PTR currentPos = _pEditView->execute(SCI_GETCURRENTPOS);
-    INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
-	INT_PTR docLength = _pEditView->execute(SCI_GETLENGTH) + 1;
+	intptr_t tabWidth = _pEditView->execute(SCI_GETTABWIDTH);
+	intptr_t currentPos = _pEditView->execute(SCI_GETCURRENTPOS);
+    intptr_t lastLine = _pEditView->lastZeroBasedLineNumber();
+	intptr_t docLength = _pEditView->execute(SCI_GETLENGTH) + 1;
     if (docLength < 2)
         return;
 
-    INT_PTR count = 0;
-    INT_PTR column = 0;
-    INT_PTR newCurrentPos = 0;
-	INT_PTR tabStop = tabWidth - 1;   // remember, counting from zero !
+    intptr_t count = 0;
+    intptr_t column = 0;
+    intptr_t newCurrentPos = 0;
+	intptr_t tabStop = tabWidth - 1;   // remember, counting from zero !
     bool onlyLeading = false;
     vector<int> bookmarks;
     vector<int> folding;
@@ -1249,7 +1249,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
             {
                 if (source[i] == '\t')
                 {
-                    INT_PTR insertTabs = tabWidth - (column % tabWidth);
+                    intptr_t insertTabs = tabWidth - (column % tabWidth);
                     for (int j = 0; j < insertTabs; ++j)
                     {
                         *dest++ = ' ';
@@ -2011,8 +2011,8 @@ void Notepad_plus::filePrint(bool showDialog)
 {
 	Printer printer;
 
-	INT_PTR startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
-	INT_PTR endPos = _pEditView->execute(SCI_GETSELECTIONEND);
+	intptr_t startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
+	intptr_t endPos = _pEditView->execute(SCI_GETSELECTIONEND);
 
 	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, int(startPos), int(endPos), _nativeLangSpeaker.isRTL());
 	printer.doPrint();
@@ -2399,9 +2399,9 @@ generic_string Notepad_plus::getLangDesc(LangType langType, bool getName)
 
 void Notepad_plus::copyMarkedLines()
 {
-	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
+	intptr_t lastLine = _pEditView->lastZeroBasedLineNumber();
 	generic_string globalStr = TEXT("");
-	for (INT_PTR i = lastLine ; i >= 0 ; i--)
+	for (intptr_t i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
 		{
@@ -2418,11 +2418,11 @@ void Notepad_plus::cutMarkedLines()
 {
 	std::lock_guard<std::mutex> lock(mark_mutex);
 
-	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
+	intptr_t lastLine = _pEditView->lastZeroBasedLineNumber();
 	generic_string globalStr = TEXT("");
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
-	for (INT_PTR i = lastLine ; i >= 0 ; i--)
+	for (intptr_t i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
 		{
@@ -2440,10 +2440,10 @@ void Notepad_plus::deleteMarkedLines(bool isMarked)
 {
 	std::lock_guard<std::mutex> lock(mark_mutex);
 
-	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
+	intptr_t lastLine = _pEditView->lastZeroBasedLineNumber();
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
-	for (INT_PTR i = lastLine ; i >= 0 ; i--)
+	for (intptr_t i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i) == isMarked)
 			deleteMarkedline(i);
@@ -2461,7 +2461,7 @@ void Notepad_plus::pasteToMarkedLines()
 	BOOL canPaste = ::IsClipboardFormatAvailable(clipFormat);
 	if (!canPaste)
 		return;
-	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
+	intptr_t lastLine = _pEditView->lastZeroBasedLineNumber();
 
 	::OpenClipboard(_pPublicInterface->getHSelf());
 	HANDLE clipboardData = ::GetClipboardData(clipFormat);
@@ -2475,7 +2475,7 @@ void Notepad_plus::pasteToMarkedLines()
 	::CloseClipboard();
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
-	for (INT_PTR i = lastLine ; i >= 0 ; i--)
+	for (intptr_t i = lastLine ; i >= 0 ; i--)
 	{
 		if (bookmarkPresent(i))
 		{
@@ -2487,8 +2487,8 @@ void Notepad_plus::pasteToMarkedLines()
 
 void Notepad_plus::deleteMarkedline(size_t ln)
 {
-	INT_PTR lineLen = _pEditView->execute(SCI_LINELENGTH, ln);
-	INT_PTR lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
+	intptr_t lineLen = _pEditView->execute(SCI_LINELENGTH, ln);
+	intptr_t lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
 
 	bookmarkDelete(ln);
 	TCHAR emptyString[2] = TEXT("");
@@ -2497,7 +2497,7 @@ void Notepad_plus::deleteMarkedline(size_t ln)
 
 void Notepad_plus::inverseMarks()
 {
-	INT_PTR lastLine = _pEditView->lastZeroBasedLineNumber();
+	intptr_t lastLine = _pEditView->lastZeroBasedLineNumber();
 	for (int i = 0 ; i <= lastLine  ; ++i)
 	{
 		if (bookmarkPresent(i))
@@ -2513,8 +2513,8 @@ void Notepad_plus::inverseMarks()
 
 void Notepad_plus::replaceMarkedline(size_t ln, const TCHAR *str)
 {
-	INT_PTR lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
-	INT_PTR lineEnd = _pEditView->execute(SCI_GETLINEENDPOSITION, ln);
+	intptr_t lineBegin = _pEditView->execute(SCI_POSITIONFROMLINE, ln);
+	intptr_t lineEnd = _pEditView->execute(SCI_GETLINEENDPOSITION, ln);
 
 	_pEditView->replaceTarget(str, lineBegin, lineEnd);
 }
@@ -2532,14 +2532,14 @@ generic_string Notepad_plus::getMarkedLine(size_t ln)
 	return line;
 }
 
-void Notepad_plus::findMatchingBracePos(INT_PTR& braceAtCaret, INT_PTR& braceOpposite)
+void Notepad_plus::findMatchingBracePos(intptr_t& braceAtCaret, intptr_t& braceOpposite)
 {
-	INT_PTR caretPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	intptr_t caretPos = _pEditView->execute(SCI_GETCURRENTPOS);
 	braceAtCaret = -1;
 	braceOpposite = -1;
 	TCHAR charBefore = '\0';
 
-	INT_PTR lengthDoc = _pEditView->execute(SCI_GETLENGTH);
+	intptr_t lengthDoc = _pEditView->execute(SCI_GETLENGTH);
 
 	if ((lengthDoc > 0) && (caretPos > 0))
     {
@@ -2567,8 +2567,8 @@ void Notepad_plus::findMatchingBracePos(INT_PTR& braceAtCaret, INT_PTR& braceOpp
 // return true if 1 or 2 (matched) brace(s) is found
 bool Notepad_plus::braceMatch()
 {
-	INT_PTR braceAtCaret = -1;
-	INT_PTR braceOpposite = -1;
+	intptr_t braceAtCaret = -1;
+	intptr_t braceOpposite = -1;
 	findMatchingBracePos(braceAtCaret, braceOpposite);
 
 	if ((braceAtCaret != -1) && (braceOpposite == -1))
@@ -2582,8 +2582,8 @@ bool Notepad_plus::braceMatch()
 
 		if (_pEditView->isShownIndentGuide())
         {
-            INT_PTR columnAtCaret = _pEditView->execute(SCI_GETCOLUMN, braceAtCaret);
-		    INT_PTR columnOpposite = _pEditView->execute(SCI_GETCOLUMN, braceOpposite);
+            intptr_t columnAtCaret = _pEditView->execute(SCI_GETCOLUMN, braceAtCaret);
+		    intptr_t columnOpposite = _pEditView->execute(SCI_GETCOLUMN, braceOpposite);
 			_pEditView->execute(SCI_SETHIGHLIGHTGUIDE, (columnAtCaret < columnOpposite)?columnAtCaret:columnOpposite);
         }
     }
@@ -2993,8 +2993,8 @@ void Notepad_plus::addHotSpot(ScintillaEditView* view)
 		pView->execute(SCI_INDICSETFLAGS, URL_INDIC, SC_INDICFLAG_VALUEFORE);
 	}
 
-	INT_PTR startPos = 0;
-	INT_PTR endPos = -1;
+	intptr_t startPos = 0;
+	intptr_t endPos = -1;
 	pView->getVisibleStartAndEndPosition(&startPos, &endPos);
 	if (startPos >= endPos) return;
 	pView->execute(SCI_SETINDICATORCURRENT, URL_INDIC);
@@ -3041,7 +3041,7 @@ void Notepad_plus::addHotSpot(ScintillaEditView* view)
 	delete[] wideText;
 }
 
-bool Notepad_plus::isConditionExprLine(INT_PTR lineNumber)
+bool Notepad_plus::isConditionExprLine(intptr_t lineNumber)
 {
 	if (lineNumber < 0 || lineNumber > _pEditView->execute(SCI_GETLINECOUNT))
 		return false;
@@ -3064,7 +3064,7 @@ bool Notepad_plus::isConditionExprLine(INT_PTR lineNumber)
 	return false;
 }
 
-INT_PTR Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol)
+intptr_t Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol)
 {
 	if (startPos == endPos)
 		return -1;
@@ -3072,7 +3072,7 @@ INT_PTR Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char ta
 	if (startPos > endPos) // backward
 	{
 		int balance = 0;
-		for (INT_PTR i = startPos; i >= static_cast<INT_PTR>(endPos); --i)
+		for (intptr_t i = startPos; i >= static_cast<intptr_t>(endPos); --i)
 		{
 			char aChar = static_cast<char>(_pEditView->execute(SCI_GETCHARAT, i));
 			if (aChar == targetSymbol)
@@ -3095,11 +3095,11 @@ INT_PTR Notepad_plus::findMachedBracePos(size_t startPos, size_t endPos, char ta
 
 void Notepad_plus::maintainIndentation(TCHAR ch)
 {
-	INT_PTR eolMode = _pEditView->execute(SCI_GETEOLMODE);
-	INT_PTR curLine = _pEditView->getCurrentLineNumber();
-	INT_PTR prevLine = curLine - 1;
-	INT_PTR indentAmountPrevLine = 0;
-	INT_PTR tabWidth = _pEditView->execute(SCI_GETTABWIDTH);
+	intptr_t eolMode = _pEditView->execute(SCI_GETEOLMODE);
+	intptr_t curLine = _pEditView->getCurrentLineNumber();
+	intptr_t prevLine = curLine - 1;
+	intptr_t indentAmountPrevLine = 0;
+	intptr_t tabWidth = _pEditView->execute(SCI_GETTABWIDTH);
 
 	LangType type = _pEditView->getCurrentBuffer()->getLangType();
 
@@ -3125,7 +3125,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 			}
 
 			// get previous char from current line
-			INT_PTR prevPos = _pEditView->execute(SCI_GETCURRENTPOS) - (eolMode == SC_EOL_CRLF ? 3 : 2);
+			intptr_t prevPos = _pEditView->execute(SCI_GETCURRENTPOS) - (eolMode == SC_EOL_CRLF ? 3 : 2);
 			UCHAR prevChar = (UCHAR)_pEditView->execute(SCI_GETCHARAT, prevPos);
 			auto curPos = _pEditView->execute(SCI_GETCURRENTPOS);
 			UCHAR nextChar = (UCHAR)_pEditView->execute(SCI_GETCHARAT, curPos);
@@ -3200,7 +3200,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 
 				const char braceExpr[] = "[ \t]*\\{.*";
 
-				INT_PTR posFound = _pEditView->execute(SCI_SEARCHINTARGET, strlen(braceExpr), reinterpret_cast<LPARAM>(braceExpr));
+				intptr_t posFound = _pEditView->execute(SCI_SEARCHINTARGET, strlen(braceExpr), reinterpret_cast<LPARAM>(braceExpr));
 				if (posFound >= 0)
 				{
 					auto end = _pEditView->execute(SCI_GETTARGETEND);
@@ -3215,17 +3215,17 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 		else if (ch == '}')
 		{
 			// Look backward for the pair {
-			INT_PTR startPos = _pEditView->execute(SCI_GETCURRENTPOS);
+			intptr_t startPos = _pEditView->execute(SCI_GETCURRENTPOS);
 			if (startPos != 0)
 				startPos -= 1;
-			INT_PTR posFound = findMachedBracePos(startPos - 1, 0, '{', '}');
+			intptr_t posFound = findMachedBracePos(startPos - 1, 0, '{', '}');
 
 			// if no { found, do nothing
 			if (posFound == -1)
 				return;
 
 			// if { is in the same line, do nothing
-			INT_PTR matchedPairLine = _pEditView->execute(SCI_LINEFROMPOSITION, posFound);
+			intptr_t matchedPairLine = _pEditView->execute(SCI_LINEFROMPOSITION, posFound);
 			if (matchedPairLine == curLine)
 				return;
 
@@ -3741,7 +3741,7 @@ void Notepad_plus::updateStatusBar()
 
 	TCHAR strDocLen[256];
 	size_t docLen = _pEditView->getCurrentDocLen();
-	INT_PTR nbLine = _pEditView->execute(SCI_GETLINECOUNT);
+	intptr_t nbLine = _pEditView->execute(SCI_GETLINECOUNT);
 	wsprintf(strDocLen, TEXT("length : %s    lines : %s"),
 		commafyInt(docLen).c_str(),
 		commafyInt(nbLine).c_str());
@@ -3815,8 +3815,8 @@ void Notepad_plus::updateStatusBar()
 	}
 
 	TCHAR strLnColSel[128];
-	INT_PTR curLN = _pEditView->getCurrentLineNumber();
-	INT_PTR curCN = _pEditView->getCurrentColumnNumber();
+	intptr_t curLN = _pEditView->getCurrentLineNumber();
+	intptr_t curCN = _pEditView->getCurrentColumnNumber();
 	wsprintf(strLnColSel, TEXT("Ln : %s    Col : %s    %s"),
 		commafyInt(curLN + 1).c_str(),
 		commafyInt(curCN + 1).c_str(),
@@ -4454,14 +4454,14 @@ void Notepad_plus::bookmarkNext(bool forwardScan)
 	size_t lineno = _pEditView->getCurrentLineNumber();
 	int sci_marker = SCI_MARKERNEXT;
 	size_t lineStart = lineno + 1;	//Scan starting from next line
-	INT_PTR lineRetry = 0;				//If not found, try from the beginning
+	intptr_t lineRetry = 0;				//If not found, try from the beginning
 	if (!forwardScan)
     {
 		lineStart = lineno - 1;		//Scan starting from previous line
 		lineRetry = _pEditView->execute(SCI_GETLINECOUNT);	//If not found, try from the end
 		sci_marker = SCI_MARKERPREVIOUS;
 	}
-	INT_PTR nextLine = _pEditView->execute(sci_marker, lineStart, 1 << MARK_BOOKMARK);
+	intptr_t nextLine = _pEditView->execute(sci_marker, lineStart, 1 << MARK_BOOKMARK);
 	if (nextLine < 0)
 		nextLine = _pEditView->execute(sci_marker, lineRetry, 1 << MARK_BOOKMARK);
 
@@ -4762,9 +4762,9 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
     size_t caretPosition = _pEditView->execute(SCI_GETCURRENTPOS);
     // checking if caret is located in _beginning_ of selected block
     bool move_caret = caretPosition < selectionEnd;
-	INT_PTR selStartLine = _pEditView->execute(SCI_LINEFROMPOSITION, selectionStart);
-	INT_PTR selEndLine = _pEditView->execute(SCI_LINEFROMPOSITION, selectionEnd);
-	INT_PTR lines = selEndLine - selStartLine;
+	intptr_t selStartLine = _pEditView->execute(SCI_LINEFROMPOSITION, selectionStart);
+	intptr_t selEndLine = _pEditView->execute(SCI_LINEFROMPOSITION, selectionEnd);
+	intptr_t lines = selEndLine - selStartLine;
     // "caret return" is part of the last selected line
     if ((lines > 0) && (selectionEnd == static_cast<size_t>(_pEditView->execute(SCI_POSITIONFROMLINE, selEndLine))))
 		selEndLine--;
@@ -4777,7 +4777,7 @@ bool Notepad_plus::doBlockComment(comment_mode currCommentMode)
 
     _pEditView->execute(SCI_BEGINUNDOACTION);
 
-    for (INT_PTR i = selStartLine; i <= selEndLine; ++i)
+    for (intptr_t i = selStartLine; i <= selEndLine; ++i)
 	{
 		size_t lineStart = _pEditView->execute(SCI_POSITIONFROMLINE, i);
 		size_t lineIndent = _pEditView->execute(SCI_GETLINEINDENTPOSITION, i);
@@ -5596,17 +5596,17 @@ void Notepad_plus::distractionFreeToggle()
 
 void Notepad_plus::doSynScorll(HWND whichView)
 {
-	INT_PTR column = 0;
-	INT_PTR line = 0;
+	intptr_t column = 0;
+	intptr_t line = 0;
 	ScintillaEditView *pView;
 
 	// var for Line
-	INT_PTR mainCurrentLine, subCurrentLine;
+	intptr_t mainCurrentLine, subCurrentLine;
 
 	// var for Column
-	INT_PTR mxoffset, sxoffset;
-	INT_PTR pixel;
-	INT_PTR mainColumn, subColumn;
+	intptr_t mxoffset, sxoffset;
+	intptr_t pixel;
+	intptr_t mainColumn, subColumn;
 
     if (whichView == _mainEditView.getHSelf())
 	{
@@ -7905,10 +7905,10 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		//-- First, search all start_comment and end_comment before and after the selectionStart and selectionEnd position.
 		const int iSelStart=0, iSelEnd=1;
 		const size_t N_CMNT = 2;
-		INT_PTR posStartCommentBefore[N_CMNT], posEndCommentBefore[N_CMNT], posStartCommentAfter[N_CMNT], posEndCommentAfter[N_CMNT];
+		intptr_t posStartCommentBefore[N_CMNT], posEndCommentBefore[N_CMNT], posStartCommentAfter[N_CMNT], posEndCommentAfter[N_CMNT];
 		bool blnStartCommentBefore[N_CMNT], blnEndCommentBefore[N_CMNT], blnStartCommentAfter[N_CMNT], blnEndCommentAfter[N_CMNT];
-		INT_PTR posStartComment, posEndComment;
-		INT_PTR selectionStartMove, selectionEndMove;
+		intptr_t posStartComment, posEndComment;
+		intptr_t selectionStartMove, selectionEndMove;
 		int flags;
 
 		//-- Directly use Scintilla-Functions
@@ -7977,8 +7977,8 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		//-- Ok, there are valid start-comment and valid end-comment around the caret-position.
 		//   Now, un-comment stream-comment:
 		retVal = true;
-		INT_PTR startCommentLength = start_comment_length;
-		INT_PTR endCommentLength = end_comment_length;
+		intptr_t startCommentLength = start_comment_length;
+		intptr_t endCommentLength = end_comment_length;
 
 		//-- First delete end-comment, so that posStartCommentBefore does not change!
 		//-- Get character before end-comment to decide, if there is a white character before the end-comment, which will be removed too!

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2014,7 +2014,7 @@ void Notepad_plus::filePrint(bool showDialog)
 	intptr_t startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
 	intptr_t endPos = _pEditView->execute(SCI_GETSELECTIONEND);
 
-	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, int(startPos), int(endPos), _nativeLangSpeaker.isRTL());
+	printer.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pEditView, showDialog, startPos, endPos, _nativeLangSpeaker.isRTL());
 	printer.doPrint();
 }
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -360,8 +360,8 @@ private:
 	//Synchronized Scolling
 	struct SyncInfo final
 	{
-		INT_PTR _line = 0;
-		INT_PTR _column = 0;
+		intptr_t _line = 0;
+		intptr_t _column = 0;
 		bool _isSynScollV = false;
 		bool _isSynScollH = false;
 
@@ -372,7 +372,7 @@ private:
 	bool _isUDDocked = false;
 
 	trayIconControler* _pTrayIco = nullptr;
-	INT_PTR _zoomOriginalValue = 0;
+	intptr_t _zoomOriginalValue = 0;
 
 	Accelerator _accelerator;
 	ScintillaAccelerator _scintaccelerator;
@@ -496,13 +496,13 @@ private:
 		::CheckMenuItem(_mainMenuHandle, itemID, MF_BYCOMMAND | (willBeChecked?MF_CHECKED:MF_UNCHECKED));
 	}
 
-	bool isConditionExprLine(INT_PTR lineNumber);
-	INT_PTR findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol);
+	bool isConditionExprLine(intptr_t lineNumber);
+	intptr_t findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol);
 	void maintainIndentation(TCHAR ch);
 
 	void addHotSpot(ScintillaEditView* view = NULL);
 
-    void bookmarkAdd(INT_PTR lineno) const {
+    void bookmarkAdd(intptr_t lineno) const {
 		if (lineno == -1)
 			lineno = _pEditView->getCurrentLineNumber();
 		if (!bookmarkPresent(lineno))
@@ -516,14 +516,14 @@ private:
 			_pEditView->execute(SCI_MARKERDELETE, lineno, MARK_BOOKMARK);
 	}
 
-    bool bookmarkPresent(INT_PTR lineno) const {
+    bool bookmarkPresent(intptr_t lineno) const {
 		if (lineno == -1)
 			lineno = _pEditView->getCurrentLineNumber();
 		LRESULT state = _pEditView->execute(SCI_MARKERGET, lineno);
 		return ((state & (1 << MARK_BOOKMARK)) != 0);
 	}
 
-    void bookmarkToggle(INT_PTR lineno) const {
+    void bookmarkToggle(intptr_t lineno) const {
 		if (lineno == -1)
 			lineno = _pEditView->getCurrentLineNumber();
 
@@ -546,7 +546,7 @@ private:
 	void inverseMarks();
 	void replaceMarkedline(size_t ln, const TCHAR *str);
 	generic_string getMarkedLine(size_t ln);
-    void findMatchingBracePos(INT_PTR& braceAtCaret, INT_PTR& braceOpposite);
+    void findMatchingBracePos(intptr_t& braceAtCaret, intptr_t& braceOpposite);
     bool braceMatch();
 
     void activateNextDoc(bool direction);

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -360,8 +360,8 @@ private:
 	//Synchronized Scolling
 	struct SyncInfo final
 	{
-		int _line = 0;
-		int _column = 0;
+		INT_PTR _line = 0;
+		INT_PTR _column = 0;
 		bool _isSynScollV = false;
 		bool _isSynScollH = false;
 
@@ -496,8 +496,8 @@ private:
 		::CheckMenuItem(_mainMenuHandle, itemID, MF_BYCOMMAND | (willBeChecked?MF_CHECKED:MF_UNCHECKED));
 	}
 
-	bool isConditionExprLine(int lineNumber);
-	int findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol);
+	bool isConditionExprLine(INT_PTR lineNumber);
+	INT_PTR findMachedBracePos(size_t startPos, size_t endPos, char targetSymbol, char matchedSymbol);
 	void maintainIndentation(TCHAR ch);
 
 	void addHotSpot(ScintillaEditView* view = NULL);
@@ -546,7 +546,7 @@ private:
 	void inverseMarks();
 	void replaceMarkedline(size_t ln, const TCHAR *str);
 	generic_string getMarkedLine(size_t ln);
-    void findMatchingBracePos(int & braceAtCaret, int & braceOpposite);
+    void findMatchingBracePos(INT_PTR& braceAtCaret, INT_PTR& braceOpposite);
     bool braceMatch();
 
     void activateNextDoc(bool direction);

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -502,7 +502,7 @@ private:
 
 	void addHotSpot(ScintillaEditView* view = NULL);
 
-    void bookmarkAdd(int lineno) const {
+    void bookmarkAdd(INT_PTR lineno) const {
 		if (lineno == -1)
 			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
 		if (!bookmarkPresent(lineno))
@@ -523,7 +523,7 @@ private:
 		return ((state & (1 << MARK_BOOKMARK)) != 0);
 	}
 
-    void bookmarkToggle(int lineno) const {
+    void bookmarkToggle(INT_PTR lineno) const {
 		if (lineno == -1)
 			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -372,7 +372,7 @@ private:
 	bool _isUDDocked = false;
 
 	trayIconControler* _pTrayIco = nullptr;
-	int _zoomOriginalValue = 0;
+	INT_PTR _zoomOriginalValue = 0;
 
 	Accelerator _accelerator;
 	ScintillaAccelerator _scintaccelerator;
@@ -509,16 +509,16 @@ private:
 			_pEditView->execute(SCI_MARKERADD, lineno, MARK_BOOKMARK);
 	}
 
-    void bookmarkDelete(int lineno) const {
+    void bookmarkDelete(size_t lineno) const {
 		if (lineno == -1)
 			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
 		while (bookmarkPresent(lineno))
 			_pEditView->execute(SCI_MARKERDELETE, lineno, MARK_BOOKMARK);
 	}
 
-    bool bookmarkPresent(int lineno) const {
+    bool bookmarkPresent(INT_PTR lineno) const {
 		if (lineno == -1)
-			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
+			lineno = _pEditView->getCurrentLineNumber();
 		LRESULT state = _pEditView->execute(SCI_MARKERGET, lineno);
 		return ((state & (1 << MARK_BOOKMARK)) != 0);
 	}
@@ -542,10 +542,10 @@ private:
 	void cutMarkedLines();
 	void deleteMarkedLines(bool isMarked);
 	void pasteToMarkedLines();
-	void deleteMarkedline(int ln);
+	void deleteMarkedline(size_t ln);
 	void inverseMarks();
-	void replaceMarkedline(int ln, const TCHAR *str);
-	generic_string getMarkedLine(int ln);
+	void replaceMarkedline(size_t ln, const TCHAR *str);
+	generic_string getMarkedLine(size_t ln);
     void findMatchingBracePos(int & braceAtCaret, int & braceOpposite);
     bool braceMatch();
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -504,14 +504,14 @@ private:
 
     void bookmarkAdd(INT_PTR lineno) const {
 		if (lineno == -1)
-			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
+			lineno = _pEditView->getCurrentLineNumber();
 		if (!bookmarkPresent(lineno))
 			_pEditView->execute(SCI_MARKERADD, lineno, MARK_BOOKMARK);
 	}
 
     void bookmarkDelete(size_t lineno) const {
 		if (lineno == -1)
-			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
+			lineno = _pEditView->getCurrentLineNumber();
 		while (bookmarkPresent(lineno))
 			_pEditView->execute(SCI_MARKERDELETE, lineno, MARK_BOOKMARK);
 	}
@@ -525,7 +525,7 @@ private:
 
     void bookmarkToggle(INT_PTR lineno) const {
 		if (lineno == -1)
-			lineno = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
+			lineno = _pEditView->getCurrentLineNumber();
 
 		if (bookmarkPresent(lineno))
 			bookmarkDelete(lineno);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -881,7 +881,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			TCHAR str[strSize];
 			TCHAR strLine[strSize];
 			size_t lineNumber;
-			INT_PTR col;
+			intptr_t col;
 			int hasSlash;
 			TCHAR *pTchar = reinterpret_cast<TCHAR *>(lParam);
 
@@ -894,8 +894,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			if (hasSlash == FALSE)
 			{
 				// it's not a full file name so try to find the beginning and ending of it
-				INT_PTR start;
-				INT_PTR end;
+				intptr_t start;
+				intptr_t end;
 				const TCHAR *delimiters;
 
 				lineNumber = _pEditView->getCurrentLineNumber();
@@ -1313,11 +1313,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					break;
 
 				int counter = 0;
-				INT_PTR lastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1;
-				INT_PTR currLine = _pEditView->getCurrentLineNumber();
+				intptr_t lastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1;
+				intptr_t currLine = _pEditView->getCurrentLineNumber();
 				int indexMacro = _runMacroDlg.getMacro2Exec();
-				INT_PTR deltaLastLine = 0;
-				INT_PTR deltaCurrLine = 0;
+				intptr_t deltaLastLine = 0;
+				intptr_t deltaCurrLine = 0;
 
 				Macro m = _macro;
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1290,7 +1290,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_FRSAVE_INT:
 		{
-			_macro.push_back(recordedMacroStep(static_cast<int32_t>(wParam), 0, static_cast<long>(lParam), NULL, recordedMacroStep::mtSavedSnR));
+			_macro.push_back(recordedMacroStep(static_cast<int32_t>(wParam), 0, lParam, NULL, recordedMacroStep::mtSavedSnR));
 			break;
 		}
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -881,20 +881,21 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			TCHAR str[strSize];
 			TCHAR strLine[strSize];
 			size_t lineNumber;
-			int col;
-			int i;
+			INT_PTR col;
 			int hasSlash;
 			TCHAR *pTchar = reinterpret_cast<TCHAR *>(lParam);
 
 			_pEditView->getGenericSelectedText(str, strSize); // this is either the selected text, or the word under the cursor if there is no selection
 			hasSlash = FALSE;
-			for (i = 0; str[i] != 0; i++) if (CharacterIs(str[i], TEXT("\\/"))) hasSlash = TRUE;
+			for (int i = 0; str[i] != 0; i++)
+				if (CharacterIs(str[i], TEXT("\\/")))
+					hasSlash = TRUE;
 
 			if (hasSlash == FALSE)
 			{
 				// it's not a full file name so try to find the beginning and ending of it
-				int start;
-				int end;
+				INT_PTR start;
+				INT_PTR end;
 				const TCHAR *delimiters;
 
 				lineNumber = _pEditView->getCurrentLineNumber();
@@ -904,7 +905,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				// find the start
 				start = col;
 				delimiters = TEXT(" \t[(\"<>");
-				while ((start > 0) && (CharacterIs(strLine[start], delimiters) == FALSE)) start--;
+				while ((start > 0) && (CharacterIs(strLine[start], delimiters) == FALSE))
+					start--;
+
 				if (CharacterIs(strLine[start], delimiters)) start++;
 
 				// find the end
@@ -912,7 +915,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				delimiters = TEXT(" \t:()[]<>\"\r\n");
 				while ((strLine[end] != 0) && (CharacterIs(strLine[end], delimiters) == FALSE)) end++;
 
-				lstrcpyn(str, &strLine[start], end - start + 1);
+				lstrcpyn(str, &strLine[start], static_cast<int>(end - start + 1));
 			}
 
 			if (lstrlen(str) >= int(wParam))	//buffer too small

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1313,11 +1313,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					break;
 
 				int counter = 0;
-				int lastLine = static_cast<int32_t>(_pEditView->execute(SCI_GETLINECOUNT)) - 1;
-				int currLine = static_cast<int32_t>(_pEditView->getCurrentLineNumber());
+				INT_PTR lastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1;
+				INT_PTR currLine = _pEditView->getCurrentLineNumber();
 				int indexMacro = _runMacroDlg.getMacro2Exec();
-				int deltaLastLine = 0;
-				int deltaCurrLine = 0;
+				INT_PTR deltaLastLine = 0;
+				INT_PTR deltaCurrLine = 0;
 
 				Macro m = _macro;
 
@@ -1340,8 +1340,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					else // run until eof
 					{
 						bool cursorMovedUp = deltaCurrLine < 0;
-						deltaLastLine = static_cast<int32_t>(_pEditView->execute(SCI_GETLINECOUNT)) - 1 - lastLine;
-						deltaCurrLine = static_cast<int32_t>(_pEditView->getCurrentLineNumber()) - currLine;
+						deltaLastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1 - lastLine;
+						deltaCurrLine = _pEditView->getCurrentLineNumber() - currLine;
 
 						if (( deltaCurrLine == 0 )	// line no. not changed?
 							&& (deltaLastLine >= 0))  // and no lines removed?

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -373,7 +373,7 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_COPY_BINARY:
 		case IDM_EDIT_CUT_BINARY:
 		{
-			int textLen = static_cast<int32_t>(_pEditView->execute(SCI_GETSELTEXT, 0, 0)) - 1;
+			size_t textLen = _pEditView->execute(SCI_GETSELTEXT, 0, 0) - 1;
 			if (!textLen)
 				return;
 
@@ -414,7 +414,7 @@ void Notepad_plus::command(int id)
 
 			// Lock the handle and copy the text to the buffer.
 			unsigned long *lpLenCopy = (unsigned long *)GlobalLock(hglbLenCopy);
-			*lpLenCopy = textLen;
+			*lpLenCopy = static_cast<unsigned long>(textLen);
 
 			GlobalUnlock(hglbLenCopy);
 
@@ -432,7 +432,7 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_PASTE:
 		{
 			std::lock_guard<std::mutex> lock(command_mutex);
-			int eolMode = int(_pEditView->execute(SCI_GETEOLMODE));
+			INT_PTR eolMode = _pEditView->execute(SCI_GETEOLMODE);
 			_pEditView->execute(SCI_PASTE);
 			_pEditView->execute(SCI_CONVERTEOLS, eolMode);
 		}
@@ -1596,8 +1596,8 @@ void Notepad_plus::command(int id)
 		case IDM_SEARCH_GOTOMATCHINGBRACE :
 		case IDM_SEARCH_SELECTMATCHINGBRACES :
 		{
-			int braceAtCaret = -1;
-			int braceOpposite = -1;
+			INT_PTR braceAtCaret = -1;
+			INT_PTR braceOpposite = -1;
 			findMatchingBracePos(braceAtCaret, braceOpposite);
 
 			if (braceOpposite != -1)
@@ -2386,8 +2386,8 @@ void Notepad_plus::command(int id)
             _syncInfo._isSynScollV = isSynScollV;
 			if (_syncInfo._isSynScollV)
 			{
-				int mainCurrentLine = static_cast<int32_t>(_mainEditView.execute(SCI_GETFIRSTVISIBLELINE));
-				int subCurrentLine = static_cast<int32_t>(_subEditView.execute(SCI_GETFIRSTVISIBLELINE));
+				INT_PTR mainCurrentLine = _mainEditView.execute(SCI_GETFIRSTVISIBLELINE);
+				INT_PTR subCurrentLine = _subEditView.execute(SCI_GETFIRSTVISIBLELINE);
 				_syncInfo._line = mainCurrentLine - subCurrentLine;
 			}
 
@@ -2403,13 +2403,13 @@ void Notepad_plus::command(int id)
             _syncInfo._isSynScollH = isSynScollH;
 			if (_syncInfo._isSynScollH)
 			{
-				int mxoffset = static_cast<int32_t>(_mainEditView.execute(SCI_GETXOFFSET));
-				int pixel = static_cast<int32_t>(_mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
-				int mainColumn = mxoffset/pixel;
+				INT_PTR mxoffset = _mainEditView.execute(SCI_GETXOFFSET);
+				INT_PTR pixel = _mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
+				INT_PTR mainColumn = mxoffset/pixel;
 
-				int sxoffset = static_cast<int32_t>(_subEditView.execute(SCI_GETXOFFSET));
-				pixel = int(_subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
-				int subColumn = sxoffset/pixel;
+				INT_PTR sxoffset = _subEditView.execute(SCI_GETXOFFSET);
+				pixel = _subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
+				INT_PTR subColumn = sxoffset/pixel;
 				_syncInfo._column = mainColumn - subColumn;
 			}
 		}
@@ -3085,10 +3085,10 @@ void Notepad_plus::command(int id)
 				size_t selectionStart = _pEditView->execute(SCI_GETSELECTIONSTART);
 				size_t selectionEnd = _pEditView->execute(SCI_GETSELECTIONEND);
 
-				int32_t strLen = static_cast<int32_t>(selectionEnd - selectionStart);
+				INT_PTR strLen = selectionEnd - selectionStart;
 				if (strLen)
 				{
-					int strSize = strLen + 1;
+					INT_PTR strSize = strLen + 1;
 					char *selectedStr = new char[strSize];
 					_pEditView->execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selectedStr));
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3128,10 +3128,10 @@ void Notepad_plus::command(int id)
 				size_t selectionStart = _pEditView->execute(SCI_GETSELECTIONSTART);
 				size_t selectionEnd = _pEditView->execute(SCI_GETSELECTIONEND);
 
-				int32_t strLen = static_cast<int32_t>(selectionEnd - selectionStart);
+				INT_PTR strLen = selectionEnd - selectionStart;
 				if (strLen)
 				{
-					int strSize = strLen + 1;
+					INT_PTR strSize = strLen + 1;
 					char *selectedStr = new char[strSize];
 					_pEditView->execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selectedStr));
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -359,7 +359,7 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_COPY_LINK:
 		{
-			int startPos = 0, endPos = 0, curPos = 0;
+			size_t startPos = 0, endPos = 0, curPos = 0;
 			if (_pEditView->getIndicatorRange(URL_INDIC, &startPos, &endPos, &curPos))
 			{
 				_pEditView->execute(SCI_SETSEL, startPos, endPos);
@@ -673,7 +673,7 @@ void Notepad_plus::command(int id)
 				hasLineSelection = selStart != selEnd;
 				if (hasLineSelection)
 				{
-					const pair<int, int> lineRange = _pEditView->getSelectionLinesRange();
+					const pair<size_t, size_t> lineRange = _pEditView->getSelectionLinesRange();
 					// One single line selection is not allowed.
 					if (lineRange.first == lineRange.second)
 					{
@@ -1427,8 +1427,8 @@ void Notepad_plus::command(int id)
 			if (range.cpMin == range.cpMax)
 			{
 				auto caretPos = _pEditView->execute(SCI_GETCURRENTPOS, 0, 0);
-				range.cpMin = static_cast<int>(_pEditView->execute(SCI_WORDSTARTPOSITION, caretPos, true));
-				range.cpMax = static_cast<int>(_pEditView->execute(SCI_WORDENDPOSITION, caretPos, true));
+				range.cpMin = static_cast<Sci_PositionCR>(_pEditView->execute(SCI_WORDSTARTPOSITION, caretPos, true));
+				range.cpMax = static_cast<Sci_PositionCR>(_pEditView->execute(SCI_WORDENDPOSITION, caretPos, true));
 			}
 			if (range.cpMax > range.cpMin)
 			{
@@ -1705,11 +1705,11 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_RMV_TAB:
 		{
 			bool forwards = id == IDM_EDIT_INS_TAB;
-			int selStartPos = static_cast<int>(_pEditView->execute(SCI_GETSELECTIONSTART));
-			int lineNumber = static_cast<int>(_pEditView->execute(SCI_LINEFROMPOSITION, selStartPos));
-			int numSelections = static_cast<int>(_pEditView->execute(SCI_GETSELECTIONS));
-			int selEndPos = static_cast<int>(_pEditView->execute(SCI_GETSELECTIONEND));
-			int selEndLineNumber = static_cast<int>(_pEditView->execute(SCI_LINEFROMPOSITION, selEndPos));
+			size_t selStartPos = _pEditView->execute(SCI_GETSELECTIONSTART);
+			size_t lineNumber = _pEditView->execute(SCI_LINEFROMPOSITION, selStartPos);
+			size_t numSelections = _pEditView->execute(SCI_GETSELECTIONS);
+			size_t selEndPos = _pEditView->execute(SCI_GETSELECTIONEND);
+			size_t selEndLineNumber = _pEditView->execute(SCI_LINEFROMPOSITION, selEndPos);
 			if ((numSelections > 1) || (lineNumber != selEndLineNumber))
 			{
 				// multiple-selection or multi-line selection; use Scintilla SCI_TAB / SCI_BACKTAB behavior
@@ -1719,10 +1719,10 @@ void Notepad_plus::command(int id)
 			{
 				// zero-length selection (simple single caret) or selected text is all on single line
 				// depart from Scintilla behavior and do it our way
-				int currentIndent = static_cast<int>(_pEditView->execute(SCI_GETLINEINDENTATION, lineNumber));
-				int indentDelta = static_cast<int>(_pEditView->execute(SCI_GETTABWIDTH));
+				size_t currentIndent = _pEditView->execute(SCI_GETLINEINDENTATION, lineNumber);
+				INT_PTR indentDelta = _pEditView->execute(SCI_GETTABWIDTH);
 				if (!forwards) indentDelta = -indentDelta;
-				_pEditView->setLineIndent(lineNumber, currentIndent + indentDelta);
+				_pEditView->setLineIndent(lineNumber, static_cast<INT_PTR>(currentIndent) + indentDelta);
 			}
 		}
 		break;
@@ -1747,12 +1747,12 @@ void Notepad_plus::command(int id)
 		{
 			if (_pEditView->execute(SCI_GETSELECTIONS) == 1)
 			{
-				pair<int, int> lineRange = _pEditView->getSelectionLinesRange();
+				pair<size_t, size_t> lineRange = _pEditView->getSelectionLinesRange();
 				auto anchorPos = _pEditView->execute(SCI_POSITIONFROMLINE, lineRange.first);
 				auto caretPos = _pEditView->execute(SCI_GETLINEENDPOSITION, lineRange.second);
 				_pEditView->execute(SCI_SETSELECTION, caretPos, anchorPos);
 				_pEditView->execute(SCI_TARGETFROMSELECTION);
-				int edgeMode = static_cast<int>(_pEditView->execute(SCI_GETEDGEMODE));
+				size_t edgeMode = _pEditView->execute(SCI_GETEDGEMODE);
 				if (edgeMode == EDGE_NONE)
 				{
 					_pEditView->execute(SCI_LINESSPLIT, 0);
@@ -1776,7 +1776,7 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_JOIN_LINES:
 		{
-			const pair<int, int> lineRange = _pEditView->getSelectionLinesRange();
+			const pair<size_t, size_t> lineRange = _pEditView->getSelectionLinesRange();
 			if (lineRange.first != lineRange.second)
 			{
 				auto anchorPos = _pEditView->execute(SCI_POSITIONFROMLINE, lineRange.first);
@@ -2454,13 +2454,13 @@ void Notepad_plus::command(int id)
 				generic_string nbRangeLabel = pNativeSpeaker->getLocalizedStrFromID("summary-nbrange", TEXT(" ranges"));
 
 				UniMode um = _pEditView->getCurrentBuffer()->getUnicodeMode();
-				auto nbChar = getCurrentDocCharCount(um);
+				size_t nbChar = getCurrentDocCharCount(um);
 				int nbWord = wordCount();
-				auto nbLine = _pEditView->execute(SCI_GETLINECOUNT);
-				auto nbByte = _pEditView->execute(SCI_GETLENGTH);
-				auto nbSel = getSelectedCharNumber(um);
-				auto nbSelByte = getSelectedBytes();
-				auto nbRange = getSelectedAreas();
+				size_t nbLine = _pEditView->execute(SCI_GETLINECOUNT);
+				size_t nbByte = _pEditView->execute(SCI_GETLENGTH);
+				size_t nbSel = getSelectedCharNumber(um);
+				size_t nbSelByte = getSelectedBytes();
+				size_t nbRange = getSelectedAreas();
 
 				characterNumber += nbCharLabel;
 				characterNumber += commafyInt(nbChar).c_str();
@@ -2471,7 +2471,7 @@ void Notepad_plus::command(int id)
 				characterNumber += TEXT("\r");
 
 				characterNumber += nbLineLabel;
-				characterNumber += commafyInt(static_cast<int>(nbLine)).c_str();
+				characterNumber += commafyInt(nbLine).c_str();
 				characterNumber += TEXT("\r");
 
 				characterNumber += nbByteLabel;
@@ -2895,7 +2895,7 @@ void Notepad_plus::command(int id)
 				_pEditView->saveCurrentPos();
 
 				// Cut all text
-				int docLen = _pEditView->getCurrentDocLen();
+				size_t docLen = _pEditView->getCurrentDocLen();
 				_pEditView->execute(SCI_COPYRANGE, 0, docLen);
 				_pEditView->execute(SCI_CLEARALL);
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -163,7 +163,7 @@ void Notepad_plus::command(int id)
 			// As per MSDN (https://msdn.microsoft.com/en-us/library/windows/desktop/bb762153(v=vs.85).aspx)
 			// If the function succeeds, it returns a value greater than 32.
 			// If the function fails, it returns an error value that indicates the cause of the failure.
-			int retResult = static_cast<int>(reinterpret_cast<INT_PTR>(res));
+			int retResult = static_cast<int>(reinterpret_cast<intptr_t>(res));
 			if (retResult <= 32)
 			{
 				generic_string errorMsg;
@@ -432,7 +432,7 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_PASTE:
 		{
 			std::lock_guard<std::mutex> lock(command_mutex);
-			INT_PTR eolMode = _pEditView->execute(SCI_GETEOLMODE);
+			intptr_t eolMode = _pEditView->execute(SCI_GETEOLMODE);
 			_pEditView->execute(SCI_PASTE);
 			_pEditView->execute(SCI_CONVERTEOLS, eolMode);
 		}
@@ -1596,8 +1596,8 @@ void Notepad_plus::command(int id)
 		case IDM_SEARCH_GOTOMATCHINGBRACE :
 		case IDM_SEARCH_SELECTMATCHINGBRACES :
 		{
-			INT_PTR braceAtCaret = -1;
-			INT_PTR braceOpposite = -1;
+			intptr_t braceAtCaret = -1;
+			intptr_t braceOpposite = -1;
 			findMatchingBracePos(braceAtCaret, braceOpposite);
 
 			if (braceOpposite != -1)
@@ -1720,9 +1720,9 @@ void Notepad_plus::command(int id)
 				// zero-length selection (simple single caret) or selected text is all on single line
 				// depart from Scintilla behavior and do it our way
 				size_t currentIndent = _pEditView->execute(SCI_GETLINEINDENTATION, lineNumber);
-				INT_PTR indentDelta = _pEditView->execute(SCI_GETTABWIDTH);
+				intptr_t indentDelta = _pEditView->execute(SCI_GETTABWIDTH);
 				if (!forwards) indentDelta = -indentDelta;
-				_pEditView->setLineIndent(lineNumber, static_cast<INT_PTR>(currentIndent) + indentDelta);
+				_pEditView->setLineIndent(lineNumber, static_cast<intptr_t>(currentIndent) + indentDelta);
 			}
 		}
 		break;
@@ -2386,8 +2386,8 @@ void Notepad_plus::command(int id)
             _syncInfo._isSynScollV = isSynScollV;
 			if (_syncInfo._isSynScollV)
 			{
-				INT_PTR mainCurrentLine = _mainEditView.execute(SCI_GETFIRSTVISIBLELINE);
-				INT_PTR subCurrentLine = _subEditView.execute(SCI_GETFIRSTVISIBLELINE);
+				intptr_t mainCurrentLine = _mainEditView.execute(SCI_GETFIRSTVISIBLELINE);
+				intptr_t subCurrentLine = _subEditView.execute(SCI_GETFIRSTVISIBLELINE);
 				_syncInfo._line = mainCurrentLine - subCurrentLine;
 			}
 
@@ -2403,13 +2403,13 @@ void Notepad_plus::command(int id)
             _syncInfo._isSynScollH = isSynScollH;
 			if (_syncInfo._isSynScollH)
 			{
-				INT_PTR mxoffset = _mainEditView.execute(SCI_GETXOFFSET);
-				INT_PTR pixel = _mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
-				INT_PTR mainColumn = mxoffset/pixel;
+				intptr_t mxoffset = _mainEditView.execute(SCI_GETXOFFSET);
+				intptr_t pixel = _mainEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
+				intptr_t mainColumn = mxoffset/pixel;
 
-				INT_PTR sxoffset = _subEditView.execute(SCI_GETXOFFSET);
+				intptr_t sxoffset = _subEditView.execute(SCI_GETXOFFSET);
 				pixel = _subEditView.execute(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P"));
-				INT_PTR subColumn = sxoffset/pixel;
+				intptr_t subColumn = sxoffset/pixel;
 				_syncInfo._column = mainColumn - subColumn;
 			}
 		}
@@ -3085,10 +3085,10 @@ void Notepad_plus::command(int id)
 				size_t selectionStart = _pEditView->execute(SCI_GETSELECTIONSTART);
 				size_t selectionEnd = _pEditView->execute(SCI_GETSELECTIONEND);
 
-				INT_PTR strLen = selectionEnd - selectionStart;
+				intptr_t strLen = selectionEnd - selectionStart;
 				if (strLen)
 				{
-					INT_PTR strSize = strLen + 1;
+					intptr_t strSize = strLen + 1;
 					char *selectedStr = new char[strSize];
 					_pEditView->execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selectedStr));
 
@@ -3128,10 +3128,10 @@ void Notepad_plus::command(int id)
 				size_t selectionStart = _pEditView->execute(SCI_GETSELECTIONSTART);
 				size_t selectionEnd = _pEditView->execute(SCI_GETSELECTIONEND);
 
-				INT_PTR strLen = selectionEnd - selectionStart;
+				intptr_t strLen = selectionEnd - selectionStart;
 				if (strLen)
 				{
-					INT_PTR strSize = strLen + 1;
+					intptr_t strSize = strLen + 1;
 					char *selectedStr = new char[strSize];
 					_pEditView->execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selectedStr));
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -589,7 +589,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			else if (notification->nmhdr.hwndFrom == _subEditView.getHSelf())
 				switchEditViewTo(SUB_VIEW);
 
-			int lineClick = int(_pEditView->execute(SCI_LINEFROMPOSITION, notification->position));
+			INT_PTR lineClick = _pEditView->execute(SCI_LINEFROMPOSITION, notification->position);
 
 			if (notification->margin == ScintillaEditView::_SC_MARGE_FOLDER)
 			{

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -589,7 +589,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			else if (notification->nmhdr.hwndFrom == _subEditView.getHSelf())
 				switchEditViewTo(SUB_VIEW);
 
-			INT_PTR lineClick = _pEditView->execute(SCI_LINEFROMPOSITION, notification->position);
+			intptr_t lineClick = _pEditView->execute(SCI_LINEFROMPOSITION, notification->position);
 
 			if (notification->margin == ScintillaEditView::_SC_MARGE_FOLDER)
 			{

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2162,14 +2162,14 @@ bool NppParameters::getSessionFromXmlTree(TiXmlDocument *pSessionDoc, Session& s
 				if (fileName)
 				{
 					Position position;
-					(childNode->ToElement())->Attribute(TEXT("firstVisibleLine"), &position._firstVisibleLine);
-					(childNode->ToElement())->Attribute(TEXT("xOffset"), &position._xOffset);
-					(childNode->ToElement())->Attribute(TEXT("startPos"), &position._startPos);
-					(childNode->ToElement())->Attribute(TEXT("endPos"), &position._endPos);
-					(childNode->ToElement())->Attribute(TEXT("selMode"), &position._selMode);
-					(childNode->ToElement())->Attribute(TEXT("scrollWidth"), &position._scrollWidth);
-					(childNode->ToElement())->Attribute(TEXT("offset"), &position._offset);
-					(childNode->ToElement())->Attribute(TEXT("wrapCount"), &position._wrapCount);
+					(childNode->ToElement())->Attribute(TEXT("firstVisibleLine"), reinterpret_cast<int*>(&position._firstVisibleLine));
+					(childNode->ToElement())->Attribute(TEXT("xOffset"), reinterpret_cast<int*>(&position._xOffset));
+					(childNode->ToElement())->Attribute(TEXT("startPos"), reinterpret_cast<int*>(&position._startPos));
+					(childNode->ToElement())->Attribute(TEXT("endPos"), reinterpret_cast<int*>(&position._endPos));
+					(childNode->ToElement())->Attribute(TEXT("selMode"), reinterpret_cast<int*>(&position._selMode));
+					(childNode->ToElement())->Attribute(TEXT("scrollWidth"), reinterpret_cast<int*>(&position._scrollWidth));
+					(childNode->ToElement())->Attribute(TEXT("offset"), reinterpret_cast<int*>(&position._offset));
+					(childNode->ToElement())->Attribute(TEXT("wrapCount"), reinterpret_cast<int*>(&position._wrapCount));
 					MapPosition mapPosition;
 					int32_t mapPosVal;
 					const TCHAR *mapPosStr = (childNode->ToElement())->Attribute(TEXT("mapFirstVisibleDisplayLine"), &mapPosVal);
@@ -3273,14 +3273,14 @@ void NppParameters::writeSession(const Session & session, const TCHAR *fileName)
 			{
 				TiXmlNode *fileNameNode = viewElems[k].viewNode->InsertEndChild(TiXmlElement(TEXT("File")));
 
-				(fileNameNode->ToElement())->SetAttribute(TEXT("firstVisibleLine"), viewSessionFiles[i]._firstVisibleLine);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("xOffset"), viewSessionFiles[i]._xOffset);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("scrollWidth"), viewSessionFiles[i]._scrollWidth);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("startPos"), viewSessionFiles[i]._startPos);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("endPos"), viewSessionFiles[i]._endPos);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("selMode"), viewSessionFiles[i]._selMode);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("offset"), viewSessionFiles[i]._offset);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("wrapCount"), viewSessionFiles[i]._wrapCount);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("firstVisibleLine"), static_cast<int>(viewSessionFiles[i]._firstVisibleLine));
+				(fileNameNode->ToElement())->SetAttribute(TEXT("xOffset"), static_cast<int>(viewSessionFiles[i]._xOffset));
+				(fileNameNode->ToElement())->SetAttribute(TEXT("scrollWidth"), static_cast<int>(viewSessionFiles[i]._scrollWidth));
+				(fileNameNode->ToElement())->SetAttribute(TEXT("startPos"), static_cast<int>(viewSessionFiles[i]._startPos));
+				(fileNameNode->ToElement())->SetAttribute(TEXT("endPos"), static_cast<int>(viewSessionFiles[i]._endPos));
+				(fileNameNode->ToElement())->SetAttribute(TEXT("selMode"), static_cast<int>(viewSessionFiles[i]._selMode));
+				(fileNameNode->ToElement())->SetAttribute(TEXT("offset"), static_cast<int>(viewSessionFiles[i]._offset));
+				(fileNameNode->ToElement())->SetAttribute(TEXT("wrapCount"), static_cast<int>(viewSessionFiles[i]._wrapCount));
 				(fileNameNode->ToElement())->SetAttribute(TEXT("lang"), viewSessionFiles[i]._langName.c_str());
 				(fileNameNode->ToElement())->SetAttribute(TEXT("encoding"), viewSessionFiles[i]._encoding);
 				(fileNameNode->ToElement())->SetAttribute(TEXT("userReadOnly"), (viewSessionFiles[i]._isUserReadOnly && !viewSessionFiles[i]._isMonitoring) ? TEXT("yes") : TEXT("no"));
@@ -6004,8 +6004,8 @@ bool NppParameters::writeScintillaParams()
 	}
 	(scintNode->ToElement())->SetAttribute(TEXT("isEdgeBgMode"), _svp._isEdgeBgMode ? TEXT("yes") : TEXT("no"));
 	(scintNode->ToElement())->SetAttribute(TEXT("edgeMultiColumnPos"), edgeColumnPosStr);
-	(scintNode->ToElement())->SetAttribute(TEXT("zoom"), _svp._zoom);
-	(scintNode->ToElement())->SetAttribute(TEXT("zoom2"), _svp._zoom2);
+	(scintNode->ToElement())->SetAttribute(TEXT("zoom"), static_cast<int>(_svp._zoom));
+	(scintNode->ToElement())->SetAttribute(TEXT("zoom2"), static_cast<int>(_svp._zoom2));
 	(scintNode->ToElement())->SetAttribute(TEXT("whiteSpaceShow"), _svp._whiteSpaceShow?TEXT("show"):TEXT("hide"));
 	(scintNode->ToElement())->SetAttribute(TEXT("eolShow"), _svp._eolShow?TEXT("show"):TEXT("hide"));
 	(scintNode->ToElement())->SetAttribute(TEXT("borderWidth"), _svp._borderWidth);

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3290,15 +3290,15 @@ void NppParameters::writeSession(const Session & session, const TCHAR *fileName)
 				(fileNameNode->ToElement())->SetAttribute(TEXT("originalFileLastModifTimestampHigh"), static_cast<int32_t>(viewSessionFiles[i]._originalFileLastModifTimestamp.dwHighDateTime));
 				
 				// docMap 
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapFirstVisibleDisplayLine"), viewSessionFiles[i]._mapPos._firstVisibleDisplayLine);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapFirstVisibleDocLine"), viewSessionFiles[i]._mapPos._firstVisibleDocLine);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapLastVisibleDocLine"), viewSessionFiles[i]._mapPos._lastVisibleDocLine);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapNbLine"), viewSessionFiles[i]._mapPos._nbLine);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapHigherPos"), viewSessionFiles[i]._mapPos._higherPos);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapWidth"), viewSessionFiles[i]._mapPos._width);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapHeight"), viewSessionFiles[i]._mapPos._height);
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapKByteInDoc"), static_cast<int>(viewSessionFiles[i]._mapPos._KByteInDoc));
-				(fileNameNode->ToElement())->SetAttribute(TEXT("mapWrapIndentMode"), viewSessionFiles[i]._mapPos._wrapIndentMode);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapFirstVisibleDisplayLine"), (int)viewSessionFiles[i]._mapPos._firstVisibleDisplayLine);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapFirstVisibleDocLine"), (int)viewSessionFiles[i]._mapPos._firstVisibleDocLine);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapLastVisibleDocLine"), (int)viewSessionFiles[i]._mapPos._lastVisibleDocLine);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapNbLine"), (int)viewSessionFiles[i]._mapPos._nbLine);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapHigherPos"), (int)viewSessionFiles[i]._mapPos._higherPos);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapWidth"), (int)viewSessionFiles[i]._mapPos._width);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapHeight"), (int)viewSessionFiles[i]._mapPos._height);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapKByteInDoc"), (int)viewSessionFiles[i]._mapPos._KByteInDoc);
+				(fileNameNode->ToElement())->SetAttribute(TEXT("mapWrapIndentMode"), (int)viewSessionFiles[i]._mapPos._wrapIndentMode);
 				fileNameNode->ToElement()->SetAttribute(TEXT("mapIsWrap"), viewSessionFiles[i]._mapPos._isWrap ? TEXT("yes") : TEXT("no"));
 
 				for (size_t j = 0, len = viewSessionFiles[i]._marks.size() ; j < len ; ++j)

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -156,24 +156,24 @@ struct Position
 
 struct MapPosition
 {
-	INT_PTR _firstVisibleDisplayLine = -1;
+	intptr_t _firstVisibleDisplayLine = -1;
 
-	INT_PTR _firstVisibleDocLine = -1; // map
-	INT_PTR _lastVisibleDocLine = -1;  // map
-	INT_PTR _nbLine = -1;              // map
-	INT_PTR _higherPos = -1;           // map
-	INT_PTR _width = -1;
-	INT_PTR _height = -1;
-	INT_PTR _wrapIndentMode = -1;
+	intptr_t _firstVisibleDocLine = -1; // map
+	intptr_t _lastVisibleDocLine = -1;  // map
+	intptr_t _nbLine = -1;              // map
+	intptr_t _higherPos = -1;           // map
+	intptr_t _width = -1;
+	intptr_t _height = -1;
+	intptr_t _wrapIndentMode = -1;
 
-	INT_PTR _KByteInDoc = _maxPeekLenInKB;
+	intptr_t _KByteInDoc = _maxPeekLenInKB;
 
 	bool _isWrap = false;
 	bool isValid() const { return (_firstVisibleDisplayLine != -1); };
 	bool canScroll() const { return (_KByteInDoc < _maxPeekLenInKB); }; // _nbCharInDoc < _maxPeekLen : Don't scroll the document for the performance issue
 
 private:
-	INT_PTR _maxPeekLenInKB = 512; // 512 KB
+	intptr_t _maxPeekLenInKB = 512; // 512 KB
 };
 
 
@@ -874,8 +874,8 @@ struct ScintillaViewParams
 	bool _isEdgeBgMode = false;
 
 	std::vector<size_t> _edgeMultiColumnPos;
-	INT_PTR _zoom = 0;
-	INT_PTR _zoom2 = 0;
+	intptr_t _zoom = 0;
+	intptr_t _zoom2 = 0;
 	bool _whiteSpaceShow = false;
 	bool _eolShow = false;
 	int _borderWidth = 2;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -156,24 +156,24 @@ struct Position
 
 struct MapPosition
 {
-	int32_t _firstVisibleDisplayLine = -1;
+	INT_PTR _firstVisibleDisplayLine = -1;
 
-	int32_t _firstVisibleDocLine = -1; // map
-	int32_t _lastVisibleDocLine = -1;  // map
-	int32_t _nbLine = -1;              // map
-	int32_t _higherPos = -1;           // map
-	int32_t _width = -1;
-	int32_t _height = -1;
-	int32_t _wrapIndentMode = -1;
+	INT_PTR _firstVisibleDocLine = -1; // map
+	INT_PTR _lastVisibleDocLine = -1;  // map
+	INT_PTR _nbLine = -1;              // map
+	INT_PTR _higherPos = -1;           // map
+	INT_PTR _width = -1;
+	INT_PTR _height = -1;
+	INT_PTR _wrapIndentMode = -1;
 
-	int64_t _KByteInDoc = _maxPeekLenInKB;
+	INT_PTR _KByteInDoc = _maxPeekLenInKB;
 
 	bool _isWrap = false;
 	bool isValid() const { return (_firstVisibleDisplayLine != -1); };
 	bool canScroll() const { return (_KByteInDoc < _maxPeekLenInKB); }; // _nbCharInDoc < _maxPeekLen : Don't scroll the document for the performance issue
 
 private:
-	int64_t _maxPeekLenInKB = 512; // 512 KB
+	INT_PTR _maxPeekLenInKB = 512; // 512 KB
 };
 
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -143,14 +143,14 @@ void cutString(const TCHAR *str2cut, std::vector<generic_string> & patternVect);
 
 struct Position
 {
-	int _firstVisibleLine = 0;
-	int _startPos = 0;
-	int _endPos = 0;
-	int _xOffset = 0;
-	int _selMode = 0;
-	int _scrollWidth = 1;
-	int _offset = 0;
-	int _wrapCount = 0;
+	size_t _firstVisibleLine = 0;
+	size_t _startPos = 0;
+	size_t _endPos = 0;
+	size_t _xOffset = 0;
+	size_t _selMode = 0;
+	size_t _scrollWidth = 1;
+	size_t _offset = 0;
+	size_t _wrapCount = 0;
 };
 
 
@@ -874,8 +874,8 @@ struct ScintillaViewParams
 	bool _isEdgeBgMode = false;
 
 	std::vector<size_t> _edgeMultiColumnPos;
-	int _zoom = 0;
-	int _zoom2 = 0;
+	INT_PTR _zoom = 0;
+	INT_PTR _zoom2 = 0;
 	bool _whiteSpaceShow = false;
 	bool _eolShow = false;
 	int _borderWidth = 2;

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -47,8 +47,8 @@ bool AutoCompletion::showApiComplete()
 		return false;
 
 	// calculate entered word's length
-	int curPos = int(_pEditView->execute(SCI_GETCURRENTPOS));
-	int startPos = int(_pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true));
+	INT_PTR curPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	INT_PTR startPos = _pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true);
 
 	if (curPos == startPos)
 		return false;
@@ -160,7 +160,7 @@ void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beg
 	expr += beginChars;
 	expr += TEXT("[^ \\t\\n\\r.,;:\"(){}=<>'+!?\\[\\]]+");
 
-	int docLength = int(_pEditView->execute(SCI_GETLENGTH));
+	size_t docLength = _pEditView->execute(SCI_GETLENGTH);
 
 	int flags = SCFIND_WORDSTART | SCFIND_MATCHCASE | SCFIND_REGEXP | SCFIND_POSIX;
 
@@ -169,8 +169,8 @@ void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beg
 
 	while (posFind >= 0)
 	{
-		int wordStart = int(_pEditView->execute(SCI_GETTARGETSTART));
-		int wordEnd = int(_pEditView->execute(SCI_GETTARGETEND));
+		INT_PTR wordStart = _pEditView->execute(SCI_GETTARGETSTART);
+		INT_PTR wordEnd = _pEditView->execute(SCI_GETTARGETEND);
 
 		size_t foundTextLen = wordEnd - wordStart;
 		if (foundTextLen < bufSize)
@@ -280,7 +280,7 @@ void AutoCompletion::showPathCompletion()
 	{
 		const size_t bufSize = MAX_PATH;
 		TCHAR buf[bufSize + 1];
-		const size_t currentPos = static_cast<size_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+		const size_t currentPos = _pEditView->execute(SCI_GETCURRENTPOS);
 		const auto startPos = max(0, currentPos - bufSize);
 		_pEditView->getGenericText(buf, bufSize + 1, startPos, currentPos);
 		currentLine = buf;
@@ -346,9 +346,9 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 {
 	// Get beginning of word and complete word
 
-	int curPos = int(_pEditView->execute(SCI_GETCURRENTPOS));
-	int startPos = int(_pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true));
-	int endPos = int(_pEditView->execute(SCI_WORDENDPOSITION, curPos, true));
+	INT_PTR curPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	INT_PTR startPos = _pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true);
+	INT_PTR endPos = _pEditView->execute(SCI_WORDENDPOSITION, curPos, true);
 
 	if (curPos == startPos)
 		return false;

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -183,7 +183,7 @@ void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beg
 					wordArray.push_back(w);
 			}
 		}
-		posFind = _pEditView->searchInTarget(expr.c_str(), static_cast<int32_t>(expr.length()), wordEnd, docLength);
+		posFind = _pEditView->searchInTarget(expr.c_str(), expr.length(), wordEnd, docLength);
 	}
 }
 

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -47,8 +47,8 @@ bool AutoCompletion::showApiComplete()
 		return false;
 
 	// calculate entered word's length
-	INT_PTR curPos = _pEditView->execute(SCI_GETCURRENTPOS);
-	INT_PTR startPos = _pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true);
+	intptr_t curPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	intptr_t startPos = _pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true);
 
 	if (curPos == startPos)
 		return false;
@@ -165,12 +165,12 @@ void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beg
 	int flags = SCFIND_WORDSTART | SCFIND_MATCHCASE | SCFIND_REGEXP | SCFIND_POSIX;
 
 	_pEditView->execute(SCI_SETSEARCHFLAGS, flags);
-	INT_PTR posFind = _pEditView->searchInTarget(expr.c_str(), expr.length(), 0, docLength);
+	intptr_t posFind = _pEditView->searchInTarget(expr.c_str(), expr.length(), 0, docLength);
 
 	while (posFind >= 0)
 	{
-		INT_PTR wordStart = _pEditView->execute(SCI_GETTARGETSTART);
-		INT_PTR wordEnd = _pEditView->execute(SCI_GETTARGETEND);
+		intptr_t wordStart = _pEditView->execute(SCI_GETTARGETSTART);
+		intptr_t wordEnd = _pEditView->execute(SCI_GETTARGETEND);
 
 		size_t foundTextLen = wordEnd - wordStart;
 		if (foundTextLen < bufSize)
@@ -346,9 +346,9 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 {
 	// Get beginning of word and complete word
 
-	INT_PTR curPos = _pEditView->execute(SCI_GETCURRENTPOS);
-	INT_PTR startPos = _pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true);
-	INT_PTR endPos = _pEditView->execute(SCI_WORDENDPOSITION, curPos, true);
+	intptr_t curPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	intptr_t startPos = _pEditView->execute(SCI_WORDSTARTPOSITION, curPos, true);
+	intptr_t endPos = _pEditView->execute(SCI_WORDENDPOSITION, curPos, true);
 
 	if (curPos == startPos)
 		return false;
@@ -379,7 +379,7 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 
 	if (wordArray.size() == 1 && autoInsert)
 	{
-		INT_PTR replacedLength = _pEditView->replaceTarget(wordArray[0].c_str(), startPos, curPos);
+		intptr_t replacedLength = _pEditView->replaceTarget(wordArray[0].c_str(), startPos, curPos);
 		_pEditView->execute(SCI_GOTOPOS, startPos + replacedLength);
 		return true;
 	}
@@ -442,17 +442,17 @@ void AutoCompletion::getCloseTag(char *closeTag, size_t closeTagSize, size_t car
 	_pEditView->execute(SCI_SETSEARCHFLAGS, flags);
 	TCHAR tag2find[] = TEXT("<[^\\s>]*");
 
-	INT_PTR targetStart = _pEditView->searchInTarget(tag2find, lstrlen(tag2find), caretPos, 0);
+	intptr_t targetStart = _pEditView->searchInTarget(tag2find, lstrlen(tag2find), caretPos, 0);
 
 	if (targetStart < 0)
 		return;
 
-	INT_PTR targetEnd = _pEditView->execute(SCI_GETTARGETEND);
-	INT_PTR foundTextLen = targetEnd - targetStart;
+	intptr_t targetEnd = _pEditView->execute(SCI_GETTARGETEND);
+	intptr_t foundTextLen = targetEnd - targetStart;
 	if (foundTextLen < 2) // "<>" will be ignored
 		return;
 
-	if (foundTextLen > static_cast<INT_PTR>(closeTagSize) - 2) // buffer size is not large enough. -2 for '/' & '\0'
+	if (foundTextLen > static_cast<intptr_t>(closeTagSize) - 2) // buffer size is not large enough. -2 for '/' & '\0'
 		return;
 
 	char tagHead[tagMaxLen];
@@ -527,7 +527,7 @@ void InsertedMatchedChars::add(MatchedCharInserted mci)
 // if current pos > matchedStartSybol Pos and current pos is on the same line of matchedStartSybolPos, it'll be checked then removed
 // otherwise it is just removed
 // return the pos of matchedEndSybol or -1 if matchedEndSybol not found
-INT_PTR InsertedMatchedChars::search(char startChar, char endChar, size_t posToDetect)
+intptr_t InsertedMatchedChars::search(char startChar, char endChar, size_t posToDetect)
 {
 	if (isEmpty())
 		return -1;
@@ -653,7 +653,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 			{
 				if (!_insertedMatchedChars.isEmpty())
 				{
-					INT_PTR pos = _insertedMatchedChars.search('"', static_cast<char>(character), caretPos);
+					intptr_t pos = _insertedMatchedChars.search('"', static_cast<char>(character), caretPos);
 					if (pos != -1)
 					{
 						_pEditView->execute(SCI_DELETERANGE, pos, 1);
@@ -677,7 +677,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 			{
 				if (!_insertedMatchedChars.isEmpty())
 				{
-					INT_PTR pos = _insertedMatchedChars.search('\'', static_cast<char>(character), caretPos);
+					intptr_t pos = _insertedMatchedChars.search('\'', static_cast<char>(character), caretPos);
 					if (pos != -1)
 					{
 						_pEditView->execute(SCI_DELETERANGE, pos, 1);
@@ -733,7 +733,7 @@ void AutoCompletion::insertMatchedChars(int character, const MatchedPairConf & m
 					startChar = '{';
 				}
 
-				INT_PTR pos = _insertedMatchedChars.search(startChar, static_cast<char>(character), caretPos);
+				intptr_t pos = _insertedMatchedChars.search(startChar, static_cast<char>(character), caretPos);
 				if (pos != -1)
 				{
 					_pEditView->execute(SCI_DELETERANGE, pos, 1);

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.h
@@ -37,7 +37,7 @@ public:
 	void removeInvalidElements(MatchedCharInserted mci);
 	void add(MatchedCharInserted mci);
 	bool isEmpty() const { return _insertedMatchedChars.size() == 0; };
-	INT_PTR search(char startChar, char endChar, size_t posToDetect);
+	intptr_t search(char startChar, char endChar, size_t posToDetect);
 
 private:
 	std::vector<MatchedCharInserted> _insertedMatchedChars;

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.h
@@ -27,8 +27,8 @@ class ScintillaEditView;
 struct MatchedCharInserted {
 	MatchedCharInserted() = delete;
 	char _c;
-	int _pos;
-	MatchedCharInserted(char c, int pos) : _c(c), _pos(pos) {};
+	size_t _pos;
+	MatchedCharInserted(char c, size_t pos) : _c(c), _pos(pos) {};
 };
 
 class InsertedMatchedChars {
@@ -37,7 +37,7 @@ public:
 	void removeInvalidElements(MatchedCharInserted mci);
 	void add(MatchedCharInserted mci);
 	bool isEmpty() const { return _insertedMatchedChars.size() == 0; };
-	int search(char startChar, char endChar, int posToDetect);
+	INT_PTR search(char startChar, char endChar, size_t posToDetect);
 
 private:
 	std::vector<MatchedCharInserted> _insertedMatchedChars;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -664,7 +664,7 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
 
 	Utf8_16_Read UnicodeConvertor;	//declare here so we can get information after loading is done
 
-	char data[blockSize + 8]; // +8 for incomplete multibyte char
+	char* data = new char[blockSize + 8]; // +8 for incomplete multibyte char
 
 	LoadedFileFormat loadedFileFormat;
 	loadedFileFormat._encoding = encoding;
@@ -672,6 +672,9 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
 	loadedFileFormat._language = L_TEXT;
 
 	bool res = loadFileData(doc, backupFileName ? backupFileName : fullpath, data, &UnicodeConvertor, loadedFileFormat);
+
+	delete[] data;
+
 	if (res)
 	{
 		Buffer* newBuf = new Buffer(this, _nextBufferID, doc, DOC_REGULAR, fullpath);
@@ -722,7 +725,7 @@ bool FileManager::reloadBuffer(BufferID id)
 	Document doc = buf->getDocument();
 	Utf8_16_Read UnicodeConvertor;
 
-	char data[blockSize + 8]; // +8 for incomplete multibyte char
+	char* data = new char[blockSize + 8]; // +8 for incomplete multibyte char
 
 	LoadedFileFormat loadedFileFormat;
 	loadedFileFormat._encoding = buf->getEncoding();
@@ -736,6 +739,7 @@ bool FileManager::reloadBuffer(BufferID id)
 
 	bool res = loadFileData(doc, buf->getFullPathName(), data, &UnicodeConvertor, loadedFileFormat);
 
+	delete[] data;
 	buf->_canNotify = true;
 
 	if (res)
@@ -1342,7 +1346,7 @@ bool FileManager::loadFileData(Document doc, const TCHAR * filename, char* data,
 	unsigned __int64 fileSize =_ftelli64(fp);
 	rewind(fp);
 	// size/6 is the normal room Scintilla keeps for editing, but here we limit it to 1MiB when loading (maybe we want to load big files without editing them too much)
-	unsigned __int64 bufferSizeRequested = fileSize + min(1<<20, fileSize/6);
+	unsigned __int64 bufferSizeRequested = fileSize +min(1 << 20, fileSize / 6);
 	
 	NppParameters& nppParam = NppParameters::getInstance();
 	NativeLangSpeaker* pNativeSpeaker = nppParam.getNativeLangSpeaker();

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1378,6 +1378,24 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const TCHAR * fil
 			fclose(fp);
 			return false;
 		}
+		else // x64
+		{
+			int res = pNativeSpeaker->messageBox("WantToOpenHugeFile",
+				_pNotepadPlus->_pEditView->getHSelf(),
+				TEXT("Opening a huge file of 2GB+ could take several minutes.\nDo you want to open it?"),
+				TEXT("Opening huge file warning"),
+				MB_YESNO | MB_APPLMODAL);
+
+			if (res == IDYES)
+			{
+				// Do nothing, continue the loading
+			}
+			else
+			{
+				fclose(fp);
+				return false;
+			}
+		}
 	}
 
 	//Setup scratchtilla for new filedata

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -124,7 +124,7 @@ private:
 	FileManager& operator=(FileManager&&) = delete;
 
 	int detectCodepage(char* buf, size_t len);
-	bool loadFileData(Document doc, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat);
+	bool loadFileData(Document doc, size_t fileSize, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat);
 	LangType detectLanguageFromTextBegining(const unsigned char *data, size_t dataLen);
 
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -24,6 +24,7 @@ class Notepad_plus;
 class Buffer;
 typedef Buffer* BufferID;	//each buffer has unique ID by which it can be retrieved
 #define BUFFER_INVALID	reinterpret_cast<BufferID>(0)
+#define NPP_STYLING_FILESIZE_LIMIT (200 * 1024 * 1024) // 200MB+ file won't be styled
 
 typedef sptr_t Document;
 
@@ -124,7 +125,7 @@ private:
 	FileManager& operator=(FileManager&&) = delete;
 
 	int detectCodepage(char* buf, size_t len);
-	bool loadFileData(Document doc, size_t fileSize, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat);
+	bool loadFileData(Document doc, int64_t fileSize, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat);
 	LangType detectLanguageFromTextBegining(const unsigned char *data, size_t dataLen);
 
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -131,7 +131,7 @@ private:
 private:
 	Notepad_plus* _pNotepadPlus = nullptr;
 	ScintillaEditView* _pscratchTilla = nullptr;
-	Document _scratchDocDefault;
+	Document _scratchDocDefault = 0;
 	std::vector<Buffer*> _buffers;
 	BufferID _nextBufferID = 0;
 	size_t _nbBufs = 0;

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -101,7 +101,7 @@ public:
 		return instance;
 	};
 	int getFileNameFromBuffer(BufferID id, TCHAR * fn2copy);
-	int docLength(Buffer * buffer) const;
+	size_t docLength(Buffer * buffer) const;
 	size_t nextUntitledNewNumber() const;
 
 private:
@@ -258,14 +258,14 @@ public:
 	int addReference(ScintillaEditView * identifier);		//if ID not registered, creates a new Position for that ID and new foldstate
 	int removeReference(ScintillaEditView * identifier);		//reduces reference. If zero, Document is purged
 
-	void setHideLineChanged(bool isHide, int location);
+	void setHideLineChanged(bool isHide, size_t location);
 
 	void setDeferredReload();
 
 	bool getNeedReload() const { return _needReloading; }
 	void setNeedReload(bool reload) { _needReloading = reload; }
 
-	int docLength() const {
+	size_t docLength() const {
 		assert(_pManager != nullptr);
 		return _pManager->docLength(_id);
 	}

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -1894,13 +1894,13 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 		stringSizeFind = Searching::convertExtendedToString(txt2find, pText, stringSizeFind);
 	}
 
-	int docLength = int((*_ppEditView)->execute(SCI_GETLENGTH));
+	INT_PTR docLength = (*_ppEditView)->execute(SCI_GETLENGTH);
 	Sci_CharacterRange cr = (*_ppEditView)->getSelection();
 
 
 	//The search "zone" is relative to the selection, so search happens 'outside'
-	int startPosition = cr.cpMax;
-	int endPosition = docLength;
+	INT_PTR startPosition = cr.cpMax;
+	INT_PTR endPosition = docLength;
 
 
 	if (pOptions->_whichDirection == DIR_UP)
@@ -2038,7 +2038,7 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 	}
 
 	start =	posFind;
-	end = int((*_ppEditView)->execute(SCI_GETTARGETEND));
+	end = (*_ppEditView)->execute(SCI_GETTARGETEND);
 
 	setStatusbarMessage(TEXT(""), FSNoMessage);
 
@@ -3972,7 +3972,7 @@ void Finder::addSearchLine(const TCHAR *searchName)
 	setFinderReadOnly(false);
 	_scintView.addGenericText(str.c_str());
 	setFinderReadOnly(true);
-	_lastSearchHeaderPos = static_cast<int32_t>(_scintView.execute(SCI_GETCURRENTPOS) - 2);
+	_lastSearchHeaderPos = _scintView.execute(SCI_GETCURRENTPOS) - 2;
 
 	_pMainFoundInfos->push_back(EmptyFoundInfo);
 	_pMainMarkings->push_back(EmptySearchResultMarking);
@@ -3987,7 +3987,7 @@ void Finder::addFileNameTitle(const TCHAR * fileName)
 	setFinderReadOnly(false);
 	_scintView.addGenericText(str.c_str());
 	setFinderReadOnly(true);
-	_lastFileHeaderPos = static_cast<int32_t>(_scintView.execute(SCI_GETCURRENTPOS) - 2);
+	_lastFileHeaderPos = _scintView.execute(SCI_GETCURRENTPOS) - 2;
 
 	_pMainFoundInfos->push_back(EmptyFoundInfo);
 	_pMainMarkings->push_back(EmptySearchResultMarking);

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -200,7 +200,7 @@ bool Searching::readBase(const TCHAR * str, int * value, int base, int size)
 	return true;
 }
 
-void Searching::displaySectionCentered(int posStart, int posEnd, ScintillaEditView * pEditView, bool isDownwards)
+void Searching::displaySectionCentered(size_t posStart, size_t posEnd, ScintillaEditView * pEditView, bool isDownwards)
 {
 	// Make sure target lines are unfolded
 	pEditView->execute(SCI_ENSUREVISIBLE, pEditView->execute(SCI_LINEFROMPOSITION, posStart));
@@ -1953,8 +1953,8 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 			break;
 	}
 
-	int start, end;
-	int posFind;
+	INT_PTR start, end;
+	INT_PTR posFind;
 
 	// Never allow a zero length match in the middle of a line end marker
 	if ((*_ppEditView)->execute(SCI_GETCHARAT, startPosition - 1) == '\r'
@@ -2097,8 +2097,8 @@ bool FindReplaceDlg::processReplace(const TCHAR *txt2find, const TCHAR *txt2repl
 		{
 			bool isRegExp = replaceOptions._searchType == FindRegex;
 
-			int start = currentSelection.cpMin;
-			int replacedLen = 0;
+			INT_PTR start = currentSelection.cpMin;
+			INT_PTR replacedLen = 0;
 			if (isRegExp)
 			{
 				replacedLen = (*_ppEditView)->replaceTargetRegExMode(txt2replace);
@@ -2207,14 +2207,14 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 	const TCHAR *txt2replace = pOptions->_str4Replace.c_str();
 
 	Sci_CharacterRange cr = (*_ppEditView)->getSelection();
-	int docLength = int((*_ppEditView)->execute(SCI_GETLENGTH));
+	size_t docLength = (*_ppEditView)->execute(SCI_GETLENGTH);
 
 	// Default :
 	//        direction : down
 	//        begin at : 0
 	//        end at : end of doc
-	int startPosition = 0;
-	int endPosition = docLength;
+	size_t startPosition = 0;
+	size_t endPosition = docLength;
 
 	bool direction = pOptions->_whichDirection;
 
@@ -2266,7 +2266,7 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 
 	if (nbProcessed > 0 && op == ProcessReplaceAll && pOptions->_isInSelection)
 	{
-		int newDocLength = static_cast<int>((*_ppEditView)->execute(SCI_GETLENGTH));
+		size_t newDocLength = (*_ppEditView)->execute(SCI_GETLENGTH);
 		endPosition += newDocLength - docLength;
 		(*_ppEditView)->execute(SCI_SETSELECTION, endPosition, startPosition);
 		(*_ppEditView)->execute(SCI_SCROLLRANGE, startPosition, endPosition);
@@ -2368,8 +2368,8 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		}
 	}
 
-	int targetStart = 0;
-	int targetEnd = 0;
+	INT_PTR targetStart = 0;
+	INT_PTR targetEnd = 0;
 
 	//Initial range for searching
 	pEditView->execute(SCI_SETSEARCHFLAGS, flags);
@@ -2385,7 +2385,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		if (targetStart == -1 || targetStart == -2)
 			break;
 
-		targetEnd = int(pEditView->execute(SCI_GETTARGETEND));
+		targetEnd = pEditView->execute(SCI_GETTARGETEND);
 
 		if (targetEnd > findReplaceInfo._endRange)
 		{
@@ -2393,8 +2393,8 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 			break;
 		}
 
-		int foundTextLen = targetEnd - targetStart;
-		int replaceDelta = 0;
+		INT_PTR foundTextLen = targetEnd - targetStart;
+		INT_PTR replaceDelta = 0;
 		bool processed = true;
 
 		switch (op)
@@ -2412,9 +2412,9 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				}
 
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
-				int lend = static_cast<int32_t>(pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber));
-				int lstart = static_cast<int32_t>(pEditView->execute(SCI_POSITIONFROMLINE, lineNumber));
-				int nbChar = lend - lstart;
+				INT_PTR lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
+				INT_PTR lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
+				INT_PTR nbChar = lend - lstart;
 
 				// use the static buffer
 				TCHAR lineBuf[SC_SEARCHRESULT_LINEBUFFERMAXLENGTH];
@@ -2422,16 +2422,16 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				if (nbChar > SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 3)
 					lend = lstart + SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 4;
 
-				int start_mark = targetStart - lstart;
-				int end_mark = targetEnd - lstart;
+				INT_PTR start_mark = targetStart - lstart;
+				INT_PTR end_mark = targetEnd - lstart;
 
 				pEditView->getGenericText(lineBuf, SC_SEARCHRESULT_LINEBUFFERMAXLENGTH, lstart, lend, &start_mark, &end_mark);
 
 				generic_string line = lineBuf;
 				line += TEXT("\r\n");
 				SearchResultMarking srm;
-				srm._start = start_mark;
-				srm._end = end_mark;
+				srm._start = static_cast<long>(start_mark);
+				srm._end = static_cast<long>(end_mark);
 				_pFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str());
 
 				break;
@@ -2445,9 +2445,9 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				const TCHAR *pFileName = pFindersInfo->_pFileName ? pFindersInfo->_pFileName : TEXT("");
 
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
-				int lend = static_cast<int32_t>(pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber));
-				int lstart = static_cast<int32_t>(pEditView->execute(SCI_POSITIONFROMLINE, lineNumber));
-				int nbChar = lend - lstart;
+				INT_PTR lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
+				INT_PTR lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
+				INT_PTR nbChar = lend - lstart;
 
 				// use the static buffer
 				TCHAR lineBuf[SC_SEARCHRESULT_LINEBUFFERMAXLENGTH];
@@ -2455,16 +2455,16 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				if (nbChar > SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 3)
 					lend = lstart + SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 4;
 
-				int start_mark = targetStart - lstart;
-				int end_mark = targetEnd - lstart;
+				INT_PTR start_mark = targetStart - lstart;
+				INT_PTR end_mark = targetEnd - lstart;
 
 				pEditView->getGenericText(lineBuf, SC_SEARCHRESULT_LINEBUFFERMAXLENGTH, lstart, lend, &start_mark, &end_mark);
 
 				generic_string line = lineBuf;
 				line += TEXT("\r\n");
 				SearchResultMarking srm;
-				srm._start = start_mark;
-				srm._end = end_mark;
+				srm._start = static_cast<long>(start_mark);
+				srm._end = static_cast<long>(end_mark);
 				processed = (!pOptions->_isMatchLineNumber) || (pFindersInfo->_pSourceFinder->canFind(pFileName, lineNumber + 1));
 				if (processed)
 				{
@@ -2480,7 +2480,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 
 			case ProcessReplaceAll:
 			{
-				int replacedLength;
+				INT_PTR replacedLength;
 				if (isRegExp)
 					replacedLength = pEditView->replaceTargetRegExMode(pTextReplace);
 				else
@@ -3629,10 +3629,10 @@ LRESULT FAR PASCAL FindReplaceDlg::comboEditProc(HWND hwnd, UINT message, WPARAM
 
 	if (isDropped && (message == WM_KEYDOWN) && (wParam == VK_DELETE))
 	{
-		int curSel = static_cast<int>(::SendMessage(hwndCombo, CB_GETCURSEL, 0, 0));
+		auto curSel = ::SendMessage(hwndCombo, CB_GETCURSEL, 0, 0);
 		if (curSel != CB_ERR)
 		{
-			int itemsRemaining = static_cast<int>(::SendMessage(hwndCombo, CB_DELETESTRING, curSel, 0));
+			auto itemsRemaining = ::SendMessage(hwndCombo, CB_DELETESTRING, curSel, 0);
 			// if we close the dropdown and reopen it, it will be correctly-sized for remaining items
 			::SendMessage(hwndCombo, CB_SHOWDROPDOWN, FALSE, 0);
 			if (itemsRemaining > 0)
@@ -4191,7 +4191,7 @@ void Finder::copy()
 
 	size_t fromLine, toLine;
 	{
-		const pair<int, int> lineRange = _scintView.getSelectionLinesRange();
+		const pair<size_t, size_t> lineRange = _scintView.getSelectionLinesRange();
 		fromLine = lineRange.first;
 		toLine = lineRange.second;
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -703,7 +703,7 @@ void FindInFinderDlg::writeOptions()
 	_options._dotMatchesNewline = isCheckedOrNot(IDREDOTMATCHNL_FIFOLDER);
 }
 
-INT_PTR CALLBACK FindInFinderDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
+intptr_t CALLBACK FindInFinderDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -880,7 +880,7 @@ void FindReplaceDlg::resizeDialogElements(LONG newWidth)
 
 std::mutex findOps_mutex;
 
-INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{
@@ -1115,7 +1115,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 			if (LOWORD(wParam) == WA_ACTIVE || LOWORD(wParam) == WA_CLICKACTIVE)
 			{
 				Sci_CharacterRange cr = (*_ppEditView)->getSelection();
-				INT_PTR nbSelected = cr.cpMax - cr.cpMin;
+				intptr_t nbSelected = cr.cpMax - cr.cpMin;
 
 				_options._isInSelection = isCheckedOrNot(IDC_IN_SELECTION_CHECK)?1:0;
 				int checkVal = _options._isInSelection?BST_CHECKED:BST_UNCHECKED;
@@ -1894,13 +1894,13 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 		stringSizeFind = Searching::convertExtendedToString(txt2find, pText, stringSizeFind);
 	}
 
-	INT_PTR docLength = (*_ppEditView)->execute(SCI_GETLENGTH);
+	intptr_t docLength = (*_ppEditView)->execute(SCI_GETLENGTH);
 	Sci_CharacterRange cr = (*_ppEditView)->getSelection();
 
 
 	//The search "zone" is relative to the selection, so search happens 'outside'
-	INT_PTR startPosition = cr.cpMax;
-	INT_PTR endPosition = docLength;
+	intptr_t startPosition = cr.cpMax;
+	intptr_t endPosition = docLength;
 
 
 	if (pOptions->_whichDirection == DIR_UP)
@@ -1953,8 +1953,8 @@ bool FindReplaceDlg::processFindNext(const TCHAR *txt2find, const FindOption *op
 			break;
 	}
 
-	INT_PTR start, end;
-	INT_PTR posFind;
+	intptr_t start, end;
+	intptr_t posFind;
 
 	// Never allow a zero length match in the middle of a line end marker
 	if ((*_ppEditView)->execute(SCI_GETCHARAT, startPosition - 1) == '\r'
@@ -2097,8 +2097,8 @@ bool FindReplaceDlg::processReplace(const TCHAR *txt2find, const TCHAR *txt2repl
 		{
 			bool isRegExp = replaceOptions._searchType == FindRegex;
 
-			INT_PTR start = currentSelection.cpMin;
-			INT_PTR replacedLen = 0;
+			intptr_t start = currentSelection.cpMin;
+			intptr_t replacedLen = 0;
 			if (isRegExp)
 			{
 				replacedLen = (*_ppEditView)->replaceTargetRegExMode(txt2replace);
@@ -2368,8 +2368,8 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		}
 	}
 
-	INT_PTR targetStart = 0;
-	INT_PTR targetEnd = 0;
+	intptr_t targetStart = 0;
+	intptr_t targetEnd = 0;
 
 	//Initial range for searching
 	pEditView->execute(SCI_SETSEARCHFLAGS, flags);
@@ -2393,8 +2393,8 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 			break;
 		}
 
-		INT_PTR foundTextLen = targetEnd - targetStart;
-		INT_PTR replaceDelta = 0;
+		intptr_t foundTextLen = targetEnd - targetStart;
+		intptr_t replaceDelta = 0;
 		bool processed = true;
 
 		switch (op)
@@ -2412,9 +2412,9 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				}
 
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
-				INT_PTR lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
-				INT_PTR lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
-				INT_PTR nbChar = lend - lstart;
+				intptr_t lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
+				intptr_t lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
+				intptr_t nbChar = lend - lstart;
 
 				// use the static buffer
 				TCHAR lineBuf[SC_SEARCHRESULT_LINEBUFFERMAXLENGTH];
@@ -2422,8 +2422,8 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				if (nbChar > SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 3)
 					lend = lstart + SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 4;
 
-				INT_PTR start_mark = targetStart - lstart;
-				INT_PTR end_mark = targetEnd - lstart;
+				intptr_t start_mark = targetStart - lstart;
+				intptr_t end_mark = targetEnd - lstart;
 
 				pEditView->getGenericText(lineBuf, SC_SEARCHRESULT_LINEBUFFERMAXLENGTH, lstart, lend, &start_mark, &end_mark);
 
@@ -2445,9 +2445,9 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				const TCHAR *pFileName = pFindersInfo->_pFileName ? pFindersInfo->_pFileName : TEXT("");
 
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
-				INT_PTR lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
-				INT_PTR lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
-				INT_PTR nbChar = lend - lstart;
+				intptr_t lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
+				intptr_t lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
+				intptr_t nbChar = lend - lstart;
 
 				// use the static buffer
 				TCHAR lineBuf[SC_SEARCHRESULT_LINEBUFFERMAXLENGTH];
@@ -2455,8 +2455,8 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				if (nbChar > SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 3)
 					lend = lstart + SC_SEARCHRESULT_LINEBUFFERMAXLENGTH - 4;
 
-				INT_PTR start_mark = targetStart - lstart;
-				INT_PTR end_mark = targetEnd - lstart;
+				intptr_t start_mark = targetStart - lstart;
+				intptr_t end_mark = targetEnd - lstart;
 
 				pEditView->getGenericText(lineBuf, SC_SEARCHRESULT_LINEBUFFERMAXLENGTH, lstart, lend, &start_mark, &end_mark);
 
@@ -2480,7 +2480,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 
 			case ProcessReplaceAll:
 			{
-				INT_PTR replacedLength;
+				intptr_t replacedLength;
 				if (isRegExp)
 					replacedLength = pEditView->replaceTargetRegExMode(pTextReplace);
 				else
@@ -3433,8 +3433,8 @@ void FindReplaceDlg::clearMarks(const FindOption& opt)
 	{
 		Sci_CharacterRange cr = (*_ppEditView)->getSelection();
 
-		INT_PTR startPosition = cr.cpMin;
-		INT_PTR endPosition = cr.cpMax;
+		intptr_t startPosition = cr.cpMin;
+		intptr_t endPosition = cr.cpMax;
 
 		(*_ppEditView)->execute(SCI_SETINDICATORCURRENT, SCE_UNIVERSAL_FOUND_STYLE);
 		(*_ppEditView)->execute(SCI_INDICATORCLEARRANGE, startPosition, endPosition - startPosition);
@@ -4328,7 +4328,7 @@ void Finder::setFinderStyle()
 	_scintView.setMakerStyle(svp._folderStyle == FOLDER_STYLE_NONE ? FOLDER_STYLE_BOX : svp._folderStyle);
 }
 
-INT_PTR CALLBACK Finder::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK Finder::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{
@@ -4540,7 +4540,7 @@ void FindIncrementDlg::display(bool toShow) const
 	_pRebar->setIDVisible(_rbBand.wID, toShow);
 }
 
-INT_PTR CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -1115,7 +1115,7 @@ INT_PTR CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 			if (LOWORD(wParam) == WA_ACTIVE || LOWORD(wParam) == WA_CLICKACTIVE)
 			{
 				Sci_CharacterRange cr = (*_ppEditView)->getSelection();
-				int nbSelected = cr.cpMax - cr.cpMin;
+				INT_PTR nbSelected = cr.cpMax - cr.cpMin;
 
 				_options._isInSelection = isCheckedOrNot(IDC_IN_SELECTION_CHECK)?1:0;
 				int checkVal = _options._isInSelection?BST_CHECKED:BST_UNCHECKED;
@@ -3433,8 +3433,8 @@ void FindReplaceDlg::clearMarks(const FindOption& opt)
 	{
 		Sci_CharacterRange cr = (*_ppEditView)->getSelection();
 
-		int startPosition = cr.cpMin;
-		int endPosition = cr.cpMax;
+		INT_PTR startPosition = cr.cpMin;
+		INT_PTR endPosition = cr.cpMax;
 
 		(*_ppEditView)->execute(SCI_SETINDICATORCURRENT, SCE_UNIVERSAL_FOUND_STYLE);
 		(*_ppEditView)->execute(SCI_INDICATORCLEARRANGE, startPosition, endPosition - startPosition);

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -500,7 +500,7 @@ bool Finder::notify(SCNotification *notification)
 
 			size_t pos = notification->position;
 			if (pos == INVALID_POSITION)
-				pos = static_cast<int32_t>(_scintView.execute(SCI_GETLINEENDPOSITION, notification->line));
+				pos = _scintView.execute(SCI_GETLINEENDPOSITION, notification->line);
 			_scintView.execute(SCI_SETSEL, pos, pos);
 
 			gotoFoundLine();

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -157,8 +157,8 @@ private:
 	ScintillaEditView _scintView;
 	unsigned int _nbFoundFiles = 0;
 
-	int _lastFileHeaderPos = 0;
-	int _lastSearchHeaderPos = 0;
+	INT_PTR _lastFileHeaderPos = 0;
+	INT_PTR _lastSearchHeaderPos = 0;
 
 	bool _canBeVolatiled = true;
 	bool _longLinesAreWrapped = false;

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -39,10 +39,10 @@ enum DIALOG_TYPE {FIND_DLG, REPLACE_DLG, FINDINFILES_DLG, FINDINPROJECTS_DLG, MA
 enum InWhat{ALL_OPEN_DOCS, FILES_IN_DIR, CURRENT_DOC, CURR_DOC_SELECTION, FILES_IN_PROJECTS};
 
 struct FoundInfo {
-	FoundInfo(INT_PTR start, INT_PTR end, size_t lineNumber, const TCHAR *fullPath)
+	FoundInfo(intptr_t start, intptr_t end, size_t lineNumber, const TCHAR *fullPath)
 		: _start(start), _end(end), _lineNumber(lineNumber), _fullPath(fullPath) {};
-	INT_PTR _start;
-	INT_PTR _end;
+	intptr_t _start;
+	intptr_t _end;
 	size_t _lineNumber;
 	generic_string _fullPath;
 };
@@ -138,7 +138,7 @@ public:
 	generic_string getHitsString(int count) const;
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	bool notify(SCNotification *notification);
 
 private:
@@ -157,8 +157,8 @@ private:
 	ScintillaEditView _scintView;
 	unsigned int _nbFoundFiles = 0;
 
-	INT_PTR _lastFileHeaderPos = 0;
-	INT_PTR _lastSearchHeaderPos = 0;
+	intptr_t _lastFileHeaderPos = 0;
+	intptr_t _lastSearchHeaderPos = 0;
 
 	bool _canBeVolatiled = true;
 	bool _longLinesAreWrapped = false;
@@ -190,8 +190,8 @@ struct FindReplaceInfo
 {
 	const TCHAR *_txt2find = nullptr;
 	const TCHAR *_txt2replace = nullptr;
-	INT_PTR _startRange = -1;
-	INT_PTR _endRange = -1;
+	intptr_t _startRange = -1;
+	intptr_t _endRange = -1;
 };
 
 struct FindersInfo
@@ -216,7 +216,7 @@ private:
 	Finder  *_pFinder2Search = nullptr;
 	FindOption _options;
 	
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void initFromOptions();
 	void writeOptions();
 };
@@ -350,7 +350,7 @@ public :
 
 protected :
 	void resizeDialogElements(LONG newWidth);
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	static LONG_PTR originalFinderProc;
 	static LONG_PTR originalComboEditProc;
 
@@ -473,7 +473,7 @@ private :
 	ReBar* _pRebar = nullptr;
 	REBARBANDINFO _rbBand;
 
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void markSelectedTextInc(bool enable, FindOption *opt = NULL);
 };
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -39,10 +39,10 @@ enum DIALOG_TYPE {FIND_DLG, REPLACE_DLG, FINDINFILES_DLG, FINDINPROJECTS_DLG, MA
 enum InWhat{ALL_OPEN_DOCS, FILES_IN_DIR, CURRENT_DOC, CURR_DOC_SELECTION, FILES_IN_PROJECTS};
 
 struct FoundInfo {
-	FoundInfo(int start, int end, size_t lineNumber, const TCHAR *fullPath)
+	FoundInfo(INT_PTR start, INT_PTR end, size_t lineNumber, const TCHAR *fullPath)
 		: _start(start), _end(end), _lineNumber(lineNumber), _fullPath(fullPath) {};
-	int _start;
-	int _end;
+	INT_PTR _start;
+	INT_PTR _end;
 	size_t _lineNumber;
 	generic_string _fullPath;
 };
@@ -91,7 +91,7 @@ public:
 				(option->_searchType == FindRegex ? SCFIND_REGEXP|SCFIND_POSIX : 0) |
 				((option->_searchType == FindRegex && option->_dotMatchesNewline) ? SCFIND_REGEXP_DOTMATCHESNL : 0);
 	};
-	static void displaySectionCentered(int posStart, int posEnd, ScintillaEditView * pEditView, bool isDownwards = true);
+	static void displaySectionCentered(size_t posStart, size_t posEnd, ScintillaEditView * pEditView, bool isDownwards = true);
 
 private:
 	static bool readBase(const TCHAR * str, int * value, int base, int size);
@@ -190,8 +190,8 @@ struct FindReplaceInfo
 {
 	const TCHAR *_txt2find = nullptr;
 	const TCHAR *_txt2replace = nullptr;
-	int _startRange = -1;
-	int _endRange = -1;
+	INT_PTR _startRange = -1;
+	INT_PTR _endRange = -1;
 };
 
 struct FindersInfo

--- a/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
+++ b/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
@@ -380,13 +380,13 @@ void FunctionCallTip::showCalltip()
 	//Check if the current overload still holds. If the current param exceeds amounti n overload, see if another one fits better (enough params)
 	stringVec & params = _overloads.at(_currentOverload);
 	size_t psize = params.size()+1;
-	if ((size_t)_currentParam >= psize)
+	if (_currentParam >= psize)
 	{
 		size_t osize = _overloads.size();
 		for (size_t i = 0; i < osize; ++i)
 		{
 			psize = _overloads.at(i).size()+1;
-			if ((size_t)_currentParam < psize)
+			if (_currentParam < psize)
 			{
 				_currentOverload = static_cast<int32_t>(i);
 				break;
@@ -408,7 +408,7 @@ void FunctionCallTip::showCalltip()
 	size_t nbParams = params.size();
 	for (size_t i = 0; i < nbParams; ++i)
 	{
-		if (int(i) == _currentParam) 
+		if (i == _currentParam) 
 		{
 			highlightstart = static_cast<int>(callTipText.str().length());
 			highlightend = highlightstart + lstrlen(params.at(i));

--- a/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
+++ b/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
@@ -388,7 +388,7 @@ void FunctionCallTip::showCalltip()
 			psize = _overloads.at(i).size()+1;
 			if (_currentParam < psize)
 			{
-				_currentOverload = static_cast<int32_t>(i);
+				_currentOverload = i;
 				break;
 			}
 		}

--- a/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
+++ b/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
@@ -130,11 +130,11 @@ void FunctionCallTip::close()
 bool FunctionCallTip::getCursorFunction()
 {
 	auto line = _pEditView->execute(SCI_LINEFROMPOSITION, _curPos);
-	INT_PTR startpos = _pEditView->execute(SCI_POSITIONFROMLINE, line);
-	INT_PTR endpos = _pEditView->execute(SCI_GETLINEENDPOSITION, line);
-	INT_PTR len = endpos - startpos + 3;	//also take CRLF in account, even if not there
-	INT_PTR offset = _curPos - startpos;	//offset is cursor location, only stuff before cursor has influence
-	const INT_PTR maxLen = 256;
+	intptr_t startpos = _pEditView->execute(SCI_POSITIONFROMLINE, line);
+	intptr_t endpos = _pEditView->execute(SCI_GETLINEENDPOSITION, line);
+	intptr_t len = endpos - startpos + 3;	//also take CRLF in account, even if not there
+	intptr_t offset = _curPos - startpos;	//offset is cursor location, only stuff before cursor has influence
+	const intptr_t maxLen = 256;
 
 	if ((offset < 2) || (len >= maxLen))
 	{

--- a/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
+++ b/PowerEditor/src/ScintillaComponent/FunctionCallTip.cpp
@@ -89,7 +89,7 @@ bool FunctionCallTip::updateCalltip(int ch, bool needShown)
 	if (!needShown && ch != _start && ch != _param && !isVisible())		//must be already visible
 		return false;
 
-	_curPos = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
+	_curPos = _pEditView->execute(SCI_GETCURRENTPOS);
 
 	//recalculate everything
 	if (!getCursorFunction())
@@ -130,11 +130,11 @@ void FunctionCallTip::close()
 bool FunctionCallTip::getCursorFunction()
 {
 	auto line = _pEditView->execute(SCI_LINEFROMPOSITION, _curPos);
-	int startpos = static_cast<int32_t>(_pEditView->execute(SCI_POSITIONFROMLINE, line));
-	int endpos = static_cast<int32_t>(_pEditView->execute(SCI_GETLINEENDPOSITION, line));
-	int len = endpos - startpos + 3;	//also take CRLF in account, even if not there
-	int offset = _curPos - startpos;	//offset is cursor location, only stuff before cursor has influence
-	const int maxLen = 256;
+	INT_PTR startpos = _pEditView->execute(SCI_POSITIONFROMLINE, line);
+	INT_PTR endpos = _pEditView->execute(SCI_GETLINEENDPOSITION, line);
+	INT_PTR len = endpos - startpos + 3;	//also take CRLF in account, even if not there
+	INT_PTR offset = _curPos - startpos;	//offset is cursor location, only stuff before cursor has influence
+	const INT_PTR maxLen = 256;
 
 	if ((offset < 2) || (len >= maxLen))
 	{

--- a/PowerEditor/src/ScintillaComponent/FunctionCallTip.h
+++ b/PowerEditor/src/ScintillaComponent/FunctionCallTip.h
@@ -36,8 +36,8 @@ private:
 	ScintillaEditView * _pEditView = nullptr;	//Scintilla to display calltip in
 	TiXmlElement * _pXmlKeyword = nullptr;	//current keyword node (first one)
 
-	int _curPos = 0;					//cursor position
-	int _startPos = 0;					//display start position
+	INT_PTR _curPos = 0;					//cursor position
+	INT_PTR _startPos = 0;					//display start position
 
 	TiXmlElement * _curFunction = nullptr;	//current function element
 	//cache some XML values n stuff

--- a/PowerEditor/src/ScintillaComponent/FunctionCallTip.h
+++ b/PowerEditor/src/ScintillaComponent/FunctionCallTip.h
@@ -47,7 +47,7 @@ private:
 	stringVec _descriptions;		//vecotr of function descriptions
 	size_t _currentNbOverloads = 0;		//current amount of overloads
 	size_t _currentOverload = 0;			//current chosen overload
-	int _currentParam = 0;				//current highlighted param
+	size_t _currentParam = 0;				//current highlighted param
 
 	TCHAR _start = '(';
 	TCHAR _stop = ')';

--- a/PowerEditor/src/ScintillaComponent/FunctionCallTip.h
+++ b/PowerEditor/src/ScintillaComponent/FunctionCallTip.h
@@ -36,8 +36,8 @@ private:
 	ScintillaEditView * _pEditView = nullptr;	//Scintilla to display calltip in
 	TiXmlElement * _pXmlKeyword = nullptr;	//current keyword node (first one)
 
-	INT_PTR _curPos = 0;					//cursor position
-	INT_PTR _startPos = 0;					//display start position
+	intptr_t _curPos = 0;					//cursor position
+	intptr_t _startPos = 0;					//display start position
 
 	TiXmlElement * _curFunction = nullptr;	//current function element
 	//cache some XML values n stuff

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
@@ -100,13 +100,13 @@ INT_PTR CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 						}
 						else
 						{
-							int posToGoto = 0;
+							size_t posToGoto = 0;
 							if (line > 0)
 							{
 								// make sure not jumping into the middle of a multibyte character
 								// or into the middle of a CR/LF pair for Windows files
 								auto before = (*_ppEditView)->execute(SCI_POSITIONBEFORE, line);
-								posToGoto = static_cast<int>((*_ppEditView)->execute(SCI_POSITIONAFTER, before));
+								posToGoto = (*_ppEditView)->execute(SCI_POSITIONAFTER, before);
 							}
 							auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, posToGoto);
 							(*_ppEditView)->execute(SCI_ENSUREVISIBLE, sci_line);
@@ -182,7 +182,7 @@ void GoToLineDlg::updateLinesNumbers() const
 	else
 	{
 		current = static_cast<unsigned int>((*_ppEditView)->execute(SCI_GETCURRENTPOS));
-		int currentDocLength = (*_ppEditView)->getCurrentDocLen();
+		size_t currentDocLength = (*_ppEditView)->getCurrentDocLen();
 		limit = static_cast<unsigned int>(currentDocLength > 0 ? currentDocLength - 1 : 0);
 	}
     ::SetDlgItemInt(_hSelf, ID_CURRLINE, current, FALSE);

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
@@ -171,20 +171,20 @@ INT_PTR CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 
 void GoToLineDlg::updateLinesNumbers() const 
 {
-	unsigned int current = 0;
-	unsigned int limit = 0;
+	size_t current = 0;
+	size_t limit = 0;
 	
 	if (_mode == go2line)
 	{
-		current = static_cast<unsigned int>((*_ppEditView)->getCurrentLineNumber() + 1);
-		limit = static_cast<unsigned int>((*_ppEditView)->execute(SCI_GETLINECOUNT));
+		current = (*_ppEditView)->getCurrentLineNumber() + 1;
+		limit = (*_ppEditView)->execute(SCI_GETLINECOUNT);
 	}
 	else
 	{
-		current = static_cast<unsigned int>((*_ppEditView)->execute(SCI_GETCURRENTPOS));
+		current = (*_ppEditView)->execute(SCI_GETCURRENTPOS);
 		size_t currentDocLength = (*_ppEditView)->getCurrentDocLen();
-		limit = static_cast<unsigned int>(currentDocLength > 0 ? currentDocLength - 1 : 0);
+		limit = (currentDocLength > 0 ? currentDocLength - 1 : 0);
 	}
-    ::SetDlgItemInt(_hSelf, ID_CURRLINE, current, FALSE);
-    ::SetDlgItemInt(_hSelf, ID_LASTLINE, limit, FALSE);
+    ::SetDlgItemInt(_hSelf, ID_CURRLINE, (UINT)current, FALSE);
+    ::SetDlgItemInt(_hSelf, ID_LASTLINE, (UINT)limit, FALSE);
 }

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
@@ -88,15 +88,15 @@ intptr_t CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 
 				case IDOK :
                 {
-                    int line = getLine();
+                    long long line = getLine();
                     if (line != -1)
                     {
                         display(false);
                         cleanLineEdit();
 						if (_mode == go2line)
 						{
-							(*_ppEditView)->execute(SCI_ENSUREVISIBLE, line-1);
-							(*_ppEditView)->execute(SCI_GOTOLINE, line-1);
+							(*_ppEditView)->execute(SCI_ENSUREVISIBLE, static_cast<WPARAM>(line - 1));
+							(*_ppEditView)->execute(SCI_GOTOLINE, static_cast<WPARAM>(line - 1));
 						}
 						else
 						{
@@ -105,7 +105,7 @@ intptr_t CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 							{
 								// make sure not jumping into the middle of a multibyte character
 								// or into the middle of a CR/LF pair for Windows files
-								auto before = (*_ppEditView)->execute(SCI_POSITIONBEFORE, line);
+								auto before = (*_ppEditView)->execute(SCI_POSITIONBEFORE, static_cast<WPARAM>(line));
 								posToGoto = (*_ppEditView)->execute(SCI_POSITIONAFTER, before);
 							}
 							auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, posToGoto);
@@ -185,6 +185,8 @@ void GoToLineDlg::updateLinesNumbers() const
 		size_t currentDocLength = (*_ppEditView)->getCurrentDocLen();
 		limit = (currentDocLength > 0 ? currentDocLength - 1 : 0);
 	}
-    ::SetDlgItemInt(_hSelf, ID_CURRLINE, (UINT)current, FALSE);
-    ::SetDlgItemInt(_hSelf, ID_LASTLINE, (UINT)limit, FALSE);
+    
+	
+	::SetDlgItemTextA(_hSelf, ID_CURRLINE, std::to_string(current).c_str());
+	::SetDlgItemTextA(_hSelf, ID_LASTLINE, std::to_string(limit).c_str());
 }

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
@@ -18,7 +18,7 @@
 #include "GoToLineDlg.h"
 
 
-INT_PTR CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	switch (message) 
 	{

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.h
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.h
@@ -61,10 +61,14 @@ private :
         ::SetDlgItemText(_hSelf, ID_GOLINE_EDIT, TEXT(""));
     };
 
-    int getLine() const {
-        BOOL isSuccessful;
-        int line = ::GetDlgItemInt(_hSelf, ID_GOLINE_EDIT, &isSuccessful, FALSE);
-        return (isSuccessful?line:-1);
+    long long getLine() const {
+		const int maxLen = 256;
+		char goLineEditStr[maxLen] = {'\0'};
+		UINT count = ::GetDlgItemTextA(_hSelf, ID_GOLINE_EDIT, goLineEditStr, maxLen);
+		if (!count)
+			return -1;
+		char* p_end;
+		return strtoll(goLineEditStr, &p_end, 10);
     };
 
 };

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.h
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.h
@@ -50,7 +50,7 @@ public :
 protected :
 	enum mode {go2line, go2offsset};
 	mode _mode = go2line;
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private :
     ScintillaEditView **_ppEditView = nullptr;

--- a/PowerEditor/src/ScintillaComponent/Printer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Printer.cpp
@@ -67,11 +67,7 @@ void Printer::init(HINSTANCE hInst, HWND hwnd, ScintillaEditView *pSEView, bool 
 
 
 size_t Printer::doPrint(bool justDoIt)
-{/*
-	if (!::PrintDlg(&_pdlg))
-			return 0;
-*/
-
+{
 	const NppGUI & nppGUI = (NppParameters::getInstance()).getNppGUI();
 
 	POINT ptPage;
@@ -190,9 +186,9 @@ size_t Printer::doPrint(bool justDoIt)
 	}
 	
 	// By default, we will print all the document
-	long lengthPrinted = 0;
-	long lengthDoc = _pSEView->getCurrentDocLen();
-	long lengthDocMax = lengthDoc;
+	size_t lengthPrinted = 0;
+	size_t lengthDoc = _pSEView->getCurrentDocLen();
+	size_t lengthDocMax = lengthDoc;
 
 	// In the case that the print dialog was launched and that there's a range of selection
 	// We print the range of selection
@@ -200,13 +196,13 @@ size_t Printer::doPrint(bool justDoIt)
 	{
 		if (_startPos > _endPos) 
 		{
-			lengthPrinted = static_cast<long>(_endPos);
-			lengthDoc = static_cast<long>(_startPos);
+			lengthPrinted = _endPos;
+			lengthDoc = _startPos;
 		}
 		else 
 		{
-			lengthPrinted = static_cast<long>(_startPos);
-			lengthDoc = static_cast<long>(_endPos);
+			lengthPrinted = _startPos;
+			lengthDoc = _endPos;
 		}
 
 		if (lengthPrinted < 0)
@@ -408,8 +404,8 @@ size_t Printer::doPrint(bool justDoIt)
 			}
 		}
 		
-		frPrint.chrg.cpMin = lengthPrinted;
-		frPrint.chrg.cpMax = lengthDoc;
+		frPrint.chrg.cpMin = static_cast<Sci_PositionCR>(lengthPrinted);
+		frPrint.chrg.cpMax = static_cast<Sci_PositionCR>(lengthDoc);
 		lengthPrinted = long(_pSEView->execute(SCI_FORMATRANGE, printPage, reinterpret_cast<LPARAM>(&frPrint)));
 
 		if (printPage) 

--- a/PowerEditor/src/ScintillaComponent/Printer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Printer.cpp
@@ -27,7 +27,7 @@ void replaceStr(generic_string & str, generic_string str2BeReplaced, generic_str
 		str.replace(pos, str2BeReplaced.length(), replacement);
 }
 
-void Printer::init(HINSTANCE hInst, HWND hwnd, ScintillaEditView *pSEView, bool showDialog, int startPos, int endPos, bool isRTL)
+void Printer::init(HINSTANCE hInst, HWND hwnd, ScintillaEditView *pSEView, bool showDialog, size_t startPos, size_t endPos, bool isRTL)
 {
 	_pSEView = pSEView;
 	_startPos = startPos;

--- a/PowerEditor/src/ScintillaComponent/Printer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Printer.cpp
@@ -406,7 +406,7 @@ size_t Printer::doPrint(bool justDoIt)
 		
 		frPrint.chrg.cpMin = static_cast<Sci_PositionCR>(lengthPrinted);
 		frPrint.chrg.cpMax = static_cast<Sci_PositionCR>(lengthDoc);
-		lengthPrinted = long(_pSEView->execute(SCI_FORMATRANGE, printPage, reinterpret_cast<LPARAM>(&frPrint)));
+		lengthPrinted = _pSEView->execute(SCI_FORMATRANGE, printPage, reinterpret_cast<LPARAM>(&frPrint));
 
 		if (printPage) 
 		{

--- a/PowerEditor/src/ScintillaComponent/Printer.h
+++ b/PowerEditor/src/ScintillaComponent/Printer.h
@@ -33,7 +33,7 @@ class Printer
 public :
 	Printer() = default;
 
-	void init(HINSTANCE hInst, HWND hwnd, ScintillaEditView *pSEView, bool showDialog, int startPos, int endPos, bool isRTL = false);
+	void init(HINSTANCE hInst, HWND hwnd, ScintillaEditView *pSEView, bool showDialog, size_t startPos, size_t endPos, bool isRTL = false);
 	size_t doPrint() {
 		if (!::PrintDlg(&_pdlg))
 				return 0;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2254,7 +2254,7 @@ char * ScintillaEditView::getWordFromRange(char * txt, size_t size, size_t pos1,
 	return txt;
 }
 
-char * ScintillaEditView::getWordOnCaretPos(char * txt, int size)
+char * ScintillaEditView::getWordOnCaretPos(char * txt, size_t size)
 {
     if (!size)
 		return NULL;
@@ -2276,7 +2276,7 @@ TCHAR * ScintillaEditView::getGenericWordOnCaretPos(TCHAR * txt, int size)
 	return txt;
 }
 
-char * ScintillaEditView::getSelectedText(char * txt, int size, bool expand)
+char * ScintillaEditView::getSelectedText(char * txt, size_t size, bool expand)
 {
 	if (!size)
 		return NULL;
@@ -2288,7 +2288,7 @@ char * ScintillaEditView::getSelectedText(char * txt, int size, bool expand)
 	}
 	if (!(size > (range.cpMax - range.cpMin)))	//there must be atleast 1 byte left for zero terminator
 	{
-		range.cpMax = range.cpMin+size-1;	//keep room for zero terminator
+		range.cpMax = range.cpMin + (Sci_PositionCR)size -1;	//keep room for zero terminator
 	}
 	//getText(txt, range.cpMin, range.cpMax);
 	return getWordFromRange(txt, size, range.cpMin, range.cpMax);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2286,7 +2286,7 @@ char * ScintillaEditView::getSelectedText(char * txt, size_t size, bool expand)
 		expandWordSelection();
 		range = getSelection();
 	}
-	if (!(size > (range.cpMax - range.cpMin)))	//there must be atleast 1 byte left for zero terminator
+	if (!(static_cast<Sci_PositionCR>(size) > (range.cpMax - range.cpMin)))	//there must be atleast 1 byte left for zero terminator
 	{
 		range.cpMax = range.cpMin + (Sci_PositionCR)size -1;	//keep room for zero terminator
 	}

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -386,8 +386,8 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 
 			if (wParam == IMR_RECONVERTSTRING)
 			{
-				INT_PTR					textLength;
-				INT_PTR					selectSize;
+				intptr_t					textLength;
+				intptr_t					selectSize;
 				char				smallTextBuffer[128];
 				char			  *	selectedStr = smallTextBuffer;
 				RECONVERTSTRING   *	reconvert = (RECONVERTSTRING *)lParam;
@@ -1805,7 +1805,7 @@ void ScintillaEditView::restoreCurrentPosPreStep()
 		execute(SCI_SETXOFFSET, pos._xOffset);
 	}
 	execute(SCI_CHOOSECARETX); // choose current x position
-	INT_PTR lineToShow = execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine);
+	intptr_t lineToShow = execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine);
 	execute(SCI_SETFIRSTVISIBLELINE, lineToShow);
 	if (isWrap())
 	{
@@ -1848,7 +1848,7 @@ void ScintillaEditView::restoreCurrentPosPostStep()
 	{
 		
 		// Scintilla has paint the buffer but the position is not correct.
-		INT_PTR lineToShow = execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine);
+		intptr_t lineToShow = execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine);
 		execute(SCI_SETFIRSTVISIBLELINE, lineToShow);
 	}
 	else if (pos._offset > 0)
@@ -2028,9 +2028,9 @@ namespace {
 struct FoldLevelStack
 {
 	int levelCount = 0; // 1-based level number
-	INT_PTR levelStack[MAX_FOLD_COLLAPSE_LEVEL]{};
+	intptr_t levelStack[MAX_FOLD_COLLAPSE_LEVEL]{};
 
-	void push(INT_PTR level)
+	void push(intptr_t level)
 	{
 		while (levelCount != 0 && level <= levelStack[levelCount - 1])
 		{
@@ -2049,12 +2049,12 @@ void ScintillaEditView::collapseFoldIndentationBased(int level2Collapse, bool mo
 	FoldLevelStack levelStack;
 	++level2Collapse; // 1-based level number
 
-	const INT_PTR maxLine = execute(SCI_GETLINECOUNT);
-	INT_PTR line = 0;
+	const intptr_t maxLine = execute(SCI_GETLINECOUNT);
+	intptr_t line = 0;
 
 	while (line < maxLine)
 	{
-		INT_PTR level = execute(SCI_GETFOLDLEVEL, line);
+		intptr_t level = execute(SCI_GETFOLDLEVEL, line);
 		if (level & SC_FOLDLEVELHEADERFLAG)
 		{
 			level &= SC_FOLDLEVELNUMBERMASK;
@@ -2086,11 +2086,11 @@ void ScintillaEditView::collapse(int level2Collapse, bool mode)
 
 	execute(SCI_COLOURISE, 0, -1);
 
-	INT_PTR maxLine = execute(SCI_GETLINECOUNT);
+	intptr_t maxLine = execute(SCI_GETLINECOUNT);
 
 	for (int line = 0; line < maxLine; ++line)
 	{
-		INT_PTR level = execute(SCI_GETFOLDLEVEL, line);
+		intptr_t level = execute(SCI_GETFOLDLEVEL, line);
 		if (level & SC_FOLDLEVELHEADERFLAG)
 		{
 			level -= SC_FOLDLEVELBASE;
@@ -2119,7 +2119,7 @@ void ScintillaEditView::fold(size_t line, bool mode)
     if (endStyled < len)
         execute(SCI_COLOURISE, 0, -1);
 
-	INT_PTR headerLine;
+	intptr_t headerLine;
 	auto level = execute(SCI_GETFOLDLEVEL, line);
 
 	if (level & SC_FOLDLEVELHEADERFLAG)
@@ -2193,7 +2193,7 @@ void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, size_t start
 // "mstart" and "mend" are pointers to indexes in the read string,
 // which are converted to the corresponding indexes in the returned TCHAR string.
 
-void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, size_t start, size_t end, INT_PTR* mstart, INT_PTR* mend) const
+void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, size_t start, size_t end, intptr_t* mstart, intptr_t* mend) const
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	char *destA = new char[end - start + 1];
@@ -2217,7 +2217,7 @@ void ScintillaEditView::replaceSelWith(const char * replaceText)
 	execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(replaceText));
 }
 
-void ScintillaEditView::getVisibleStartAndEndPosition(INT_PTR* startPos, INT_PTR* endPos)
+void ScintillaEditView::getVisibleStartAndEndPosition(intptr_t* startPos, intptr_t* endPos)
 {
 	assert(startPos != NULL && endPos != NULL);
 	// Get the position of the 1st and last showing chars from the edit view
@@ -2302,7 +2302,7 @@ TCHAR * ScintillaEditView::getGenericSelectedText(TCHAR * txt, int size, bool ex
 	return txt;
 }
 
-INT_PTR ScintillaEditView::searchInTarget(const TCHAR * text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const
+intptr_t ScintillaEditView::searchInTarget(const TCHAR * text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const
 {
 	execute(SCI_SETTARGETRANGE, fromPos, toPos);
 
@@ -2338,7 +2338,7 @@ void ScintillaEditView::addGenericText(const TCHAR * text2Append, long* mstart, 
 	execute(SCI_ADDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
 }
 
-INT_PTR ScintillaEditView::replaceTarget(const TCHAR * str2replace, INT_PTR fromTargetPos, INT_PTR toTargetPos) const
+intptr_t ScintillaEditView::replaceTarget(const TCHAR * str2replace, intptr_t fromTargetPos, intptr_t toTargetPos) const
 {
 	if (fromTargetPos != -1 || toTargetPos != -1)
 	{
@@ -2350,7 +2350,7 @@ INT_PTR ScintillaEditView::replaceTarget(const TCHAR * str2replace, INT_PTR from
 	return execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(str2replaceA));
 }
 
-INT_PTR ScintillaEditView::replaceTargetRegExMode(const TCHAR * re, INT_PTR fromTargetPos, INT_PTR toTargetPos) const
+intptr_t ScintillaEditView::replaceTargetRegExMode(const TCHAR * re, intptr_t fromTargetPos, intptr_t toTargetPos) const
 {
 	if (fromTargetPos != -1 || toTargetPos != -1)
 	{
@@ -2445,7 +2445,7 @@ void ScintillaEditView::showMargin(int whichMarge, bool willBeShowed)
 
 void ScintillaEditView::updateBeginEndSelectPosition(bool is_insert, size_t position, size_t length)
 {
-	if (_beginSelectPosition != -1 && static_cast<INT_PTR>(position) < _beginSelectPosition - 1)
+	if (_beginSelectPosition != -1 && static_cast<intptr_t>(position) < _beginSelectPosition - 1)
 	{
 		if (is_insert)
 			_beginSelectPosition += length;
@@ -2459,7 +2459,7 @@ void ScintillaEditView::updateBeginEndSelectPosition(bool is_insert, size_t posi
 void ScintillaEditView::marginClick(Sci_Position position, int modifiers)
 {
 	size_t lineClick = execute(SCI_LINEFROMPOSITION, position, 0);
-	INT_PTR levelClick = execute(SCI_GETFOLDLEVEL, lineClick, 0);
+	intptr_t levelClick = execute(SCI_GETFOLDLEVEL, lineClick, 0);
 	if (levelClick & SC_FOLDLEVELHEADERFLAG)
     {
 		if (modifiers & SCMOD_SHIFT)
@@ -2493,7 +2493,7 @@ void ScintillaEditView::marginClick(Sci_Position position, int modifiers)
 	}
 }
 
-void ScintillaEditView::expand(size_t& line, bool doExpand, bool force, INT_PTR visLevels, INT_PTR level)
+void ScintillaEditView::expand(size_t& line, bool doExpand, bool force, intptr_t visLevels, intptr_t level)
 {
 	size_t lineMaxSubord = execute(SCI_GETLASTCHILD, line, level & SC_FOLDLEVELNUMBERMASK);
 	++line;
@@ -2509,7 +2509,7 @@ void ScintillaEditView::expand(size_t& line, bool doExpand, bool force, INT_PTR 
 				execute(SCI_SHOWLINES, line, line);
 		}
 
-		INT_PTR levelLine = level;
+		intptr_t levelLine = level;
 		if (levelLine == -1)
 			levelLine = execute(SCI_GETFOLDLEVEL, line, 0);
 
@@ -2738,8 +2738,8 @@ void ScintillaEditView::setMultiSelections(const ColumnModeInfos & cmi)
 	{
 		if (cmi[i].isValid())
 		{
-			INT_PTR selStart = cmi[i]._direction == L2R?cmi[i]._selLpos:cmi[i]._selRpos;
-			INT_PTR selEnd   = cmi[i]._direction == L2R?cmi[i]._selRpos:cmi[i]._selLpos;
+			intptr_t selStart = cmi[i]._direction == L2R?cmi[i]._selLpos:cmi[i]._selRpos;
+			intptr_t selEnd   = cmi[i]._direction == L2R?cmi[i]._selRpos:cmi[i]._selLpos;
 			execute(SCI_SETSELECTIONNSTART, i, selStart);
 			execute(SCI_SETSELECTIONNEND, i, selEnd);
 		}
@@ -2753,7 +2753,7 @@ void ScintillaEditView::setMultiSelections(const ColumnModeInfos & cmi)
 
 // Get selection range (fromLine, toLine) for the specified selection
 // specify selectionNumber = -1 for the MAIN selection
-pair<size_t, size_t> ScintillaEditView::getSelectionLinesRange(INT_PTR selectionNumber /* = -1 */) const
+pair<size_t, size_t> ScintillaEditView::getSelectionLinesRange(intptr_t selectionNumber /* = -1 */) const
 {
 	size_t numSelections = execute(SCI_GETSELECTIONS);
 
@@ -2933,12 +2933,12 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 
 		for (size_t i = 0, cmiLen = cmi.size(); i < cmiLen ; ++i)
 		{
-			const INT_PTR len = cmi[i]._selRpos - cmi[i]._selLpos;
+			const intptr_t len = cmi[i]._selRpos - cmi[i]._selLpos;
 			char *srcStr = new char[len+1];
 			wchar_t *destStr = new wchar_t[len+1];
 
-			INT_PTR start = cmi[i]._selLpos;
-			INT_PTR end = cmi[i]._selRpos;
+			intptr_t start = cmi[i]._selLpos;
+			intptr_t end = cmi[i]._selRpos;
 			getText(srcStr, start, end);
 
 			int nbChar = ::MultiByteToWideChar(codepage, 0, srcStr, (int)len, destStr, (int)len);
@@ -3073,14 +3073,14 @@ ColumnModeInfos ScintillaEditView::getColumnModeSelectInfo()
 	ColumnModeInfos columnModeInfos;
 	if (execute(SCI_GETSELECTIONS) > 1) // Multi-Selection || Column mode
 	{
-		INT_PTR nbSel = execute(SCI_GETSELECTIONS);
+		intptr_t nbSel = execute(SCI_GETSELECTIONS);
 
 		for (int i = 0 ; i < nbSel ; ++i)
 		{
-			INT_PTR absPosSelStartPerLine = execute(SCI_GETSELECTIONNANCHOR, i);
-			INT_PTR absPosSelEndPerLine = execute(SCI_GETSELECTIONNCARET, i);
-			INT_PTR nbVirtualAnchorSpc = execute(SCI_GETSELECTIONNANCHORVIRTUALSPACE, i);
-			INT_PTR nbVirtualCaretSpc = execute(SCI_GETSELECTIONNCARETVIRTUALSPACE, i);
+			intptr_t absPosSelStartPerLine = execute(SCI_GETSELECTIONNANCHOR, i);
+			intptr_t absPosSelEndPerLine = execute(SCI_GETSELECTIONNCARET, i);
+			intptr_t nbVirtualAnchorSpc = execute(SCI_GETSELECTIONNANCHORVIRTUALSPACE, i);
+			intptr_t nbVirtualCaretSpc = execute(SCI_GETSELECTIONNCARETVIRTUALSPACE, i);
 
 			if (absPosSelStartPerLine == absPosSelEndPerLine && execute(SCI_SELECTIONISRECTANGLE))
 			{
@@ -3098,13 +3098,13 @@ ColumnModeInfos ScintillaEditView::getColumnModeSelectInfo()
 
 void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, const TCHAR *str)
 {
-	INT_PTR totalDiff = 0;
+	intptr_t totalDiff = 0;
 	for (size_t i = 0, len = cmi.size(); i < len ; ++i)
 	{
 		if (cmi[i].isValid())
 		{
-			INT_PTR len2beReplace = cmi[i]._selRpos - cmi[i]._selLpos;
-			INT_PTR diff = lstrlen(str) - len2beReplace;
+			intptr_t len2beReplace = cmi[i]._selRpos - cmi[i]._selLpos;
+			intptr_t diff = lstrlen(str) - len2beReplace;
 
 			cmi[i]._selLpos += totalDiff;
 			cmi[i]._selRpos += totalDiff;
@@ -3112,7 +3112,7 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, const TCHAR *str)
 
 			if (hasVirtualSpc) // if virtual space is present, then insert space
 			{
-				for (INT_PTR j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
+				for (intptr_t j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
 				{
 					execute(SCI_INSERTTEXT, k, reinterpret_cast<LPARAM>(" "));
 				}
@@ -3203,14 +3203,14 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 	const int kibInit = getNbDigits(initial, base);
 	const int kib = std::max<int>(kibInit, kibEnd);
 
-	INT_PTR totalDiff = 0;
+	intptr_t totalDiff = 0;
 	const size_t len = cmi.size();
 	for (size_t i = 0 ; i < len ; i++)
 	{
 		if (cmi[i].isValid())
 		{
-			const INT_PTR len2beReplaced = cmi[i]._selRpos - cmi[i]._selLpos;
-			const INT_PTR diff = kib - len2beReplaced;
+			const intptr_t len2beReplaced = cmi[i]._selRpos - cmi[i]._selLpos;
+			const intptr_t diff = kib - len2beReplaced;
 
 			cmi[i]._selLpos += totalDiff;
 			cmi[i]._selRpos += totalDiff;
@@ -3220,7 +3220,7 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 			const bool hasVirtualSpc = cmi[i]._nbVirtualAnchorSpc > 0;
 			if (hasVirtualSpc) // if virtual space is present, then insert space
 			{
-				for (INT_PTR j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
+				for (intptr_t j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
 				{
 					execute(SCI_INSERTTEXT, k, reinterpret_cast<LPARAM>(" "));
 				}
@@ -3276,7 +3276,7 @@ void ScintillaEditView::foldChanged(size_t line, int levelNow, int levelPrev)
 	        ((levelPrev & SC_FOLDLEVELNUMBERMASK) > (levelNow & SC_FOLDLEVELNUMBERMASK)))
 	{
 		// See if should still be hidden
-		INT_PTR parentLine = execute(SCI_GETFOLDPARENT, line);
+		intptr_t parentLine = execute(SCI_GETFOLDPARENT, line);
 		if ((parentLine < 0) || !isFolded(parentLine && execute(SCI_GETLINEVISIBLE, parentLine)))
 			execute(SCI_SHOWLINES, line, line);
 	}
@@ -3683,7 +3683,7 @@ void ScintillaEditView::changeTextDirection(bool isRTL)
 
 generic_string ScintillaEditView::getEOLString()
 {
-	INT_PTR eol_mode = execute(SCI_GETEOLMODE);
+	intptr_t eol_mode = execute(SCI_GETEOLMODE);
 	if (eol_mode == SC_EOL_CRLF)
 	{
 		return TEXT("\r\n");
@@ -3750,7 +3750,7 @@ int ScintillaEditView::getTextZoneWidth() const
 	RECT editorRect;
 	getClientRect(editorRect);
 
-	INT_PTR marginWidths = 0;
+	intptr_t marginWidths = 0;
 	for (int m = 0; m < 4; ++m)
 	{
 		marginWidths += execute(SCI_GETMARGINWIDTHN, m);
@@ -3790,7 +3790,7 @@ pair<size_t, size_t> ScintillaEditView::getSelectedCharsAndLinesCount(long long 
 			v.push_back(getSelectionLinesRange(s));
 		}
 		sort(v.begin(), v.end());
-		INT_PTR previousSecondLine = -1;
+		intptr_t previousSecondLine = -1;
 		for (auto lineRange : v)
 		{
 			selectedCharsAndLines.second += lineRange.second - lineRange.first;
@@ -3798,7 +3798,7 @@ pair<size_t, size_t> ScintillaEditView::getSelectedCharsAndLinesCount(long long 
 			{
 				++selectedCharsAndLines.second;
 			}
-			previousSecondLine = static_cast<INT_PTR>(lineRange.second);
+			previousSecondLine = static_cast<intptr_t>(lineRange.second);
 		}
 	}
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -386,7 +386,7 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 
 			if (wParam == IMR_RECONVERTSTRING)
 			{
-				int					textLength;
+				INT_PTR					textLength;
 				int					selectSize;
 				char				smallTextBuffer[128];
 				char			  *	selectedStr = smallTextBuffer;
@@ -398,7 +398,8 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 
 				// get the codepage of the text
 
-				UINT codepage = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+				size_t cp = execute(SCI_GETCODEPAGE);
+				UINT codepage = static_cast<UINT>(cp);
 
 				// get the current text selection
 
@@ -441,9 +442,9 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 
 					// fill the structure
 					reconvert->dwVersion		 = 0;
-					reconvert->dwStrLen			 = textLength;
+					reconvert->dwStrLen			 = static_cast<DWORD>(textLength);
 					reconvert->dwStrOffset		 = sizeof(RECONVERTSTRING);
-					reconvert->dwCompStrLen		 = textLength;
+					reconvert->dwCompStrLen		 = static_cast<DWORD>(textLength);
 					reconvert->dwCompStrOffset	 = 0;
 					reconvert->dwTargetStrLen	 = reconvert->dwCompStrLen;
 					reconvert->dwTargetStrOffset = reconvert->dwCompStrOffset;
@@ -485,8 +486,8 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			bool rightClickKeepsSelection = ((NppParameters::getInstance()).getSVP())._rightClickKeepsSelection;
 			if (rightClickKeepsSelection)
 			{
-				int clickX = GET_X_LPARAM(lParam);
-				int marginX = static_cast<int>(execute(SCI_POINTXFROMPOSITION, 0, 0));
+				size_t clickX = GET_X_LPARAM(lParam);
+				size_t marginX = execute(SCI_POINTXFROMPOSITION, 0, 0);
 				if (clickX >= marginX)
 				{
 					// if right-click in the editing area (not the margins!),
@@ -1763,21 +1764,21 @@ BufferID ScintillaEditView::attachDefaultDoc()
 void ScintillaEditView::saveCurrentPos()
 {
 	//Save data so, that the current topline becomes visible again after restoring.
-	int32_t displayedLine = static_cast<int32_t>(execute(SCI_GETFIRSTVISIBLELINE));
-	int32_t docLine = static_cast<int32_t>(execute(SCI_DOCLINEFROMVISIBLE, displayedLine));		//linenumber of the line displayed in the top
-	int32_t offset = displayedLine - static_cast<int32_t>(execute(SCI_VISIBLEFROMDOCLINE, docLine));		//use this to calc offset of wrap. If no wrap this should be zero
-	int wrapCount = static_cast<int32_t>(execute(SCI_WRAPCOUNT, docLine));
+	size_t displayedLine = execute(SCI_GETFIRSTVISIBLELINE);
+	size_t docLine = execute(SCI_DOCLINEFROMVISIBLE, displayedLine);		//linenumber of the line displayed in the top
+	size_t offset = displayedLine - execute(SCI_VISIBLEFROMDOCLINE, docLine);		//use this to calc offset of wrap. If no wrap this should be zero
+	size_t wrapCount = execute(SCI_WRAPCOUNT, docLine);
 
 	Buffer * buf = MainFileManager.getBufferByID(_currentBufferID);
 
 	Position pos;
 	// the correct visible line number
 	pos._firstVisibleLine = docLine;
-	pos._startPos = static_cast<int>(execute(SCI_GETANCHOR));
-	pos._endPos = static_cast<int>(execute(SCI_GETCURRENTPOS));
-	pos._xOffset = static_cast<int>(execute(SCI_GETXOFFSET));
-	pos._selMode = static_cast<int32_t>(execute(SCI_GETSELECTIONMODE));
-	pos._scrollWidth = static_cast<int32_t>(execute(SCI_GETSCROLLWIDTH));
+	pos._startPos = execute(SCI_GETANCHOR);
+	pos._endPos = execute(SCI_GETCURRENTPOS);
+	pos._xOffset = execute(SCI_GETXOFFSET);
+	pos._selMode = execute(SCI_GETSELECTIONMODE);
+	pos._scrollWidth = execute(SCI_GETSCROLLWIDTH);
 	pos._offset = offset;
 	pos._wrapCount = wrapCount;
 
@@ -1803,7 +1804,7 @@ void ScintillaEditView::restoreCurrentPosPreStep()
 		execute(SCI_SETXOFFSET, pos._xOffset);
 	}
 	execute(SCI_CHOOSECARETX); // choose current x position
-	int lineToShow = static_cast<int32_t>(execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine));
+	INT_PTR lineToShow = execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine);
 	execute(SCI_SETFIRSTVISIBLELINE, lineToShow);
 	if (isWrap())
 	{
@@ -1837,8 +1838,8 @@ void ScintillaEditView::restoreCurrentPosPostStep()
 		return;
 	}
 	
-	int32_t displayedLine = static_cast<int32_t>(execute(SCI_GETFIRSTVISIBLELINE));
-	int32_t docLine = static_cast<int32_t>(execute(SCI_DOCLINEFROMVISIBLE, displayedLine));		//linenumber of the line displayed in the 
+	size_t displayedLine = execute(SCI_GETFIRSTVISIBLELINE);
+	size_t docLine = execute(SCI_DOCLINEFROMVISIBLE, displayedLine);		//linenumber of the line displayed in the 
 	
 
 	// check docLine must equals saved position
@@ -1846,14 +1847,14 @@ void ScintillaEditView::restoreCurrentPosPostStep()
 	{
 		
 		// Scintilla has paint the buffer but the position is not correct.
-		int lineToShow = static_cast<int32_t>(execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine));
+		INT_PTR lineToShow = execute(SCI_VISIBLEFROMDOCLINE, pos._firstVisibleLine);
 		execute(SCI_SETFIRSTVISIBLELINE, lineToShow);
 	}
 	else if (pos._offset > 0)
 	{
 		// don't scroll anything if the wrap count is different than the saved one.
 		// Buffer update may be in progress (in case wrap is enabled)
-		int wrapCount = static_cast<int32_t>(execute(SCI_WRAPCOUNT, docLine));
+		size_t wrapCount = execute(SCI_WRAPCOUNT, docLine);
 		if (wrapCount == pos._wrapCount)
 		{
 			scroll(0, pos._offset);
@@ -1927,10 +1928,10 @@ void ScintillaEditView::activateBuffer(BufferID buffer)
 	restoreCurrentPosPreStep();
 
 	//setup line number margin
-	int numLines = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
+	INT_PTR numLines = execute(SCI_GETLINECOUNT);
 
 	char numLineStr[32];
-	itoa(numLines, numLineStr, 10);
+	itoa(static_cast<int>(numLines), numLineStr, 10);
 
 	runMarkers(true, 0, true, false);
     return;	//all done
@@ -1943,7 +1944,7 @@ void ScintillaEditView::getCurrentFoldStates(std::vector<size_t> & lineStateVect
 	size_t contractedFoldHeaderLine = 0;
 
 	do {
-		contractedFoldHeaderLine = static_cast<size_t>(execute(SCI_CONTRACTEDFOLDNEXT, contractedFoldHeaderLine));
+		contractedFoldHeaderLine = execute(SCI_CONTRACTEDFOLDNEXT, contractedFoldHeaderLine);
 		if (contractedFoldHeaderLine != -1)
 		{
 			//-- Store contracted line
@@ -2032,9 +2033,9 @@ namespace {
 struct FoldLevelStack
 {
 	int levelCount = 0; // 1-based level number
-	int levelStack[MAX_FOLD_COLLAPSE_LEVEL]{};
+	INT_PTR levelStack[MAX_FOLD_COLLAPSE_LEVEL]{};
 
-	void push(int level)
+	void push(INT_PTR level)
 	{
 		while (levelCount != 0 && level <= levelStack[levelCount - 1])
 		{
@@ -2053,12 +2054,12 @@ void ScintillaEditView::collapseFoldIndentationBased(int level2Collapse, bool mo
 	FoldLevelStack levelStack;
 	++level2Collapse; // 1-based level number
 
-	const int maxLine = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
-	int line = 0;
+	const INT_PTR maxLine = execute(SCI_GETLINECOUNT);
+	INT_PTR line = 0;
 
 	while (line < maxLine)
 	{
-		int level = static_cast<int32_t>(execute(SCI_GETFOLDLEVEL, line));
+		INT_PTR level = execute(SCI_GETFOLDLEVEL, line);
 		if (level & SC_FOLDLEVELHEADERFLAG)
 		{
 			level &= SC_FOLDLEVELNUMBERMASK;
@@ -2071,7 +2072,7 @@ void ScintillaEditView::collapseFoldIndentationBased(int level2Collapse, bool mo
 					fold(line, mode);
 				}
 				// skip all children lines, required to avoid buffer overrun.
-				line = static_cast<int32_t>(execute(SCI_GETLASTCHILD, line, -1));
+				line = execute(SCI_GETLASTCHILD, line, -1);
 			}
 		}
 		++line;
@@ -2090,11 +2091,11 @@ void ScintillaEditView::collapse(int level2Collapse, bool mode)
 
 	execute(SCI_COLOURISE, 0, -1);
 
-	int maxLine = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
+	INT_PTR maxLine = execute(SCI_GETLINECOUNT);
 
 	for (int line = 0; line < maxLine; ++line)
 	{
-		int level = static_cast<int32_t>(execute(SCI_GETFOLDLEVEL, line));
+		INT_PTR level = execute(SCI_GETFOLDLEVEL, line);
 		if (level & SC_FOLDLEVELHEADERFLAG)
 		{
 			level -= SC_FOLDLEVELBASE;
@@ -2123,14 +2124,14 @@ void ScintillaEditView::fold(size_t line, bool mode)
     if (endStyled < len)
         execute(SCI_COLOURISE, 0, -1);
 
-	int headerLine;
+	INT_PTR headerLine;
 	auto level = execute(SCI_GETFOLDLEVEL, line);
 
 	if (level & SC_FOLDLEVELHEADERFLAG)
-		headerLine = static_cast<int32_t>(line);
+		headerLine = line;
 	else
 	{
-		headerLine = static_cast<int32_t>(execute(SCI_GETFOLDPARENT, line));
+		headerLine = execute(SCI_GETFOLDPARENT, line);
 		if (headerLine == -1)
 			return;
 	}
@@ -2166,8 +2167,8 @@ void ScintillaEditView::foldAll(bool mode)
 void ScintillaEditView::getText(char *dest, size_t start, size_t end) const
 {
 	Sci_TextRange tr;
-	tr.chrg.cpMin = static_cast<long>(start);
-	tr.chrg.cpMax = static_cast<long>(end);
+	tr.chrg.cpMin = static_cast<Sci_PositionCR>(start);
+	tr.chrg.cpMax = static_cast<Sci_PositionCR>(end);
 	tr.lpstrText = dest;
 	execute(SCI_GETTEXTRANGE, 0, reinterpret_cast<LPARAM>(&tr));
 }
@@ -2188,7 +2189,7 @@ void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, size_t start
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	char *destA = new char[end - start + 1];
 	getText(destA, start, end);
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const TCHAR *destW = wmc.char2wchar(destA, cp);
 	_tcsncpy_s(dest, destlen, destW, _TRUNCATE);
 	delete [] destA;
@@ -2197,12 +2198,12 @@ void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, size_t start
 // "mstart" and "mend" are pointers to indexes in the read string,
 // which are converted to the corresponding indexes in the returned TCHAR string.
 
-void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, int start, int end, int *mstart, int *mend) const
+void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, size_t start, size_t end, INT_PTR* mstart, INT_PTR* mend) const
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	char *destA = new char[end - start + 1];
 	getText(destA, start, end);
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE))    ;
+	size_t cp = execute(SCI_GETCODEPAGE)    ;
 	const TCHAR *destW = wmc.char2wchar(destA, cp, mstart, mend);
 	_tcsncpy_s(dest, destlen, destW, _TRUNCATE);
 	delete [] destA;
@@ -2211,7 +2212,7 @@ void ScintillaEditView::getGenericText(TCHAR *dest, size_t destlen, int start, i
 void ScintillaEditView::insertGenericTextFrom(size_t position, const TCHAR *text2insert) const
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *text2insertA = wmc.wchar2char(text2insert, cp);
 	execute(SCI_INSERTTEXT, position, reinterpret_cast<LPARAM>(text2insertA));
 }
@@ -2221,7 +2222,7 @@ void ScintillaEditView::replaceSelWith(const char * replaceText)
 	execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(replaceText));
 }
 
-void ScintillaEditView::getVisibleStartAndEndPosition(int * startPos, int * endPos)
+void ScintillaEditView::getVisibleStartAndEndPosition(INT_PTR* startPos, INT_PTR* endPos)
 {
 	assert(startPos != NULL && endPos != NULL);
 	// Get the position of the 1st and last showing chars from the edit view
@@ -2229,24 +2230,24 @@ void ScintillaEditView::getVisibleStartAndEndPosition(int * startPos, int * endP
 	getClientRect(rcEditView);
 	LRESULT pos = execute(SCI_POSITIONFROMPOINT, 0, 0);
 	LRESULT line = execute(SCI_LINEFROMPOSITION, pos);
-	*startPos = static_cast<int32_t>(execute(SCI_POSITIONFROMLINE, line));
+	*startPos = execute(SCI_POSITIONFROMLINE, line);
 	pos = execute(SCI_POSITIONFROMPOINT, rcEditView.right - rcEditView.left, rcEditView.bottom - rcEditView.top);
 	line = execute(SCI_LINEFROMPOSITION, pos);
-	*endPos = static_cast<int32_t>(execute(SCI_GETLINEENDPOSITION, line));
+	*endPos = execute(SCI_GETLINEENDPOSITION, line);
 }
 
-char * ScintillaEditView::getWordFromRange(char * txt, int size, int pos1, int pos2)
+char * ScintillaEditView::getWordFromRange(char * txt, size_t size, size_t pos1, size_t pos2)
 {
     if (!size)
 		return NULL;
     if (pos1 > pos2)
     {
-        int tmp = pos1;
+        size_t tmp = pos1;
         pos1 = pos2;
         pos2 = tmp;
     }
 
-    if (size < pos2-pos1)
+    if (size < pos2 - pos1)
         return NULL;
 
     getText(txt, pos1, pos2);
@@ -2258,14 +2259,14 @@ char * ScintillaEditView::getWordOnCaretPos(char * txt, int size)
     if (!size)
 		return NULL;
 
-    pair<int,int> range = getWordRange();
+    pair<size_t, size_t> range = getWordRange();
     return getWordFromRange(txt, size, range.first, range.second);
 }
 
 TCHAR * ScintillaEditView::getGenericWordOnCaretPos(TCHAR * txt, int size)
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	char *txtA = new char[size + 1];
 	getWordOnCaretPos(txtA, size);
 
@@ -2296,7 +2297,7 @@ char * ScintillaEditView::getSelectedText(char * txt, int size, bool expand)
 TCHAR * ScintillaEditView::getGenericSelectedText(TCHAR * txt, int size, bool expand)
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	char *txtA = new char[size + 1];
 	getSelectedText(txtA, size, expand);
 
@@ -2306,22 +2307,22 @@ TCHAR * ScintillaEditView::getGenericSelectedText(TCHAR * txt, int size, bool ex
 	return txt;
 }
 
-int ScintillaEditView::searchInTarget(const TCHAR * text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const
+INT_PTR ScintillaEditView::searchInTarget(const TCHAR * text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const
 {
 	execute(SCI_SETTARGETRANGE, fromPos, toPos);
 
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *text2FindA = wmc.wchar2char(text2Find, cp);
 	size_t text2FindALen = strlen(text2FindA);
    	size_t len = (lenOfText2Find > text2FindALen) ? lenOfText2Find : text2FindALen;
-	return static_cast<int32_t>(execute(SCI_SEARCHINTARGET, len, reinterpret_cast<LPARAM>(text2FindA)));
+	return execute(SCI_SEARCHINTARGET, len, reinterpret_cast<LPARAM>(text2FindA));
 }
 
 void ScintillaEditView::appandGenericText(const TCHAR * text2Append) const
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *text2AppendA =wmc.wchar2char(text2Append, cp);
 	execute(SCI_APPENDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
 }
@@ -2329,7 +2330,7 @@ void ScintillaEditView::appandGenericText(const TCHAR * text2Append) const
 void ScintillaEditView::addGenericText(const TCHAR * text2Append) const
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *text2AppendA =wmc.wchar2char(text2Append, cp);
 	execute(SCI_ADDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
 }
@@ -2337,76 +2338,76 @@ void ScintillaEditView::addGenericText(const TCHAR * text2Append) const
 void ScintillaEditView::addGenericText(const TCHAR * text2Append, long *mstart, long *mend) const
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *text2AppendA =wmc.wchar2char(text2Append, cp, mstart, mend);
 	execute(SCI_ADDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
 }
 
-int32_t ScintillaEditView::replaceTarget(const TCHAR * str2replace, int fromTargetPos, int toTargetPos) const
+INT_PTR ScintillaEditView::replaceTarget(const TCHAR * str2replace, INT_PTR fromTargetPos, INT_PTR toTargetPos) const
 {
 	if (fromTargetPos != -1 || toTargetPos != -1)
 	{
 		execute(SCI_SETTARGETRANGE, fromTargetPos, toTargetPos);
 	}
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *str2replaceA = wmc.wchar2char(str2replace, cp);
-	return static_cast<int32_t>(execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(str2replaceA)));
+	return execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(str2replaceA));
 }
 
-int ScintillaEditView::replaceTargetRegExMode(const TCHAR * re, int fromTargetPos, int toTargetPos) const
+INT_PTR ScintillaEditView::replaceTargetRegExMode(const TCHAR * re, INT_PTR fromTargetPos, INT_PTR toTargetPos) const
 {
 	if (fromTargetPos != -1 || toTargetPos != -1)
 	{
 		execute(SCI_SETTARGETRANGE, fromTargetPos, toTargetPos);
 	}
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *reA = wmc.wchar2char(re, cp);
-	return static_cast<int32_t>(execute(SCI_REPLACETARGETRE, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(reA)));
+	return execute(SCI_REPLACETARGETRE, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(reA));
 }
 
 void ScintillaEditView::showAutoComletion(size_t lenEntered, const TCHAR* list)
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *listA = wmc.wchar2char(list, cp);
 	execute(SCI_AUTOCSHOW, lenEntered, reinterpret_cast<LPARAM>(listA));
 }
 
-void ScintillaEditView::showCallTip(int startPos, const TCHAR * def)
+void ScintillaEditView::showCallTip(size_t startPos, const TCHAR * def)
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *defA = wmc.wchar2char(def, cp);
 	execute(SCI_CALLTIPSHOW, startPos, reinterpret_cast<LPARAM>(defA));
 }
 
 generic_string ScintillaEditView::getLine(size_t lineNumber)
 {
-	int32_t lineLen = static_cast<int32_t>(execute(SCI_LINELENGTH, lineNumber));
-	const int bufSize = lineLen + 1;
+	size_t lineLen = execute(SCI_LINELENGTH, lineNumber);
+	const size_t bufSize = lineLen + 1;
 	std::unique_ptr<TCHAR[]> buf = std::make_unique<TCHAR[]>(bufSize);
 	getLine(lineNumber, buf.get(), bufSize);
 	return buf.get();
 }
 
-void ScintillaEditView::getLine(size_t lineNumber, TCHAR * line, int lineBufferLen)
+void ScintillaEditView::getLine(size_t lineNumber, TCHAR * line, size_t lineBufferLen)
 {
 	// make sure the buffer length is enough to get the whole line
-	auto lineLen = execute(SCI_LINELENGTH, lineNumber);
+	size_t lineLen = execute(SCI_LINELENGTH, lineNumber);
 	if (lineLen >= lineBufferLen)
 		return;
 
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+	size_t cp = execute(SCI_GETCODEPAGE);
 	char *lineA = new char[lineBufferLen];
 	// From Scintilla documentation for SCI_GETLINE: "The buffer is not terminated by a 0 character."
 	memset(lineA, 0x0, sizeof(char) * lineBufferLen);
 	
 	execute(SCI_GETLINE, lineNumber, reinterpret_cast<LPARAM>(lineA));
 	const TCHAR *lineW = wmc.char2wchar(lineA, cp);
-	lstrcpyn(line, lineW, lineBufferLen);
+	lstrcpyn(line, lineW, static_cast<int>(lineBufferLen));
 	delete [] lineA;
 }
 
@@ -2419,7 +2420,7 @@ void ScintillaEditView::beginOrEndSelect()
 {
 	if (_beginSelectPosition == -1)
 	{
-		_beginSelectPosition = static_cast<int32_t>(execute(SCI_GETCURRENTPOS));
+		_beginSelectPosition = execute(SCI_GETCURRENTPOS);
 	}
 	else
 	{
@@ -2449,12 +2450,12 @@ void ScintillaEditView::showMargin(int whichMarge, bool willBeShowed)
 
 void ScintillaEditView::updateBeginEndSelectPosition(bool is_insert, size_t position, size_t length)
 {
-	if (_beginSelectPosition != -1 && static_cast<long long>(position) < _beginSelectPosition - 1)
+	if (_beginSelectPosition != -1 && static_cast<INT_PTR>(position) < _beginSelectPosition - 1)
 	{
 		if (is_insert)
-			_beginSelectPosition += static_cast<long long>(length);
+			_beginSelectPosition += length;
 		else
-			_beginSelectPosition -= static_cast<long long>(length);
+			_beginSelectPosition -= length;
 
 		assert(_beginSelectPosition >= 0);
 	}
@@ -2463,7 +2464,7 @@ void ScintillaEditView::updateBeginEndSelectPosition(bool is_insert, size_t posi
 void ScintillaEditView::marginClick(Sci_Position position, int modifiers)
 {
 	size_t lineClick = execute(SCI_LINEFROMPOSITION, position, 0);
-	int levelClick = int(execute(SCI_GETFOLDLEVEL, lineClick, 0));
+	INT_PTR levelClick = execute(SCI_GETFOLDLEVEL, lineClick, 0);
 	if (levelClick & SC_FOLDLEVELHEADERFLAG)
     {
 		if (modifiers & SCMOD_SHIFT)
@@ -2497,7 +2498,7 @@ void ScintillaEditView::marginClick(Sci_Position position, int modifiers)
 	}
 }
 
-void ScintillaEditView::expand(size_t& line, bool doExpand, bool force, int visLevels, int level)
+void ScintillaEditView::expand(size_t& line, bool doExpand, bool force, INT_PTR visLevels, INT_PTR level)
 {
 	size_t lineMaxSubord = execute(SCI_GETLASTCHILD, line, level & SC_FOLDLEVELNUMBERMASK);
 	++line;
@@ -2513,9 +2514,9 @@ void ScintillaEditView::expand(size_t& line, bool doExpand, bool force, int visL
 				execute(SCI_SHOWLINES, line, line);
 		}
 
-		int levelLine = level;
+		INT_PTR levelLine = level;
 		if (levelLine == -1)
-			levelLine = int(execute(SCI_GETFOLDLEVEL, line, 0));
+			levelLine = execute(SCI_GETFOLDLEVEL, line, 0);
 
 		if (levelLine & SC_FOLDLEVELHEADERFLAG)
         {
@@ -2650,44 +2651,42 @@ void ScintillaEditView::showIndentGuideLine(bool willBeShowed)
 	execute(SCI_SETINDENTATIONGUIDES, willBeShowed ? docIndentMode : SC_IV_NONE);
 }
 
-void ScintillaEditView::setLineIndent(int line, int indent) const
+void ScintillaEditView::setLineIndent(size_t line, size_t indent) const
 {
-	if (indent < 0)
-		return;
 	Sci_CharacterRange crange = getSelection();
-	int posBefore = static_cast<int32_t>(execute(SCI_GETLINEINDENTPOSITION, line));
+	size_t posBefore = execute(SCI_GETLINEINDENTPOSITION, line);
 	execute(SCI_SETLINEINDENTATION, line, indent);
-	int32_t posAfter = static_cast<int32_t>(execute(SCI_GETLINEINDENTPOSITION, line));
-	int posDifference = posAfter - posBefore;
+	size_t posAfter = execute(SCI_GETLINEINDENTPOSITION, line);
+	long long posDifference = posAfter - posBefore;
 	if (posAfter > posBefore)
 	{
 		// Move selection on
-		if (crange.cpMin >= posBefore)
+		if (crange.cpMin >= static_cast<Sci_PositionCR>(posBefore))
 		{
-			crange.cpMin += posDifference;
+			crange.cpMin += static_cast<Sci_PositionCR>(posDifference);
 		}
-		if (crange.cpMax >= posBefore)
+		if (crange.cpMax >= static_cast<Sci_PositionCR>(posBefore))
 		{
-			crange.cpMax += posDifference;
+			crange.cpMax += static_cast<Sci_PositionCR>(posDifference);
 		}
 	}
 	else if (posAfter < posBefore)
 	{
 		// Move selection back
-		if (crange.cpMin >= posAfter)
+		if (crange.cpMin >= static_cast<Sci_PositionCR>(posAfter))
 		{
-			if (crange.cpMin >= posBefore)
-				crange.cpMin += posDifference;
+			if (crange.cpMin >= static_cast<Sci_PositionCR>(posBefore))
+				crange.cpMin += static_cast<Sci_PositionCR>(posDifference);
 			else
-				crange.cpMin = posAfter;
+				crange.cpMin = static_cast<Sci_PositionCR>(posAfter);
 		}
 
-		if (crange.cpMax >= posAfter)
+		if (crange.cpMax >= static_cast<Sci_PositionCR>(posAfter))
 		{
-			if (crange.cpMax >= posBefore)
-				crange.cpMax += posDifference;
+			if (crange.cpMax >= static_cast<Sci_PositionCR>(posBefore))
+				crange.cpMax += static_cast<Sci_PositionCR>(posDifference);
 			else
-				crange.cpMax = posAfter;
+				crange.cpMax = static_cast<Sci_PositionCR>(posAfter);
 		}
 	}
 	execute(SCI_SETSEL, crange.cpMin, crange.cpMax);
@@ -2744,51 +2743,49 @@ void ScintillaEditView::setMultiSelections(const ColumnModeInfos & cmi)
 	{
 		if (cmi[i].isValid())
 		{
-			int selStart = cmi[i]._direction == L2R?cmi[i]._selLpos:cmi[i]._selRpos;
-			int selEnd   = cmi[i]._direction == L2R?cmi[i]._selRpos:cmi[i]._selLpos;
+			INT_PTR selStart = cmi[i]._direction == L2R?cmi[i]._selLpos:cmi[i]._selRpos;
+			INT_PTR selEnd   = cmi[i]._direction == L2R?cmi[i]._selRpos:cmi[i]._selLpos;
 			execute(SCI_SETSELECTIONNSTART, i, selStart);
 			execute(SCI_SETSELECTIONNEND, i, selEnd);
 		}
-		//if (cmi[i].hasVirtualSpace())
-		//{
+
 		if (cmi[i]._nbVirtualAnchorSpc)
 			execute(SCI_SETSELECTIONNANCHORVIRTUALSPACE, i, cmi[i]._nbVirtualAnchorSpc);
 		if (cmi[i]._nbVirtualCaretSpc)
 			execute(SCI_SETSELECTIONNCARETVIRTUALSPACE, i, cmi[i]._nbVirtualCaretSpc);
-		//}
 	}
 }
 
 // Get selection range (fromLine, toLine) for the specified selection
 // specify selectionNumber = -1 for the MAIN selection
-pair<int, int> ScintillaEditView::getSelectionLinesRange(int selectionNumber /* = -1 */) const
+pair<size_t, size_t> ScintillaEditView::getSelectionLinesRange(INT_PTR selectionNumber /* = -1 */) const
 {
-	int numSelections = static_cast<int>(execute(SCI_GETSELECTIONS));
+	size_t numSelections = execute(SCI_GETSELECTIONS);
 
-	int start_pos, end_pos;
+	size_t start_pos, end_pos;
 
-	if ((selectionNumber < 0) || (selectionNumber >= numSelections))
+	if ((selectionNumber < 0) || (static_cast<size_t>(selectionNumber) >= numSelections))
 	{
-		start_pos = static_cast<int>(execute(SCI_GETSELECTIONSTART));
-		end_pos = static_cast<int>(execute(SCI_GETSELECTIONEND));
+		start_pos = execute(SCI_GETSELECTIONSTART);
+		end_pos = execute(SCI_GETSELECTIONEND);
 	}
 	else
 	{
-		start_pos = static_cast<int>(execute(SCI_GETSELECTIONNSTART, selectionNumber));
-		end_pos = static_cast<int>(execute(SCI_GETSELECTIONNEND, selectionNumber));
+		start_pos = execute(SCI_GETSELECTIONNSTART, selectionNumber);
+		end_pos = execute(SCI_GETSELECTIONNEND, selectionNumber);
 	}
 
-	int line1 = static_cast<int>(execute(SCI_LINEFROMPOSITION, start_pos));
-	int line2 = static_cast<int>(execute(SCI_LINEFROMPOSITION, end_pos));
+	size_t line1 = execute(SCI_LINEFROMPOSITION, start_pos);
+	size_t line2 = execute(SCI_LINEFROMPOSITION, end_pos);
 
-	if ((line1 != line2) && (execute(SCI_POSITIONFROMLINE, line2) == end_pos))
+	if ((line1 != line2) && (static_cast<size_t>(execute(SCI_POSITIONFROMLINE, line2)) == end_pos))
 	{
 		// if the end of the selection includes the line-ending, 
 		// then don't include the following line in the range
 		--line2;
 	}
 
-	return pair<int, int>(line1, line2);
+	return pair<size_t, size_t>(line1, line2);
 }
 
 void ScintillaEditView::currentLinesUp() const
@@ -2941,19 +2938,19 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 
 		for (size_t i = 0, cmiLen = cmi.size(); i < cmiLen ; ++i)
 		{
-			const int len = cmi[i]._selRpos - cmi[i]._selLpos;
+			const INT_PTR len = cmi[i]._selRpos - cmi[i]._selLpos;
 			char *srcStr = new char[len+1];
 			wchar_t *destStr = new wchar_t[len+1];
 
-			int start = cmi[i]._selLpos;
-			int end = cmi[i]._selRpos;
+			INT_PTR start = cmi[i]._selLpos;
+			INT_PTR end = cmi[i]._selRpos;
 			getText(srcStr, start, end);
 
-			int nbChar = ::MultiByteToWideChar(codepage, 0, srcStr, len, destStr, len);
+			int nbChar = ::MultiByteToWideChar(codepage, 0, srcStr, (int)len, destStr, (int)len);
 
 			changeCase(destStr, nbChar, caseToConvert);
 
-			::WideCharToMultiByte(codepage, 0, destStr, len, srcStr, len, NULL, NULL);
+			::WideCharToMultiByte(codepage, 0, destStr, (int)len, srcStr, (int)len, NULL, NULL);
 
 			execute(SCI_SETTARGETRANGE, start, end);
 			execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(srcStr));
@@ -2971,21 +2968,21 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 	size_t selectionStart = execute(SCI_GETSELECTIONSTART);
 	size_t selectionEnd = execute(SCI_GETSELECTIONEND);
 
-	int32_t strLen = static_cast<int32_t>(selectionEnd - selectionStart);
+	size_t strLen = selectionEnd - selectionStart;
 	if (strLen)
 	{
-		int strSize = strLen + 1;
+		size_t strSize = strLen + 1;
 		char *selectedStr = new char[strSize];
-		int strWSize = strSize * 2;
+		size_t strWSize = strSize * 2;
 		wchar_t *selectedStrW = new wchar_t[strWSize+3];
 
 		execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(selectedStr));
 
-		int nbChar = ::MultiByteToWideChar(codepage, 0, selectedStr, strSize, selectedStrW, strWSize);
+		int nbChar = ::MultiByteToWideChar(codepage, 0, selectedStr, static_cast<int>(strSize), selectedStrW, static_cast<int>(strWSize));
 
 		changeCase(selectedStrW, nbChar, caseToConvert);
 
-		::WideCharToMultiByte(codepage, 0, selectedStrW, strWSize, selectedStr, strSize, NULL, NULL);
+		::WideCharToMultiByte(codepage, 0, selectedStrW, static_cast<int>(strWSize), selectedStr, static_cast<int>(strSize), NULL, NULL);
 
 		execute(SCI_SETTARGETRANGE, selectionStart, selectionEnd);
 		execute(SCI_REPLACETARGET, strLen, reinterpret_cast<LPARAM>(selectedStr));
@@ -2996,18 +2993,17 @@ void ScintillaEditView::convertSelectedTextTo(const TextCase & caseToConvert)
 }
 
 
-
-pair<int, int> ScintillaEditView::getWordRange()
+pair<size_t, size_t> ScintillaEditView::getWordRange()
 {
-    auto caretPos = execute(SCI_GETCURRENTPOS, 0, 0);
-	int startPos = static_cast<int>(execute(SCI_WORDSTARTPOSITION, caretPos, true));
-	int endPos = static_cast<int>(execute(SCI_WORDENDPOSITION, caretPos, true));
-    return pair<int, int>(startPos, endPos);
+	size_t caretPos = execute(SCI_GETCURRENTPOS, 0, 0);
+	size_t startPos = execute(SCI_WORDSTARTPOSITION, caretPos, true);
+	size_t endPos = execute(SCI_WORDENDPOSITION, caretPos, true);
+    return pair<size_t, size_t>(startPos, endPos);
 }
 
 bool ScintillaEditView::expandWordSelection()
 {
-    pair<int, int> wordRange = 	getWordRange();
+    pair<size_t, size_t> wordRange = 	getWordRange();
     if (wordRange.first != wordRange.second)
 	{
         execute(SCI_SETSELECTIONSTART, wordRange.first);
@@ -3082,14 +3078,14 @@ ColumnModeInfos ScintillaEditView::getColumnModeSelectInfo()
 	ColumnModeInfos columnModeInfos;
 	if (execute(SCI_GETSELECTIONS) > 1) // Multi-Selection || Column mode
 	{
-		int nbSel = static_cast<int32_t>(execute(SCI_GETSELECTIONS));
+		INT_PTR nbSel = execute(SCI_GETSELECTIONS);
 
 		for (int i = 0 ; i < nbSel ; ++i)
 		{
-			int absPosSelStartPerLine = static_cast<int32_t>(execute(SCI_GETSELECTIONNANCHOR, i));
-			int absPosSelEndPerLine = static_cast<int32_t>(execute(SCI_GETSELECTIONNCARET, i));
-			int nbVirtualAnchorSpc = static_cast<int32_t>(execute(SCI_GETSELECTIONNANCHORVIRTUALSPACE, i));
-			int nbVirtualCaretSpc = static_cast<int32_t>(execute(SCI_GETSELECTIONNCARETVIRTUALSPACE, i));
+			INT_PTR absPosSelStartPerLine = execute(SCI_GETSELECTIONNANCHOR, i);
+			INT_PTR absPosSelEndPerLine = execute(SCI_GETSELECTIONNCARET, i);
+			INT_PTR nbVirtualAnchorSpc = execute(SCI_GETSELECTIONNANCHORVIRTUALSPACE, i);
+			INT_PTR nbVirtualCaretSpc = execute(SCI_GETSELECTIONNCARETVIRTUALSPACE, i);
 
 			if (absPosSelStartPerLine == absPosSelEndPerLine && execute(SCI_SELECTIONISRECTANGLE))
 			{
@@ -3107,13 +3103,13 @@ ColumnModeInfos ScintillaEditView::getColumnModeSelectInfo()
 
 void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, const TCHAR *str)
 {
-	int totalDiff = 0;
+	INT_PTR totalDiff = 0;
 	for (size_t i = 0, len = cmi.size(); i < len ; ++i)
 	{
 		if (cmi[i].isValid())
 		{
-			int len2beReplace = cmi[i]._selRpos - cmi[i]._selLpos;
-			int diff = lstrlen(str) - len2beReplace;
+			INT_PTR len2beReplace = cmi[i]._selRpos - cmi[i]._selLpos;
+			INT_PTR diff = lstrlen(str) - len2beReplace;
 
 			cmi[i]._selLpos += totalDiff;
 			cmi[i]._selRpos += totalDiff;
@@ -3121,7 +3117,7 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, const TCHAR *str)
 
 			if (hasVirtualSpc) // if virtual space is present, then insert space
 			{
-				for (int j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
+				for (INT_PTR j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
 				{
 					execute(SCI_INSERTTEXT, k, reinterpret_cast<LPARAM>(" "));
 				}
@@ -3132,7 +3128,7 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, const TCHAR *str)
 			execute(SCI_SETTARGETRANGE, cmi[i]._selLpos, cmi[i]._selRpos);
 
 			WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-			UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+			size_t cp = execute(SCI_GETCODEPAGE);
 			const char *strA = wmc.wchar2char(str, cp);
 			execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(strA));
 
@@ -3212,14 +3208,14 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 	const int kibInit = getNbDigits(initial, base);
 	const int kib = std::max<int>(kibInit, kibEnd);
 
-	int totalDiff = 0;
+	INT_PTR totalDiff = 0;
 	const size_t len = cmi.size();
 	for (size_t i = 0 ; i < len ; i++)
 	{
 		if (cmi[i].isValid())
 		{
-			const int len2beReplaced = cmi[i]._selRpos - cmi[i]._selLpos;
-			const int diff = kib - len2beReplaced;
+			const INT_PTR len2beReplaced = cmi[i]._selRpos - cmi[i]._selLpos;
+			const INT_PTR diff = kib - len2beReplaced;
 
 			cmi[i]._selLpos += totalDiff;
 			cmi[i]._selRpos += totalDiff;
@@ -3229,7 +3225,7 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 			const bool hasVirtualSpc = cmi[i]._nbVirtualAnchorSpc > 0;
 			if (hasVirtualSpc) // if virtual space is present, then insert space
 			{
-				for (int j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
+				for (INT_PTR j = 0, k = cmi[i]._selLpos; j < cmi[i]._nbVirtualCaretSpc ; ++j, ++k)
 				{
 					execute(SCI_INSERTTEXT, k, reinterpret_cast<LPARAM>(" "));
 				}
@@ -3239,7 +3235,7 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 			execute(SCI_SETTARGETRANGE, cmi[i]._selLpos, cmi[i]._selRpos);
 
 			WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-			UINT cp = static_cast<UINT>(execute(SCI_GETCODEPAGE));
+			size_t cp = execute(SCI_GETCODEPAGE);
 			const char *strA = wmc.wchar2char(str, cp);
 			execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(strA));
 
@@ -3285,20 +3281,20 @@ void ScintillaEditView::foldChanged(size_t line, int levelNow, int levelPrev)
 	        ((levelPrev & SC_FOLDLEVELNUMBERMASK) > (levelNow & SC_FOLDLEVELNUMBERMASK)))
 	{
 		// See if should still be hidden
-		int parentLine = static_cast<int32_t>(execute(SCI_GETFOLDPARENT, line));
+		INT_PTR parentLine = execute(SCI_GETFOLDPARENT, line);
 		if ((parentLine < 0) || !isFolded(parentLine && execute(SCI_GETLINEVISIBLE, parentLine)))
 			execute(SCI_SHOWLINES, line, line);
 	}
 }
 
-bool ScintillaEditView::getIndicatorRange(int indicatorNumber, int *from, int *to, int *cur)
+bool ScintillaEditView::getIndicatorRange(size_t indicatorNumber, size_t* from, size_t* to, size_t* cur)
 {
-	int curPos = static_cast<int>(execute(SCI_GETCURRENTPOS));
-	int indicMsk = static_cast<int>(execute(SCI_INDICATORALLONFOR, curPos));
-	if (!(indicMsk & (1 << indicatorNumber)))
+	size_t curPos = execute(SCI_GETCURRENTPOS);
+	size_t indicMsk = execute(SCI_INDICATORALLONFOR, curPos);
+	if (!(static_cast<int>(indicMsk) & (1 << indicatorNumber)))
 		return false;
-	int startPos = static_cast<int>(execute(SCI_INDICATORSTART, indicatorNumber, curPos));
-	int endPos = static_cast<int>(execute(SCI_INDICATOREND, indicatorNumber, curPos));
+	size_t startPos = execute(SCI_INDICATORSTART, indicatorNumber, curPos);
+	size_t endPos = execute(SCI_INDICATOREND, indicatorNumber, curPos);
 	if ((curPos < startPos) || (curPos > endPos))
 		return false;
 	if (from) *from = startPos;
@@ -3313,19 +3309,19 @@ void ScintillaEditView::scrollPosToCenter(size_t pos)
 	_positionRestoreNeeded = false;
 
 	execute(SCI_GOTOPOS, pos);
-	int line = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, pos));
+	size_t line = execute(SCI_LINEFROMPOSITION, pos);
 
-	int firstVisibleDisplayLine = static_cast<int32_t>(execute(SCI_GETFIRSTVISIBLELINE));
-	int firstVisibleDocLine = static_cast<int32_t>(execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine));
-	int nbLine = static_cast<int32_t>(execute(SCI_LINESONSCREEN, firstVisibleDisplayLine));
-	int lastVisibleDocLine = static_cast<int32_t>(execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine + nbLine));
+	size_t firstVisibleDisplayLine = execute(SCI_GETFIRSTVISIBLELINE);
+	size_t firstVisibleDocLine = execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine);
+	size_t nbLine = execute(SCI_LINESONSCREEN, firstVisibleDisplayLine);
+	size_t lastVisibleDocLine = execute(SCI_DOCLINEFROMVISIBLE, firstVisibleDisplayLine + nbLine);
 
-	int middleLine;
+	size_t middleLine;
 	if (line - firstVisibleDocLine < lastVisibleDocLine - line)
 		middleLine = firstVisibleDocLine + nbLine/2;
 	else
 		middleLine = lastVisibleDocLine -  nbLine/2;
-	int nbLines2scroll =  line - middleLine;
+	size_t nbLines2scroll =  line - middleLine;
 	scroll(0, nbLines2scroll);
 	execute(SCI_ENSUREVISIBLEENFORCEPOLICY, line);
 }
@@ -3336,11 +3332,11 @@ void ScintillaEditView::hideLines()
 	//Adding runMarkers(hide, foldstart) directly (folding on single document) can help
 
 	//Special func on buffer. If markers are added, create notification with location of start, and hide bool set to true
-	int startLine = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, execute(SCI_GETSELECTIONSTART)));
-	int endLine = static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, execute(SCI_GETSELECTIONEND)));
+	size_t startLine = execute(SCI_LINEFROMPOSITION, execute(SCI_GETSELECTIONSTART));
+	size_t endLine = execute(SCI_LINEFROMPOSITION, execute(SCI_GETSELECTIONEND));
 	//perform range check: cannot hide very first and very last lines
 	//Offset them one off the edges, and then check if they are within the reasonable
-	int nbLines = static_cast<int32_t>(execute(SCI_GETLINECOUNT));
+	size_t nbLines = execute(SCI_GETLINECOUNT);
 	if (nbLines < 3)
 		return;	//cannot possibly hide anything
 	if (!startLine)
@@ -3360,7 +3356,7 @@ void ScintillaEditView::hideLines()
 
 	//remove any markers in between
 	int scope = 0;
-	for (int i = startLine; i <= endLine; ++i)
+	for (size_t i = startLine; i <= endLine; ++i)
 	{
 		auto state = execute(SCI_MARKERGET, i);
 		bool closePresent = ((state & (1 << MARK_HIDELINESEND)) != 0);	//check close first, then open, since close closes scope
@@ -3420,7 +3416,7 @@ bool ScintillaEditView::markerMarginClick(int lineNumber)
 	return true;
 }
 
-void ScintillaEditView::notifyMarkers(Buffer * buf, bool isHide, int location, bool del)
+void ScintillaEditView::notifyMarkers(Buffer * buf, bool isHide, size_t location, bool del)
 {
 	if (buf != _currentBuffer)	//if not visible buffer dont do a thing
 		return;
@@ -3585,7 +3581,7 @@ void ScintillaEditView::insertNewLineAboveCurrentLine()
 	else
 	{
 		const auto eol_length = newline.length();
-		const auto position = static_cast<size_t>(execute(SCI_POSITIONFROMLINE, current_line)) - eol_length;
+		const auto position = execute(SCI_POSITIONFROMLINE, current_line) - eol_length;
 		insertGenericTextFrom(position, newline.c_str());
 	}
 	execute(SCI_SETEMPTYSELECTION, execute(SCI_POSITIONFROMLINE, current_line));
@@ -3595,7 +3591,7 @@ void ScintillaEditView::insertNewLineAboveCurrentLine()
 void ScintillaEditView::insertNewLineBelowCurrentLine()
 {
 	generic_string newline = getEOLString();
-	const auto line_count = static_cast<size_t>(execute(SCI_GETLINECOUNT));
+	const auto line_count = execute(SCI_GETLINECOUNT);
 	const auto current_line = getCurrentLineNumber();
 	if (current_line == line_count - 1)
 	{
@@ -3645,7 +3641,7 @@ void ScintillaEditView::sortLines(size_t fromLine, size_t toLine, ISorter* pSort
 	}
 	if (text != joined)
 	{
-		replaceTarget(joined.c_str(), int(startPos), int(endPos));
+		replaceTarget(joined.c_str(), startPos, endPos);
 	}
 }
 
@@ -3693,7 +3689,7 @@ void ScintillaEditView::changeTextDirection(bool isRTL)
 
 generic_string ScintillaEditView::getEOLString()
 {
-	const int eol_mode = int(execute(SCI_GETEOLMODE));
+	INT_PTR eol_mode = execute(SCI_GETEOLMODE);
 	if (eol_mode == SC_EOL_CRLF)
 	{
 		return TEXT("\r\n");
@@ -3760,25 +3756,25 @@ int ScintillaEditView::getTextZoneWidth() const
 	RECT editorRect;
 	getClientRect(editorRect);
 
-	int marginWidths = 0;
+	INT_PTR marginWidths = 0;
 	for (int m = 0; m < 4; ++m)
 	{
-		marginWidths += static_cast<int32_t>(execute(SCI_GETMARGINWIDTHN, m));
+		marginWidths += execute(SCI_GETMARGINWIDTHN, m);
 	}
-	return editorRect.right - editorRect.left - marginWidths;
+	return editorRect.right - editorRect.left - static_cast<LONG>(marginWidths);
 }
 
-pair<int, int> ScintillaEditView::getSelectedCharsAndLinesCount(int maxSelectionsForLineCount /* = -1 */) const
+pair<size_t, size_t> ScintillaEditView::getSelectedCharsAndLinesCount(long long maxSelectionsForLineCount /* = -1 */) const
 {
-	pair<int, int> selectedCharsAndLines(0, 0);
+	pair<size_t, size_t> selectedCharsAndLines(0, 0);
 
 	selectedCharsAndLines.first = getUnicodeSelectedLength();
 
-	int numSelections = static_cast<int>(execute(SCI_GETSELECTIONS));
+	size_t numSelections = execute(SCI_GETSELECTIONS);
 
 	if (numSelections == 1)
 	{
-		pair<int, int> lineRange = getSelectionLinesRange();
+		pair<size_t, size_t> lineRange = getSelectionLinesRange();
 		selectedCharsAndLines.second = lineRange.second - lineRange.first + 1;
 	}
 	else if (execute(SCI_SELECTIONISRECTANGLE))
@@ -3786,7 +3782,7 @@ pair<int, int> ScintillaEditView::getSelectedCharsAndLinesCount(int maxSelection
 		selectedCharsAndLines.second = numSelections;
 	}
 	else if ((maxSelectionsForLineCount == -1) ||  // -1 means process ALL of the selections
-		(numSelections <= maxSelectionsForLineCount))
+		(numSelections <= static_cast<size_t>(maxSelectionsForLineCount)))
 	{
 		// selections are obtained from Scintilla in the order user creates them,
 		// not in a lowest-to-highest position-based order;
@@ -3794,37 +3790,37 @@ pair<int, int> ScintillaEditView::getSelectedCharsAndLinesCount(int maxSelection
 		// we have to reorder the lines touched
 		// by selection into low-to-high line number order before processing them further
 
-		vector< pair <int, int> > v;
-		for (int s = 0; s < numSelections; ++s)
+		vector< pair <size_t, size_t> > v;
+		for (size_t s = 0; s < numSelections; ++s)
 		{
 			v.push_back(getSelectionLinesRange(s));
 		}
 		sort(v.begin(), v.end());
-		int previousSecondLine = -1;
+		INT_PTR previousSecondLine = -1;
 		for (auto lineRange : v)
 		{
 			selectedCharsAndLines.second += lineRange.second - lineRange.first;
-			if (lineRange.first != previousSecondLine)
+			if (lineRange.first != static_cast<size_t>(previousSecondLine))
 			{
 				++selectedCharsAndLines.second;
 			}
-			previousSecondLine = lineRange.second;
+			previousSecondLine = static_cast<INT_PTR>(lineRange.second);
 		}
 	}
 
 	return selectedCharsAndLines;
 };
 
-int ScintillaEditView::getUnicodeSelectedLength() const
+size_t ScintillaEditView::getUnicodeSelectedLength() const
 {
-	int length = 0;
-	int numSelections = static_cast<int>(execute(SCI_GETSELECTIONS));
+	size_t length = 0;
+	size_t numSelections = execute(SCI_GETSELECTIONS);
 
-	for (int s = 0; s < numSelections; ++s)
+	for (size_t s = 0; s < numSelections; ++s)
 	{
-		int start = static_cast<int>(execute(SCI_GETSELECTIONNSTART, s));
-		int end = static_cast<int>(execute(SCI_GETSELECTIONNEND, s));
-		length += static_cast<int>(execute(SCI_COUNTCHARACTERS, start, end));
+		size_t start = execute(SCI_GETSELECTIONNSTART, s);
+		size_t end = execute(SCI_GETSELECTIONNEND, s);
+		length += execute(SCI_COUNTCHARACTERS, start, end);
 	}
 
 	return length;
@@ -3850,7 +3846,7 @@ void ScintillaEditView::markedTextToClipboard(int indiStyle, bool doAll /*= fals
 	}
 
 	// vector of pairs: starting position of styled text, and styled text
-	std::vector<std::pair<int, generic_string>> styledVect;
+	std::vector<std::pair<size_t, generic_string>> styledVect;
 
 	const generic_string cr = TEXT("\r");
 	const generic_string lf = TEXT("\n");
@@ -3859,11 +3855,11 @@ void ScintillaEditView::markedTextToClipboard(int indiStyle, bool doAll /*= fals
 
 	for (int si = 0; styleIndicators[si] != -1; ++si)
 	{
-		int pos = static_cast<int>(execute(SCI_INDICATOREND, styleIndicators[si], 0));
+		size_t pos = execute(SCI_INDICATOREND, styleIndicators[si], 0);
 		if (pos > 0)
 		{
 			bool atEndOfIndic = execute(SCI_INDICATORVALUEAT, styleIndicators[si], 0) != 0;
-			int prevPos = pos;
+			size_t prevPos = pos;
 			if (atEndOfIndic) prevPos = 0;
 
 			do
@@ -3883,7 +3879,7 @@ void ScintillaEditView::markedTextToClipboard(int indiStyle, bool doAll /*= fals
 				}
 				atEndOfIndic = !atEndOfIndic;
 				prevPos = pos;
-				pos = static_cast<int>(execute(SCI_INDICATOREND, styleIndicators[si], pos));
+				pos = execute(SCI_INDICATOREND, styleIndicators[si], pos);
 			} while (pos != prevPos);
 		}
 	}
@@ -3926,7 +3922,7 @@ void ScintillaEditView::removeAnyDuplicateLines()
 
 	if (hasLineSelection)
 	{
-		const pair<int, int> lineRange = getSelectionLinesRange();
+		const pair<size_t, size_t> lineRange = getSelectionLinesRange();
 		// One single line selection is not allowed.
 		if (lineRange.first == lineRange.second)
 		{
@@ -3973,7 +3969,7 @@ void ScintillaEditView::removeAnyDuplicateLines()
 		}
 		if (text != joined)
 		{
-			replaceTarget(joined.c_str(), int(startPos), int(endPos));
+			replaceTarget(joined.c_str(), startPos, endPos);
 		}
 	}
 }

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -3383,7 +3383,7 @@ void ScintillaEditView::hideLines()
 	_currentBuffer->setHideLineChanged(true, startLine-1);
 }
 
-bool ScintillaEditView::markerMarginClick(int lineNumber)
+bool ScintillaEditView::markerMarginClick(size_t lineNumber)
 {
 	auto state = execute(SCI_MARKERGET, lineNumber);
 	bool openPresent = ((state & (1 << MARK_HIDELINESBEGIN | 1 << MARK_HIDELINESUNDERLINE)) != 0);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -387,7 +387,7 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			if (wParam == IMR_RECONVERTSTRING)
 			{
 				INT_PTR					textLength;
-				int					selectSize;
+				INT_PTR					selectSize;
 				char				smallTextBuffer[128];
 				char			  *	selectedStr = smallTextBuffer;
 				RECONVERTSTRING   *	reconvert = (RECONVERTSTRING *)lParam;
@@ -426,7 +426,7 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 				{
 					// convert the selection to Unicode, and get the number
 					// of bytes required for the converted text
-					textLength = sizeof(WCHAR) * ::MultiByteToWideChar(codepage, 0, selectedStr, selectSize, NULL, 0);
+					textLength = sizeof(WCHAR) * ::MultiByteToWideChar(codepage, 0, selectedStr, (int)selectSize, NULL, 0);
 				}
 				else
 				{
@@ -436,7 +436,7 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 					// dwCompStrOffset, and dwTargetStrOffset specify byte counts.
 
 					textLength = ::MultiByteToWideChar(	codepage, 0,
-														selectedStr, selectSize,
+														selectedStr, (int)selectSize,
 														(LPWSTR)((LPSTR)reconvert + sizeof(RECONVERTSTRING)),
 														reconvert->dwSize - sizeof(RECONVERTSTRING));
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -1705,7 +1705,7 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 			if (typeDoc >= L_EXTERNAL && typeDoc < NppParameters::getInstance().L_END)
 				setExternalLexer(typeDoc);
 			else
-				execute(SCI_SETLEXER, (_codepage == CP_CHINESE_TRADITIONAL)?SCLEX_MAKEFILE:SCLEX_NULL);
+				execute(SCI_SETLEXER, (_codepage == CP_CHINESE_TRADITIONAL) ? SCLEX_MAKEFILE : SCLEX_NULL);
 			break;
 
 	}
@@ -3539,7 +3539,6 @@ void ScintillaEditView::runMarkers(bool doHide, size_t searchStart, bool endOfDo
 				if (isInSection && !isFolded(i))
 				{
 					execute(SCI_SHOWLINES, startShowing, i);
-					//startShowing = execute(SCI_GETLASTCHILD, i, (levelLine & SC_FOLDLEVELNUMBERMASK));
 				}
 			}
 		}

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -782,6 +782,7 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>(name), reinterpret_cast<LPARAM>(userLangContainer->_isPrefix[i] ? "1" : "0"));
 	}
 
+	char* temp = new char[max_char];
 	for (int i = 0 ; i < SCE_USER_KWLIST_TOTAL ; ++i)
 	{
 		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
@@ -793,7 +794,6 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 		}
 		else // OPERATORS2, FOLDERS_IN_CODE2, FOLDERS_IN_COMMENT, KEYWORDS1-8
 		{
-			char temp[max_char];
 			bool inDoubleQuote = false;
 			bool inSingleQuote = false;
 			bool nonWSFound = false;
@@ -844,6 +844,7 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 			execute(SCI_SETKEYWORDS, setKeywordsCounter++, reinterpret_cast<LPARAM>(temp));
 		}
 	}
+	delete[] temp;
 
  	char intBuffer[32];
 
@@ -1927,12 +1928,6 @@ void ScintillaEditView::activateBuffer(BufferID buffer)
 
 	restoreCurrentPosPreStep();
 
-	//setup line number margin
-	INT_PTR numLines = execute(SCI_GETLINECOUNT);
-
-	char numLineStr[32];
-	itoa(static_cast<int>(numLines), numLineStr, 10);
-
 	runMarkers(true, 0, true, false);
     return;	//all done
 }
@@ -2335,7 +2330,7 @@ void ScintillaEditView::addGenericText(const TCHAR * text2Append) const
 	execute(SCI_ADDTEXT, strlen(text2AppendA), reinterpret_cast<LPARAM>(text2AppendA));
 }
 
-void ScintillaEditView::addGenericText(const TCHAR * text2Append, long *mstart, long *mend) const
+void ScintillaEditView::addGenericText(const TCHAR * text2Append, long* mstart, long* mend) const
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	size_t cp = execute(SCI_GETCODEPAGE);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -134,14 +134,14 @@ const bool L2R = true;
 const bool R2L = false;
 
 struct ColumnModeInfo {
-	INT_PTR _selLpos = 0;
-	INT_PTR _selRpos = 0;
-	INT_PTR _order = -1; // 0 based index
+	intptr_t _selLpos = 0;
+	intptr_t _selRpos = 0;
+	intptr_t _order = -1; // 0 based index
 	bool _direction = L2R; // L2R or R2L
-	INT_PTR _nbVirtualCaretSpc = 0;
-	INT_PTR _nbVirtualAnchorSpc = 0;
+	intptr_t _nbVirtualCaretSpc = 0;
+	intptr_t _nbVirtualAnchorSpc = 0;
 
-	ColumnModeInfo(INT_PTR lPos, INT_PTR rPos, INT_PTR order, bool dir = L2R, INT_PTR vAnchorNbSpc = 0, INT_PTR vCaretNbSpc = 0)
+	ColumnModeInfo(intptr_t lPos, intptr_t rPos, intptr_t order, bool dir = L2R, intptr_t vAnchorNbSpc = 0, intptr_t vCaretNbSpc = 0)
 		: _selLpos(lPos), _selRpos(rPos), _order(order), _direction(dir), _nbVirtualAnchorSpc(vAnchorNbSpc), _nbVirtualCaretSpc(vCaretNbSpc){};
 
 	bool isValid() const {
@@ -229,28 +229,28 @@ public:
 
 	void getText(char *dest, size_t start, size_t end) const;
 	void getGenericText(TCHAR *dest, size_t destlen, size_t start, size_t end) const;
-	void getGenericText(TCHAR *dest, size_t deslen, size_t start, size_t end, INT_PTR* mstart, INT_PTR* mend) const;
+	void getGenericText(TCHAR *dest, size_t deslen, size_t start, size_t end, intptr_t* mstart, intptr_t* mend) const;
 	generic_string getGenericTextAsString(size_t start, size_t end) const;
 	void insertGenericTextFrom(size_t position, const TCHAR *text2insert) const;
 	void replaceSelWith(const char * replaceText);
 
-	INT_PTR getSelectedTextCount() {
+	intptr_t getSelectedTextCount() {
 		Sci_CharacterRange range = getSelection();
 		return (range.cpMax - range.cpMin);
 	};
 
-	void getVisibleStartAndEndPosition(INT_PTR* startPos, INT_PTR* endPos);
+	void getVisibleStartAndEndPosition(intptr_t* startPos, intptr_t* endPos);
     char * getWordFromRange(char * txt, size_t size, size_t pos1, size_t pos2);
 	char * getSelectedText(char * txt, size_t size, bool expand = true);
     char * getWordOnCaretPos(char * txt, size_t size);
     TCHAR * getGenericWordOnCaretPos(TCHAR * txt, int size);
 	TCHAR * getGenericSelectedText(TCHAR * txt, int size, bool expand = true);
-	INT_PTR searchInTarget(const TCHAR * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
+	intptr_t searchInTarget(const TCHAR * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
 	void appandGenericText(const TCHAR * text2Append) const;
 	void addGenericText(const TCHAR * text2Append) const;
 	void addGenericText(const TCHAR * text2Append, long* mstart, long* mend) const;
-	INT_PTR replaceTarget(const TCHAR * str2replace, INT_PTR fromTargetPos = -1, INT_PTR toTargetPos = -1) const;
-	INT_PTR replaceTargetRegExMode(const TCHAR * re, INT_PTR fromTargetPos = -1, INT_PTR toTargetPos = -1) const;
+	intptr_t replaceTarget(const TCHAR * str2replace, intptr_t fromTargetPos = -1, intptr_t toTargetPos = -1) const;
+	intptr_t replaceTargetRegExMode(const TCHAR * re, intptr_t fromTargetPos = -1, intptr_t toTargetPos = -1) const;
 	void showAutoComletion(size_t lenEntered, const TCHAR * list);
 	void showCallTip(size_t startPos, const TCHAR * def);
 	generic_string getLine(size_t lineNumber);
@@ -280,7 +280,7 @@ public:
 		return crange;
 	};
 
-	void getWordToCurrentPos(TCHAR * str, INT_PTR strLen) const {
+	void getWordToCurrentPos(TCHAR * str, intptr_t strLen) const {
 		auto caretPos = execute(SCI_GETCURRENTPOS);
 		auto startPos = execute(SCI_WORDSTARTPOSITION, caretPos, true);
 
@@ -391,16 +391,16 @@ public:
 		execute(SCI_SETWRAPVISUALFLAGS, willBeShown?SC_WRAPVISUALFLAG_END:SC_WRAPVISUALFLAG_NONE);
     };
 
-	INT_PTR getCurrentLineNumber()const {
+	intptr_t getCurrentLineNumber()const {
 		return execute(SCI_LINEFROMPOSITION, execute(SCI_GETCURRENTPOS));
 	};
 
-	INT_PTR lastZeroBasedLineNumber() const {
+	intptr_t lastZeroBasedLineNumber() const {
 		auto endPos = execute(SCI_GETLENGTH);
 		return execute(SCI_LINEFROMPOSITION, endPos);
 	};
 
-	INT_PTR getCurrentXOffset()const{
+	intptr_t getCurrentXOffset()const{
 		return execute(SCI_GETXOFFSET);
 	};
 
@@ -412,26 +412,26 @@ public:
 		execute(SCI_LINESCROLL, column, line);
 	};
 
-	INT_PTR getCurrentPointX()const{
+	intptr_t getCurrentPointX()const{
 		return execute(SCI_POINTXFROMPOSITION, 0, execute(SCI_GETCURRENTPOS));
 	};
 
-	INT_PTR getCurrentPointY()const{
+	intptr_t getCurrentPointY()const{
 		return execute(SCI_POINTYFROMPOSITION, 0, execute(SCI_GETCURRENTPOS));
 	};
 
-	INT_PTR getTextHeight()const{
+	intptr_t getTextHeight()const{
 		return execute(SCI_TEXTHEIGHT);
 	};
 
 	int getTextZoneWidth() const;
 
-	void gotoLine(INT_PTR line){
+	void gotoLine(intptr_t line){
 		if (line < execute(SCI_GETLINECOUNT))
 			execute(SCI_GOTOLINE,line);
 	};
 
-	INT_PTR getCurrentColumnNumber() const {
+	intptr_t getCurrentColumnNumber() const {
         return execute(SCI_GETCOLUMN, execute(SCI_GETCURRENTPOS));
     };
 
@@ -439,11 +439,11 @@ public:
 
 	size_t getUnicodeSelectedLength() const;
 
-	INT_PTR getLineLength(size_t line) const {
+	intptr_t getLineLength(size_t line) const {
 		return execute(SCI_GETLINEENDPOSITION, line) - execute(SCI_POSITIONFROMLINE, line);
 	};
 
-	INT_PTR getLineIndent(size_t line) const {
+	intptr_t getLineIndent(size_t line) const {
 		return execute(SCI_GETLINEINDENTATION, line);
 	};
 
@@ -481,9 +481,9 @@ public:
 
 	void performGlobalStyles();
 
-	void expand(size_t& line, bool doExpand, bool force = false, INT_PTR visLevels = 0, INT_PTR level = -1);
+	void expand(size_t& line, bool doExpand, bool force = false, intptr_t visLevels = 0, intptr_t level = -1);
 
-	std::pair<size_t, size_t> getSelectionLinesRange(INT_PTR selectionNumber = -1) const;
+	std::pair<size_t, size_t> getSelectionLinesRange(intptr_t selectionNumber = -1) const;
     void currentLinesUp() const;
     void currentLinesDown() const;
 
@@ -641,7 +641,7 @@ protected:
 	typedef std::unordered_map<BufferID, StyleMap*> BufferStyleMap;
 	BufferStyleMap _hotspotStyles;
 
-	INT_PTR _beginSelectPosition = -1;
+	intptr_t _beginSelectPosition = -1;
 
 	static std::string _defaultCharList;
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -248,7 +248,7 @@ public:
 	INT_PTR searchInTarget(const TCHAR * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
 	void appandGenericText(const TCHAR * text2Append) const;
 	void addGenericText(const TCHAR * text2Append) const;
-	void addGenericText(const TCHAR * text2Append, long *mstart, long *mend) const;
+	void addGenericText(const TCHAR * text2Append, long* mstart, long* mend) const;
 	INT_PTR replaceTarget(const TCHAR * str2replace, INT_PTR fromTargetPos = -1, INT_PTR toTargetPos = -1) const;
 	INT_PTR replaceTargetRegExMode(const TCHAR * re, INT_PTR fromTargetPos = -1, INT_PTR toTargetPos = -1) const;
 	void showAutoComletion(size_t lenEntered, const TCHAR * list);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -241,8 +241,8 @@ public:
 
 	void getVisibleStartAndEndPosition(INT_PTR* startPos, INT_PTR* endPos);
     char * getWordFromRange(char * txt, size_t size, size_t pos1, size_t pos2);
-	char * getSelectedText(char * txt, int size, bool expand = true);
-    char * getWordOnCaretPos(char * txt, int size);
+	char * getSelectedText(char * txt, size_t size, bool expand = true);
+    char * getWordOnCaretPos(char * txt, size_t size);
     TCHAR * getGenericWordOnCaretPos(TCHAR * txt, int size);
 	TCHAR * getGenericSelectedText(TCHAR * txt, int size, bool expand = true);
 	INT_PTR searchInTarget(const TCHAR * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
@@ -443,7 +443,7 @@ public:
 		return execute(SCI_GETLINEENDPOSITION, line) - execute(SCI_POSITIONFROMLINE, line);
 	};
 
-	INT_PTR getLineIndent(int line) const {
+	INT_PTR getLineIndent(size_t line) const {
 		return execute(SCI_GETLINEINDENTATION, line);
 	};
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -234,7 +234,7 @@ public:
 	void insertGenericTextFrom(size_t position, const TCHAR *text2insert) const;
 	void replaceSelWith(const char * replaceText);
 
-	int getSelectedTextCount() {
+	INT_PTR getSelectedTextCount() {
 		Sci_CharacterRange range = getSelection();
 		return (range.cpMax - range.cpMin);
 	};

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -275,12 +275,12 @@ public:
 
 	Sci_CharacterRange getSelection() const {
 		Sci_CharacterRange crange;
-		crange.cpMin = long(execute(SCI_GETSELECTIONSTART));
-		crange.cpMax = long(execute(SCI_GETSELECTIONEND));
+		crange.cpMin = static_cast<Sci_PositionCR>(execute(SCI_GETSELECTIONSTART));
+		crange.cpMax = static_cast<Sci_PositionCR>(execute(SCI_GETSELECTIONEND));
 		return crange;
 	};
 
-	void getWordToCurrentPos(TCHAR * str, int strLen) const {
+	void getWordToCurrentPos(TCHAR * str, INT_PTR strLen) const {
 		auto caretPos = execute(SCI_GETCURRENTPOS);
 		auto startPos = execute(SCI_WORDSTARTPOSITION, caretPos, true);
 
@@ -426,7 +426,7 @@ public:
 
 	int getTextZoneWidth() const;
 
-	void gotoLine(int line){
+	void gotoLine(INT_PTR line){
 		if (line < execute(SCI_GETLINECOUNT))
 			execute(SCI_GOTOLINE,line);
 	};

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -551,7 +551,7 @@ public:
 
 	void hideLines();
 
-	bool markerMarginClick(int lineNumber);	//true if it did something
+	bool markerMarginClick(size_t lineNumber);	//true if it did something
 	void notifyMarkers(Buffer * buf, bool isHide, size_t location, bool del);
 	void runMarkers(bool doHide, size_t searchStart, bool endOfDoc, bool doDelete);
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -134,14 +134,14 @@ const bool L2R = true;
 const bool R2L = false;
 
 struct ColumnModeInfo {
-	int _selLpos = 0;
-	int _selRpos = 0;
-	int _order = -1; // 0 based index
+	INT_PTR _selLpos = 0;
+	INT_PTR _selRpos = 0;
+	INT_PTR _order = -1; // 0 based index
 	bool _direction = L2R; // L2R or R2L
-	int _nbVirtualCaretSpc = 0;
-	int _nbVirtualAnchorSpc = 0;
+	INT_PTR _nbVirtualCaretSpc = 0;
+	INT_PTR _nbVirtualAnchorSpc = 0;
 
-	ColumnModeInfo(int lPos, int rPos, int order, bool dir = L2R, int vAnchorNbSpc = 0, int vCaretNbSpc = 0)
+	ColumnModeInfo(INT_PTR lPos, INT_PTR rPos, INT_PTR order, bool dir = L2R, INT_PTR vAnchorNbSpc = 0, INT_PTR vCaretNbSpc = 0)
 		: _selLpos(lPos), _selRpos(rPos), _order(order), _direction(dir), _nbVirtualAnchorSpc(vAnchorNbSpc), _nbVirtualCaretSpc(vCaretNbSpc){};
 
 	bool isValid() const {
@@ -229,7 +229,7 @@ public:
 
 	void getText(char *dest, size_t start, size_t end) const;
 	void getGenericText(TCHAR *dest, size_t destlen, size_t start, size_t end) const;
-	void getGenericText(TCHAR *dest, size_t deslen, int start, int end, int *mstart, int *mend) const;
+	void getGenericText(TCHAR *dest, size_t deslen, size_t start, size_t end, INT_PTR* mstart, INT_PTR* mend) const;
 	generic_string getGenericTextAsString(size_t start, size_t end) const;
 	void insertGenericTextFrom(size_t position, const TCHAR *text2insert) const;
 	void replaceSelWith(const char * replaceText);
@@ -239,22 +239,22 @@ public:
 		return (range.cpMax - range.cpMin);
 	};
 
-	void getVisibleStartAndEndPosition(int * startPos, int * endPos);
-    char * getWordFromRange(char * txt, int size, int pos1, int pos2);
+	void getVisibleStartAndEndPosition(INT_PTR* startPos, INT_PTR* endPos);
+    char * getWordFromRange(char * txt, size_t size, size_t pos1, size_t pos2);
 	char * getSelectedText(char * txt, int size, bool expand = true);
     char * getWordOnCaretPos(char * txt, int size);
     TCHAR * getGenericWordOnCaretPos(TCHAR * txt, int size);
 	TCHAR * getGenericSelectedText(TCHAR * txt, int size, bool expand = true);
-	int searchInTarget(const TCHAR * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
+	INT_PTR searchInTarget(const TCHAR * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
 	void appandGenericText(const TCHAR * text2Append) const;
 	void addGenericText(const TCHAR * text2Append) const;
 	void addGenericText(const TCHAR * text2Append, long *mstart, long *mend) const;
-	int replaceTarget(const TCHAR * str2replace, int fromTargetPos = -1, int toTargetPos = -1) const;
-	int replaceTargetRegExMode(const TCHAR * re, int fromTargetPos = -1, int toTargetPos = -1) const;
+	INT_PTR replaceTarget(const TCHAR * str2replace, INT_PTR fromTargetPos = -1, INT_PTR toTargetPos = -1) const;
+	INT_PTR replaceTargetRegExMode(const TCHAR * re, INT_PTR fromTargetPos = -1, INT_PTR toTargetPos = -1) const;
 	void showAutoComletion(size_t lenEntered, const TCHAR * list);
-	void showCallTip(int startPos, const TCHAR * def);
+	void showCallTip(size_t startPos, const TCHAR * def);
 	generic_string getLine(size_t lineNumber);
-	void getLine(size_t lineNumber, TCHAR * line, int lineBufferLen);
+	void getLine(size_t lineNumber, TCHAR * line, size_t lineBufferLen);
 	void addText(size_t length, const char *buf);
 
 	void insertNewLineAboveCurrentLine();
@@ -269,8 +269,8 @@ public:
 		return _beginSelectPosition != -1;
 	};
 
-	int getCurrentDocLen() const {
-		return int(execute(SCI_GETLENGTH));
+	size_t getCurrentDocLen() const {
+		return size_t(execute(SCI_GETLENGTH));
 	};
 
 	Sci_CharacterRange getSelection() const {
@@ -391,37 +391,37 @@ public:
 		execute(SCI_SETWRAPVISUALFLAGS, willBeShown?SC_WRAPVISUALFLAG_END:SC_WRAPVISUALFLAG_NONE);
     };
 
-	size_t getCurrentLineNumber()const {
-		return static_cast<size_t>(execute(SCI_LINEFROMPOSITION, execute(SCI_GETCURRENTPOS)));
+	INT_PTR getCurrentLineNumber()const {
+		return execute(SCI_LINEFROMPOSITION, execute(SCI_GETCURRENTPOS));
 	};
 
-	int32_t lastZeroBasedLineNumber() const {
+	INT_PTR lastZeroBasedLineNumber() const {
 		auto endPos = execute(SCI_GETLENGTH);
-		return static_cast<int32_t>(execute(SCI_LINEFROMPOSITION, endPos));
+		return execute(SCI_LINEFROMPOSITION, endPos);
 	};
 
-	long getCurrentXOffset()const{
-		return long(execute(SCI_GETXOFFSET));
+	INT_PTR getCurrentXOffset()const{
+		return execute(SCI_GETXOFFSET);
 	};
 
 	void setCurrentXOffset(long xOffset){
 		execute(SCI_SETXOFFSET,xOffset);
 	};
 
-	void scroll(int column, int line){
+	void scroll(size_t column, size_t line){
 		execute(SCI_LINESCROLL, column, line);
 	};
 
-	long getCurrentPointX()const{
-		return long (execute(SCI_POINTXFROMPOSITION, 0, execute(SCI_GETCURRENTPOS)));
+	INT_PTR getCurrentPointX()const{
+		return execute(SCI_POINTXFROMPOSITION, 0, execute(SCI_GETCURRENTPOS));
 	};
 
-	long getCurrentPointY()const{
-		return long (execute(SCI_POINTYFROMPOSITION, 0, execute(SCI_GETCURRENTPOS)));
+	INT_PTR getCurrentPointY()const{
+		return execute(SCI_POINTYFROMPOSITION, 0, execute(SCI_GETCURRENTPOS));
 	};
 
-	long getTextHeight()const{
-		return long(execute(SCI_TEXTHEIGHT));
+	INT_PTR getTextHeight()const{
+		return execute(SCI_TEXTHEIGHT);
 	};
 
 	int getTextZoneWidth() const;
@@ -431,23 +431,23 @@ public:
 			execute(SCI_GOTOLINE,line);
 	};
 
-	long getCurrentColumnNumber() const {
-        return long(execute(SCI_GETCOLUMN, execute(SCI_GETCURRENTPOS)));
+	INT_PTR getCurrentColumnNumber() const {
+        return execute(SCI_GETCOLUMN, execute(SCI_GETCURRENTPOS));
     };
 
-	std::pair<int, int> getSelectedCharsAndLinesCount(int maxSelectionsForLineCount = -1) const;
+	std::pair<size_t, size_t> getSelectedCharsAndLinesCount(long long maxSelectionsForLineCount = -1) const;
 
-	int getUnicodeSelectedLength() const;
+	size_t getUnicodeSelectedLength() const;
 
-	long getLineLength(int line) const {
-		return long(execute(SCI_GETLINEENDPOSITION, line) - execute(SCI_POSITIONFROMLINE, line));
+	INT_PTR getLineLength(size_t line) const {
+		return execute(SCI_GETLINEENDPOSITION, line) - execute(SCI_POSITIONFROMLINE, line);
 	};
 
-	long getLineIndent(int line) const {
-		return long(execute(SCI_GETLINEINDENTATION, line));
+	INT_PTR getLineIndent(int line) const {
+		return execute(SCI_GETLINEINDENTATION, line);
 	};
 
-	void setLineIndent(int line, int indent) const;
+	void setLineIndent(size_t line, size_t indent) const;
 
 	void updateLineNumbersMargin(bool forcedToHide) {
 		const ScintillaViewParams& svp = NppParameters::getInstance().getSVP();
@@ -481,9 +481,9 @@ public:
 
 	void performGlobalStyles();
 
-	void expand(size_t& line, bool doExpand, bool force = false, int visLevels = 0, int level = -1);
+	void expand(size_t& line, bool doExpand, bool force = false, INT_PTR visLevels = 0, INT_PTR level = -1);
 
-	std::pair<int, int> getSelectionLinesRange(int selectionNumber = -1) const;
+	std::pair<size_t, size_t> getSelectionLinesRange(INT_PTR selectionNumber = -1) const;
     void currentLinesUp() const;
     void currentLinesDown() const;
 
@@ -533,13 +533,13 @@ public:
 
 	void foldChanged(size_t line, int levelNow, int levelPrev);
 	void clearIndicator(int indicatorNumber) {
-		int docStart = 0;
-		int docEnd = getCurrentDocLen();
+		size_t docStart = 0;
+		size_t docEnd = getCurrentDocLen();
 		execute(SCI_SETINDICATORCURRENT, indicatorNumber);
-		execute(SCI_INDICATORCLEARRANGE, docStart, docEnd-docStart);
+		execute(SCI_INDICATORCLEARRANGE, docStart, docEnd - docStart);
 	};
 
-	bool getIndicatorRange(int indicatorNumber, int *from = NULL, int *to = NULL, int *cur = NULL);
+	bool getIndicatorRange(size_t indicatorNumber, size_t* from = NULL, size_t* to = NULL, size_t* cur = NULL);
 
 	static LanguageName langNames[L_EXTERNAL+1];
 
@@ -552,7 +552,7 @@ public:
 	void hideLines();
 
 	bool markerMarginClick(int lineNumber);	//true if it did something
-	void notifyMarkers(Buffer * buf, bool isHide, int location, bool del);
+	void notifyMarkers(Buffer * buf, bool isHide, size_t location, bool del);
 	void runMarkers(bool doHide, size_t searchStart, bool endOfDoc, bool doDelete);
 
 	bool isSelecting() const {
@@ -641,7 +641,7 @@ protected:
 	typedef std::unordered_map<BufferID, StyleMap*> BufferStyleMap;
 	BufferStyleMap _hotspotStyles;
 
-	long long _beginSelectPosition = -1;
+	INT_PTR _beginSelectPosition = -1;
 
 	static std::string _defaultCharList;
 
@@ -1003,7 +1003,7 @@ protected:
 		}
 	};
 
-	std::pair<int, int> getWordRange();
+	std::pair<size_t, size_t> getWordRange();
 	bool expandWordSelection();
 	void getFoldColor(COLORREF& fgColor, COLORREF& bgColor, COLORREF& activeFgColor);
 };

--- a/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
@@ -38,9 +38,9 @@ void SmartHighlighter::highlightViewWithWord(ScintillaEditView * pHighlightView,
 	auto nbLines = min(nbLineOnScreen, MAXLINEHIGHLIGHT) + 1;
 	auto lastLine = firstLine + nbLines;
 	size_t startPos = 0;
-	INT_PTR endPos = 0;
+	intptr_t endPos = 0;
 	auto currentLine = firstLine;
-	INT_PTR prevDocLineChecked = -1;	//invalid start
+	intptr_t prevDocLineChecked = -1;	//invalid start
 
 	// Determine mode for SmartHighlighting
 	bool isWordOnly = true;
@@ -71,10 +71,10 @@ void SmartHighlighter::highlightViewWithWord(ScintillaEditView * pHighlightView,
 
 	for (; currentLine < lastLine; ++currentLine)
 	{
-		INT_PTR docLine = pHighlightView->execute(SCI_DOCLINEFROMVISIBLE, currentLine);
+		intptr_t docLine = pHighlightView->execute(SCI_DOCLINEFROMVISIBLE, currentLine);
 		if (docLine == prevDocLineChecked)
 			continue;	//still on same line (wordwrap)
-		prevDocLineChecked = static_cast<INT_PTR>(docLine);
+		prevDocLineChecked = static_cast<intptr_t>(docLine);
 		startPos = pHighlightView->execute(SCI_POSITIONFROMLINE, docLine);
 		endPos = pHighlightView->execute(SCI_POSITIONFROMLINE, docLine + 1);
 		
@@ -116,7 +116,7 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 
 	auto curPos = pHighlightView->execute(SCI_GETCURRENTPOS);
 	auto range = pHighlightView->getSelection();
-	INT_PTR textlen = range.cpMax - range.cpMin;
+	intptr_t textlen = range.cpMax - range.cpMin;
 
 	// Determine mode for SmartHighlighting
 	bool isWordOnly = true;

--- a/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
@@ -116,7 +116,7 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 
 	auto curPos = pHighlightView->execute(SCI_GETCURRENTPOS);
 	auto range = pHighlightView->getSelection();
-	int textlen = range.cpMax - range.cpMin;
+	INT_PTR textlen = range.cpMax - range.cpMin;
 
 	// Determine mode for SmartHighlighting
 	bool isWordOnly = true;

--- a/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
@@ -33,14 +33,14 @@ void SmartHighlighter::highlightViewWithWord(ScintillaEditView * pHighlightView,
 	auto originalEndPos = pHighlightView->execute(SCI_GETTARGETEND);
 
 	// Get the range of text visible and highlight everything in it
-	auto firstLine = static_cast<int>(pHighlightView->execute(SCI_GETFIRSTVISIBLELINE));
+	auto firstLine = pHighlightView->execute(SCI_GETFIRSTVISIBLELINE);
 	auto nbLineOnScreen = pHighlightView->execute(SCI_LINESONSCREEN);
 	auto nbLines = min(nbLineOnScreen, MAXLINEHIGHLIGHT) + 1;
 	auto lastLine = firstLine + nbLines;
-	int startPos = 0;
-	int endPos = 0;
+	size_t startPos = 0;
+	INT_PTR endPos = 0;
 	auto currentLine = firstLine;
-	int prevDocLineChecked = -1;	//invalid start
+	INT_PTR prevDocLineChecked = -1;	//invalid start
 
 	// Determine mode for SmartHighlighting
 	bool isWordOnly = true;
@@ -71,12 +71,12 @@ void SmartHighlighter::highlightViewWithWord(ScintillaEditView * pHighlightView,
 
 	for (; currentLine < lastLine; ++currentLine)
 	{
-		int docLine = static_cast<int>(pHighlightView->execute(SCI_DOCLINEFROMVISIBLE, currentLine));
+		INT_PTR docLine = pHighlightView->execute(SCI_DOCLINEFROMVISIBLE, currentLine);
 		if (docLine == prevDocLineChecked)
 			continue;	//still on same line (wordwrap)
-		prevDocLineChecked = docLine;
-		startPos = static_cast<int>(pHighlightView->execute(SCI_POSITIONFROMLINE, docLine));
-		endPos = static_cast<int>(pHighlightView->execute(SCI_POSITIONFROMLINE, docLine + 1));
+		prevDocLineChecked = static_cast<INT_PTR>(docLine);
+		startPos = pHighlightView->execute(SCI_POSITIONFROMLINE, docLine);
+		endPos = pHighlightView->execute(SCI_POSITIONFROMLINE, docLine + 1);
 		
 		frInfo._startRange = startPos;
 		frInfo._endRange = endPos;

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -96,7 +96,7 @@ bool SharedParametersDialog::setPropertyByCheck(HWND hwnd, WPARAM id, bool & boo
     return TRUE;
 }
 
-INT_PTR CALLBACK SharedParametersDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM /*lParam*/)
+intptr_t CALLBACK SharedParametersDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM /*lParam*/)
 {
     switch (Message)
     {
@@ -151,7 +151,7 @@ INT_PTR CALLBACK SharedParametersDialog::run_dlgProc(UINT Message, WPARAM wParam
     return FALSE;
 }
 
-INT_PTR CALLBACK FolderStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK FolderStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
     switch (Message)
     {
@@ -268,7 +268,7 @@ void FolderStyleDialog::retrieve(TCHAR *dest, const TCHAR *toRetrieve, TCHAR *pr
     dest[j++] = '\0';
 }
 
-INT_PTR CALLBACK KeyWordsStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK KeyWordsStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
     switch (Message)
     {
@@ -409,7 +409,7 @@ void KeyWordsStyleDialog::updateDlg()
     ::SendDlgItemMessage(_hSelf, IDC_KEYWORD8_PREFIX_CHECK, BM_SETCHECK, _pUserLang->_isPrefix[7], 0);
 }
 
-INT_PTR CALLBACK CommentStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK CommentStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
     switch (Message)
     {
@@ -676,7 +676,7 @@ void SymbolsStyleDialog::updateDlg()
     ::SendDlgItemMessage(_hSelf, IDC_OPERATOR2_EDIT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(_pUserLang->_keywordLists[SCE_USER_KWLIST_OPERATORS2]));
 }
 
-INT_PTR CALLBACK SymbolsStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK SymbolsStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
     switch (Message)
     {
@@ -976,7 +976,7 @@ void UserDefineDialog::updateDlg()
 }
 
 
-INT_PTR CALLBACK UserDefineDialog::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK UserDefineDialog::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
     NppParameters& nppParam = NppParameters::getInstance();
 	NativeLangSpeaker * pNativeSpeaker = nppParam.getNativeLangSpeaker();
@@ -1522,7 +1522,7 @@ INT_PTR CALLBACK UserDefineDialog::run_dlgProc(UINT message, WPARAM wParam, LPAR
     return FALSE;
 }
 
-INT_PTR CALLBACK StringDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK StringDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 {
     switch (Message)
     {
@@ -1616,7 +1616,7 @@ INT_PTR CALLBACK StringDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
                     tmpName[0] = '\0';
                     ::GetDlgItemText(_hSelf, IDC_STRING_EDIT, tmpName, langNameLenMax);
                     _textValue = tmpName;
-                    ::EndDialog(_hSelf, reinterpret_cast<INT_PTR>(_textValue.c_str()));
+                    ::EndDialog(_hSelf, reinterpret_cast<intptr_t>(_textValue.c_str()));
                     return TRUE;
                 }
 
@@ -1723,7 +1723,7 @@ void StylerDlg::move2CtrlRight(HWND hwndDlg, int ctrlID, HWND handle2Move, int h
     ::MoveWindow(handle2Move, p.x, p.y, handle2MoveWidth, handle2MoveHeight, TRUE);
 }
 
-INT_PTR CALLBACK StylerDlg::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK StylerDlg::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
     StylerDlg * dlg = (StylerDlg *)::GetProp(hwnd, TEXT("Styler dialog prop"));
     NppParameters& nppParam = NppParameters::getInstance();

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -522,8 +522,10 @@ void CommentStyleDialog::setKeywords2List(int id)
     }
     if (index != -1)
     {
-        TCHAR newList[max_char] = TEXT("");
-        TCHAR buffer[max_char] = TEXT("");
+        TCHAR* newList = new TCHAR[max_char];
+        newList[0] = '\0';
+        TCHAR* buffer = new TCHAR[max_char];
+        buffer[0] = '\0';
         TCHAR intBuffer[10] = {'0', 0};
 
         const int list[] = {
@@ -542,6 +544,8 @@ void CommentStyleDialog::setKeywords2List(int id)
         }
 
 		wcscpy_s(_pUserLang->_keywordLists[index], newList);
+        delete[] newList;
+        delete[] buffer;
     }
 }
 
@@ -583,7 +587,8 @@ void CommentStyleDialog::retrieve(TCHAR *dest, const TCHAR *toRetrieve, TCHAR *p
 
 void CommentStyleDialog::updateDlg()
 {
-    TCHAR buffer[max_char] = TEXT("");
+    TCHAR* buffer = new TCHAR[max_char];
+    buffer[0] = '\0';
     TCHAR intBuffer[10] = {'0', 0};
 
     const int list[] = {
@@ -618,11 +623,14 @@ void CommentStyleDialog::updateDlg()
     ::SendDlgItemMessage(_hSelf, IDC_NUMBER_SUFFIX1_EDIT,    WM_SETTEXT, 0, reinterpret_cast<LPARAM>(_pUserLang->_keywordLists[SCE_USER_KWLIST_NUMBER_SUFFIX1]));
     ::SendDlgItemMessage(_hSelf, IDC_NUMBER_SUFFIX2_EDIT,    WM_SETTEXT, 0, reinterpret_cast<LPARAM>(_pUserLang->_keywordLists[SCE_USER_KWLIST_NUMBER_SUFFIX2]));
     ::SendDlgItemMessage(_hSelf, IDC_NUMBER_RANGE_EDIT,      WM_SETTEXT, 0, reinterpret_cast<LPARAM>(_pUserLang->_keywordLists[SCE_USER_KWLIST_NUMBER_RANGE]));
+
+    delete[] buffer;
 }
 
 void SymbolsStyleDialog::updateDlg()
 {
-    TCHAR buffer[max_char] = TEXT("");
+    TCHAR* buffer = new TCHAR[max_char];
+    buffer[0] = '\0';
     const int list[] = {
         IDC_DELIMITER1_BOUNDARYOPEN_EDIT,
         IDC_DELIMITER1_ESCAPE_EDIT,
@@ -660,6 +668,8 @@ void SymbolsStyleDialog::updateDlg()
 
         retrieve(buffer, _pUserLang->_keywordLists[SCE_USER_KWLIST_DELIMITERS], intBuffer);
 		::SendDlgItemMessage(_hSelf, list[i], WM_SETTEXT, 0, reinterpret_cast<LPARAM>(buffer));
+
+        delete[] buffer;
     }
 
     ::SendDlgItemMessage(_hSelf, IDC_OPERATOR1_EDIT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(_pUserLang->_keywordLists[SCE_USER_KWLIST_OPERATORS1]));
@@ -810,8 +820,10 @@ void SymbolsStyleDialog::setKeywords2List(int id)
         case IDC_DELIMITER8_ESCAPE_EDIT :
         case IDC_DELIMITER8_BOUNDARYCLOSE_EDIT :
         {
-            TCHAR newList[max_char] = TEXT("");
-            TCHAR buffer[max_char] = TEXT("");
+            TCHAR* newList = new TCHAR[max_char];
+            newList[0] = '\0';
+            TCHAR* buffer = new TCHAR[max_char];
+            buffer[0] = '\0';
             TCHAR intBuffer[10] = {'0', 0};
 
             const int list[] = {
@@ -854,6 +866,8 @@ void SymbolsStyleDialog::setKeywords2List(int id)
             }
 
 			wcscpy_s(_pUserLang->_keywordLists[SCE_USER_KWLIST_DELIMITERS], newList);
+            delete[] newList;
+            delete[] buffer;
             break;
         }
         default :

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.h
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.h
@@ -247,7 +247,7 @@ protected :
     //Shared data
     static UserLangContainer *_pUserLang;
     static ScintillaEditView *_pScintilla;
-    INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+    intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
     bool setPropertyByCheck(HWND hwnd, WPARAM id, bool & bool2set);
     virtual void setKeywords2List(int ctrlID) = 0;
 };
@@ -258,7 +258,7 @@ public:
     FolderStyleDialog() = default;
     void updateDlg();
 protected :
-    INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+    intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
     void setKeywords2List(int ctrlID);
 private :
     void retrieve(TCHAR *dest, const TCHAR *toRetrieve, TCHAR *prefix) const;
@@ -271,7 +271,7 @@ public:
     KeyWordsStyleDialog() = default;
     void updateDlg();
 protected :
-    INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+    intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
     void setKeywords2List(int id);
 };
 
@@ -281,7 +281,7 @@ public :
     CommentStyleDialog() = default;
     void updateDlg();
 protected :
-    INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+    intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
     void setKeywords2List(int id);
 private :
     void retrieve(TCHAR *dest, const TCHAR *toRetrieve, TCHAR *prefix) const;
@@ -293,7 +293,7 @@ public :
     SymbolsStyleDialog() = default;
     void updateDlg();
 protected :
-    INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+    intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
     void setKeywords2List(int id);
 private :
     void retrieve(TCHAR *dest, const TCHAR *toRetrieve, TCHAR *prefix) const;
@@ -358,7 +358,7 @@ public :
         _ctrlTab.renameTab(index, name2set);
     };
 protected :
-    virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+    virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 private :
     ControlsTab _ctrlTab;
     WindowVector _wVector;
@@ -401,14 +401,14 @@ public :
 		}
 	};
 
-    INT_PTR doDialog() {
+    intptr_t doDialog() {
         return ::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_STRING_DLG), _hParent,  dlgProc, reinterpret_cast<LPARAM>(this));
     };
 
     virtual void destroy() {};
 	
 protected :
-    INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM);
+    intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM);
 
 	// Custom proc to subclass edit control
 	LRESULT static CALLBACK customEditProc(HWND hEdit, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -447,7 +447,7 @@ public:
 		return long(::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_STYLER_POPUP_DLG), _parent, dlgProc, reinterpret_cast<LPARAM>(this)));
     };
 
-    static INT_PTR CALLBACK dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+    static intptr_t CALLBACK dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
     HINSTANCE _hInst = nullptr;

--- a/PowerEditor/src/ScintillaComponent/columnEditor.cpp
+++ b/PowerEditor/src/ScintillaComponent/columnEditor.cpp
@@ -170,7 +170,7 @@ intptr_t CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 										
 									s2r.insert(posRelative2Start, str);
 								}
-								(*_ppEditView)->replaceTarget(s2r.c_str(), int(lineBegin), int(lineEnd));
+								(*_ppEditView)->replaceTarget(s2r.c_str(), lineBegin, lineEnd);
 							}
 							delete [] line;
 						}

--- a/PowerEditor/src/ScintillaComponent/columnEditor.cpp
+++ b/PowerEditor/src/ScintillaComponent/columnEditor.cpp
@@ -36,7 +36,7 @@ void ColumnEditorDlg::display(bool toShow) const
         ::SetFocus(::GetDlgItem(_hSelf, ID_GOLINE_EDIT));
 }
 
-INT_PTR CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	switch (message) 
 	{

--- a/PowerEditor/src/ScintillaComponent/columnEditor.h
+++ b/PowerEditor/src/ScintillaComponent/columnEditor.h
@@ -47,7 +47,7 @@ public :
 	UCHAR getFormat();
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private :
     ScintillaEditView **_ppEditView = nullptr;

--- a/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -25,11 +25,11 @@
 
 using namespace std;
 
-vector< pair<int, int> > XmlMatchedTagsHighlighter::getAttributesPos(int start, int end)
+vector< pair<INT_PTR, INT_PTR> > XmlMatchedTagsHighlighter::getAttributesPos(INT_PTR start, INT_PTR end)
 {
-	vector< pair<int, int> > attributes;
+	vector< pair<INT_PTR, INT_PTR> > attributes;
 
-	int bufLen = end - start + 1;
+	INT_PTR bufLen = end - start + 1;
 	char *buf = new char[bufLen+1];
 	_pEditView->getText(buf, start, end);
 
@@ -119,12 +119,12 @@ vector< pair<int, int> > XmlMatchedTagsHighlighter::getAttributesPos(int start, 
 
 		if (state == attr_valid)
 		{
-			attributes.push_back(pair<int, int>(start+startPos, start+i+oneMoreChar));
+			attributes.push_back(pair<INT_PTR, INT_PTR>(start+startPos, start+i+oneMoreChar));
 			state = attr_invalid;
 		}
 	}
 	if (state == attr_value)
-		attributes.push_back(pair<int, int>(start+startPos, start+i-1));
+		attributes.push_back(pair<INT_PTR, INT_PTR>(start+startPos, start+i-1));
 
 	delete [] buf;
 	return attributes;
@@ -135,8 +135,8 @@ vector< pair<int, int> > XmlMatchedTagsHighlighter::getAttributesPos(int start, 
 bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 {
 	bool tagFound = false;
-	int caret = static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS));
-	int searchStartPoint = caret;
+	INT_PTR caret = _pEditView->execute(SCI_GETCURRENTPOS);
+	INT_PTR searchStartPoint = caret;
 	LRESULT styleAt;
 	FindResult openFound;
 	
@@ -164,7 +164,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 		if (!closeFound.success)
 		{
 			// We're in a tag (either a start tag or an end tag)
-			int nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, openFound.start + 1));
+			INT_PTR nextChar = _pEditView->execute(SCI_GETCHARAT, openFound.start + 1);
 
 
 			/////////////////////////////////////////////////////////////////////////
@@ -173,24 +173,24 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 			if ('/' == nextChar)
 			{
 				xmlTags.tagCloseStart = openFound.start;
-				int docLength = static_cast<int32_t>(_pEditView->execute(SCI_GETLENGTH));
+				INT_PTR docLength = _pEditView->execute(SCI_GETLENGTH);
 				FindResult endCloseTag = findText(">", caret, docLength, 0);
 				if (endCloseTag.success)
 				{
 					xmlTags.tagCloseEnd = endCloseTag.end;
 				}
 				// Now find the tagName
-				int position = openFound.start + 2;
+				INT_PTR position = openFound.start + 2;
 
 				// UTF-8 or ASCII tag name
 				std::string tagName;
-				nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, position));
+				nextChar = _pEditView->execute(SCI_GETCHARAT, position);
 				// Checking for " or ' is actually wrong here, but it means it works better with invalid XML
 				while (position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'')
 				{
 					tagName.push_back(static_cast<char>(nextChar));
 					++position;
-					nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, position));
+					nextChar = _pEditView->execute(SCI_GETCHARAT, position);
 				}
 				
 				// Now we know where the end of the tag is, and we know what the tag is called
@@ -212,8 +212,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 					 * <TAGNAME attrib="value"><TAGNAME>something</TAGNAME></TAGNAME></TAGNA|ME>
 					 * Maybe count all closing tags between start point and start of our end tag.???
 					 */
-					int currentEndPoint = xmlTags.tagCloseStart;
-					int openTagsRemaining = 1;
+					INT_PTR currentEndPoint = xmlTags.tagCloseStart;
+					INT_PTR openTagsRemaining = 1;
 					FindResult nextOpenTag;
 					do 
 					{
@@ -229,8 +229,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 							//                         ^^^^^^^^ we've found this guy
 							//                                           ^^^^^^^^^^ ^^^^^^^^ Now we need to cound these fellas
 							FindResult inbetweenCloseTag;
-							int currentStartPosition = nextOpenTag.end;
-							int closeTagsFound = 0;
+							INT_PTR currentStartPosition = nextOpenTag.end;
+							INT_PTR closeTagsFound = 0;
 							bool forwardSearch = (currentStartPosition < currentEndPoint);
 
 							do
@@ -278,19 +278,19 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 			/////////////////////////////////////////////////////////////////////////
 			// CURSOR IN OPEN TAG   
 			/////////////////////////////////////////////////////////////////////////
-				int position = openFound.start + 1;
-				int docLength = static_cast<int32_t>(_pEditView->execute(SCI_GETLENGTH));
+				INT_PTR position = openFound.start + 1;
+				INT_PTR docLength = _pEditView->execute(SCI_GETLENGTH);
 				
 				xmlTags.tagOpenStart = openFound.start;
 
 				std::string tagName;
-				nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, position));
+				nextChar = _pEditView->execute(SCI_GETCHARAT, position);
 				// Checking for " or ' is actually wrong here, but it means it works better with invalid XML
 				while (position < docLength && !isWhitespace(nextChar) && nextChar != '/' && nextChar != '>' && nextChar != '\"' && nextChar != '\'' )
 				{
 					tagName.push_back(static_cast<char>(nextChar));
 					++position;
-					nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, position));
+					nextChar = _pEditView->execute(SCI_GETCHARAT, position);
 				}
 				
 				// Now we know where the end of the tag is, and we know what the tag is called
@@ -299,7 +299,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 					// First we need to check if this is a self-closing tag.
 					// If it is, then we can just return this tag to highlight itself.
 					xmlTags.tagNameEnd = openFound.start + static_cast<int32_t>(tagName.size()) + 1;
-					int closeAnglePosition = findCloseAngle(position, docLength);
+					INT_PTR closeAnglePosition = findCloseAngle(position, docLength);
 					if (-1 != closeAnglePosition)
 					{
 						xmlTags.tagOpenEnd = closeAnglePosition + 1;
@@ -325,8 +325,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 							 *       e.g.  <TA|GNAME><TAGNAME attrib="value">some text</TAGNAME></TAGNAME>
 							 *             (cursor represented by |)
 							 */
-							int currentStartPosition = xmlTags.tagOpenEnd;
-							int closeTagsRemaining = 1;
+							INT_PTR currentStartPosition = xmlTags.tagOpenEnd;
+							INT_PTR closeTagsRemaining = 1;
 							FindResult nextCloseTag;
 							do 
 							{
@@ -342,8 +342,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 									//                                            ^^^^^^^^ we've found this guy
 									//                         ^^^^^^^^^ Now we need to find this fella
 									FindResult inbetweenOpenTag;
-									int currentEndPosition = nextCloseTag.start;
-									int openTagsFound = 0;
+									INT_PTR currentEndPosition = nextCloseTag.start;
+									INT_PTR openTagsFound = 0;
 
 									do
 									{
@@ -385,17 +385,17 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 	return tagFound;
 }
 
-XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(const std::string& tagName, int start, int end)
+XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(const std::string& tagName, INT_PTR start, INT_PTR end)
 {
 	std::string search("<");
 	search.append(tagName);
 	FindResult openTagFound;
 	openTagFound.success = false;
 	FindResult result;
-	int nextChar = 0; 
-	int styleAt;
-	int searchStart = start;
-	int searchEnd = end;
+	INT_PTR nextChar = 0; 
+	INT_PTR styleAt;
+	INT_PTR searchStart = start;
+	INT_PTR searchEnd = end;
 	bool forwardSearch = (start < end);
 	do
 	{
@@ -403,8 +403,8 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 		result = findText(search.c_str(), searchStart, searchEnd, 0);
 		if (result.success)
 		{
-			nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, result.end));
-			styleAt = static_cast<int32_t>(_pEditView->execute(SCI_GETSTYLEAT, result.start));
+			nextChar = _pEditView->execute(SCI_GETCHARAT, result.end);
+			styleAt = _pEditView->execute(SCI_GETSTYLEAT, result.start);
 			if (styleAt != SCE_H_CDATA && styleAt != SCE_H_DOUBLESTRING && styleAt != SCE_H_SINGLESTRING && styleAt != SCE_H_COMMENT)
 			{
 				// We've got an open tag for this tag name (i.e. nextChar was space or '>')
@@ -418,7 +418,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 				}
 				else if (isWhitespace(nextChar))
 				{
-					int closeAnglePosition = findCloseAngle(result.end, forwardSearch ? end : start);
+					INT_PTR closeAnglePosition = findCloseAngle(result.end, forwardSearch ? end : start);
 					if (-1 != closeAnglePosition && '/' != _pEditView->execute(SCI_GETCHARAT, closeAnglePosition - 1))
 					{
 						openTagFound.end = closeAnglePosition;
@@ -450,18 +450,18 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 }
 
 
-int XmlMatchedTagsHighlighter::findCloseAngle(int startPosition, int endPosition)
+INT_PTR XmlMatchedTagsHighlighter::findCloseAngle(INT_PTR startPosition, INT_PTR endPosition)
 {
 	// We'll search for the next '>', and check it's not in an attribute using the style
 	FindResult closeAngle;
 	
 	bool isValidClose; 
-	int returnPosition = -1;
+	INT_PTR returnPosition = -1;
 	
 	// Only search forwards
 	if (startPosition > endPosition)
 	{
-		int temp = endPosition;
+		INT_PTR temp = endPosition;
 		endPosition = startPosition;
 		startPosition = temp;
 	}
@@ -492,16 +492,16 @@ int XmlMatchedTagsHighlighter::findCloseAngle(int startPosition, int endPosition
 }
 
 
-XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(const std::string& tagName, int start, int end)
+XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(const std::string& tagName, INT_PTR start, INT_PTR end)
 {
 	std::string search("</");
 	search.append(tagName);
 	FindResult closeTagFound;
 	closeTagFound.success = false;
 	FindResult result;
-	int nextChar; 
-	int searchStart = start;
-	int searchEnd = end;
+	INT_PTR nextChar; 
+	INT_PTR searchStart = start;
+	INT_PTR searchEnd = end;
 	bool forwardSearch = (start < end);
 	bool validCloseTag;
 	do
@@ -510,7 +510,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 		result = findText(search.c_str(), searchStart, searchEnd, 0);
 		if (result.success)
 		{
-			nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, result.end));
+			nextChar = _pEditView->execute(SCI_GETCHARAT, result.end);
 			auto styleAt = _pEditView->execute(SCI_GETSTYLEAT, result.start);
 		
 			// Setup the parameters for the next search, if there is one.
@@ -535,11 +535,11 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 				}
 				else if (isWhitespace(nextChar))  // Otherwise, if it's whitespace, then allow whitespace until a '>' - any other character is invalid.
 				{
-					int whitespacePoint = result.end;
+					INT_PTR whitespacePoint = result.end;
 					do
 					{
 						++whitespacePoint;
-						nextChar = static_cast<int32_t>(_pEditView->execute(SCI_GETCHARAT, whitespacePoint));
+						nextChar = _pEditView->execute(SCI_GETCHARAT, whitespacePoint);
 				
 					} while (isWhitespace(nextChar));
 			
@@ -560,15 +560,15 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 
 }
 
-XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findText(const char *text, int start, int end, int flags)
+XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findText(const char *text, INT_PTR start, INT_PTR end, int flags)
 {
 	FindResult returnValue;
 	
 	Sci_TextToFind search;
 	search.lpstrText = const_cast<char *>(text); // Grrrrrr
-	search.chrg.cpMin = start;
-	search.chrg.cpMax = end;
-	int result = static_cast<int32_t>(_pEditView->execute(SCI_FINDTEXT, flags, reinterpret_cast<LPARAM>(&search)));
+	search.chrg.cpMin = static_cast<Sci_PositionCR>(start);
+	search.chrg.cpMax = static_cast<Sci_PositionCR>(end);
+	INT_PTR result = _pEditView->execute(SCI_FINDTEXT, flags, reinterpret_cast<LPARAM>(&search));
 	if (-1 == result)
 	{
 		returnValue.success = false;
@@ -600,7 +600,7 @@ void XmlMatchedTagsHighlighter::tagMatch(bool doHiliteAttr)
 		std::string codeBeginTag = lang == L_PHP ? "<?" : "<%";
 		std::string codeEndTag = lang == L_PHP ? "?>" : "%>";
 
-		const int caret = 1 + static_cast<int32_t>(_pEditView->execute(SCI_GETCURRENTPOS)); // +1 to deal with the case when the caret is between the angle and the question mark in "<?" (or between '<' and '%').
+		const INT_PTR caret = 1 + _pEditView->execute(SCI_GETCURRENTPOS); // +1 to deal with the case when the caret is between the angle and the question mark in "<?" (or between '<' and '%').
 		const FindResult startFound = findText(codeBeginTag.c_str(), caret, 0, 0); // This searches backwards from "caret".
 		const FindResult endFound= findText(codeEndTag.c_str(), caret, 0, 0); // This searches backwards from "caret".
 
@@ -642,7 +642,7 @@ void XmlMatchedTagsHighlighter::tagMatch(bool doHiliteAttr)
         // Colouising its attributs
         if (doHiliteAttr)
 		{
-			vector< pair<int, int> > attributes = getAttributesPos(xmlTags.tagNameEnd, xmlTags.tagOpenEnd - openTagTailLen);
+			vector< pair<INT_PTR, INT_PTR> > attributes = getAttributesPos(xmlTags.tagNameEnd, xmlTags.tagOpenEnd - openTagTailLen);
 			_pEditView->execute(SCI_SETINDICATORCURRENT,  SCE_UNIVERSAL_TAGATTR);
 			for (size_t i = 0, len = attributes.size(); i < len ; ++i)
 			{
@@ -653,11 +653,11 @@ void XmlMatchedTagsHighlighter::tagMatch(bool doHiliteAttr)
         // Colouising indent guide line position
 		if (_pEditView->isShownIndentGuide())
 		{
-			int columnAtCaret  = int(_pEditView->execute(SCI_GETCOLUMN, xmlTags.tagOpenStart));
-			int columnOpposite = int(_pEditView->execute(SCI_GETCOLUMN, xmlTags.tagCloseStart));
+			INT_PTR columnAtCaret  = _pEditView->execute(SCI_GETCOLUMN, xmlTags.tagOpenStart);
+			INT_PTR columnOpposite = _pEditView->execute(SCI_GETCOLUMN, xmlTags.tagCloseStart);
 
-			int lineAtCaret  = int(_pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagOpenStart));
-			int lineOpposite = int(_pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagCloseStart));
+			INT_PTR lineAtCaret  = _pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagOpenStart);
+			INT_PTR lineOpposite = _pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagCloseStart);
 
 			if (xmlTags.tagCloseStart != -1 && lineAtCaret != lineOpposite)
 			{

--- a/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -25,11 +25,11 @@
 
 using namespace std;
 
-vector< pair<INT_PTR, INT_PTR> > XmlMatchedTagsHighlighter::getAttributesPos(INT_PTR start, INT_PTR end)
+vector< pair<intptr_t, intptr_t> > XmlMatchedTagsHighlighter::getAttributesPos(intptr_t start, intptr_t end)
 {
-	vector< pair<INT_PTR, INT_PTR> > attributes;
+	vector< pair<intptr_t, intptr_t> > attributes;
 
-	INT_PTR bufLen = end - start + 1;
+	intptr_t bufLen = end - start + 1;
 	char *buf = new char[bufLen+1];
 	_pEditView->getText(buf, start, end);
 
@@ -119,12 +119,12 @@ vector< pair<INT_PTR, INT_PTR> > XmlMatchedTagsHighlighter::getAttributesPos(INT
 
 		if (state == attr_valid)
 		{
-			attributes.push_back(pair<INT_PTR, INT_PTR>(start+startPos, start+i+oneMoreChar));
+			attributes.push_back(pair<intptr_t, intptr_t>(start+startPos, start+i+oneMoreChar));
 			state = attr_invalid;
 		}
 	}
 	if (state == attr_value)
-		attributes.push_back(pair<INT_PTR, INT_PTR>(start+startPos, start+i-1));
+		attributes.push_back(pair<intptr_t, intptr_t>(start+startPos, start+i-1));
 
 	delete [] buf;
 	return attributes;
@@ -135,8 +135,8 @@ vector< pair<INT_PTR, INT_PTR> > XmlMatchedTagsHighlighter::getAttributesPos(INT
 bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 {
 	bool tagFound = false;
-	INT_PTR caret = _pEditView->execute(SCI_GETCURRENTPOS);
-	INT_PTR searchStartPoint = caret;
+	intptr_t caret = _pEditView->execute(SCI_GETCURRENTPOS);
+	intptr_t searchStartPoint = caret;
 	LRESULT styleAt;
 	FindResult openFound;
 	
@@ -164,7 +164,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 		if (!closeFound.success)
 		{
 			// We're in a tag (either a start tag or an end tag)
-			INT_PTR nextChar = _pEditView->execute(SCI_GETCHARAT, openFound.start + 1);
+			intptr_t nextChar = _pEditView->execute(SCI_GETCHARAT, openFound.start + 1);
 
 
 			/////////////////////////////////////////////////////////////////////////
@@ -173,14 +173,14 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 			if ('/' == nextChar)
 			{
 				xmlTags.tagCloseStart = openFound.start;
-				INT_PTR docLength = _pEditView->execute(SCI_GETLENGTH);
+				intptr_t docLength = _pEditView->execute(SCI_GETLENGTH);
 				FindResult endCloseTag = findText(">", caret, docLength, 0);
 				if (endCloseTag.success)
 				{
 					xmlTags.tagCloseEnd = endCloseTag.end;
 				}
 				// Now find the tagName
-				INT_PTR position = openFound.start + 2;
+				intptr_t position = openFound.start + 2;
 
 				// UTF-8 or ASCII tag name
 				std::string tagName;
@@ -212,8 +212,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 					 * <TAGNAME attrib="value"><TAGNAME>something</TAGNAME></TAGNAME></TAGNA|ME>
 					 * Maybe count all closing tags between start point and start of our end tag.???
 					 */
-					INT_PTR currentEndPoint = xmlTags.tagCloseStart;
-					INT_PTR openTagsRemaining = 1;
+					intptr_t currentEndPoint = xmlTags.tagCloseStart;
+					intptr_t openTagsRemaining = 1;
 					FindResult nextOpenTag;
 					do 
 					{
@@ -229,8 +229,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 							//                         ^^^^^^^^ we've found this guy
 							//                                           ^^^^^^^^^^ ^^^^^^^^ Now we need to cound these fellas
 							FindResult inbetweenCloseTag;
-							INT_PTR currentStartPosition = nextOpenTag.end;
-							INT_PTR closeTagsFound = 0;
+							intptr_t currentStartPosition = nextOpenTag.end;
+							intptr_t closeTagsFound = 0;
 							bool forwardSearch = (currentStartPosition < currentEndPoint);
 
 							do
@@ -278,8 +278,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 			/////////////////////////////////////////////////////////////////////////
 			// CURSOR IN OPEN TAG   
 			/////////////////////////////////////////////////////////////////////////
-				INT_PTR position = openFound.start + 1;
-				INT_PTR docLength = _pEditView->execute(SCI_GETLENGTH);
+				intptr_t position = openFound.start + 1;
+				intptr_t docLength = _pEditView->execute(SCI_GETLENGTH);
 				
 				xmlTags.tagOpenStart = openFound.start;
 
@@ -299,7 +299,7 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 					// First we need to check if this is a self-closing tag.
 					// If it is, then we can just return this tag to highlight itself.
 					xmlTags.tagNameEnd = openFound.start + static_cast<int32_t>(tagName.size()) + 1;
-					INT_PTR closeAnglePosition = findCloseAngle(position, docLength);
+					intptr_t closeAnglePosition = findCloseAngle(position, docLength);
 					if (-1 != closeAnglePosition)
 					{
 						xmlTags.tagOpenEnd = closeAnglePosition + 1;
@@ -325,8 +325,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 							 *       e.g.  <TA|GNAME><TAGNAME attrib="value">some text</TAGNAME></TAGNAME>
 							 *             (cursor represented by |)
 							 */
-							INT_PTR currentStartPosition = xmlTags.tagOpenEnd;
-							INT_PTR closeTagsRemaining = 1;
+							intptr_t currentStartPosition = xmlTags.tagOpenEnd;
+							intptr_t closeTagsRemaining = 1;
 							FindResult nextCloseTag;
 							do 
 							{
@@ -342,8 +342,8 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 									//                                            ^^^^^^^^ we've found this guy
 									//                         ^^^^^^^^^ Now we need to find this fella
 									FindResult inbetweenOpenTag;
-									INT_PTR currentEndPosition = nextCloseTag.start;
-									INT_PTR openTagsFound = 0;
+									intptr_t currentEndPosition = nextCloseTag.start;
+									intptr_t openTagsFound = 0;
 
 									do
 									{
@@ -385,17 +385,17 @@ bool XmlMatchedTagsHighlighter::getXmlMatchedTagsPos(XmlMatchedTagsPos &xmlTags)
 	return tagFound;
 }
 
-XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(const std::string& tagName, INT_PTR start, INT_PTR end)
+XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(const std::string& tagName, intptr_t start, intptr_t end)
 {
 	std::string search("<");
 	search.append(tagName);
 	FindResult openTagFound;
 	openTagFound.success = false;
 	FindResult result;
-	INT_PTR nextChar = 0; 
-	INT_PTR styleAt;
-	INT_PTR searchStart = start;
-	INT_PTR searchEnd = end;
+	intptr_t nextChar = 0; 
+	intptr_t styleAt;
+	intptr_t searchStart = start;
+	intptr_t searchEnd = end;
 	bool forwardSearch = (start < end);
 	do
 	{
@@ -418,7 +418,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 				}
 				else if (isWhitespace(nextChar))
 				{
-					INT_PTR closeAnglePosition = findCloseAngle(result.end, forwardSearch ? end : start);
+					intptr_t closeAnglePosition = findCloseAngle(result.end, forwardSearch ? end : start);
 					if (-1 != closeAnglePosition && '/' != _pEditView->execute(SCI_GETCHARAT, closeAnglePosition - 1))
 					{
 						openTagFound.end = closeAnglePosition;
@@ -450,18 +450,18 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findOpenTag(con
 }
 
 
-INT_PTR XmlMatchedTagsHighlighter::findCloseAngle(INT_PTR startPosition, INT_PTR endPosition)
+intptr_t XmlMatchedTagsHighlighter::findCloseAngle(intptr_t startPosition, intptr_t endPosition)
 {
 	// We'll search for the next '>', and check it's not in an attribute using the style
 	FindResult closeAngle;
 	
 	bool isValidClose; 
-	INT_PTR returnPosition = -1;
+	intptr_t returnPosition = -1;
 	
 	// Only search forwards
 	if (startPosition > endPosition)
 	{
-		INT_PTR temp = endPosition;
+		intptr_t temp = endPosition;
 		endPosition = startPosition;
 		startPosition = temp;
 	}
@@ -492,16 +492,16 @@ INT_PTR XmlMatchedTagsHighlighter::findCloseAngle(INT_PTR startPosition, INT_PTR
 }
 
 
-XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(const std::string& tagName, INT_PTR start, INT_PTR end)
+XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(const std::string& tagName, intptr_t start, intptr_t end)
 {
 	std::string search("</");
 	search.append(tagName);
 	FindResult closeTagFound;
 	closeTagFound.success = false;
 	FindResult result;
-	INT_PTR nextChar; 
-	INT_PTR searchStart = start;
-	INT_PTR searchEnd = end;
+	intptr_t nextChar; 
+	intptr_t searchStart = start;
+	intptr_t searchEnd = end;
 	bool forwardSearch = (start < end);
 	bool validCloseTag;
 	do
@@ -535,7 +535,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 				}
 				else if (isWhitespace(nextChar))  // Otherwise, if it's whitespace, then allow whitespace until a '>' - any other character is invalid.
 				{
-					INT_PTR whitespacePoint = result.end;
+					intptr_t whitespacePoint = result.end;
 					do
 					{
 						++whitespacePoint;
@@ -560,7 +560,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 
 }
 
-XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findText(const char *text, INT_PTR start, INT_PTR end, int flags)
+XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findText(const char *text, intptr_t start, intptr_t end, int flags)
 {
 	FindResult returnValue;
 	
@@ -568,7 +568,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findText(const 
 	search.lpstrText = const_cast<char *>(text); // Grrrrrr
 	search.chrg.cpMin = static_cast<Sci_PositionCR>(start);
 	search.chrg.cpMax = static_cast<Sci_PositionCR>(end);
-	INT_PTR result = _pEditView->execute(SCI_FINDTEXT, flags, reinterpret_cast<LPARAM>(&search));
+	intptr_t result = _pEditView->execute(SCI_FINDTEXT, flags, reinterpret_cast<LPARAM>(&search));
 	if (-1 == result)
 	{
 		returnValue.success = false;
@@ -600,7 +600,7 @@ void XmlMatchedTagsHighlighter::tagMatch(bool doHiliteAttr)
 		std::string codeBeginTag = lang == L_PHP ? "<?" : "<%";
 		std::string codeEndTag = lang == L_PHP ? "?>" : "%>";
 
-		const INT_PTR caret = 1 + _pEditView->execute(SCI_GETCURRENTPOS); // +1 to deal with the case when the caret is between the angle and the question mark in "<?" (or between '<' and '%').
+		const intptr_t caret = 1 + _pEditView->execute(SCI_GETCURRENTPOS); // +1 to deal with the case when the caret is between the angle and the question mark in "<?" (or between '<' and '%').
 		const FindResult startFound = findText(codeBeginTag.c_str(), caret, 0, 0); // This searches backwards from "caret".
 		const FindResult endFound= findText(codeEndTag.c_str(), caret, 0, 0); // This searches backwards from "caret".
 
@@ -642,7 +642,7 @@ void XmlMatchedTagsHighlighter::tagMatch(bool doHiliteAttr)
         // Colouising its attributs
         if (doHiliteAttr)
 		{
-			vector< pair<INT_PTR, INT_PTR> > attributes = getAttributesPos(xmlTags.tagNameEnd, xmlTags.tagOpenEnd - openTagTailLen);
+			vector< pair<intptr_t, intptr_t> > attributes = getAttributesPos(xmlTags.tagNameEnd, xmlTags.tagOpenEnd - openTagTailLen);
 			_pEditView->execute(SCI_SETINDICATORCURRENT,  SCE_UNIVERSAL_TAGATTR);
 			for (size_t i = 0, len = attributes.size(); i < len ; ++i)
 			{
@@ -653,11 +653,11 @@ void XmlMatchedTagsHighlighter::tagMatch(bool doHiliteAttr)
         // Colouising indent guide line position
 		if (_pEditView->isShownIndentGuide())
 		{
-			INT_PTR columnAtCaret  = _pEditView->execute(SCI_GETCOLUMN, xmlTags.tagOpenStart);
-			INT_PTR columnOpposite = _pEditView->execute(SCI_GETCOLUMN, xmlTags.tagCloseStart);
+			intptr_t columnAtCaret  = _pEditView->execute(SCI_GETCOLUMN, xmlTags.tagOpenStart);
+			intptr_t columnOpposite = _pEditView->execute(SCI_GETCOLUMN, xmlTags.tagCloseStart);
 
-			INT_PTR lineAtCaret  = _pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagOpenStart);
-			INT_PTR lineOpposite = _pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagCloseStart);
+			intptr_t lineAtCaret  = _pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagOpenStart);
+			intptr_t lineOpposite = _pEditView->execute(SCI_LINEFROMPOSITION, xmlTags.tagCloseStart);
 
 			if (xmlTags.tagCloseStart != -1 && lineAtCaret != lineOpposite)
 			{

--- a/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.h
+++ b/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <windows.h>
 #include <string>
 #include <vector>
 
@@ -32,31 +33,31 @@ private:
 	ScintillaEditView *_pEditView;
 	
 	struct XmlMatchedTagsPos {
-		int tagOpenStart;
-		int tagNameEnd;
-		int tagOpenEnd;
+		INT_PTR tagOpenStart;
+		INT_PTR tagNameEnd;
+		INT_PTR tagOpenEnd;
 
-		int tagCloseStart;
-		int tagCloseEnd;
+		INT_PTR tagCloseStart;
+		INT_PTR tagCloseEnd;
 	};
 
 	struct FindResult {
-		int start;
-		int end;
+		INT_PTR start;
+		INT_PTR end;
 		bool success;
 	};
 	
 	bool getXmlMatchedTagsPos(XmlMatchedTagsPos & tagsPos);
 
 	// Allowed whitespace characters in XML
-	bool isWhitespace(int ch) { return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'; }
+	bool isWhitespace(INT_PTR ch) { return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'; }
 
-	FindResult findText(const char *text, int start, int end, int flags = 0);
-	FindResult findOpenTag(const std::string& tagName, int start, int end);
-	FindResult findCloseTag(const std::string& tagName, int start, int end);
-	int findCloseAngle(int startPosition, int endPosition);
+	FindResult findText(const char *text, INT_PTR start, INT_PTR end, int flags = 0);
+	FindResult findOpenTag(const std::string& tagName, INT_PTR start, INT_PTR end);
+	FindResult findCloseTag(const std::string& tagName, INT_PTR start, INT_PTR end);
+	INT_PTR findCloseAngle(INT_PTR startPosition, INT_PTR endPosition);
 	
-	std::vector< std::pair<int, int> > getAttributesPos(int start, int end);
+	std::vector< std::pair<INT_PTR, INT_PTR> > getAttributesPos(INT_PTR start, INT_PTR end);
 	
 };
 

--- a/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.h
+++ b/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.h
@@ -33,31 +33,31 @@ private:
 	ScintillaEditView *_pEditView;
 	
 	struct XmlMatchedTagsPos {
-		INT_PTR tagOpenStart;
-		INT_PTR tagNameEnd;
-		INT_PTR tagOpenEnd;
+		intptr_t tagOpenStart;
+		intptr_t tagNameEnd;
+		intptr_t tagOpenEnd;
 
-		INT_PTR tagCloseStart;
-		INT_PTR tagCloseEnd;
+		intptr_t tagCloseStart;
+		intptr_t tagCloseEnd;
 	};
 
 	struct FindResult {
-		INT_PTR start;
-		INT_PTR end;
+		intptr_t start;
+		intptr_t end;
 		bool success;
 	};
 	
 	bool getXmlMatchedTagsPos(XmlMatchedTagsPos & tagsPos);
 
 	// Allowed whitespace characters in XML
-	bool isWhitespace(INT_PTR ch) { return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'; }
+	bool isWhitespace(intptr_t ch) { return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'; }
 
-	FindResult findText(const char *text, INT_PTR start, INT_PTR end, int flags = 0);
-	FindResult findOpenTag(const std::string& tagName, INT_PTR start, INT_PTR end);
-	FindResult findCloseTag(const std::string& tagName, INT_PTR start, INT_PTR end);
-	INT_PTR findCloseAngle(INT_PTR startPosition, INT_PTR endPosition);
+	FindResult findText(const char *text, intptr_t start, intptr_t end, int flags = 0);
+	FindResult findOpenTag(const std::string& tagName, intptr_t start, intptr_t end);
+	FindResult findCloseTag(const std::string& tagName, intptr_t start, intptr_t end);
+	intptr_t findCloseAngle(intptr_t startPosition, intptr_t endPosition);
 	
-	std::vector< std::pair<INT_PTR, INT_PTR> > getAttributesPos(INT_PTR start, INT_PTR end);
+	std::vector< std::pair<intptr_t, intptr_t> > getAttributesPos(intptr_t start, intptr_t end);
 	
 };
 

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -353,7 +353,7 @@ bool Utf8_16_Write::writeFile(const void* p, unsigned long _size)
         case uni16BE:
         case uni16LE: {
 			static const unsigned int bufSize = 64*1024;
-			utf16 buf[bufSize];
+			utf16* buf = new utf16[bufSize];
             
             Utf8_Iter iter8;
             iter8.set(static_cast<const ubyte*>(p), _size, m_eEncoding);
@@ -370,6 +370,7 @@ bool Utf8_16_Write::writeFile(const void* p, unsigned long _size)
 				}
 			}
 			isOK = true;
+			delete[] buf;
             break;
         }    
         default:

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -21,7 +21,7 @@
 
 #pragma warning(disable : 4996) // for GetVersion()
 
-INT_PTR CALLBACK AboutDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK AboutDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{
@@ -130,7 +130,7 @@ void AboutDlg::doDialog()
 }
 
 
-INT_PTR CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
+intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -402,7 +402,7 @@ void DoSaveOrNotBox::changeLang()
 	::SetDlgItemText(_hSelf, IDC_DOSAVEORNOTTEXT, msg.c_str());
 }
 
-INT_PTR CALLBACK DoSaveOrNotBox::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
+intptr_t CALLBACK DoSaveOrNotBox::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -508,7 +508,7 @@ void DoSaveAllBox::changeLang()
 	::SetDlgItemText(_hSelf, IDC_DOSAVEALLTEXT, msg.c_str());
 }
 
-INT_PTR CALLBACK DoSaveAllBox::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
+intptr_t CALLBACK DoSaveAllBox::run_dlgProc(UINT message, WPARAM wParam, LPARAM /*lParam*/)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
@@ -49,7 +49,7 @@ public :
     };
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private :
     URLCtrl _emailLink;
@@ -75,7 +75,7 @@ public:
 	};
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
 	typedef const CHAR * (__cdecl * PWINEGETVERSION)();
@@ -109,7 +109,7 @@ public:
 	void changeLang();
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
 	int clickedButtonId = -1;
@@ -133,7 +133,7 @@ public:
 	void changeLang();
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
 	int clickedButtonId = -1;

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.cpp
@@ -25,7 +25,7 @@ void AnsiCharPanel::switchEncoding()
 	_listView.resetValues(codepage);
 }
 
-INT_PTR CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK AnsiCharPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.h
+++ b/PowerEditor/src/WinControls/AnsiCharPanel/ansiCharPanel.h
@@ -57,7 +57,7 @@ public:
     };
 	
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
 	ScintillaEditView **_ppEditView = nullptr;

--- a/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
+++ b/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
@@ -186,7 +186,7 @@ void ClipboardHistoryPanel::drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 	::DrawText(lpDrawItemStruct->hDC, ptStr, lstrlen(ptStr), &(lpDrawItemStruct->rcItem), DT_SINGLELINE | DT_VCENTER | DT_LEFT);
 }
 
-INT_PTR CALLBACK ClipboardHistoryPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK ClipboardHistoryPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.h
+++ b/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.h
@@ -75,7 +75,7 @@ public:
 	void drawItem(LPDRAWITEMSTRUCT lpDrawItemStruct);
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
 	ScintillaEditView **_ppEditView = nullptr;

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
@@ -43,7 +43,7 @@ void ColourPopup::create(int dialogID)
 	display();
 }
 
-INT_PTR CALLBACK ColourPopup::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
+intptr_t CALLBACK ColourPopup::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) 
 {
 	switch (message) 
 	{
@@ -76,7 +76,7 @@ INT_PTR CALLBACK ColourPopup::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LP
 	}
 }
 
-INT_PTR CALLBACK ColourPopup::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK ColourPopup::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 
 	switch (message)

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPopup.h
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPopup.h
@@ -61,6 +61,6 @@ private :
 	RECT _rc = {0};
 	COLORREF _colour = RGB(0xFF, 0xFF, 0xFF);
 
-	static INT_PTR CALLBACK dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	static intptr_t CALLBACK dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -72,7 +72,7 @@ void WordStyleDlg::updateGlobalOverrideCtrls()
 	::SendDlgItemMessage(_hSelf, IDC_GLOBAL_UNDERLINE_CHECK, BM_SETCHECK, nppGUI._globalOverride.enableUnderLine, 0);
 }
 
-INT_PTR CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
 	switch (Message)
 	{

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
@@ -144,7 +144,7 @@ private :
 	bool _isThemeDirty = false;
 	bool _isShownGOCtrls = false;
 
-	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
 
 
 	Style & getCurrentStyler() {

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.cpp
@@ -1062,7 +1062,7 @@ void DockingCont::drawTabItem(DRAWITEMSTRUCT *pDrawItemStruct)
 //----------------------------------------------
 //    Process function of dialog
 //
-INT_PTR CALLBACK DockingCont::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK DockingCont::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
 	switch (Message) 
 	{

--- a/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingCont.h
@@ -144,7 +144,7 @@ protected :
 		return (((DockingCont *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->runProcTab(hwnd, Message, wParam, lParam));
 	};
 
-    virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+    virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 	// drawing functions
 	void drawCaptionItem(DRAWITEMSTRUCT *pDrawItemStruct);

--- a/PowerEditor/src/WinControls/DockingWnd/DockingDlgInterface.h
+++ b/PowerEditor/src/WinControls/DockingWnd/DockingDlgInterface.h
@@ -94,7 +94,7 @@ protected :
 	generic_string _pluginName;
 	bool _isClosed = false;
 
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		switch (message)
 		{
 			case WM_ERASEBKGND:

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -183,8 +183,8 @@ void DocumentMap::wrapMap(const ScintillaEditView *editView)
 
 		if (svp._paddingLeft || svp._paddingRight)
 		{
-			INT_PTR paddingMapLeft = static_cast<INT_PTR>(svp._paddingLeft / (editZoneWidth / docMapWidth));
-			INT_PTR paddingMapRight = static_cast<INT_PTR>(svp._paddingRight / (editZoneWidth / docMapWidth));
+			intptr_t paddingMapLeft = static_cast<intptr_t>(svp._paddingLeft / (editZoneWidth / docMapWidth));
+			intptr_t paddingMapRight = static_cast<intptr_t>(svp._paddingRight / (editZoneWidth / docMapWidth));
 			_pMapView->execute(SCI_SETMARGINLEFT, 0, paddingMapLeft);
 			_pMapView->execute(SCI_SETMARGINRIGHT, 0, paddingMapRight);
 		}
@@ -318,7 +318,7 @@ void DocumentMap::redraw(bool) const
 	DockingDlgInterface::redraw(true);
 }
 
-INT_PTR CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
     switch (message)
     {
@@ -424,9 +424,9 @@ INT_PTR CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 		{
 			int newPosY = HIWORD(lParam);
 			int currentCenterPosY = _vzDlg.getCurrentCenterPosY();
-			INT_PTR pixelPerLine = _pMapView->execute(SCI_TEXTHEIGHT, 0);
-			INT_PTR jumpDistance = newPosY - currentCenterPosY;
-			INT_PTR nbLine2jump = jumpDistance/pixelPerLine;
+			intptr_t pixelPerLine = _pMapView->execute(SCI_TEXTHEIGHT, 0);
+			intptr_t jumpDistance = newPosY - currentCenterPosY;
+			intptr_t nbLine2jump = jumpDistance/pixelPerLine;
 			(*_ppEditView)->execute(SCI_LINESCROLL, 0, nbLine2jump);
 
 			scrollMap();
@@ -495,7 +495,7 @@ void ViewZoneDlg::doDialog()
 	display();
 };
 
-INT_PTR CALLBACK ViewZoneDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK ViewZoneDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) 
 	{

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -270,7 +270,7 @@ void DocumentMap::scrollMapWith(const MapPosition & mapPos)
 		}
 		else
 		{
-			higherY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, static_cast<int32_t>(mapPos._higherPos));
+			higherY = _pMapView->execute(SCI_POINTYFROMPOSITION, 0, mapPos._higherPos);
 			auto lineHeight = _pMapView->execute(SCI_TEXTHEIGHT, mapPos._firstVisibleDocLine);
 			lowerY = mapPos._nbLine * lineHeight + higherY;
 		}

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -167,7 +167,7 @@ void DocumentMap::wrapMap(const ScintillaEditView *editView)
 
 		// update the wrap needed data
 		_displayWidth = editZoneWidth;
-		_displayZoom = static_cast<int32_t>(pEditView->execute(SCI_GETZOOM));
+		_displayZoom = pEditView->execute(SCI_GETZOOM);
 		double zr = zoomRatio[_displayZoom + 10];
 
 		// compute doc map width: dzw/ezw = 1/zoomRatio
@@ -183,8 +183,8 @@ void DocumentMap::wrapMap(const ScintillaEditView *editView)
 
 		if (svp._paddingLeft || svp._paddingRight)
 		{
-			int paddingMapLeft = static_cast<int>(svp._paddingLeft / (editZoneWidth / docMapWidth));
-			int paddingMapRight = static_cast<int>(svp._paddingRight / (editZoneWidth / docMapWidth));
+			INT_PTR paddingMapLeft = static_cast<INT_PTR>(svp._paddingLeft / (editZoneWidth / docMapWidth));
+			INT_PTR paddingMapRight = static_cast<INT_PTR>(svp._paddingRight / (editZoneWidth / docMapWidth));
 			_pMapView->execute(SCI_SETMARGINLEFT, 0, paddingMapLeft);
 			_pMapView->execute(SCI_SETMARGINRIGHT, 0, paddingMapRight);
 		}
@@ -424,9 +424,9 @@ INT_PTR CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 		{
 			int newPosY = HIWORD(lParam);
 			int currentCenterPosY = _vzDlg.getCurrentCenterPosY();
-			int pixelPerLine = static_cast<int32_t>(_pMapView->execute(SCI_TEXTHEIGHT, 0));
-			int jumpDistance = newPosY - currentCenterPosY;
-			int nbLine2jump = jumpDistance/pixelPerLine;
+			INT_PTR pixelPerLine = _pMapView->execute(SCI_TEXTHEIGHT, 0);
+			INT_PTR jumpDistance = newPosY - currentCenterPosY;
+			INT_PTR nbLine2jump = jumpDistance/pixelPerLine;
 			(*_ppEditView)->execute(SCI_LINESCROLL, 0, nbLine2jump);
 
 			scrollMap();

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.h
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.h
@@ -73,7 +73,7 @@ public :
 	static void setColour(COLORREF colour2Set, ViewZoneColorIndex i);
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 	static LRESULT CALLBACK canvasStaticProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 	LRESULT CALLBACK canvas_runProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
@@ -137,7 +137,7 @@ public:
 	void setTemporarilyShowing(bool tempShowing) { _isTemporarilyShowing = tempShowing; }
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	bool needToRecomputeWith(const ScintillaEditView *editView = nullptr);
 
 private:
@@ -148,7 +148,7 @@ private:
 	bool _isTemporarilyShowing = false;
 
 	// for needToRecomputeWith function
-	INT_PTR _displayZoom = -1;
-	INT_PTR _displayWidth = 0;
+	intptr_t _displayZoom = -1;
+	intptr_t _displayWidth = 0;
 	generic_string id4dockingCont = DM_NOFOCUSWHILECLICKINGCAPTION;
 };

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.h
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.h
@@ -148,7 +148,7 @@ private:
 	bool _isTemporarilyShowing = false;
 
 	// for needToRecomputeWith function
-	int _displayZoom = -1;
-	int _displayWidth = 0;
+	INT_PTR _displayZoom = -1;
+	INT_PTR _displayWidth = 0;
 	generic_string id4dockingCont = DM_NOFOCUSWHILECLICKINGCAPTION;
 };

--- a/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
@@ -18,7 +18,7 @@
 #include "documentSnapshot.h"
 #include "ScintillaEditView.h"
 
-INT_PTR CALLBACK DocumentPeeker::run_dlgProc(UINT message, WPARAM /*wParam*/, LPARAM /*lParam*/)
+intptr_t CALLBACK DocumentPeeker::run_dlgProc(UINT message, WPARAM /*wParam*/, LPARAM /*lParam*/)
 {
 	switch (message)
 	{
@@ -167,14 +167,14 @@ void DocumentPeeker::saveCurrentSnapshot(ScintillaEditView & editView)
 		// Width
 		RECT editorRect;
 		editView.getClientRect(editorRect);
-		INT_PTR marginWidths = 0;
+		intptr_t marginWidths = 0;
 		for (int m = 0; m < 4; ++m)
 		{
 			marginWidths += editView.execute(SCI_GETMARGINWIDTHN, m);
 		}
 		double editViewWidth = editorRect.right - editorRect.left - static_cast<LONG>(marginWidths);
 		double editViewHeight = editorRect.bottom - editorRect.top;
-		mapPos._width = static_cast<INT_PTR>((editViewWidth / editViewHeight) * static_cast<double>(mapPos._height));
+		mapPos._width = static_cast<intptr_t>((editViewWidth / editViewHeight) * static_cast<double>(mapPos._height));
 
 		mapPos._wrapIndentMode = editView.execute(SCI_GETWRAPINDENTMODE);
 		mapPos._isWrap = editView.isWrap();

--- a/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
@@ -104,12 +104,12 @@ void DocumentPeeker::scrollSnapshotWith(const MapPosition & mapPos, int textZone
 		//
 		if (mapPos._height != -1 && _rc.bottom != _rc.top + mapPos._height)
 		{
-			_rc.bottom = _rc.top + mapPos._height;
+			_rc.bottom = _rc.top + static_cast<LONG>(mapPos._height);
 			hasBeenChanged = true;
 		}
 		if (mapPos._width != -1 && _rc.right != _rc.left + mapPos._width)
 		{
-			_rc.right = _rc.left + mapPos._width;
+			_rc.right = _rc.left + static_cast<LONG>(mapPos._width);
 			hasBeenChanged = true;
 		}
 		if (hasBeenChanged)
@@ -156,31 +156,31 @@ void DocumentPeeker::saveCurrentSnapshot(ScintillaEditView & editView)
 		MapPosition mapPos = buffer->getMapPosition();
 
 		// First visible document line for scrolling to this line
-		mapPos._firstVisibleDisplayLine = static_cast<int32_t>(editView.execute(SCI_GETFIRSTVISIBLELINE));
-		mapPos._firstVisibleDocLine = static_cast<int32_t>(editView.execute(SCI_DOCLINEFROMVISIBLE, mapPos._firstVisibleDisplayLine));
-		mapPos._nbLine = static_cast<int32_t>(editView.execute(SCI_LINESONSCREEN, mapPos._firstVisibleDisplayLine));
-		mapPos._lastVisibleDocLine = static_cast<int32_t>(editView.execute(SCI_DOCLINEFROMVISIBLE, mapPos._firstVisibleDisplayLine + mapPos._nbLine));
+		mapPos._firstVisibleDisplayLine = editView.execute(SCI_GETFIRSTVISIBLELINE);
+		mapPos._firstVisibleDocLine = editView.execute(SCI_DOCLINEFROMVISIBLE, mapPos._firstVisibleDisplayLine);
+		mapPos._nbLine = editView.execute(SCI_LINESONSCREEN, mapPos._firstVisibleDisplayLine);
+		mapPos._lastVisibleDocLine = editView.execute(SCI_DOCLINEFROMVISIBLE, mapPos._firstVisibleDisplayLine + mapPos._nbLine);
 
 		auto lineHeight = _pPeekerView->execute(SCI_TEXTHEIGHT, mapPos._firstVisibleDocLine);
-		mapPos._height = static_cast<int32_t>(mapPos._nbLine * lineHeight);
+		mapPos._height = mapPos._nbLine * lineHeight;
 
 		// Width
 		RECT editorRect;
 		editView.getClientRect(editorRect);
-		int marginWidths = 0;
+		INT_PTR marginWidths = 0;
 		for (int m = 0; m < 4; ++m)
 		{
-			marginWidths += static_cast<int32_t>(editView.execute(SCI_GETMARGINWIDTHN, m));
+			marginWidths += editView.execute(SCI_GETMARGINWIDTHN, m);
 		}
-		double editViewWidth = editorRect.right - editorRect.left - marginWidths;
+		double editViewWidth = editorRect.right - editorRect.left - static_cast<LONG>(marginWidths);
 		double editViewHeight = editorRect.bottom - editorRect.top;
-		mapPos._width = static_cast<int32_t>((editViewWidth / editViewHeight) * static_cast<double>(mapPos._height));
+		mapPos._width = static_cast<INT_PTR>((editViewWidth / editViewHeight) * static_cast<double>(mapPos._height));
 
-		mapPos._wrapIndentMode = static_cast<int32_t>(editView.execute(SCI_GETWRAPINDENTMODE));
-		mapPos._isWrap = static_cast<int32_t>(editView.isWrap());
+		mapPos._wrapIndentMode = editView.execute(SCI_GETWRAPINDENTMODE);
+		mapPos._isWrap = editView.isWrap();
 		if (editView.isWrap())
 		{
-			mapPos._higherPos = static_cast<int32_t>(editView.execute(SCI_POSITIONFROMPOINT, 0, 0));
+			mapPos._higherPos = editView.execute(SCI_POSITIONFROMPOINT, 0, 0);
 		}
 
 		// Length of document

--- a/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.h
+++ b/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.h
@@ -44,7 +44,7 @@ public:
 	void saveCurrentSnapshot(ScintillaEditView & editView);
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void goTo(POINT p);
 
 private:

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -92,7 +92,7 @@ bool isRelatedRootFolder(const generic_string & relatedRoot, const generic_strin
 	return relatedRootArray[index2Compare] == subFolderArray[index2Compare];
 }
 
-INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{
@@ -126,17 +126,17 @@ INT_PTR CALLBACK FileBrowser::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 			tbButtons[0].iBitmap = 0;
 			tbButtons[0].fsState = TBSTATE_ENABLED;
 			tbButtons[0].fsStyle = BTNS_BUTTON | BTNS_AUTOSIZE;
-			tbButtons[0].iString = reinterpret_cast<INT_PTR>(TEXT(""));
+			tbButtons[0].iString = reinterpret_cast<intptr_t>(TEXT(""));
 			tbButtons[1].idCommand = FB_CMD_FOLDALL;
 			tbButtons[1].iBitmap = 1;
 			tbButtons[1].fsState = TBSTATE_ENABLED;
 			tbButtons[1].fsStyle = BTNS_BUTTON | BTNS_AUTOSIZE;
-			tbButtons[1].iString = reinterpret_cast<INT_PTR>(TEXT(""));
+			tbButtons[1].iString = reinterpret_cast<intptr_t>(TEXT(""));
 			tbButtons[2].idCommand = FB_CMD_EXPANDALL;
 			tbButtons[2].iBitmap = 2;
 			tbButtons[2].fsState = TBSTATE_ENABLED;
 			tbButtons[2].fsStyle = BTNS_BUTTON | BTNS_AUTOSIZE;
-			tbButtons[2].iString = reinterpret_cast<INT_PTR>(TEXT(""));
+			tbButtons[2].iString = reinterpret_cast<intptr_t>(TEXT(""));
 
 			// tips text for toolbar buttons
 			NativeLangSpeaker *pNativeSpeaker = nppParam.getNativeLangSpeaker();

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -207,7 +207,7 @@ protected:
 
 	void removeNamesAlreadyInNode(HTREEITEM parent, std::vector<generic_string> & labels) const;
 
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void notified(LPNMHDR notification);
 	void showContextMenu(int x, int y);
 	void openSelectFile();

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
@@ -20,7 +20,7 @@
 #include "Parameters.h"
 #include "localization.h"
 
-INT_PTR CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	switch (message) 
 	{
@@ -92,7 +92,7 @@ INT_PTR CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, L
 
 				case ID_FINDCHAR_NEXT:
 				{
-					INT_PTR currentPos = (*_ppEditView)->execute(SCI_GETCURRENTPOS);
+					intptr_t currentPos = (*_ppEditView)->execute(SCI_GETCURRENTPOS);
 					unsigned char startRange = 0;
 					unsigned char endRange = 255;
 					bool direction = dirDown;
@@ -124,7 +124,7 @@ INT_PTR CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, L
 	return FALSE;
 }
 
-bool FindCharsInRangeDlg::findCharInRange(unsigned char beginRange, unsigned char endRange, INT_PTR startPos, bool direction, bool wrap)
+bool FindCharsInRangeDlg::findCharInRange(unsigned char beginRange, unsigned char endRange, intptr_t startPos, bool direction, bool wrap)
 {
 	size_t totalSize = (*_ppEditView)->getCurrentDocLen();
 	if (startPos == -1)
@@ -138,7 +138,7 @@ bool FindCharsInRangeDlg::findCharInRange(unsigned char beginRange, unsigned cha
 	bool isFound = false;
 	size_t found = 0;
 
-	for (INT_PTR i = startPos - (direction == dirUp ? 1 : 0); 
+	for (intptr_t i = startPos - (direction == dirUp ? 1 : 0); 
 		(direction == dirDown) ? i < static_cast<long long>(totalSize) : i >= 0 ;
 		(direction == dirDown) ? (++i) : (--i))
 	{

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
@@ -92,7 +92,7 @@ INT_PTR CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, L
 
 				case ID_FINDCHAR_NEXT:
 				{
-					int currentPos = static_cast<int32_t>((*_ppEditView)->execute(SCI_GETCURRENTPOS));
+					INT_PTR currentPos = (*_ppEditView)->execute(SCI_GETCURRENTPOS);
 					unsigned char startRange = 0;
 					unsigned char endRange = 255;
 					bool direction = dirDown;

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.cpp
@@ -124,56 +124,60 @@ INT_PTR CALLBACK FindCharsInRangeDlg::run_dlgProc(UINT message, WPARAM wParam, L
 	return FALSE;
 }
 
-bool FindCharsInRangeDlg::findCharInRange(unsigned char beginRange, unsigned char endRange, int startPos, bool direction, bool wrap)
+bool FindCharsInRangeDlg::findCharInRange(unsigned char beginRange, unsigned char endRange, INT_PTR startPos, bool direction, bool wrap)
 {
-	int totalSize = (*_ppEditView)->getCurrentDocLen();
+	size_t totalSize = (*_ppEditView)->getCurrentDocLen();
 	if (startPos == -1)
-		startPos = direction==dirDown?0:totalSize-1;
-	if (startPos > totalSize)
+		startPos = direction == dirDown ? 0 : totalSize - 1;
+	if (static_cast<size_t>(startPos) > totalSize)
 		return false;
 
-	char *content = new char[totalSize+1];
+	char *content = new char[totalSize + 1];
 	(*_ppEditView)->getText(content, 0, totalSize);
-	int found = -1;
 
-	for (int i = startPos-(direction == dirUp?1:0); 
-		(direction == dirDown)?i < totalSize:i >= 0 ;
-		(direction == dirDown)?(++i):(--i))
+	bool isFound = false;
+	size_t found = 0;
+
+	for (INT_PTR i = startPos - (direction == dirUp ? 1 : 0); 
+		(direction == dirDown) ? i < static_cast<long long>(totalSize) : i >= 0 ;
+		(direction == dirDown) ? (++i) : (--i))
 	{
 		if (static_cast<unsigned char>(content[i]) >= beginRange && static_cast<unsigned char>(content[i]) <= endRange)
 		{
 			found = i;
+			isFound = true;
 			break;
 		}
 	}
 	
-	if (found == -1)
+	if (!isFound)
 	{
 		if (wrap)
 		{
-			for (int i = (direction == dirUp?totalSize-1:0); 
-				(direction == dirDown)?i < totalSize:i >= 0 ;
-				(direction == dirDown)?(++i):(--i))
+			for (size_t i = (direction == dirUp ? totalSize - 1 : 0); 
+				(direction == dirDown) ? i < totalSize : i >= 0 ;
+				(direction == dirDown) ? (++i) : (--i))
 			{
 				if (static_cast<unsigned char>(content[i]) >= beginRange && static_cast<unsigned char>(content[i]) <= endRange)
 				{
 					found = i;
+					isFound = true;
 					break;
 				}
 			}
 		}
 	}
 
-	if (found != -1)
+	if (isFound)
 	{
 		//printInt(found);
 		auto sci_line = (*_ppEditView)->execute(SCI_LINEFROMPOSITION, found);
 		(*_ppEditView)->execute(SCI_ENSUREVISIBLE, sci_line);
 		(*_ppEditView)->execute(SCI_GOTOPOS, found);
-		(*_ppEditView)->execute(SCI_SETSEL, (direction == dirDown)?found:found+1, (direction == dirDown)?found+1:found);
+		(*_ppEditView)->execute(SCI_SETSEL, (direction == dirDown)? found : found+1, (direction == dirDown) ? found + 1 : found);
 	}
 	delete [] content;
-	return (found != -1);
+	return isFound;
 }
 
 void FindCharsInRangeDlg::getDirectionFromUI(bool & whichDirection, bool & isWrap)

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
@@ -47,11 +47,11 @@ public :
     };
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private :
     ScintillaEditView **_ppEditView = nullptr;
-	bool findCharInRange(unsigned char beginRange, unsigned char endRange, INT_PTR startPos, bool direction, bool wrap);
+	bool findCharInRange(unsigned char beginRange, unsigned char endRange, intptr_t startPos, bool direction, bool wrap);
 	bool getRangeFromUI(unsigned char & startRange, unsigned char & endRange);
 	void getDirectionFromUI(bool & whichDirection, bool & isWrap);
 };

--- a/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
+++ b/PowerEditor/src/WinControls/FindCharsInRange/FindCharsInRange.h
@@ -51,7 +51,7 @@ protected :
 
 private :
     ScintillaEditView **_ppEditView = nullptr;
-	bool findCharInRange(unsigned char beginRange, unsigned char endRange, int startPos, bool direction, bool wrap);
+	bool findCharInRange(unsigned char beginRange, unsigned char endRange, INT_PTR startPos, bool direction, bool wrap);
 	bool getRangeFromUI(unsigned char & startRange, unsigned char & endRange);
 	void getDirectionFromUI(bool & whichDirection, bool & isWrap);
 };

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -92,8 +92,8 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 	int flags = SCFIND_REGEXP | SCFIND_POSIX;
 
 	(*_ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	INT_PTR targetStart = (*_ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
-	INT_PTR targetEnd = 0;
+	intptr_t targetStart = (*_ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
+	intptr_t targetEnd = 0;
 
 	do
 	{
@@ -102,7 +102,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 			targetEnd = (*_ppEditView)->execute(SCI_GETTARGETEND);
 
 			// Now we determinate the symbol (open or close)
-			INT_PTR tmpStart = (*_ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
+			intptr_t tmpStart = (*_ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
 			if (tmpStart >= 0) // open symbol found
 			{
 				++cntOpen;
@@ -125,7 +125,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 	return targetEnd;
 }
 
-generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR& foundPos)
+generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, intptr_t& foundPos)
 {
 	if (begin >= end)
 	{
@@ -140,14 +140,14 @@ generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::v
 
 	(*_ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
 	const TCHAR *regExpr2search = dataToSearch[0].c_str();
-	INT_PTR targetStart = (*_ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
+	intptr_t targetStart = (*_ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
 
 	if (targetStart < 0)
 	{
 		foundPos = -1;
 		return TEXT("");
 	}
-	INT_PTR targetEnd = (*_ppEditView)->execute(SCI_GETTARGETEND);
+	intptr_t targetEnd = (*_ppEditView)->execute(SCI_GETTARGETEND);
 
 	if (dataToSearch.size() >= 2)
 	{
@@ -727,7 +727,7 @@ void FunctionListPanel::setSort(bool isEnabled)
 	::SendMessage(_hToolbarMenu, TB_SETBUTTONINFO, IDC_SORTBUTTON_FUNCLIST, reinterpret_cast<LPARAM>(&tbbuttonInfo));
 }
 
-INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{
@@ -832,13 +832,13 @@ INT_PTR CALLBACK FunctionListPanel::run_dlgProc(UINT message, WPARAM wParam, LPA
 			tbButtons[1].iBitmap = 0;
 			tbButtons[1].fsState = TBSTATE_ENABLED;
 			tbButtons[1].fsStyle = BTNS_CHECK | BTNS_AUTOSIZE;
-			tbButtons[1].iString = reinterpret_cast<INT_PTR>(TEXT(""));
+			tbButtons[1].iString = reinterpret_cast<intptr_t>(TEXT(""));
 
 			tbButtons[2].idCommand = IDC_RELOADBUTTON_FUNCLIST;
 			tbButtons[2].iBitmap = 1;
 			tbButtons[2].fsState = TBSTATE_ENABLED;
 			tbButtons[2].fsStyle = BTNS_BUTTON | BTNS_AUTOSIZE;
-			tbButtons[2].iString = reinterpret_cast<INT_PTR>(TEXT(""));
+			tbButtons[2].iString = reinterpret_cast<intptr_t>(TEXT(""));
 
 			::SendMessage(_hToolbarMenu, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 			::SendMessage(_hToolbarMenu, TB_SETBUTTONSIZE, 0, MAKELONG(nppParams._dpiManager.scaleX(16), nppParams._dpiManager.scaleY(16)));

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -77,7 +77,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 {
 	size_t cntOpen = 1;
 
-	int docLen = (*_ppEditView)->getCurrentDocLen();
+	size_t docLen = (*_ppEditView)->getCurrentDocLen();
 
 	if (begin >= (size_t)docLen)
 		return docLen;
@@ -92,17 +92,17 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 	int flags = SCFIND_REGEXP | SCFIND_POSIX;
 
 	(*_ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	int targetStart = (*_ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
-	int targetEnd = 0;
+	INT_PTR targetStart = (*_ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
+	INT_PTR targetEnd = 0;
 
 	do
 	{
 		if (targetStart >= 0) // found open or close symbol
 		{
-			targetEnd = int((*_ppEditView)->execute(SCI_GETTARGETEND));
+			targetEnd = (*_ppEditView)->execute(SCI_GETTARGETEND);
 
 			// Now we determinate the symbol (open or close)
-			int tmpStart = (*_ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
+			INT_PTR tmpStart = (*_ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
 			if (tmpStart >= 0) // open symbol found
 			{
 				++cntOpen;
@@ -125,7 +125,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 	return targetEnd;
 }
 
-generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, int & foundPos)
+generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR& foundPos)
 {
 	if (begin >= end)
 	{
@@ -140,14 +140,14 @@ generic_string FunctionListPanel::parseSubLevel(size_t begin, size_t end, std::v
 
 	(*_ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
 	const TCHAR *regExpr2search = dataToSearch[0].c_str();
-	int targetStart = (*_ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
+	INT_PTR targetStart = (*_ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
 
 	if (targetStart < 0)
 	{
 		foundPos = -1;
 		return TEXT("");
 	}
-	int targetEnd = int((*_ppEditView)->execute(SCI_GETTARGETEND));
+	INT_PTR targetEnd = (*_ppEditView)->execute(SCI_GETTARGETEND);
 
 	if (dataToSearch.size() >= 2)
 	{

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -79,7 +79,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 
 	size_t docLen = (*_ppEditView)->getCurrentDocLen();
 
-	if (begin >= (size_t)docLen)
+	if (begin >= docLen)
 		return docLen;
 
 	generic_string exprToSearch = TEXT("(");

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -32,7 +32,7 @@ using namespace std;
 
 FunctionListPanel::~FunctionListPanel()
 {
-	for (const auto s : posStrs)
+	for (const auto s : _posStrs)
 	{
 		delete s;
 	}
@@ -41,8 +41,8 @@ FunctionListPanel::~FunctionListPanel()
 void FunctionListPanel::addEntry(const TCHAR *nodeName, const TCHAR *displayText, size_t pos)
 {
 	HTREEITEM itemParent = NULL;
-	TCHAR posStr[32];
-	generic_itoa(static_cast<int32_t>(pos), posStr, 10);
+	std::wstring posStr = std::to_wstring(pos);
+
 	HTREEITEM root = _treeView.getRoot();
 
 	if (nodeName != NULL && *nodeName != '\0')
@@ -51,7 +51,7 @@ void FunctionListPanel::addEntry(const TCHAR *nodeName, const TCHAR *displayText
 		if (!itemParent)
 		{
 			generic_string* invalidValueStr = new generic_string(posStr);
-			posStrs.push_back(invalidValueStr);
+			_posStrs.push_back(invalidValueStr);
 			LPARAM lParamInvalidPosStr = reinterpret_cast<LPARAM>(invalidValueStr);
 
 			itemParent = _treeView.addItem(nodeName, root, INDEX_NODE, lParamInvalidPosStr);
@@ -61,7 +61,7 @@ void FunctionListPanel::addEntry(const TCHAR *nodeName, const TCHAR *displayText
 		itemParent = root;
 
 	generic_string* posString = new generic_string(posStr);
-	posStrs.push_back(posString);
+	_posStrs.push_back(posString);
 	LPARAM lParamPosStr = reinterpret_cast<LPARAM>(posString);
 
 	_treeView.addItem(displayText, itemParent, INDEX_LEAF, lParamPosStr);
@@ -115,7 +115,7 @@ size_t FunctionListPanel::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSym
 		else // nothing found
 		{
 			cntOpen = 0; // get me out of here
-			targetEnd = static_cast<int32_t>(begin);
+			targetEnd = begin;
 		}
 
 		targetStart = (*_ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), targetEnd, docLen);
@@ -223,7 +223,7 @@ void FunctionListPanel::sortOrUnsort()
 			const TCHAR *fn = ((*_ppEditView)->getCurrentBuffer())->getFileName();
 
 			generic_string* invalidValueStr = new generic_string(TEXT("-1"));
-			posStrs.push_back(invalidValueStr);
+			_posStrs.push_back(invalidValueStr);
 			LPARAM lParamInvalidPosStr = reinterpret_cast<LPARAM>(invalidValueStr);
 			_treeViewSearchResult.addItem(fn, NULL, INDEX_ROOT, lParamInvalidPosStr);
 
@@ -367,7 +367,7 @@ void FunctionListPanel::reload()
 	if (parsedOK)
 	{
 		generic_string* invalidValueStr = new generic_string(TEXT("-1"));
-		posStrs.push_back(invalidValueStr);
+		_posStrs.push_back(invalidValueStr);
 		LPARAM lParamInvalidPosStr = reinterpret_cast<LPARAM>(invalidValueStr);
 
 		_treeView.addItem(fn, NULL, INDEX_ROOT, lParamInvalidPosStr);
@@ -386,7 +386,7 @@ void FunctionListPanel::reload()
 		const TCHAR *fullFilePath = currentBuf->getFullPathName();
 
 		generic_string* fullPathStr = new generic_string(fullFilePath);
-		posStrs.push_back(fullPathStr);
+		_posStrs.push_back(fullPathStr);
 		LPARAM lParamFullPathStr = reinterpret_cast<LPARAM>(fullPathStr);
 
 		_treeView.setItemParam(root, lParamFullPathStr);
@@ -654,7 +654,7 @@ void FunctionListPanel::searchFuncAndSwitchView()
 		const TCHAR *fn = ((*_ppEditView)->getCurrentBuffer())->getFileName();
 
 		generic_string* invalidValueStr = new generic_string(TEXT("-1"));
-		posStrs.push_back(invalidValueStr);
+		_posStrs.push_back(invalidValueStr);
 		LPARAM lParamInvalidPosStr = reinterpret_cast<LPARAM>(invalidValueStr);
 		_treeViewSearchResult.addItem(fn, NULL, INDEX_ROOT, lParamInvalidPosStr);
 

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -97,7 +97,7 @@ public:
 	void searchFuncAndSwitchView();
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
 	HWND _hToolbarMenu = nullptr;
@@ -125,7 +125,7 @@ private:
 	std::vector<TreeParams> _treeParams;
 	HIMAGELIST _hTreeViewImaLst = nullptr;
 
-	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR& foundPos);
+	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, intptr_t& foundPos);
 	size_t getBodyClosePos(size_t begin, const TCHAR *bodyOpenSymbol, const TCHAR *bodyCloseSymbol);
 	void notified(LPNMHDR notification);
 	void addInStateArray(TreeStateNode tree2Update, const TCHAR *searchText, bool isSorted);

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -125,7 +125,7 @@ private:
 	std::vector<TreeParams> _treeParams;
 	HIMAGELIST _hTreeViewImaLst = nullptr;
 
-	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, int & foundPos);
+	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR& foundPos);
 	size_t getBodyClosePos(size_t begin, const TCHAR *bodyOpenSymbol, const TCHAR *bodyCloseSymbol);
 	void notified(LPNMHDR notification);
 	void addInStateArray(TreeStateNode tree2Update, const TCHAR *searchText, bool isSorted);

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -117,7 +117,7 @@ private:
 
 	std::vector<foundInfo> _foundFuncInfos;
 
-	std::vector<generic_string*> posStrs;
+	std::vector<generic_string*> _posStrs;
 
 	ScintillaEditView **_ppEditView = nullptr;
 	FunctionParsersManager _funcParserMgr;

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -476,7 +476,7 @@ generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vect
 		foundPos = -1;
 		return generic_string();
 	}
-	int targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
+	INT_PTR targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
 
 	if (dataToSearch.size() >= 2)
 	{

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -661,7 +661,7 @@ void FunctionParser::getInvertZones(vector< pair<size_t, size_t> > &  destZones,
 	else
 	{
 		// check the begin
-		if (int(begin) < sourceZones[0].first)
+		if (begin < sourceZones[0].first)
 		{
 			destZones.push_back(pair<size_t, size_t>(begin, sourceZones[0].first - 1));
 		}

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -418,7 +418,7 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 		}
 		else
 		{
-			INT_PTR foundPos;
+			intptr_t foundPos;
 			if (_functionNameExprArray.size())
 			{
 				fi._data = parseSubLevel(targetStart, targetEnd, _functionNameExprArray, foundPos, ppEditView);
@@ -454,7 +454,7 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 }
 
 
-generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR & foundPos, ScintillaEditView **ppEditView)
+generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, intptr_t & foundPos, ScintillaEditView **ppEditView)
 {
 	if (begin >= end)
 	{
@@ -469,14 +469,14 @@ generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vect
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
 	const TCHAR *regExpr2search = dataToSearch[0].c_str();
-	INT_PTR targetStart = (*ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
+	intptr_t targetStart = (*ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
 
 	if (targetStart < 0)
 	{
 		foundPos = -1;
 		return generic_string();
 	}
-	INT_PTR targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
+	intptr_t targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
 
 	if (dataToSearch.size() >= 2)
 	{
@@ -527,7 +527,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	INT_PTR targetStart = (*ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
+	intptr_t targetStart = (*ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
 	LRESULT targetEnd = 0;
 
 	do
@@ -540,7 +540,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 			if (!isInZones(targetStart, commentZones))
 			{
 				// Now we determinate the symbol (open or close)
-				INT_PTR tmpStart = (*ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
+				intptr_t tmpStart = (*ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
 				if (tmpStart >= 0) // open symbol found 
 				{
 					++cntOpen;
@@ -572,16 +572,16 @@ void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	INT_PTR targetStart = (*ppEditView)->searchInTarget(_rangeExpr.c_str(), _rangeExpr.length(), begin, end);
+	intptr_t targetStart = (*ppEditView)->searchInTarget(_rangeExpr.c_str(), _rangeExpr.length(), begin, end);
 
-	INT_PTR targetEnd = 0;
+	intptr_t targetEnd = 0;
 	
 	while (targetStart >= 0)
 	{
 		targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
 
 		// Get class name
-		INT_PTR foundPos = 0;
+		intptr_t foundPos = 0;
 		generic_string classStructName = parseSubLevel(targetStart, targetEnd, _classNameExprArray, foundPos, ppEditView);
 		
 
@@ -590,7 +590,7 @@ void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair
 			targetEnd = getBodyClosePos(targetEnd, _openSymbole.c_str(), _closeSymbole.c_str(), commentZones, ppEditView);
 		}
 
-		if (targetEnd > static_cast<INT_PTR>(end)) //we found a result but outside our range, therefore do not process it
+		if (targetEnd > static_cast<intptr_t>(end)) //we found a result but outside our range, therefore do not process it
 			break;
 		
 		scannedZones.push_back(pair<size_t, size_t>(targetStart, targetEnd));
@@ -619,20 +619,20 @@ void FunctionParser::getCommentZones(vector< pair<size_t, size_t> > & commentZon
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	INT_PTR targetStart = (*ppEditView)->searchInTarget(_commentExpr.c_str(), _commentExpr.length(), begin, end);
-	INT_PTR targetEnd = 0;
+	intptr_t targetStart = (*ppEditView)->searchInTarget(_commentExpr.c_str(), _commentExpr.length(), begin, end);
+	intptr_t targetEnd = 0;
 	
 	while (targetStart >= 0)
 	{
 		targetStart = (*ppEditView)->execute(SCI_GETTARGETSTART);
 		targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
-		if (targetEnd > static_cast<INT_PTR>(end)) //we found a result but outside our range, therefore do not process it
+		if (targetEnd > static_cast<intptr_t>(end)) //we found a result but outside our range, therefore do not process it
 			break;
 
 		commentZone.push_back(pair<size_t, size_t>(targetStart, targetEnd));
 
-		INT_PTR foundTextLen = targetEnd - targetStart;
-		if (targetStart + foundTextLen == static_cast<INT_PTR>(end))
+		intptr_t foundTextLen = targetEnd - targetStart;
+		if (targetStart + foundTextLen == static_cast<intptr_t>(end))
             break;
 		
 		begin = targetStart + foundTextLen;

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -377,7 +377,7 @@ FunctionParser * FunctionParsersManager::getParser(const AssociationInfo & assoI
 }
 
 
-void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName, const std::vector< std::pair<int, int> > * commentZones)
+void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName, const std::vector< std::pair<size_t, size_t> > * commentZones)
 {
 	if (begin >= end)
 		return;
@@ -388,20 +388,20 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	int targetStart = (*ppEditView)->searchInTarget(_functionExpr.c_str(), _functionExpr.length(), begin, end);
-	int targetEnd = 0;
+	size_t targetStart = (*ppEditView)->searchInTarget(_functionExpr.c_str(), _functionExpr.length(), begin, end);
+	size_t targetEnd = 0;
 	
 	//foundInfos.clear();
 	while (targetStart >= 0)
 	{
-		targetStart = int((*ppEditView)->execute(SCI_GETTARGETSTART));
-		targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
-		if (targetEnd > int(end)) //we found a result but outside our range, therefore do not process it
+		targetStart = (*ppEditView)->execute(SCI_GETTARGETSTART);
+		targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
+		if (targetEnd > end) //we found a result but outside our range, therefore do not process it
 		{
 			break;
 		}
-		int foundTextLen = targetEnd - targetStart;
-		if (targetStart + foundTextLen == int(end))
+		size_t foundTextLen = targetEnd - targetStart;
+		if (targetStart + foundTextLen == end)
             break;
 
 		foundInfo fi;
@@ -418,7 +418,7 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 		}
 		else
 		{
-			int foundPos;
+			INT_PTR foundPos;
 			if (_functionNameExprArray.size())
 			{
 				fi._data = parseSubLevel(targetStart, targetEnd, _functionNameExprArray, foundPos, ppEditView);
@@ -454,7 +454,7 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 }
 
 
-generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, int & foundPos, ScintillaEditView **ppEditView)
+generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR & foundPos, ScintillaEditView **ppEditView)
 {
 	if (begin >= end)
 	{
@@ -469,7 +469,7 @@ generic_string FunctionParser::parseSubLevel(size_t begin, size_t end, std::vect
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
 	const TCHAR *regExpr2search = dataToSearch[0].c_str();
-	int targetStart = (*ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
+	INT_PTR targetStart = (*ppEditView)->searchInTarget(regExpr2search, lstrlen(regExpr2search), begin, end);
 
 	if (targetStart < 0)
 	{
@@ -501,20 +501,20 @@ bool FunctionParsersManager::parse(std::vector<foundInfo> & foundInfos, const As
 		return false;
 
 	// parse
-	int docLen = (*_ppEditView)->getCurrentDocLen();
+	size_t docLen = (*_ppEditView)->getCurrentDocLen();
 	fp->parse(foundInfos, 0, docLen, _ppEditView);
 
 	return true;
 }
 
 
-size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSymbol, const TCHAR *bodyCloseSymbol, const std::vector< std::pair<int, int> > & commentZones, ScintillaEditView **ppEditView)
+size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSymbol, const TCHAR *bodyCloseSymbol, const std::vector< std::pair<size_t, size_t> > & commentZones, ScintillaEditView **ppEditView)
 {
 	size_t cntOpen = 1;
 
-	int docLen = (*ppEditView)->getCurrentDocLen();
+	size_t docLen = (*ppEditView)->getCurrentDocLen();
 
-	if (begin >= (size_t)docLen)
+	if (begin >= docLen)
 		return docLen;
 
 	generic_string exprToSearch = TEXT("(");
@@ -527,7 +527,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	int targetStart = (*ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
+	INT_PTR targetStart = (*ppEditView)->searchInTarget(exprToSearch.c_str(), exprToSearch.length(), begin, docLen);
 	LRESULT targetEnd = 0;
 
 	do
@@ -540,7 +540,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 			if (!isInZones(targetStart, commentZones))
 			{
 				// Now we determinate the symbol (open or close)
-				int tmpStart = (*ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
+				INT_PTR tmpStart = (*ppEditView)->searchInTarget(bodyOpenSymbol, lstrlen(bodyOpenSymbol), targetStart, targetEnd);
 				if (tmpStart >= 0) // open symbol found 
 				{
 					++cntOpen;
@@ -564,7 +564,7 @@ size_t FunctionZoneParser::getBodyClosePos(size_t begin, const TCHAR *bodyOpenSy
 	return targetEnd;
 }
 
-void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair<int, int> > &scannedZones, const std::vector< std::pair<int, int> > & commentZones, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
+void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair<size_t, size_t> > &scannedZones, const std::vector< std::pair<size_t, size_t> > & commentZones, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
 {
 	if (begin >= end)
 		return;
@@ -572,31 +572,31 @@ void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	int targetStart = (*ppEditView)->searchInTarget(_rangeExpr.c_str(), _rangeExpr.length(), begin, end);
+	INT_PTR targetStart = (*ppEditView)->searchInTarget(_rangeExpr.c_str(), _rangeExpr.length(), begin, end);
 
-	int targetEnd = 0;
+	INT_PTR targetEnd = 0;
 	
 	while (targetStart >= 0)
 	{
-		targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
+		targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
 
 		// Get class name
-		int foundPos = 0;
+		INT_PTR foundPos = 0;
 		generic_string classStructName = parseSubLevel(targetStart, targetEnd, _classNameExprArray, foundPos, ppEditView);
 		
 
 		if (!_openSymbole.empty() && !_closeSymbole.empty())
 		{
-			targetEnd = static_cast<int32_t>(getBodyClosePos(targetEnd, _openSymbole.c_str(), _closeSymbole.c_str(), commentZones, ppEditView));
+			targetEnd = getBodyClosePos(targetEnd, _openSymbole.c_str(), _closeSymbole.c_str(), commentZones, ppEditView);
 		}
 
-		if (targetEnd > int(end)) //we found a result but outside our range, therefore do not process it
+		if (targetEnd > static_cast<INT_PTR>(end)) //we found a result but outside our range, therefore do not process it
 			break;
 		
-		scannedZones.push_back(pair<int, int>(targetStart, targetEnd));
+		scannedZones.push_back(pair<size_t, size_t>(targetStart, targetEnd));
 
-		int foundTextLen = targetEnd - targetStart;
-		if (targetStart + foundTextLen == int(end))
+		size_t foundTextLen = targetEnd - targetStart;
+		if (targetStart + foundTextLen == end)
             break;
 
 		// Begin to search all method inside
@@ -611,7 +611,7 @@ void FunctionZoneParser::classParse(vector<foundInfo> & foundInfos, vector< pair
 }
 
 
-void FunctionParser::getCommentZones(vector< pair<int, int> > & commentZone, size_t begin, size_t end, ScintillaEditView **ppEditView)
+void FunctionParser::getCommentZones(vector< pair<size_t, size_t> > & commentZone, size_t begin, size_t end, ScintillaEditView **ppEditView)
 {
 	if ((begin >= end) || (_commentExpr.empty()))
 		return;
@@ -619,20 +619,20 @@ void FunctionParser::getCommentZones(vector< pair<int, int> > & commentZone, siz
 	int flags = SCFIND_REGEXP | SCFIND_POSIX | SCFIND_REGEXP_DOTMATCHESNL;
 
 	(*ppEditView)->execute(SCI_SETSEARCHFLAGS, flags);
-	int targetStart = (*ppEditView)->searchInTarget(_commentExpr.c_str(), _commentExpr.length(), begin, end);
-	int targetEnd = 0;
+	INT_PTR targetStart = (*ppEditView)->searchInTarget(_commentExpr.c_str(), _commentExpr.length(), begin, end);
+	INT_PTR targetEnd = 0;
 	
 	while (targetStart >= 0)
 	{
-		targetStart = int((*ppEditView)->execute(SCI_GETTARGETSTART));
-		targetEnd = int((*ppEditView)->execute(SCI_GETTARGETEND));
-		if (targetEnd > int(end)) //we found a result but outside our range, therefore do not process it
+		targetStart = (*ppEditView)->execute(SCI_GETTARGETSTART);
+		targetEnd = (*ppEditView)->execute(SCI_GETTARGETEND);
+		if (targetEnd > static_cast<INT_PTR>(end)) //we found a result but outside our range, therefore do not process it
 			break;
 
-		commentZone.push_back(pair<int, int>(targetStart, targetEnd));
+		commentZone.push_back(pair<size_t, size_t>(targetStart, targetEnd));
 
-		int foundTextLen = targetEnd - targetStart;
-		if (targetStart + foundTextLen == int(end))
+		INT_PTR foundTextLen = targetEnd - targetStart;
+		if (targetStart + foundTextLen == static_cast<INT_PTR>(end))
             break;
 		
 		begin = targetStart + foundTextLen;
@@ -641,7 +641,7 @@ void FunctionParser::getCommentZones(vector< pair<int, int> > & commentZone, siz
 }
 
 
-bool FunctionParser::isInZones(int pos2Test, const std::vector< std::pair<int, int> > & zones)
+bool FunctionParser::isInZones(size_t pos2Test, const std::vector< std::pair<size_t, size_t>> & zones)
 {
 	for (size_t i = 0, len = zones.size(); i < len; ++i)
 	{
@@ -652,38 +652,38 @@ bool FunctionParser::isInZones(int pos2Test, const std::vector< std::pair<int, i
 }
 
 
-void FunctionParser::getInvertZones(vector< pair<int, int> > &  destZones, vector< pair<int, int> > &  sourceZones, size_t begin, size_t end)
+void FunctionParser::getInvertZones(vector< pair<size_t, size_t> > &  destZones, vector< pair<size_t, size_t> > &  sourceZones, size_t begin, size_t end)
 {
 	if (sourceZones.size() == 0)
 	{
-		destZones.push_back(pair<int, int>(static_cast<int>(begin), static_cast<int>(end)));
+		destZones.push_back(pair<size_t, size_t>(begin, end));
 	}
 	else
 	{
 		// check the begin
 		if (int(begin) < sourceZones[0].first)
 		{
-			destZones.push_back(pair<int, int>(static_cast<int>(begin), sourceZones[0].first - 1));
+			destZones.push_back(pair<size_t, size_t>(begin, sourceZones[0].first - 1));
 		}
 
 		size_t i = 0;
 		for (size_t len = sourceZones.size() - 1; i < len; ++i)
 		{
-			int newBegin = sourceZones[i].second + 1;
-			int newEnd = sourceZones[i+1].first - 1;
+			size_t newBegin = sourceZones[i].second + 1;
+			size_t newEnd = sourceZones[i+1].first - 1;
 			if (newBegin < newEnd)
-				destZones.push_back(pair<int, int>(newBegin, newEnd));
+				destZones.push_back(pair<size_t, size_t>(newBegin, newEnd));
 		}
-		int lastBegin = sourceZones[i].second + 1;
-		if (lastBegin < int(end))
-			destZones.push_back(pair<int, int>(lastBegin, static_cast<int>(end)));
+		size_t lastBegin = sourceZones[i].second + 1;
+		if (lastBegin < end)
+			destZones.push_back(pair<size_t, size_t>(lastBegin, end));
 	}
 }
 
 
 void FunctionZoneParser::parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
 {
-	vector< pair<int, int> > classZones, commentZones, nonCommentZones;
+	vector< pair<size_t, size_t> > classZones, commentZones, nonCommentZones;
 	getCommentZones(commentZones, begin, end, ppEditView);
 	getInvertZones(nonCommentZones, commentZones, begin, end);
 	for (size_t i = 0, len = nonCommentZones.size(); i < len; ++i)
@@ -694,7 +694,7 @@ void FunctionZoneParser::parse(std::vector<foundInfo> & foundInfos, size_t begin
 
 void FunctionUnitParser::parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
 {
-	vector< pair<int, int> > commentZones, nonCommentZones;
+	vector< pair<size_t, size_t> > commentZones, nonCommentZones;
 	getCommentZones(commentZones, begin, end, ppEditView);
 	getInvertZones(nonCommentZones, commentZones, begin, end);
 	for (size_t i = 0, len = nonCommentZones.size(); i < len; ++i)
@@ -716,7 +716,7 @@ struct SortZones final
 
 void FunctionMixParser::parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName)
 {
-	vector< pair<int, int> > commentZones, scannedZones, nonScannedZones;
+	vector< pair<size_t, size_t> > commentZones, scannedZones, nonScannedZones;
 	getCommentZones(commentZones, begin, end, ppEditView);
 
 	classParse(foundInfos, scannedZones, commentZones, begin, end, ppEditView, classStructName);
@@ -724,7 +724,7 @@ void FunctionMixParser::parse(std::vector<foundInfo> & foundInfos, size_t begin,
 	// the second level
 	for (size_t i = 0, len = scannedZones.size(); i < len; ++i)
 	{
-		vector< pair<int, int> > temp;
+		vector< pair<size_t, size_t> > temp;
 		classParse(foundInfos, temp, commentZones, scannedZones[i].first, scannedZones[i].second, ppEditView, classStructName);
 	}
 	// invert scannedZones

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.h
@@ -24,8 +24,8 @@ struct foundInfo final
 {
 	generic_string _data;
 	generic_string _data2;
-	INT_PTR _pos = -1;
-	INT_PTR _pos2 = -1;
+	intptr_t _pos = -1;
+	intptr_t _pos2 = -1;
 };
 
 class FunctionParser
@@ -49,7 +49,7 @@ protected:
 	std::vector<generic_string> _classNameExprArray;
 	void getCommentZones(std::vector< std::pair<size_t, size_t> > & commentZone, size_t begin, size_t end, ScintillaEditView **ppEditView);
 	void getInvertZones(std::vector< std::pair<size_t, size_t> > & destZones, std::vector< std::pair<size_t, size_t> > & sourceZones, size_t begin, size_t end);
-	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR & foundPos, ScintillaEditView **ppEditView);
+	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, intptr_t & foundPos, ScintillaEditView **ppEditView);
 };
 
 

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.h
@@ -24,8 +24,8 @@ struct foundInfo final
 {
 	generic_string _data;
 	generic_string _data2;
-	int _pos = -1;
-	int _pos2 = -1;
+	INT_PTR _pos = -1;
+	INT_PTR _pos2 = -1;
 };
 
 class FunctionParser
@@ -36,8 +36,8 @@ public:
 	  _id(id), _displayName(displayName), _commentExpr(commentExpr?commentExpr:TEXT("")), _functionExpr(functionExpr), _functionNameExprArray(functionNameExprArray), _classNameExprArray(classNameExprArray){};
 
 	virtual void parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT("")) = 0;
-	void funcParse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT(""), const std::vector< std::pair<int, int> > * commentZones = NULL);
-	bool isInZones(int pos2Test, const std::vector< std::pair<int, int> > & zones);
+	void funcParse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT(""), const std::vector< std::pair<size_t, size_t> > * commentZones = NULL);
+	bool isInZones(size_t pos2Test, const std::vector< std::pair<size_t, size_t> > & zones);
 	virtual ~FunctionParser() = default;
 
 protected:
@@ -47,9 +47,9 @@ protected:
 	generic_string _functionExpr;
 	std::vector<generic_string> _functionNameExprArray;
 	std::vector<generic_string> _classNameExprArray;
-	void getCommentZones(std::vector< std::pair<int, int> > & commentZone, size_t begin, size_t end, ScintillaEditView **ppEditView);
-	void getInvertZones(std::vector< std::pair<int, int> > & destZones, std::vector< std::pair<int, int> > & sourceZones, size_t begin, size_t end);
-	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, int & foundPos, ScintillaEditView **ppEditView);
+	void getCommentZones(std::vector< std::pair<size_t, size_t> > & commentZone, size_t begin, size_t end, ScintillaEditView **ppEditView);
+	void getInvertZones(std::vector< std::pair<size_t, size_t> > & destZones, std::vector< std::pair<size_t, size_t> > & sourceZones, size_t begin, size_t end);
+	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, INT_PTR & foundPos, ScintillaEditView **ppEditView);
 };
 
 
@@ -64,14 +64,14 @@ public:
 	void parse(std::vector<foundInfo> & foundInfos, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT(""));
 	
 protected:
-	void classParse(std::vector<foundInfo> & foundInfos, std::vector< std::pair<int, int> > & scannedZones, const std::vector< std::pair<int, int> > & commentZones, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT(""));
+	void classParse(std::vector<foundInfo> & foundInfos, std::vector< std::pair<size_t, size_t> > & scannedZones, const std::vector< std::pair<size_t, size_t> > & commentZones, size_t begin, size_t end, ScintillaEditView **ppEditView, generic_string classStructName = TEXT(""));
 
 private:
 	generic_string _rangeExpr;
 	generic_string _openSymbole;
 	generic_string _closeSymbole;
 
-	size_t getBodyClosePos(size_t begin, const TCHAR *bodyOpenSymbol, const TCHAR *bodyCloseSymbol, const std::vector< std::pair<int, int> > & commentZones, ScintillaEditView **ppEditView);
+	size_t getBodyClosePos(size_t begin, const TCHAR *bodyOpenSymbol, const TCHAR *bodyCloseSymbol, const std::vector< std::pair<size_t, size_t> > & commentZones, ScintillaEditView **ppEditView);
 };
 
 

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -410,7 +410,7 @@ void ShortcutMapper::fillOutBabyGrid()
 	_babygrid.setInitialContent(false);
 }
 
-INT_PTR CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) 
 	{

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
@@ -59,7 +59,7 @@ public:
 	bool isFilterValid(PluginCmdShortcut sc);
 
 protected :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private:
 	BabyGridWrapper _babygrid;

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -1111,7 +1111,7 @@ void PluginsAdminDlg::switchDialog(int indexToSwitch)
 	::EnableWindow(hRemoveButton, showInstalled);
 }
 
-INT_PTR CALLBACK PluginsAdminDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK PluginsAdminDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -199,7 +199,7 @@ public :
 	generic_string getPluginListVerStr() const;
 
 protected:
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private :
 	generic_string _updaterDir;

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -91,7 +91,7 @@ static int encodings[] = {
 	20866
 };
 
-INT_PTR CALLBACK PreferenceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK PreferenceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) 
 	{
@@ -422,7 +422,7 @@ void GeneralSubDlg::disableTabbarAlternateIcons()
 }
 
 
-INT_PTR CALLBACK GeneralSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK GeneralSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	
@@ -723,7 +723,7 @@ static LRESULT CALLBACK editNumSpaceProc(HWND hwnd, UINT message, WPARAM wParam,
 }
 
 
-INT_PTR CALLBACK EditingSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK EditingSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParam.getNppGUI();
@@ -921,7 +921,7 @@ void DarkModeSubDlg::move2CtrlLeft(int ctrlID, HWND handle2Move, int handle2Move
 	::MoveWindow(handle2Move, p.x, p.y, handle2MoveWidth, handle2MoveHeight, TRUE);
 }
 
-INT_PTR CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	UNREFERENCED_PARAMETER(lParam);
 
@@ -1365,7 +1365,7 @@ void MarginsBorderEdgeSubDlg::initScintParam()
 	oldFunclstToolbarProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(::GetDlgItem(_hSelf, IDC_COLUMNPOS_EDIT), GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(editNumSpaceProc)));
 }
 
-INT_PTR CALLBACK MarginsBorderEdgeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK MarginsBorderEdgeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	switch (message) 
@@ -1558,7 +1558,7 @@ INT_PTR CALLBACK MarginsBorderEdgeSubDlg::run_dlgProc(UINT message, WPARAM wPara
 const size_t fileUpdateChoiceEnable = 0;
 const size_t fileUpdateChoiceEnable4All = 1;
 const size_t fileUpdateChoiceDisable = 2;
-INT_PTR CALLBACK MiscSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK MiscSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParam.getNppGUI();
@@ -1833,7 +1833,7 @@ void RecentFilesHistorySubDlg::setCustomLen(int val)
 	::ShowWindow(::GetDlgItem(_hSelf, IDC_CUSTOMIZELENGTHVAL_STATIC), val > 0?SW_SHOW:SW_HIDE);
 }
 
-INT_PTR CALLBACK NewDocumentSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK NewDocumentSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = (NppGUI & )nppParam.getNppGUI();
@@ -2068,7 +2068,7 @@ INT_PTR CALLBACK NewDocumentSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
  	return FALSE;
 }
 
-INT_PTR CALLBACK DefaultDirectorySubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK DefaultDirectorySubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = (NppGUI & )nppParam.getNppGUI();
@@ -2188,7 +2188,7 @@ INT_PTR CALLBACK DefaultDirectorySubDlg::run_dlgProc(UINT message, WPARAM wParam
 	return FALSE;
 }
 
-INT_PTR CALLBACK RecentFilesHistorySubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK RecentFilesHistorySubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = (NppGUI & )nppParam.getNppGUI();
@@ -2337,7 +2337,7 @@ INT_PTR CALLBACK RecentFilesHistorySubDlg::run_dlgProc(UINT message, WPARAM wPar
 	return FALSE;
 }
 
-INT_PTR CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParam.getNppGUI();
@@ -2776,7 +2776,7 @@ INT_PTR CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 	return FALSE;
 }
 
-INT_PTR CALLBACK HighlightingSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM/* lParam*/)
+intptr_t CALLBACK HighlightingSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM/* lParam*/)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = (NppGUI & )nppParam.getNppGUI();
@@ -2950,7 +2950,7 @@ INT_PTR CALLBACK HighlightingSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 	return FALSE;
 }
 
-INT_PTR CALLBACK PrintSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK PrintSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = (NppGUI & )nppParam.getNppGUI();
@@ -3303,7 +3303,7 @@ INT_PTR CALLBACK PrintSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 }
 
 
-INT_PTR CALLBACK BackupSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK BackupSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParam.getNppGUI();
@@ -3534,7 +3534,7 @@ void BackupSubDlg::updateBackupGUI()
 }
 
 
-INT_PTR CALLBACK AutoCompletionSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK AutoCompletionSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParam.getNppGUI();
@@ -3885,7 +3885,7 @@ INT_PTR CALLBACK AutoCompletionSubDlg::run_dlgProc(UINT message, WPARAM wParam, 
 }
 
 
-INT_PTR CALLBACK MultiInstanceSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK MultiInstanceSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppGUI & nppGUI = (NppParameters::getInstance()).getNppGUI();
 	switch (message) 
@@ -4088,7 +4088,7 @@ void DelimiterSubDlg::setWarningIfNeed() const
 	::SetDlgItemText(_hSelf, IDD_STATIC_WORDCHAR_WARNING, msg.c_str());
 }
 
-INT_PTR CALLBACK DelimiterSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK DelimiterSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	NppGUI & nppGUI = (NppParameters::getInstance()).getNppGUI();
 	switch (message) 
@@ -4297,7 +4297,7 @@ INT_PTR CALLBACK DelimiterSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 	return FALSE;
 }
 
-INT_PTR CALLBACK CloudAndLinkSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK CloudAndLinkSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParams = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParams.getNppGUI();
@@ -4501,7 +4501,7 @@ INT_PTR CALLBACK CloudAndLinkSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 	return FALSE;
 }
 
-INT_PTR CALLBACK SearchEngineSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK SearchEngineSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParams = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParams.getNppGUI();
@@ -4621,7 +4621,7 @@ INT_PTR CALLBACK SearchEngineSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 	return FALSE;
 }
 
-INT_PTR CALLBACK SearchingSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK SearchingSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
 	NppParameters& nppParams = NppParameters::getInstance();
 	NppGUI& nppGUI = nppParams.getNppGUI();

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.h
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.h
@@ -30,7 +30,7 @@ public :
 	MiscSubDlg() = default;
 
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class GeneralSubDlg : public StaticDialog
@@ -41,7 +41,7 @@ public :
 	void disableTabbarAlternateIcons();
 
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class EditingSubDlg : public StaticDialog
@@ -50,7 +50,7 @@ public :
 	EditingSubDlg() = default;
 	
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void initScintParam();
 };
 
@@ -71,7 +71,7 @@ private:
 	ColourPicker* _pEdgeColorPicker = nullptr;
 	ColourPicker* _pLinkColorPicker = nullptr;
 
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void enableCustomizedColorCtrls(bool doEnable);
 	void move2CtrlLeft(int ctrlID, HWND handle2Move, int handle2MoveWidth, int handle2MoveHeight);
 };
@@ -82,7 +82,7 @@ public :
 	MarginsBorderEdgeSubDlg() = default;
 	
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void initScintParam();
 };
 
@@ -104,7 +104,7 @@ private :
 			::SendDlgItemMessage(_hSelf, IDC_CHECK_OPENANSIASUTF8, BM_SETCHECK, BST_UNCHECKED, 0);
 		::EnableWindow(::GetDlgItem(_hSelf, IDC_CHECK_OPENANSIASUTF8), doIt);
 	};
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class DefaultDirectorySubDlg : public StaticDialog
@@ -113,7 +113,7 @@ public :
 	DefaultDirectorySubDlg() = default;
 
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class RecentFilesHistorySubDlg : public StaticDialog
@@ -128,7 +128,7 @@ private :
 	URLCtrl _nbHistoryVal;
 	URLCtrl _customLenVal;
 	void setCustomLen(int val);
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class LanguageSubDlg : public StaticDialog
@@ -142,7 +142,7 @@ public :
 private :
     LexerStylerArray _lsArray;
 	URLCtrl _tabSizeVal;
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	std::vector<LangMenuItem> _langList;
 };
 
@@ -153,7 +153,7 @@ public :
 
 private :
 
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 
@@ -163,7 +163,7 @@ public:
 	SearchingSubDlg() = default;
 
 private:
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 struct strCouple {
@@ -178,7 +178,7 @@ public :
 	PrintSubDlg() = default;
 
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	std::vector<strCouple> varList;
 	int _focusedEditCtrl = 0;
 };
@@ -190,7 +190,7 @@ public :
 
 private :
 	void updateBackupGUI();
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 
@@ -200,7 +200,7 @@ public :
 	AutoCompletionSubDlg() = default;
 private :
 	URLCtrl _nbCharVal;
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class MultiInstanceSubDlg : public StaticDialog
@@ -210,7 +210,7 @@ public :
 
 private :
 	const SYSTEMTIME _BTTF_time = {1985, 10, 6, 26, 16, 24, 42, 0};
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class DelimiterSubDlg : public StaticDialog
@@ -228,7 +228,7 @@ private :
 	RECT _closerLabelRect = { 0 };
 	HWND _tip = nullptr;
 
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void detectSpace(const char *text2Check, int & nbSp, int & nbTab) const;
 	generic_string getWarningText(size_t nbSp, size_t nbTab) const;
 	void setWarningIfNeed() const;
@@ -240,7 +240,7 @@ public :
 	CloudAndLinkSubDlg() = default;
 
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class SearchEngineSubDlg : public StaticDialog
@@ -249,7 +249,7 @@ public :
 	SearchEngineSubDlg() = default;
 
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
 
 class PreferenceDlg : public StaticDialog
@@ -283,7 +283,7 @@ public :
 	virtual void destroy();
 
 private :
-	INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void makeCategoryList();
 	int32_t getIndexFromName(const TCHAR *name) const;
 	void showDialogByIndex(size_t index) const;

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -39,7 +39,7 @@ ProjectPanel::~ProjectPanel()
 	}
 }
 
-INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{
@@ -65,13 +65,13 @@ INT_PTR CALLBACK ProjectPanel::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			tbButtons[0].iBitmap = I_IMAGENONE;
 			tbButtons[0].fsState = TBSTATE_ENABLED;
 			tbButtons[0].fsStyle = BTNS_BUTTON | BTNS_AUTOSIZE;
-			tbButtons[0].iString = (INT_PTR)workspace_entry.c_str();
+			tbButtons[0].iString = (intptr_t)workspace_entry.c_str();
 
 			tbButtons[1].idCommand = IDB_EDIT_BTN;
 			tbButtons[1].iBitmap = I_IMAGENONE;
 			tbButtons[1].fsState = TBSTATE_ENABLED;
 			tbButtons[1].fsStyle = BTNS_BUTTON | BTNS_AUTOSIZE;
-			tbButtons[1].iString = (INT_PTR)edit_entry.c_str();
+			tbButtons[1].iString = (intptr_t)edit_entry.c_str();
 
 			SendMessage(_hToolbarMenu, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 			SendMessage(_hToolbarMenu, TB_ADDBUTTONS, sizeof(tbButtons) / sizeof(TBBUTTON), reinterpret_cast<LPARAM>(&tbButtons));
@@ -1343,7 +1343,7 @@ void ProjectPanel::addFilesFromDirectory(HTREEITEM hTreeItem)
 	}
 }
 
-INT_PTR CALLBACK FileRelocalizerDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM) 
+intptr_t CALLBACK FileRelocalizerDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM) 
 {
 	switch (Message)
 	{

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
@@ -132,7 +132,7 @@ protected:
 	void setWorkSpaceDirty(bool isDirty);
 	void popupMenuCmd(int cmdID);
 	POINT getMenuDisplayPoint(int iButton);
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	bool buildTreeFrom(TiXmlNode *projectRoot, HTREEITEM hParentItem);
 	void notified(LPNMHDR notification);
 	void showContextMenu(int x, int y);
@@ -162,7 +162,7 @@ public :
 	};
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private :
 	generic_string _fullFilePath;

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
@@ -217,7 +217,7 @@ HINSTANCE Command::run(HWND hWnd, const TCHAR* cwd)
 	// As per MSDN (https://msdn.microsoft.com/en-us/library/windows/desktop/bb762153(v=vs.85).aspx)
 	// If the function succeeds, it returns a value greater than 32.
 	// If the function fails, it returns an error value that indicates the cause of the failure.
-	int retResult = static_cast<int>(reinterpret_cast<INT_PTR>(res));
+	int retResult = static_cast<int>(reinterpret_cast<intptr_t>(res));
 	if (retResult <= 32)
 	{
 		generic_string errorMsg;
@@ -238,7 +238,7 @@ HINSTANCE Command::run(HWND hWnd, const TCHAR* cwd)
 	return res;
 }
 
-INT_PTR CALLBACK RunDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK RunDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message) 
 	{
@@ -309,7 +309,7 @@ INT_PTR CALLBACK RunDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					_cmdLine = cmd;
 
 					HINSTANCE hInst = run(_hParent);
-					if (reinterpret_cast<INT_PTR>(hInst) > 32)
+					if (reinterpret_cast<intptr_t>(hInst) > 32)
 					{
 						addTextToCombo(_cmdLine.c_str());
 						display(false);

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.h
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.h
@@ -59,7 +59,7 @@ public :
     virtual void destroy() {};
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 
 private :
 	void addTextToCombo(const TCHAR *txt2Add) const;

--- a/PowerEditor/src/WinControls/StaticDialog/StaticDialog.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/StaticDialog.cpp
@@ -234,7 +234,7 @@ void StaticDialog::create(int dialogID, bool isRTL, bool msgDestParent)
 	::SendMessage(msgDestParent ? _hParent : (::GetParent(_hParent)), NPPM_MODELESSDIALOG, MODELESSDIALOGADD, reinterpret_cast<WPARAM>(_hSelf));
 }
 
-INT_PTR CALLBACK StaticDialog::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK StaticDialog::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/StaticDialog/StaticDialog.h
+++ b/PowerEditor/src/WinControls/StaticDialog/StaticDialog.h
@@ -69,8 +69,8 @@ public :
 
 protected:
 	RECT _rc = { 0 };
-	static INT_PTR CALLBACK dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam) = 0;
+	static intptr_t CALLBACK dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam) = 0;
 
 	HGLOBAL makeRTLResource(int dialogID, DLGTEMPLATE **ppMyDlgTemplate);
 };

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -219,7 +219,7 @@ protected:
     int _nSrcTab = -1;
 	int _nTabDragged = -1;
 	int _previousTabSwapped = -1;
-	POINT _draggingPoint; // coordinate of Screen
+	POINT _draggingPoint = {}; // coordinate of Screen
 	WNDPROC _tabBarDefaultProc = nullptr;
 
 	RECT _currentHoverTabRect;

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -56,7 +56,7 @@ LRESULT CALLBACK hookProc(int nCode, WPARAM wParam, LPARAM lParam)
 	return static_cast<int32_t>(::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_TASKLIST_DLG), _hParent, dlgProc, reinterpret_cast<LPARAM>(this)));
 }
 
-INT_PTR CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
 	switch (Message)
 	{

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -61,7 +61,7 @@ public :
 		virtual void destroy() {};
 
 protected :
-	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
 
 private :
 	TaskList _taskList;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -65,7 +65,7 @@ void VerticalFileSwitcher::startColumnSort()
 	updateHeaderArrow();
 }
 
-INT_PTR CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK VerticalFileSwitcher::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
@@ -103,7 +103,7 @@ public:
 protected:
 	HMENU _hGlobalMenu = NULL;
 
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void initPopupMenus();
 	void popupMenuCmd(int cmdID);
 private:

--- a/PowerEditor/src/WinControls/WindowsDlg/SizeableDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/SizeableDlg.cpp
@@ -48,7 +48,7 @@ LRESULT SizeableDlg::onWinMgr(WPARAM, LPARAM)
 	return 0;
 }
 
-INT_PTR CALLBACK SizeableDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK SizeableDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/WindowsDlg/SizeableDlg.h
+++ b/PowerEditor/src/WinControls/WindowsDlg/SizeableDlg.h
@@ -29,7 +29,7 @@ public:
 protected:
 	CWinMgr _winMgr;	  // window manager
 
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	virtual BOOL onInitDialog();
 	virtual void onSize(UINT nType, int cx, int cy);
 	virtual void onGetMinMaxInfo(MINMAXINFO* lpMMI);

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -422,7 +422,7 @@ INT_PTR CALLBACK WindowsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPa
 						}
 						else if (pLvdi->item.iSubItem == 3) // size
 						{
-							int docSize = buf->docLength();
+							size_t docSize = buf->docLength();
 							string docSizeText = to_string(docSize);
 							text = wstring(docSizeText.begin(), docSizeText.end());
 						}

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -262,7 +262,7 @@ void WindowsDlg::init(HINSTANCE hInst, HWND parent)
 	_pTab = NULL;
 }
 
-INT_PTR CALLBACK WindowsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
+intptr_t CALLBACK WindowsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
 	{

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.h
@@ -59,7 +59,7 @@ public :
 	void doRefresh(bool invalidate = false);
 
 protected :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	virtual BOOL onInitDialog();
 	virtual void onSize(UINT nType, int cx, int cy);
 	virtual void onGetMinMaxInfo(MINMAXINFO* lpMMI);

--- a/PowerEditor/src/WinControls/shortcut/RunMacroDlg.cpp
+++ b/PowerEditor/src/WinControls/shortcut/RunMacroDlg.cpp
@@ -40,7 +40,7 @@ void RunMacroDlg::initMacroList()
 	_macroIndex = 0;
 }
 
-INT_PTR CALLBACK RunMacroDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
+intptr_t CALLBACK RunMacroDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {	
 	switch (message) 
 	{

--- a/PowerEditor/src/WinControls/shortcut/RunMacroDlg.h
+++ b/PowerEditor/src/WinControls/shortcut/RunMacroDlg.h
@@ -54,7 +54,7 @@ public :
 	int getMacro2Exec() const;
 
 private :
-	virtual INT_PTR CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void check(int);
 
 	int _mode = RM_RUN_MULTI;

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -369,7 +369,7 @@ void Shortcut::updateConflictState(const bool endSession) const
 	::ShowWindow(::GetDlgItem(_hSelf, IDC_CONFLICT_STATIC), isConflict ? SW_SHOW : SW_HIDE);
 }
 
-INT_PTR CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam) 
+intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam) 
 {
 	switch (Message)
 	{
@@ -1042,7 +1042,7 @@ void ScintillaKeyMap::updateListItem(int index)
 	::SendDlgItemMessage(_hSelf, IDC_LIST_KEYS, LB_DELETESTRING, index+1, 0);
 }
 
-INT_PTR CALLBACK ScintillaKeyMap::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam) 
+intptr_t CALLBACK ScintillaKeyMap::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam) 
 {
 	
 	switch (Message)

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -120,7 +120,7 @@ public:
 		return !(a == b);
 	};
 
-	virtual INT_PTR doDialog()
+	virtual intptr_t doDialog()
 	{
 		return ::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_SHORTCUT_DLG), _hParent, dlgProc, reinterpret_cast<LPARAM>(this));
     };
@@ -174,7 +174,7 @@ public:
 
 protected :
 	KeyCombo _keyCombo;
-	virtual INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+	virtual intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
 	bool _canModifyName = false;
 	TCHAR _name[nameLenMax] = {'\0'};		//normal name is plain text (for display purposes)
 	TCHAR _menuName[nameLenMax] = { '\0' };	//menu name has ampersands for quick keys
@@ -227,7 +227,7 @@ public:
 	generic_string toString() const;
 	generic_string toString(size_t index) const;
 
-	INT_PTR doDialog()
+	intptr_t doDialog()
 	{
 		return ::DialogBoxParam(_hInst, MAKEINTRESOURCE(IDD_SHORTCUTSCINT_DLG), _hParent, dlgProc, reinterpret_cast<LPARAM>(this));
     };
@@ -264,7 +264,7 @@ private:
 	void showCurrentSettings();
 	void updateListItem(int index);
 protected :
-	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
+	intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
 };
 
 

--- a/PowerEditor/src/lesDlgs.cpp
+++ b/PowerEditor/src/lesDlgs.cpp
@@ -73,7 +73,7 @@ int ValueDlg::reSizeValueBox()
 	return newWidth - w;
 }
 
-INT_PTR CALLBACK ValueDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM) 
+intptr_t CALLBACK ValueDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM) 
 {
 	switch (Message)
 	{
@@ -164,7 +164,7 @@ INT_PTR CALLBACK ValueDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM)
 }
 
 
-INT_PTR CALLBACK ButtonDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM) 
+intptr_t CALLBACK ButtonDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM) 
 {
 	switch (Message)
 	{

--- a/PowerEditor/src/lesDlgs.h
+++ b/PowerEditor/src/lesDlgs.h
@@ -35,7 +35,7 @@ public :
 		void destroy() {};
 
 protected :
-	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM);
+	intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM);
 
 private :
 	int _nbNumber = DEFAULT_NB_NUMBER;
@@ -80,7 +80,7 @@ public :
 	};
 
 protected :
-	INT_PTR CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM);
+	intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM);
     int _buttonStatus = buttonStatus_nada;
 
 };

--- a/PowerEditor/src/tools/NppShell/src/NppShell.cpp
+++ b/PowerEditor/src/tools/NppShell/src/NppShell.cpp
@@ -49,7 +49,7 @@ BOOL UnregisterServer();
 void MsgBox(LPCTSTR lpszMsg);
 void MsgBoxError(LPCTSTR lpszMsg);
 BOOL CheckNpp(LPCTSTR path);
-INT_PTR CALLBACK DlgProcSettings(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+intptr_t CALLBACK DlgProcSettings(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 void InvalidateIcon(HICON * iconSmall, HICON * iconLarge);
 
 #ifdef UNICODE
@@ -257,7 +257,7 @@ BOOL CheckNpp(LPCTSTR path) {
 	return TRUE;
 }
 
-INT_PTR CALLBACK DlgProcSettings(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+intptr_t CALLBACK DlgProcSettings(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 	static TCHAR customCommand[MAX_PATH] = {0};
 	static TCHAR customText[TITLE_SIZE] = {0};
 	static TCHAR szKeyTemp[MAX_PATH + GUID_STRING_SIZE];

--- a/scintilla/include/Sci_Position.h
+++ b/scintilla/include/Sci_Position.h
@@ -20,7 +20,7 @@ typedef size_t Sci_PositionU;
 
 
 // For Sci_CharacterRange  which is defined as long to be compatible with Win32 CHARRANGE
-typedef intptr_t Sci_PositionCR;
+typedef long Sci_PositionCR;
 
 #ifdef _WIN32
 	#define SCI_METHOD __stdcall

--- a/scintilla/include/Sci_Position.h
+++ b/scintilla/include/Sci_Position.h
@@ -15,10 +15,16 @@
 typedef ptrdiff_t Sci_Position;
 
 // Unsigned variant used for ILexer::Lex and ILexer::Fold
+// Definitions of common types
 typedef size_t Sci_PositionU;
 
+
 // For Sci_CharacterRange  which is defined as long to be compatible with Win32 CHARRANGE
+#ifdef _WIN64
+typedef long long Sci_PositionCR;
+#else
 typedef long Sci_PositionCR;
+#endif
 
 #ifdef _WIN32
 	#define SCI_METHOD __stdcall

--- a/scintilla/include/Sci_Position.h
+++ b/scintilla/include/Sci_Position.h
@@ -20,11 +20,7 @@ typedef size_t Sci_PositionU;
 
 
 // For Sci_CharacterRange  which is defined as long to be compatible with Win32 CHARRANGE
-#ifdef _WIN64
-typedef long long Sci_PositionCR;
-#else
-typedef long Sci_PositionCR;
-#endif
+typedef intptr_t Sci_PositionCR;
 
 #ifdef _WIN32
 	#define SCI_METHOD __stdcall


### PR DESCRIPTION
This PR is still in progress, because for supporting 2GB or larger file, it needs to use int64 as integer type, for all the data structures which deal with Scintilla, especially for searching features. It's not enough to remove only the restriction.

The current state of this PR can open 1GB (that 32bits binary cannot even open it) to 5GB (tested). 
All the files under 2G opened flawlessly. However, once the file size is more than 2GB, file can be opened, but with plenty of NUL characters at the end of file, as mention in another PR:
https://github.com/notepad-plus-plus/notepad-plus-plus/pull/11044#issuecomment-1013236115
 I have still no idea how to fix it. If anyone has any idea here, please let me know.    

Fix #10921