### PR TITLE
line number alignment in the search result window

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4062,7 +4062,7 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
 	str += TEXT(" ");
 
 	TCHAR lnb[16];
-	wsprintf(lnb, TEXT("%d"), static_cast<int>(fi._lineNumber));
+	wsprintf(lnb, TEXT("%6u"), static_cast<int>(fi._lineNumber));
 	str += lnb;
 	str += TEXT(": ");
 	mi._start += str.length();


### PR DESCRIPTION
this small change aligns the line numbers in the search results window
it is hardcoded at 6 digits so it is better that without any alignment
see more in the issue #11135  