### PR TITLE
NPP RTL: Fixed "Preferences->Dark Mode" color pickers RTL alignment

### DIFF
--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -914,7 +914,13 @@ void DarkModeSubDlg::move2CtrlLeft(int ctrlID, HWND handle2Move, int handle2Move
 	RECT rc;
 	::GetWindowRect(::GetDlgItem(_hSelf, ctrlID), &rc);
 
-	p.x = rc.left - NppParameters::getInstance()._dpiManager.scaleX(5) - handle2MoveWidth;
+	NppParameters& nppParam = NppParameters::getInstance();
+
+	if(nppParam.getNativeLangSpeaker()->isRTL())
+		p.x = rc.right + nppParam._dpiManager.scaleX(5) + handle2MoveWidth;
+	else
+		p.x = rc.left - nppParam._dpiManager.scaleX(5) - handle2MoveWidth;
+
 	p.y = rc.top + ((rc.bottom - rc.top) / 2) - handle2MoveHeight / 2;
 
 	::ScreenToClient(_hSelf, &p);


### PR DESCRIPTION
fix #11343

![image](https://user-images.githubusercontent.com/27722888/157052438-1516aae1-f29b-423e-bc27-3bde73b4ef98.png)

@Yaron10, test it and let me know if its good.