### PR TITLE
fix for the possible crash when loading an older session file

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2175,14 +2175,31 @@ bool NppParameters::getSessionFromXmlTree(TiXmlDocument *pSessionDoc, Session& s
 				if (fileName)
 				{
 					Position position;
-					position._firstVisibleLine = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("firstVisibleLine"))));
-					position._xOffset = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("xOffset"))));
-					position._startPos = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("startPos"))));
-					position._endPos = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("endPos"))));
-					position._selMode = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("selMode"))));
-					position._scrollWidth = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("scrollWidth"))));
-					position._offset = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("offset"))));
-					position._wrapCount = static_cast<intptr_t>(_ttoi64((childNode->ToElement())->Attribute(TEXT("wrapCount"))));
+					const TCHAR* posStr = (childNode->ToElement())->Attribute(TEXT("firstVisibleLine"));
+					if (posStr)
+						position._firstVisibleLine = static_cast<intptr_t>(_ttoi64(posStr));
+					posStr = (childNode->ToElement())->Attribute(TEXT("xOffset"));
+					if (posStr)
+						position._xOffset = static_cast<intptr_t>(_ttoi64(posStr));
+					posStr = (childNode->ToElement())->Attribute(TEXT("startPos"));
+					if (posStr)
+						position._startPos = static_cast<intptr_t>(_ttoi64(posStr));
+					posStr = (childNode->ToElement())->Attribute(TEXT("endPos"));
+					if (posStr)
+						position._endPos = static_cast<intptr_t>(_ttoi64(posStr));
+					posStr = (childNode->ToElement())->Attribute(TEXT("selMode"));
+					if (posStr)
+						position._selMode = static_cast<intptr_t>(_ttoi64(posStr));
+					posStr = (childNode->ToElement())->Attribute(TEXT("scrollWidth"));
+					if (posStr)
+						position._scrollWidth = static_cast<intptr_t>(_ttoi64(posStr));
+					posStr = (childNode->ToElement())->Attribute(TEXT("offset"));
+					if (posStr)
+						position._offset = static_cast<intptr_t>(_ttoi64(posStr));
+					posStr = (childNode->ToElement())->Attribute(TEXT("wrapCount"));
+					if (posStr)
+						position._wrapCount = static_cast<intptr_t>(_ttoi64(posStr));
+
 					MapPosition mapPosition;
 					const TCHAR* mapPosStr = (childNode->ToElement())->Attribute(TEXT("mapFirstVisibleDisplayLine"));
 					if (mapPosStr)


### PR DESCRIPTION
The 2GB+ adaptation has forced the change in session integers saving via TinyXML (now saving indirectly as strings). While the `MapPosition` part inside the `NppParameters::getSessionFromXmlTree()` has been already fortified against possible missing session-file internal items, the `Position` part not. So implemented likewise the `MapPosition` way there.

Fixes #11325 .