### PR TITLE
Window Sort Document List Fix

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2880,8 +2880,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 						}
 						activateBuffer(_pDocTab->getBufferByIndex(_pDocTab->getCurrentTabIndex()), currentView());
 
-						if (_pDocumentListPanel)
-							_pDocumentListPanel->reload();
+						::SendMessage(_pDocTab->getHParent(), NPPM_INTERNAL_DOCORDERCHANGED, 0, _pDocTab->getCurrentTabIndex());
 
 						break;
 					}

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2879,6 +2879,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 							_pDocTab->setBuffer(i, tempBufs[nmdlg->Items[i]]);
 						}
 						activateBuffer(_pDocTab->getBufferByIndex(_pDocTab->getCurrentTabIndex()), currentView());
+
+						if (_pDocumentListPanel)
+							_pDocumentListPanel->reload();
+
 						break;
 					}
 				}


### PR DESCRIPTION
Fix #11272
Document List now updates itself with respect to the tabs sorted by the windows dialog
![WinSortDocList_Fix_GIF](https://user-images.githubusercontent.com/27722888/159112772-56a411b2-0445-47b0-835d-1e015f6ea674.gif)
