### PR TITLE
Update Corsican translation for Notepad++ 8.3.1

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 7th, 2022 for version 8.3.1 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 8th, 2022 for version 8.3.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on January 11th, 2022 for version 8.2.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 4th, 2021 for version 8.1.9.3 by Patriccollu di Santa Maria è Sichè
 		- Updated on September 13th, 2021 for version 8.1.5 by Patriccollu di Santa Maria è Sichè
@@ -1279,6 +1279,7 @@ Vulete andà nant’à a pagina di Notepad++ per scaricà l’ultima versione ?
             <DocTooDirtyToMonitor title="Penseru d’appustamentu" message="U ducumentu hè brutu. Ci vole à arregistrà a mudificazione nanzu à appustallu."/>
             <DocNoExistToMonitor title="Penseru d’appustamentu" message="U schedariu deve esiste per esse appustatu."/>
             <FileTooBigToOpen title="Penseru di dimensione di schedariu" message="U schedariu hè troppu maiò per esse apertu da Notepad++"/> <!-- HowToReproduce: Try to open a 4GB file (it's not easy to reproduce, it depends on your system). -->
+            <FileLoadingException title="Codice di sbagliu : $STR_REPLACE$" message="Un sbagliu hè accadutu durante u caricamentu di u schedariu !"/>
             <WantToOpenHugeFile title="Avertimentu d’apertura di schedariu maiò" message="L’apertura d’un schedariu più maiò chì 2 Go pò piglià parechji minuti.
 Vulete aprelu ?"/>
             <CreateNewFileOrNot title="Creà un novu schedariu" message="« $STR_REPLACE$ » ùn esiste. Creallu ?"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 1st, 2022 for version 8.2.2 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 7th, 2022 for version 8.3.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on January 11th, 2022 for version 8.2.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 4th, 2021 for version 8.1.9.3 by Patriccollu di Santa Maria è Sichè
 		- Updated on September 13th, 2021 for version 8.1.5 by Patriccollu di Santa Maria è Sichè
@@ -31,7 +31,7 @@ The comments are here for explanation, it's not necessary to translate them.
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 -->
 <NotepadPlus>
-    <Native-Langue name="Corsu" filename="corsican.xml" version="8.2.2">
+    <Native-Langue name="Corsu" filename="corsican.xml" version="8.3.1">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,6 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
+		- Updated on February 1st, 2022 for version 8.2.2 by Patriccollu di Santa Maria è Sichè
 		- Updated on January 11th, 2022 for version 8.2.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 4th, 2021 for version 8.1.9.3 by Patriccollu di Santa Maria è Sichè
 		- Updated on September 13th, 2021 for version 8.1.5 by Patriccollu di Santa Maria è Sichè
@@ -30,7 +31,7 @@ The comments are here for explanation, it's not necessary to translate them.
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 -->
 <NotepadPlus>
-    <Native-Langue name="Corsu" filename="corsican.xml" version="8.2.1">
+    <Native-Langue name="Corsu" filename="corsican.xml" version="8.2.2">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -969,12 +970,12 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                 <Language title="Linguaghju">
                     <Item id="6505" name="Elementi dispunibule"/>
                     <Item id="6506" name="Elementi piattati"/>
-                    <Item id="6507" name="Cumpattà u listinu di linguaghju"/>
-                    <Item id="6508" name="Listinu di linguaghju"/>
-                    <Item id="6301" name="Definisce a tabulazione"/>
-                    <Item id="6302" name="Rimpiazzà cù spaziu"/>
+                    <Item id="6507" name="Cumpattà l’affissera di u listinu"/>
+                    <Item id="6508" name="Listinu di i linguaghji affissati"/>
+                    <Item id="6301" name="Definizione di a tabulazione"/>
+                    <Item id="6302" name="Rimpiazzà cù spazii"/>
                     <Item id="6303" name="Dimensione : "/>
-                    <Item id="6510" name="Impiegà u valore predefinitu"/>
+                    <Item id="6510" name="Impiegà valore predef."/>
                     <Item id="6335" name="« \ » hè u caratteru di scappamentu per SQL"/>
                 </Language>
 
@@ -1020,6 +1021,15 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                     <Item id="6721" name="Parte à u mezu"/>
                     <Item id="6722" name="Parte à manu diritta"/>
                     <Item id="6723" name="Aghjunghje"/>
+                    <ComboBox id="6724">
+                        <Element name="Chjassu sanu di u nome di schedariu"/>
+                        <Element name="Nome di schedariu"/>
+                        <Element name="Cartulare"/>
+                        <Element name="Pagina"/>
+                        <Element name="Furmatu cortu di a data"/>
+                        <Element name="Furmatu longu di a data"/>
+                        <Element name="Ora"/>
+                    </ComboBox>
                     <Item id="6725" name="Variabile :"/>
                     <Item id="6727" name="Quì s’affissanu e vostre variabile"/>
                     <Item id="6728" name="Intestatura è bassu di pagina"/>
@@ -1269,6 +1279,8 @@ Vulete andà nant’à a pagina di Notepad++ per scaricà l’ultima versione ?
             <DocTooDirtyToMonitor title="Penseru d’appustamentu" message="U ducumentu hè brutu. Ci vole à arregistrà a mudificazione nanzu à appustallu."/>
             <DocNoExistToMonitor title="Penseru d’appustamentu" message="U schedariu deve esiste per esse appustatu."/>
             <FileTooBigToOpen title="Penseru di dimensione di schedariu" message="U schedariu hè troppu maiò per esse apertu da Notepad++"/> <!-- HowToReproduce: Try to open a 4GB file (it's not easy to reproduce, it depends on your system). -->
+            <WantToOpenHugeFile title="Avertimentu d’apertura di schedariu maiò" message="L’apertura d’un schedariu più maiò chì 2 Go pò piglià parechji minuti.
+Vulete aprelu ?"/>
             <CreateNewFileOrNot title="Creà un novu schedariu" message="« $STR_REPLACE$ » ùn esiste. Creallu ?"/>
             <CreateNewFileError title="Creà un novu schedariu" message="Ùn pò micca creà u schedariu « $STR_REPLACE$ »."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
             <OpenFileError title="SBAGLIU" message="Ùn pò micca apre u schedariu « $STR_REPLACE$ »."/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to modify the Language settings and to take into account the following commit:

  * https://github.com/notepad-plus-plus/notepad-plus-plus/pull/11093/commits/2ad9dee3dc49d6733bb5be85271d5993ad1fe988 Update english.xml to v8.2.2

Updated on February 8<sup>th</sup> for these commits:

  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/85e7207eef4f1df98817ce4ff8b98f6581a38c6c Enhance error handling while opening file
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/2c1090e554a7ed4e68e1706d72112f64546384dc Update english.xml
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/6392508cd14947d01473bafc962e46a316b61248 Solve the confilt in english.xml

Cheers,
Patriccollu.