### PR TITLE
fix for deleting the folded lines

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -331,8 +331,8 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_subEditView.execute(SCI_SETMOUSESELECTIONRECTANGULARSWITCH, true);
 
 	// Let Scintilla deal with some of the folding functionality
-	_mainEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW);
-	_subEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW);
+	_mainEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW | SC_AUTOMATICFOLD_CHANGE);
+	_subEditView.execute(SCI_SETAUTOMATICFOLD, SC_AUTOMATICFOLD_SHOW | SC_AUTOMATICFOLD_CHANGE);
 
 	// Set padding info
 	_mainEditView.execute(SCI_SETMARGINLEFT, 0, svp._paddingLeft);


### PR DESCRIPTION
Applying the Scintilla flag SC_AUTOMATICFOLD_CHANGE, ref: https://www.scintilla.org/ScintillaDoc.html#Folding

"SC_AUTOMATICFOLD_CHANGE (0x4) Show lines as needed when fold structure is changed. The SCN_MODIFIED notification is still sent unless it is disabled by the container."

and

"Most applications should be able to use the SC_AUTOMATICFOLD_SHOW and SC_AUTOMATICFOLD_CHANGE flags unless they wish to implement quite different behaviour such as defining their own fold structure."

Fixes notepad-plus-plus#11246 (details & testing in the issue).