### PR TITLE
Auto-Complete "fx" icon sort order fix

### DIFF
--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -119,10 +119,10 @@ bool AutoCompletion::showApiComplete()
 
 	if (!_isFxImageRegistered)
 	{
-		_pEditView->execute(SCI_AUTOCSETTYPESEPARATOR, WPARAM('?'));
 		_pEditView->execute(SCI_REGISTERIMAGE, FUNC_IMG_ID, LPARAM(xpmfn));
 		_isFxImageRegistered = true;
 	}
+	_pEditView->execute(SCI_AUTOCSETTYPESEPARATOR, WPARAM('\x1E'));
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, _keyWords.c_str());
@@ -208,10 +208,10 @@ bool AutoCompletion::showApiAndWordComplete()
 	// Make Scintilla show the autocompletion menu
 	if (!_isFxImageRegistered)
 	{
-		_pEditView->execute(SCI_AUTOCSETTYPESEPARATOR, WPARAM('?'));
 		_pEditView->execute(SCI_REGISTERIMAGE, FUNC_IMG_ID, LPARAM(xpmfn));
 		_isFxImageRegistered = true;
 	}
+	_pEditView->execute(SCI_AUTOCSETTYPESEPARATOR, WPARAM('\x1E'));
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, words.c_str());
@@ -972,7 +972,7 @@ bool AutoCompletion::setLanguage(LangType language)
 		for (; funcNode; funcNode = funcNode->NextSiblingElement(TEXT("KeyWord")) )
 		{
 			const TCHAR *name = funcNode->Attribute(TEXT("name"));
-			generic_string imgid = TEXT("?") + intToString(FUNC_IMG_ID);
+			generic_string imgid = TEXT("\x1E") + intToString(FUNC_IMG_ID);
 			if (name)
 			{
 				size_t len = lstrlen(name);


### PR DESCRIPTION
Fix #11233 

Not sure this is a "regression", but this was introduced by issue #11087 and commits c394a890aa0c8fc75f081ac8c58abb1949c689ee / 6c345e907b046016642782d09acd27ca3ad5f91f

## This Fix / PR

I change the default Scintilla `SCI_AUTOCSETTYPESEPARATOR` from `?` to ASCII Record Separator code value 30 (\x1E).  This has the effect of being lower than all other visible ASCII characters so when the list is sorted before display, any items with non-typical word characters will be sorted after similar items that don't have them and would otherwise be mixed up due to the `?` separator in the sort - even though it isn't displayed.  Full analysis in the Issue #11233.

![image](https://user-images.githubusercontent.com/9657169/154565358-3f0b4d0e-4d54-42e2-a306-47a4471210b7.png)
 
Now `print` sorts before `print(somestuff)`.


## Why Move `SCI_AUTOCSETTYPESEPARATOR` out of Optimization Step?

Note since we are now using a non-default Scintilla value for `SCI_AUTOCSETTYPESEPARATOR` I removed that from the optimization and make sure we execute it every time before running the `SCI_AUTOCSHOW`.  If we don't we run the risk of "someone else" setting a different - or even the default `SCI_AUTOCSETTYPESEPARATOR` and then we'll display gibberish.  I can think of three plugins - QuickText, TagLEET and some custom scripts using PythonScript - that do just that; reset the `SCI_AUTOCSETTYPESEPARATOR` to the default `?` before they call their `SCI_AUTOCSHOW` display.  If we don't set it back to ours, our new Record Separator character won't be interpreted as a separator, but as part of the autocomplete text.

Example - other plugin using AutoComplete and setting `SCI_AUTOCSETTYPESEPARATOR` to default `?`
![image](https://user-images.githubusercontent.com/9657169/154566228-f57f1065-dd2e-4e33-986a-9e3a6319ab3e.png)

and then if we do ***NOT*** reset it and keep the current "optimization", we get our `SCI_AUTOCSETTYPESEPARATOR` opcodes and image ID's in the autocomplete list and document:
![image](https://user-images.githubusercontent.com/9657169/154566155-70b6f4ad-2c67-4a11-b86a-6d650a8b93ab.png)

The above will ***not*** occur with this PR as-is, that is, including the moving of `SCI_AUTOCSETTYPESEPARATOR` out of the optimization block.

Cheers.
