### PR TITLE
Re-enable possibility to center the FindReplaceDlg on parent (#9201)

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -1287,22 +1287,34 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 				return TRUE;
 
 				case IDM_SEARCH_FIND:
-					enableReplaceFunc(false); // enable relace false so only find
+					if (_currentStatus == FIND_DLG)
+						goToCenter();
+					else
+						enableReplaceFunc(false);
 					return TRUE;
 
 				case IDM_SEARCH_REPLACE:
-					enableReplaceFunc(true);
+					if (_currentStatus == REPLACE_DLG)
+						goToCenter();
+					else
+						enableReplaceFunc(true);
 					return TRUE;
 
 				case IDM_SEARCH_FINDINFILES:
-					enableFindInFilesFunc();
+					if (_currentStatus == FINDINFILES_DLG)
+						goToCenter();
+					else
+						enableFindInFilesFunc();
 					return TRUE;
 
 				case IDM_SEARCH_MARK:
-					enableMarkFunc();
+					if (_currentStatus == MARK_DLG)
+						goToCenter();
+					else
+						enableMarkFunc();
 					return TRUE;
 
-				case IDREPLACE :
+				case IDREPLACE:
 				{
 					std::lock_guard<std::mutex> lock(findOps_mutex);
 


### PR DESCRIPTION
Re-enable possibility to center the FindReplaceDlg on parent (fixes #9201)

* add goToCenter to hotkey check in IDM_SEARCH_(FIND|REPLACE|FINDINFILES|MARK)

Before commit aa69711d it was possible to center the dialog on Notepad++ using a second CTRL+F but was lost during the implementation of #10019, #10177.

This will re-add the function:
* When the hotkey used is not associated with the current tab, it will switch to the new tab (as before).
* If the hotkey used is associated with the current tab, it will center the FindReplaceDlg on Notepad++.