### PR TITLE
Fix autocomplete may show empty list

### DIFF
--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -242,6 +242,9 @@ bool AutoCompletion::showApiAndWordComplete()
 		}
 	}
 
+	if (!wordArray.size())
+		return false;
+
 	// Sort word array and convert it to a single string with space-separated words
 
 	sort(wordArray.begin(), wordArray.end());


### PR DESCRIPTION
Fixes #9433

This seems to be the same issue reported recently to the community forum [Flashing Box Whilst Typing](https://community.notepad-plus-plus.org/topic/22788/flashing-box-whilst-typing). So, the issue still remains in Notepad++ v8.3.3.

The autocomplete is being being called even if `wordArray` is zero in size. A better option would be to check the size of `wordArray` and return false early, instead of calling the autocomplete unnecessarily, which can cause this issue.


