### PR TITLE
Fix AutoComplete file Environment tag standards for Cobol and Lua outliers

### DIFF
--- a/PowerEditor/installer/APIs/cobol.xml
+++ b/PowerEditor/installer/APIs/cobol.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
-	<Environment ignoreCase="yes" startFunc="(" stopFunc=")" paramSeparator="," additionalWordChar="-" />
 	<!-- note: this list was created using functions and reserved words known to GnuCOBOL (COBOL85,2002,2014 + extensions from IBM/MF/RM/ACUCOBOL) -->
 	<AutoComplete language="COBOL">
+		<Environment ignoreCase="yes" startFunc="(" stopFunc=")" paramSeparator="," additionalWordChar="-" />
 		<KeyWord name="3-D" />
 		<KeyWord name="ABS" func="yes">
 			<Overload retVal="Integer/Numeric" descr="absolute value of &lt;number&gt;">

--- a/PowerEditor/installer/APIs/lua.xml
+++ b/PowerEditor/installer/APIs/lua.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <NotepadPlus>
-    <Environment ignoreCase="yes" startFunc="(" stopFunc=")" paramSeparator="," terminal=";" additionalWordChar=".:" />
     <AutoComplete language="LUA">
+        <Environment ignoreCase="yes" startFunc="(" stopFunc=")" paramSeparator="," terminal=";" additionalWordChar=".:" />
         <KeyWord name="and" func="no" />
         <KeyWord name="assert" func="yes">
             <Overload retVal="void" descr="


### PR DESCRIPTION
move `<Environment>` tag into `<AutoComplete>` tag as per file definition for Cobol and Lua, Fix #11393