### PR TITLE
LexCmake.cxx: Avoid incrementation of foldLevel in case of "ElseIf" Token

### DIFF
--- a/scintilla/lexers/LexCmake.cxx
+++ b/scintilla/lexers/LexCmake.cxx
@@ -85,7 +85,7 @@ static int calculateFoldCmake(Sci_PositionU start, Sci_PositionU end, int foldle
 
     if ( CompareCaseInsensitive(s, "IF") == 0 || CompareCaseInsensitive(s, "WHILE") == 0
          || CompareCaseInsensitive(s, "MACRO") == 0 || CompareCaseInsensitive(s, "FOREACH") == 0
-         || CompareCaseInsensitive(s, "FUNCTION") == 0 || CompareCaseInsensitive(s, "ELSEIF") == 0)
+         || CompareCaseInsensitive(s, "FUNCTION") == 0)
         newFoldlevel++;
     else if ( CompareCaseInsensitive(s, "ENDIF") == 0 || CompareCaseInsensitive(s, "ENDWHILE") == 0
               || CompareCaseInsensitive(s, "ENDMACRO") == 0 || CompareCaseInsensitive(s, "ENDFOREACH") == 0


### PR DESCRIPTION
Fix notepad-plus-plus#7901

Tested with ExampleCode given in Bug-Report. 
Tested with "fold.at.else" enabled and disabled