### PR TITLE
Use plugin list plugin compability for loading plugins

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <unordered_set>
 #include <algorithm>
+#include <tchar.h>
 
 
 const bool dirUp = true;
@@ -231,3 +232,57 @@ int nbDigitsFromNbLines(size_t nbLines);
 generic_string getDateTimeStrFrom(const generic_string& dateTimeFormat, const SYSTEMTIME& st);
 
 HFONT createFont(const TCHAR* fontName, int fontSize, bool isBold, HWND hDestParent);
+
+class Version final
+{
+public:
+	Version() = default;
+	Version(const generic_string& versionStr);
+
+	void setVersionFrom(const generic_string& filePath);
+	generic_string toString();
+	bool isNumber(const generic_string& s) const {
+		return !s.empty() &&
+			find_if(s.begin(), s.end(), [](TCHAR c) { return !_istdigit(c); }) == s.end();
+	};
+
+	int compareTo(const Version& v2c) const;
+
+	bool operator < (const Version& v2c) const {
+		return compareTo(v2c) == -1;
+	};
+
+	bool operator <= (const Version& v2c) const {
+		int r = compareTo(v2c);
+		return r == -1 || r == 0;
+	};
+
+	bool operator > (const Version& v2c) const {
+		return compareTo(v2c) == 1;
+	};
+
+	bool operator >= (const Version& v2c) const {
+		int r = compareTo(v2c);
+		return r == 1 || r == 0;
+	};
+
+	bool operator == (const Version& v2c) const {
+		return compareTo(v2c) == 0;
+	};
+
+	bool operator != (const Version& v2c) const {
+		return compareTo(v2c) != 0;
+	};
+
+	bool empty() const {
+		return _major == 0 && _minor == 0 && _patch == 0 && _build == 0;
+	}
+
+	bool isCompatibleTo(const Version& from, const Version& to) const;
+
+private:
+	unsigned long _major = 0;
+	unsigned long _minor = 0;
+	unsigned long _patch = 0;
+	unsigned long _build = 0;
+};

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -333,10 +333,14 @@ bool PluginsManager::loadPluginsV2(const TCHAR* dir)
 			hFindDll = ::FindFirstFile(pluginsFullPathFilter.c_str(), &foundData);
 			if (hFindDll != INVALID_HANDLE_VALUE && !(foundData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
 			{
+				// - foundFileName: folder-name
+				// _ pluginsFullPathFilter: version
+				// 
+				// - get Npp current version & plugin compatible Notepad++ versions
 				dllNames.push_back(pluginsFullPathFilter);
 
-				PluginList & pl = nppParams.getPluginList();
-				pl.add(foundFileName, false);
+				//PluginList & pl = nppParams.getPluginList();
+				//pl.add(foundFileName, false);
 			}
 		}
 		// get plugin folder
@@ -361,10 +365,14 @@ bool PluginsManager::loadPluginsV2(const TCHAR* dir)
 				hFindDll = ::FindFirstFile(pluginsFullPathFilter2.c_str(), &foundData);
 				if (hFindDll != INVALID_HANDLE_VALUE && !(foundData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
 				{
+					// - foundFileName2: folder-name
+					// _ pluginsFullPathFilter2: version
+					// From 2 above info to find plugin in list & get this plugin compatible Notepad++ versions
+					// - get Npp current version to compare with
 					dllNames.push_back(pluginsFullPathFilter2);
 
-					PluginList & pl = nppParams.getPluginList();
-					pl.add(foundFileName2, false);
+					//PluginList & pl = nppParams.getPluginList();
+					//pl.add(foundFileName2, false);
 				}
 			}
 		}

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -23,6 +23,7 @@
 #include "IDAllocator.h"
 
 typedef BOOL (__cdecl * PFUNCISUNICODE)();
+class PluginViewList;
 
 struct PluginCommand
 {
@@ -86,7 +87,7 @@ public:
 	}
 
     int loadPlugin(const TCHAR *pluginFilePath);
-	bool loadPluginsV2(const TCHAR *dir = NULL);
+	bool loadPluginsV2(const TCHAR *dir = NULL, const PluginViewList* pluginUpdateInfoList = nullptr);
 
     bool unloadPlugin(int index, HWND nppHandle);
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -409,7 +409,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_pluginsManager.init(nppData);
 
 	bool enablePluginAdmin = _pluginsAdminDlg.initFromJson();
-	_pluginsManager.loadPluginsV2(nppParam.getPluginRootDir());
+	_pluginsManager.loadPluginsV2(nppParam.getPluginRootDir(), enablePluginAdmin ? &_pluginsAdminDlg.getAvailablePluginUpdateInfoList() : nullptr);
 	_restoreButton.init(_pPublicInterface->getHinst(), hwnd);
 
 	// ------------ //
@@ -7110,7 +7110,7 @@ static const QuoteParams quotes[] =
 	{TEXT("Anonymous #65"), QuoteParams::slow, false, SC_CP_UTF8, L_TEXT, TEXT("A man without God is like a fish without a bicycle.")},
 	{TEXT("Anonymous #66"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("I hate how spiders just sit there on the walls and act like they pay rent!")},
 	{TEXT("Anonymous #67"), QuoteParams::rapid, false, SC_CP_UTF8, L_TEXT, TEXT("Whenever someone starts a sentence by saying \"I'm not racist...\"),they are about to say something super racist.")},
-	{TEXT("Anonymous #68"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("I'm not laughing at you, I'm laughing with you, you're just not laughing.")},
+	{TEXT("Anonymous #68"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("I'm not laughing at you, I'm laughing with you, you're just not laughing.\n")},
 	{TEXT("Anonymous #69"), QuoteParams::slow, false, SC_CP_UTF8, L_TEXT, TEXT("Women need a reason to have sex. Men just need a place.")},
 	{TEXT("Anonymous #70"), QuoteParams::slow, false, SC_CP_UTF8, L_TEXT, TEXT("If abortion is murder then are condoms kidnapping?")},
 	{TEXT("Anonymous #71"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Men also have feelings.\nFor example, they can feel hungry.")},
@@ -7120,12 +7120,12 @@ static const QuoteParams quotes[] =
 	{TEXT("Anonymous #75"), QuoteParams::slow, false, SC_CP_UTF8, L_TEXT, TEXT("I think therefore I am\nnot religious.")},
 	{TEXT("Anonymous #76"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Even if being gay were a choice, so what?\nPeople choose to be assholes and they can get married.")},
 	{TEXT("Anonymous #77"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Governments are like diapers.\nThey should be changed often, and for the same reason.")},
-	{TEXT("Anonymous #78"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Mathématiquement, un cocu est un entier qui partage sa moitié avec un tiers.")},
-	{TEXT("Anonymous #79"), QuoteParams::slow, false, SC_CP_UTF8, L_TEXT, TEXT("I'm a creationist.\nI believe man created God.")},
-	{TEXT("Anonymous #80"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Let's eat kids.\nLet's eat, kids.\n\nUse a comma.\nSave lives.")},
+	{TEXT("Anonymous #78"), QuoteParams::slow, true, SC_CP_UTF8, L_TEXT, TEXT("Mathématiquement, un cocu est un entier qui partage sa moitié avec un tiers.\n")},
+	{TEXT("Anonymous #79"), QuoteParams::slow, false, SC_CP_UTF8, L_TEXT, TEXT("I'm a creationist.\nI believe man created God.\n")},
+	{TEXT("Anonymous #80"), QuoteParams::slow, true, SC_CP_UTF8, L_TEXT, TEXT("Let's eat kids.\nLet's eat, kids.\n\nUse a comma.\nSave lives.\n")},
 	{TEXT("Anonymous #81"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("A male engineering student was crossing a road one day when a frog called out to him and said, \"If you kiss me, I'll turn into a beautiful princess.\" He bent over, picked up the frog, and put it in his pocket.\n\nThe frog spoke up again and said, \"If you kiss me and turn me back into a beautiful princess, I will stay with you for one week.\" The engineering student took the frog out of his pocket, smiled at it; and returned it to his pocket.\n\nThe frog then cried out, \"If you kiss me and turn me back into a princess, I'll stay with you and do ANYTHING you want.\" Again the boy took the frog out, smiled at it, and put it back into his pocket.\n\nFinally, the frog asked, \"What is the matter? I've told you I'm a beautiful princess, that I'll stay with you for a week and do anything you want. Why won't you kiss me?\" The boy said, \"Look I'm an engineer. I don't have time for a girlfriend, but a talking frog is cool.\"\n")},
-	{TEXT("Anonymous #82"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Gamers never die.\nThey just go offline.")},
-	{TEXT("Anonymous #83"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Copy from one, it's plagiarism.\nCopy from two, it's research.")},
+	{TEXT("Anonymous #82"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Gamers never die.\nThey just go offline.\n")},
+	{TEXT("Anonymous #83"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Copy from one, it's plagiarism.\nCopy from two, it's research.\n")},
 	{TEXT("Anonymous #84"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Saying that Java is nice because it works on all OSes is like saying that anal sex is nice because it works on all genders.")},
 	{TEXT("Anonymous #85"), QuoteParams::rapid, false, SC_CP_UTF8, L_TEXT, TEXT("Race, religion, ethnic pride and nationalism etc... does nothing but teach you how to hate people that you've never met.")},
 	{TEXT("Anonymous #86"), QuoteParams::rapid, true, SC_CP_UTF8, L_TEXT, TEXT("Farts are just the ghosts of the things we eat.")},

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -408,6 +408,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_scintillaCtrls4Plugins.init(_pPublicInterface->getHinst(), hwnd);
 	_pluginsManager.init(nppData);
 
+	bool enablePluginAdmin = _pluginsAdminDlg.initFromJson();
 	_pluginsManager.loadPluginsV2(nppParam.getPluginRootDir());
 	_restoreButton.init(_pPublicInterface->getHinst(), hwnd);
 
@@ -525,7 +526,6 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	}
 
 	//Plugin menu
-	bool enablePluginAdmin = _pluginsAdminDlg.initFromJson();
 	_pluginsAdminDlg.setPluginsManager(&_pluginsManager);
 	_pluginsManager.initMenu(_mainMenuHandle, enablePluginAdmin);
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -525,7 +525,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	}
 
 	//Plugin menu
-	bool enablePluginAdmin = _pluginsAdminDlg.isValide();
+	bool enablePluginAdmin = _pluginsAdminDlg.initFromJson();
 	_pluginsAdminDlg.setPluginsManager(&_pluginsManager);
 	_pluginsManager.initMenu(_mainMenuHandle, enablePluginAdmin);
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2973,7 +2973,7 @@ void Notepad_plus::command(int id)
 			if (isFirstTime)
 			{
 				_nativeLangSpeaker.changePluginsAdminDlgLang(_pluginsAdminDlg);
-				_pluginsAdminDlg.updateListAndLoadFromJson();
+				_pluginsAdminDlg.updateList();
 			}
 			break;
 		}

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1250,19 +1250,6 @@ private:
 	generic_string _stylesXmlPath;
 };
 
-/*
-class PluginList final
-{
-public :
-	void add(generic_string fn, bool isInBL)
-	{
-		_list.push_back(std::pair<generic_string, bool>(fn, isInBL));
-	}
-
-private:
-	std::vector<std::pair<generic_string, bool>>_list;
-};
-*/
 
 struct UdlXmlFileState final {
 	TiXmlDocument* _udlXmlDoc = nullptr;
@@ -1600,7 +1587,6 @@ public:
 		return false;
 	}
 
-	//PluginList & getPluginList() {return _pluginList;};
 	bool importUDLFromFile(const generic_string& sourceFile);
 	bool exportUDLToFile(size_t langIndex2export, const generic_string& fileName2save);
 	NativeLangSpeaker* getNativeLangSpeaker() {
@@ -1732,7 +1718,6 @@ private:
 
 	std::vector<generic_string> _fontlist;
 	std::vector<generic_string> _blacklist;
-	//PluginList _pluginList;
 
 	HMODULE _hUXTheme = nullptr;
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1250,7 +1250,7 @@ private:
 	generic_string _stylesXmlPath;
 };
 
-
+/*
 class PluginList final
 {
 public :
@@ -1262,7 +1262,7 @@ public :
 private:
 	std::vector<std::pair<generic_string, bool>>_list;
 };
-
+*/
 
 struct UdlXmlFileState final {
 	TiXmlDocument* _udlXmlDoc = nullptr;
@@ -1600,7 +1600,7 @@ public:
 		return false;
 	}
 
-	PluginList & getPluginList() {return _pluginList;};
+	//PluginList & getPluginList() {return _pluginList;};
 	bool importUDLFromFile(const generic_string& sourceFile);
 	bool exportUDLToFile(size_t langIndex2export, const generic_string& fileName2save);
 	NativeLangSpeaker* getNativeLangSpeaker() {
@@ -1732,7 +1732,7 @@ private:
 
 	std::vector<generic_string> _fontlist;
 	std::vector<generic_string> _blacklist;
-	PluginList _pluginList;
+	//PluginList _pluginList;
 
 	HMODULE _hUXTheme = nullptr;
 

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -691,7 +691,6 @@ void PluginViewList::pushBack(PluginUpdateInfo* pi)
 		values2Add.push_back(pi->_displayName);
 		Version v = pi->_version;
 		values2Add.push_back(v.toString());
-		//values2Add.push_back(TEXT("Yes"));
 
 		// add in order
 		size_t i = _ui.findAlphabeticalOrderPos(pi->_displayName, _sortType == DISPLAY_NAME_ALPHABET_ENCREASE ? _ui.sortEncrease : _ui.sortDecrease);
@@ -844,7 +843,7 @@ PluginUpdateInfo::PluginUpdateInfo(const generic_string& fullFilePath, const gen
 typedef const char * (__cdecl * PFUNCGETPLUGINLIST)();
 
 
-bool PluginsAdminDlg::isValide()
+bool PluginsAdminDlg::initFromJson()
 {
 	// GUP.exe doesn't work under XP
 	winVer winVersion = (NppParameters::getInstance()).getWinVersion();
@@ -928,7 +927,7 @@ bool PluginsAdminDlg::isValide()
 	return loadFromJson(_availableList, j);
 }
 
-bool PluginsAdminDlg::updateListAndLoadFromJson()
+bool PluginsAdminDlg::updateList()
 {
 	// initialize update list view
 	checkUpdates();

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -83,6 +83,13 @@ struct PluginUpdateInfo
 	generic_string _folderName;   // plugin folder name - should be the same name with plugin and should be uniq among the plugins
 	generic_string _displayName;  // plugin description name
 	Version _version;
+	// Optional
+	std::pair<Version, Version> _nppCompatibleVersions; // compatible to Notepad++ interval versions: <from, to> example: 
+														// <0.0.0.0, 0.0.0.0>: plugin is compatible to all Notepad++ versions (due to invalid format set)
+														// <6.9, 6.9>: plugin is compatible to only v6.9
+														// <4.2, 6.6.6>: from v4.2 (included) to v6.6.6 (included)
+														// <0.0.0.0, 8.2.1> all until v8.2.1 (included)
+														// <8.3, 0.0.0.0> from v8.3 (included) to all
 	generic_string _homepage;
 	generic_string _sourceUrl;
 	generic_string _description;

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -203,12 +203,12 @@ public :
 	    display();
     };
 
-	bool isValide();
+	bool initFromJson();
 
 	void switchDialog(int indexToSwitch);
 	void setPluginsManager(PluginsManager *pluginsManager) { _pPluginsManager = pluginsManager; };
 
-	bool updateListAndLoadFromJson();
+	bool updateList();
 	void setAdminMode(bool isAdm) { _nppCurrentStatus._isAdminMode = isAdm; };
 
 	bool installPlugins();

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -26,56 +26,6 @@
 
 class PluginsManager;
 
-struct Version
-{
-	unsigned long _major = 0;
-	unsigned long _minor = 0;
-	unsigned long _patch = 0;
-	unsigned long _build = 0;
-
-	Version() = default;
-	Version(const generic_string& versionStr);
-
-	void setVersionFrom(const generic_string& filePath);
-	generic_string toString();
-	bool isNumber(const generic_string& s) const {
-		return !s.empty() && 
-			find_if(s.begin(), s.end(), [](_TCHAR c) { return !_istdigit(c); }) == s.end();
-	};
-
-	int compareTo(const Version& v2c) const;
-
-	bool operator < (const Version& v2c) const {
-		return compareTo(v2c) == -1;
-	};
-
-	bool operator <= (const Version& v2c) const {
-		int r = compareTo(v2c);
-		return r == -1 || r == 0;
-	};
-
-	bool operator > (const Version& v2c) const {
-		return compareTo(v2c) == 1;
-	};
-
-	bool operator >= (const Version& v2c) const {
-		int r = compareTo(v2c);
-		return r == 1 || r == 0;
-	};
-
-	bool operator == (const Version& v2c) const {
-		return compareTo(v2c) == 0;
-	};
-
-	bool operator != (const Version& v2c) const {
-		return compareTo(v2c) != 0;
-	};
-
-	bool empty() const {
-		return _major == 0 && _minor == 0 && _patch == 0 && _build == 0;
-	}
-};
-
 struct PluginUpdateInfo
 {
 	generic_string _fullFilePath; // only for the installed Plugin
@@ -220,6 +170,9 @@ public :
 	void changeTabName(LIST_TYPE index, const TCHAR *name2change);
 	void changeColumnName(COLUMN_TYPE index, const TCHAR *name2change);
 	generic_string getPluginListVerStr() const;
+	const PluginViewList & getAvailablePluginUpdateInfoList() const {
+		return _availableList;
+	};
 
 protected:
 	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -135,6 +135,8 @@ struct SortDisplayNameDecrease final
 
 class PluginViewList
 {
+friend class PluginsAdminDlg;
+
 public:
 	PluginViewList() = default;
 	~PluginViewList() {
@@ -250,6 +252,7 @@ private :
 		return searchFromCurrentSel(str2search, _inDescs, isNextMode);
 	};
 	
+	bool initAvailablePluginsViewFromList();
 	bool loadFromPluginInfos();
 	bool checkUpdates();
 

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -35,11 +35,11 @@ struct PluginUpdateInfo
 	Version _version;
 	// Optional
 	std::pair<Version, Version> _nppCompatibleVersions; // compatible to Notepad++ interval versions: <from, to> example: 
-														// <0.0.0.0, 0.0.0.0>: plugin is compatible to all Notepad++ versions (due to invalid format set)
-														// <6.9, 6.9>: plugin is compatible to only v6.9
-														// <4.2, 6.6.6>: from v4.2 (included) to v6.6.6 (included)
-														// <0.0.0.0, 8.2.1> all until v8.2.1 (included)
-														// <8.3, 0.0.0.0> from v8.3 (included) to all
+	                                                    // <0.0.0.0, 0.0.0.0>: plugin is compatible to all Notepad++ versions (due to invalid format set)
+	                                                    // <6.9, 6.9>: plugin is compatible to only v6.9
+	                                                    // <4.2, 6.6.6>: from v4.2 (included) to v6.6.6 (included)
+	                                                    // <0.0.0.0, 8.2.1> all until v8.2.1 (included)
+	                                                    // <8.3, 0.0.0.0> from v8.3 (included) to all
 	generic_string _homepage;
 	generic_string _sourceUrl;
 	generic_string _description;


### PR DESCRIPTION
A new ability for checking plugins' compatibility with running  Notepad++ has been added in Plugin List & Plugin Admin (https://github.com/notepad-plus-plus/notepad-plus-plus/commit/a06b404708e73ed25bec3c2e9ed132d1a1e5c2ef).
This PR extends this ability by using Plugin Admin's plugin list to filter plugins to load - if any plugin to load with **the same folder name**, **the same version** (as in the plugin list) and it's **not compatible** with the running Notepad++ version found while loading plugins, it will be skipped for being loaded. 

Fix #11353