### PR TITLE
N++ unnecessarily stalled at exit (regression)

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1975,7 +1975,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				}
 
 				Session currentSession;
-				getCurrentOpenedFiles(currentSession, true);
+				if (!((nppgui._multiInstSetting == monoInst) && !nppgui._rememberLastSession))
+					getCurrentOpenedFiles(currentSession, true);
 
 				if (nppgui._rememberLastSession)
 				{


### PR DESCRIPTION
This is only a small regression from the fix #11017 .

N++ is unnecessarily stalled in the situation, when closing a N++ with a large file opened within, but the session.xml file cannot be updated at all due to the current N++ settings chosen.

Fixes #11219 .