### PR TITLE
Make Find in Files Search Result line number aligned

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -16,6 +16,7 @@
 
 
 #include <shlwapi.h>
+#include "math.h"
 #include "FindReplaceDlg.h"
 #include "ScintillaEditView.h"
 #include "ILexer.h"

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -2441,6 +2441,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 					findAllFileNameAdded = true;
 				}
 
+				auto totalLineNumber = pEditView->execute(SCI_GETLINECOUNT);
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
 				intptr_t lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
 				intptr_t lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
@@ -2462,7 +2463,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				SearchResultMarking srm;
 				srm._start = static_cast<long>(start_mark);
 				srm._end = static_cast<long>(end_mark);
-				_pFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str());
+				_pFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str(), totalLineNumber);
 
 				break;
 			}
@@ -2474,6 +2475,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 
 				const TCHAR *pFileName = pFindersInfo->_pFileName ? pFindersInfo->_pFileName : TEXT("");
 
+				auto totalLineNumber = pEditView->execute(SCI_GETLINECOUNT);
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
 				intptr_t lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
 				intptr_t lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
@@ -2503,7 +2505,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 						pFindersInfo->_pDestFinder->addFileNameTitle(pFileName);
 						findAllFileNameAdded = true;
 					}
-					pFindersInfo->_pDestFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str());
+					pFindersInfo->_pDestFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str(), totalLineNumber);
 				}
 				break;
 			}
@@ -4083,7 +4085,7 @@ void Finder::addSearchHitCount(int count, int countSearched, bool isMatchLines, 
 	setFinderReadOnly(true);
 }
 
-void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
+void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline, size_t totalLineNumber)
 {
 	_pMainFoundInfos->push_back(fi);
 
@@ -4091,7 +4093,14 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
 	str += _prefixLineStr;
 	str += TEXT(" ");
 
-	str += std::to_wstring(fi._lineNumber);
+	size_t totalLineNumberDigit = size_t(log10(totalLineNumber) + 1);
+	size_t currentLineNumberDigit = size_t(log10(fi._lineNumber) + 1);
+
+	generic_string lineNumberStr = TEXT("");
+	lineNumberStr.append(totalLineNumberDigit - currentLineNumberDigit, ' ');
+	lineNumberStr.append(std::to_wstring(fi._lineNumber));
+	str += lineNumberStr;
+
 	str += TEXT(": ");
 	mi._start += str.length();
 	mi._end += str.length();

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -16,13 +16,13 @@
 
 
 #include <shlwapi.h>
-#include "math.h"
 #include "FindReplaceDlg.h"
 #include "ScintillaEditView.h"
 #include "ILexer.h"
 #include "Lexilla.h"
 #include "Notepad_plus_msgs.h"
 #include "localization.h"
+#include "Common.h"
 #include "Utf8.h"
 
 using namespace std;
@@ -4094,8 +4094,8 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline, s
 	str += _prefixLineStr;
 	str += TEXT(" ");
 
-	size_t totalLineNumberDigit = size_t(log10(totalLineNumber) + 1);
-	size_t currentLineNumberDigit = size_t(log10(fi._lineNumber) + 1);
+	size_t totalLineNumberDigit = static_cast<size_t>(nbDigitsFromNbLines(totalLineNumber) + 1);
+	size_t currentLineNumberDigit = static_cast<size_t>(nbDigitsFromNbLines(fi._lineNumber) + 1);
 
 	generic_string lineNumberStr = TEXT("");
 	lineNumberStr.append(totalLineNumberDigit - currentLineNumberDigit, ' ');

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -2441,7 +2441,6 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 					findAllFileNameAdded = true;
 				}
 
-				auto totalLineNumber = pEditView->execute(SCI_GETLINECOUNT);
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
 				intptr_t lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
 				intptr_t lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
@@ -2463,7 +2462,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 				SearchResultMarking srm;
 				srm._start = static_cast<long>(start_mark);
 				srm._end = static_cast<long>(end_mark);
-				_pFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str(), totalLineNumber);
+				_pFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str());
 
 				break;
 			}
@@ -2475,7 +2474,6 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 
 				const TCHAR *pFileName = pFindersInfo->_pFileName ? pFindersInfo->_pFileName : TEXT("");
 
-				auto totalLineNumber = pEditView->execute(SCI_GETLINECOUNT);
 				auto lineNumber = pEditView->execute(SCI_LINEFROMPOSITION, targetStart);
 				intptr_t lend = pEditView->execute(SCI_GETLINEENDPOSITION, lineNumber);
 				intptr_t lstart = pEditView->execute(SCI_POSITIONFROMLINE, lineNumber);
@@ -2505,7 +2503,7 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 						pFindersInfo->_pDestFinder->addFileNameTitle(pFileName);
 						findAllFileNameAdded = true;
 					}
-					pFindersInfo->_pDestFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str(), totalLineNumber);
+					pFindersInfo->_pDestFinder->add(FoundInfo(targetStart, targetEnd, lineNumber + 1, pFileName), srm, line.c_str());
 				}
 				break;
 			}
@@ -4085,7 +4083,7 @@ void Finder::addSearchHitCount(int count, int countSearched, bool isMatchLines, 
 	setFinderReadOnly(true);
 }
 
-void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline, size_t totalLineNumber)
+void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
 {
 	_pMainFoundInfos->push_back(fi);
 
@@ -4093,14 +4091,7 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline, s
 	str += _prefixLineStr;
 	str += TEXT(" ");
 
-	size_t totalLineNumberDigit = size_t(log10(totalLineNumber) + 1);
-	size_t currentLineNumberDigit = size_t(log10(fi._lineNumber) + 1);
-
-	generic_string lineNumberStr = TEXT("");
-	lineNumberStr.append(totalLineNumberDigit - currentLineNumberDigit, ' ');
-	lineNumberStr.append(std::to_wstring(fi._lineNumber));
-	str += lineNumberStr;
-
+	str += std::to_wstring(fi._lineNumber);
 	str += TEXT(": ");
 	mi._start += str.length();
 	mi._end += str.length();

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -119,7 +119,7 @@ public:
 	void addFileNameTitle(const TCHAR * fileName);
 	void addFileHitCount(int count);
 	void addSearchHitCount(int count, int countSearched, bool isMatchLines, bool searchedEntireNotSelection);
-	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline, size_t totalLineNumber);
+	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline);
 	void setFinderStyle();
 	void removeAll();
 	void openAll();

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -119,7 +119,7 @@ public:
 	void addFileNameTitle(const TCHAR * fileName);
 	void addFileHitCount(int count);
 	void addSearchHitCount(int count, int countSearched, bool isMatchLines, bool searchedEntireNotSelection);
-	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline);
+	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline, size_t totalLineNumber);
 	void setFinderStyle();
 	void removeAll();
 	void openAll();

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -928,7 +928,7 @@ protected:
 
 	void setREBOLLexer() {
 		setLexer(SCLEX_REBOL, L_REBOL, LIST_0 | LIST_1 | LIST_2 | LIST_3 | LIST_4 | LIST_5 | LIST_6);
-		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?!.?-*&|=_~"));
+		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?!.’+-*&|=_~"));
 	};
 
 	void setRegistryLexer() {

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -928,7 +928,7 @@ protected:
 
 	void setREBOLLexer() {
 		setLexer(SCLEX_REBOL, L_REBOL, LIST_0 | LIST_1 | LIST_2 | LIST_3 | LIST_4 | LIST_5 | LIST_6);
-		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?!.’+-*&|=_~"));
+		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?!.?-*&|=_~"));
 	};
 
 	void setRegistryLexer() {


### PR DESCRIPTION
Added a new size_t argument to Finder::add() to indicate the totalLineNumber of the current searched file in order to create nice formatted output in the result window.

Fix #11119