### PR TITLE
Fixed blurry disabled static texts in Dark mode

### DIFF
--- a/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
@@ -125,7 +125,7 @@ intptr_t CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPa
 				result = NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 			}
 			//set the static text colors to show enable/disable instead of ::EnableWindow which causes blurry text
-			if (
+			if  (
 				(HWND)lParam == ::GetDlgItem(_hSelf, IDC_SUPPORTEDEXTS_STATIC) ||
 				(HWND)lParam == ::GetDlgItem(_hSelf, IDC_REGISTEREDEXTS_STATIC)
 				)

--- a/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
@@ -83,6 +83,7 @@ void RegExtDlg::doDialog(bool isRTL)
 
 intptr_t CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam)
 {
+	NppParameters& nppParam = NppParameters::getInstance();
 	switch (Message)
 	{
 		case WM_INITDIALOG :
@@ -92,14 +93,11 @@ intptr_t CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPa
 			::EnableWindow(::GetDlgItem(_hSelf, IDC_ADDFROMLANGEXT_BUTTON), false);
 			::EnableWindow(::GetDlgItem(_hSelf, IDC_REMOVEEXT_BUTTON), false);
 
-			NppParameters& nppParam = NppParameters::getInstance();
 			if (!nppParam.isAdmin())
 			{
 				::EnableWindow(::GetDlgItem(_hSelf, IDC_REGEXT_LANG_LIST), false);
 				::EnableWindow(::GetDlgItem(_hSelf, IDC_REGEXT_LANGEXT_LIST), false);
 				::EnableWindow(::GetDlgItem(_hSelf, IDC_REGEXT_REGISTEREDEXTS_LIST), false);
-				::EnableWindow(::GetDlgItem(_hSelf, IDC_SUPPORTEDEXTS_STATIC), false);
-				::EnableWindow(::GetDlgItem(_hSelf, IDC_REGISTEREDEXTS_STATIC), false);
 			}
 			else
 			{
@@ -121,11 +119,23 @@ intptr_t CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPa
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
+			LRESULT result = FALSE;
 			if (NppDarkMode::isEnabled())
 			{
-				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+				result = NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 			}
-			break;
+			//set the static text colors to show enable/disable instead of ::EnableWindow which causes blurry text
+			if (
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDC_SUPPORTEDEXTS_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDC_REGISTEREDEXTS_STATIC)
+				)
+			{
+				if (nppParam.isAdmin())
+					SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
+				else
+					SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
+			}
+			return result;
 		}
 
 		case WM_PRINTCLIENT:

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1035,10 +1035,12 @@ intptr_t CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 				)
 			{
 				if (nppGUI._darkmode._isEnabled && nppGUI._darkmode._colorTone == NppDarkMode::customizedTone)
+				{
 					if (NppDarkMode::isEnabled())
 						SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
 					else
 						SetTextColor((HDC)wParam, RGB(0, 0, 0));
+				}
 				else
 					SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
 			}
@@ -3394,10 +3396,12 @@ intptr_t CALLBACK BackupSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			{
 				if (BST_CHECKED != ::SendDlgItemMessage(_hSelf, IDC_RADIO_BKNONE, BM_GETCHECK, 0, 0) &&
 					BST_CHECKED == ::SendDlgItemMessage(_hSelf, IDC_BACKUPDIR_CHECK, BM_GETCHECK, 0, 0))
+				{
 					if (NppDarkMode::isEnabled())
 						SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
 					else
 						SetTextColor((HDC)wParam, RGB(0, 0, 0));
+				}
 				else
 					SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
 			}
@@ -3408,10 +3412,12 @@ intptr_t CALLBACK BackupSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 				)
 			{
 				if (isCheckedOrNot(IDC_BACKUPDIR_RESTORESESSION_CHECK))
+				{
 					if (NppDarkMode::isEnabled())
 						SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
 					else
 						SetTextColor((HDC)wParam, RGB(0, 0, 0));
+				}
 				else
 					SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
 			}

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1020,11 +1020,26 @@ intptr_t CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 				result = NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 			}
 
-			//set the static text colors to show enable/disable instead of ::EnableWindow
-			if (nppGUI._darkmode._isEnabled && nppGUI._darkmode._colorTone == NppDarkMode::customizedTone)
-				SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
-			else
-				SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
+			//set the static text colors to show enable/disable instead of ::EnableWindow which causes blurry text
+			if	( 
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR1_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR2_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR3_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR4_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR5_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR6_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR7_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR8_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR9_STATIC) ||
+				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR10_STATIC)
+				)
+			{
+				if (nppGUI._darkmode._isEnabled && nppGUI._darkmode._colorTone == NppDarkMode::customizedTone)
+					SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
+				else
+					SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
+			}
+			
 
 			return result;
 		}

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -3592,7 +3592,7 @@ intptr_t CALLBACK AutoCompletionSubDlg::run_dlgProc(UINT message, WPARAM wParam,
 			::SetDlgItemInt(_hSelf, IDD_AUTOC_STATIC_N,  static_cast<UINT>(nppGUI._autocFromLen), FALSE);
 			_nbCharVal.init(_hInst, _hSelf);
 			_nbCharVal.create(::GetDlgItem(_hSelf, IDD_AUTOC_STATIC_N), IDD_AUTOC_STATIC_N);
-
+			
 			bool isEnableAutoC = nppGUI._autocStatus != nppGUI.autoc_none;
 
 			::SendDlgItemMessage(_hSelf, IDD_AUTOC_ENABLECHECK, BM_SETCHECK, isEnableAutoC?BST_CHECKED:BST_UNCHECKED, 0);
@@ -3708,18 +3708,24 @@ intptr_t CALLBACK AutoCompletionSubDlg::run_dlgProc(UINT message, WPARAM wParam,
 			//set the static text colors to show enable/disable instead of ::EnableWindow which causes blurry text
 			if (
 				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_AUTOC_STATIC_FROM) ||
-				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_AUTOC_STATIC_N) ||
 				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_AUTOC_STATIC_CHAR) ||
 				(HWND)lParam == ::GetDlgItem(_hSelf, IDD_AUTOC_STATIC_NOTE)
 				)
 			{
 				if (BST_CHECKED == ::SendDlgItemMessage(_hSelf, IDD_AUTOC_ENABLECHECK, BM_GETCHECK, 0, 0))
+				{
 					if (NppDarkMode::isEnabled())
 						SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
 					else
-						SetTextColor((HDC)wParam, RGB(0,0,0));
+						SetTextColor((HDC)wParam, RGB(0, 0, 0));
+
+					_nbCharVal.display(true);
+				}
 				else
+				{
 					SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
+					_nbCharVal.display(false);
+				}
 			}
 			return result;
 		}

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -3598,7 +3598,7 @@ intptr_t CALLBACK AutoCompletionSubDlg::run_dlgProc(UINT message, WPARAM wParam,
 			::SetDlgItemInt(_hSelf, IDD_AUTOC_STATIC_N,  static_cast<UINT>(nppGUI._autocFromLen), FALSE);
 			_nbCharVal.init(_hInst, _hSelf);
 			_nbCharVal.create(::GetDlgItem(_hSelf, IDD_AUTOC_STATIC_N), IDD_AUTOC_STATIC_N);
-			
+
 			bool isEnableAutoC = nppGUI._autocStatus != nppGUI.autoc_none;
 
 			::SendDlgItemMessage(_hSelf, IDD_AUTOC_ENABLECHECK, BM_SETCHECK, isEnableAutoC?BST_CHECKED:BST_UNCHECKED, 0);

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1016,7 +1016,7 @@ intptr_t CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 		{
 			LRESULT result = FALSE;
 			if (NppDarkMode::isEnabled())
-			{			
+			{
 				result = NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 			}
 

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1039,7 +1039,6 @@ intptr_t CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 				else
 					SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
 			}
-			
 
 			return result;
 		}

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -878,17 +878,6 @@ void DarkModeSubDlg::enableCustomizedColorCtrls(bool doEnable)
 	::EnableWindow(_pEdgeColorPicker->getHSelf(), doEnable);
 	::EnableWindow(_pLinkColorPicker->getHSelf(), doEnable);
 
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR1_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR2_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR3_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR4_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR5_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR6_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR7_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR8_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR9_STATIC), doEnable);
-	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_COLOR10_STATIC), doEnable);
-
 	::EnableWindow(::GetDlgItem(_hSelf, IDD_CUSTOMIZED_RESET_BUTTON), doEnable);
 
 	if (doEnable)
@@ -1025,11 +1014,19 @@ intptr_t CALLBACK DarkModeSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
+			LRESULT result = FALSE;
 			if (NppDarkMode::isEnabled())
-			{
-				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			{			
+				result = NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 			}
-			break;
+
+			//set the static text colors to show enable/disable instead of ::EnableWindow
+			if (nppGUI._darkmode._isEnabled && nppGUI._darkmode._colorTone == NppDarkMode::customizedTone)
+				SetTextColor((HDC)wParam, NppDarkMode::getTextColor());
+			else
+				SetTextColor((HDC)wParam, NppDarkMode::getDisabledTextColor());
+
+			return result;
 		}
 
 		case WM_PRINTCLIENT:


### PR DESCRIPTION
Fix #10823, fix #11331

Preferences -> Dark mode tab

![BlurryTextFix_GIF](https://user-images.githubusercontent.com/27722888/156874423-1801949a-cc96-4ef7-9961-4c32ede18b87.gif)

Preferences -> File Association tab

![image](https://user-images.githubusercontent.com/27722888/156877637-e2c9ba04-3ea2-4bbd-bbf3-fe4d7cf7f50f.png)

Preferences -> Backup

![image](https://user-images.githubusercontent.com/27722888/156879123-04f46410-87ff-4536-b574-5a5617a408e7.png)

Preferences -> Auto-Completion

![BlurryTextFix1_GIF](https://user-images.githubusercontent.com/27722888/156883553-e8537251-dd2a-43d9-b0f4-69b3deef43dc.gif)

