### PR TITLE
line number alignment in the search result window

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -3996,15 +3996,15 @@ void Finder::addFileNameTitle(const TCHAR * fileName)
 
 void Finder::setLineNumFormatStr()
 {
-   size_t NumLines = (*_ppEditView)->execute(SCI_GETLINECOUNT);
+	size_t NumLines = (*_ppEditView)->execute(SCI_GETLINECOUNT);
 	size_t NumDigits = 0;
-   while (NumLines != 0) {
-      NumLines = NumLines / 10;
-      ++NumDigits;
-   }
+	while (NumLines != 0) {
+		NumLines = NumLines / 10;
+		++NumDigits;
+	}
 
-   TCHAR strFormat[10];
-   wsprintf(strFormat, TEXT("%%%uu"), NumDigits);
+	TCHAR strFormat[10];
+	wsprintf(strFormat, TEXT("%%%uu"), NumDigits);
 	_LineNumFormatStr = strFormat;
 }
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -2408,6 +2408,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				if (!findAllFileNameAdded)	//add new filetitle in hits if we haven't already
 				{
 					_pFinder->addFileNameTitle(pFileName);
+					_pFinder->setLineNumFormatStr();
 					findAllFileNameAdded = true;
 				}
 
@@ -3993,6 +3994,20 @@ void Finder::addFileNameTitle(const TCHAR * fileName)
 	_pMainMarkings->push_back(EmptySearchResultMarking);
 }
 
+void Finder::setLineNumFormatStr()
+{
+   size_t NumLines = (*_ppEditView)->execute(SCI_GETLINECOUNT);
+	size_t NumDigits = 0;
+   while (NumLines != 0) {
+      NumLines = NumLines / 10;
+      ++NumDigits;
+   }
+
+   TCHAR strFormat[10];
+   wsprintf(strFormat, TEXT("%%%uu"), NumDigits);
+	_LineNumFormatStr = strFormat;
+}
+
 void Finder::addFileHitCount(int count)
 {
 	wstring text = TEXT(" ");
@@ -4062,7 +4077,7 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
 	str += TEXT(" ");
 
 	TCHAR lnb[16];
-	wsprintf(lnb, TEXT("%d"), static_cast<int>(fi._lineNumber));
+	wsprintf(lnb, _LineNumFormatStr.c_str(), static_cast<int>(fi._lineNumber));
 	str += lnb;
 	str += TEXT(": ");
 	mi._start += str.length();

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -105,6 +105,7 @@ public:
 	Finder() : DockingDlgInterface(IDD_FINDRESULT) {
 		_markingsStruct._length = 0;
 		_markingsStruct._markings = NULL;
+		_LineNumFormatStr = TEXT("%u");
 	};
 
 	~Finder() {
@@ -117,6 +118,7 @@ public:
 
 	void addSearchLine(const TCHAR *searchName);
 	void addFileNameTitle(const TCHAR * fileName);
+	void setLineNumFormatStr();
 	void addFileHitCount(int count);
 	void addSearchHitCount(int count, int countSearched, bool isMatchLines, bool searchedEntireNotSelection);
 	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline);
@@ -165,6 +167,7 @@ private:
 	bool _purgeBeforeEverySearch = false;
 
 	generic_string _prefixLineStr;
+	generic_string _LineNumFormatStr;
 
 	void setFinderReadOnly(bool isReadOnly) {
 		_scintView.execute(SCI_SETREADONLY, isReadOnly);


### PR DESCRIPTION
added appropriate number of leading spaces for line number in the search result window
the issue #11135 