### PR TITLE
Restore external lexer library support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,6 @@ UpgradeLog*.htm
 *.bak
 
 PowerEditor/bin/notepad++.exe
-PowerEditor/bin/Notepad++.exp
-PowerEditor/bin/Notepad++.lib
 PowerEditor/bin/SciLexer.dll
 PowerEditor/bin/config.xml
 PowerEditor/bin/stylers.xml

--- a/PowerEditor/src/MISC/FileNameStringSplitter.h
+++ b/PowerEditor/src/MISC/FileNameStringSplitter.h
@@ -23,6 +23,7 @@ class FileNameStringSplitter
 public:
 	FileNameStringSplitter(const TCHAR *fileNameStr)
 	{
+		//if (!fileNameStr) return;
 		TCHAR *pStr = NULL;
 		bool isInsideQuotes = false;
 		const int filePathLength = MAX_PATH;

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -35,7 +35,7 @@ enum LangType {L_TEXT, L_PHP , L_C, L_CPP, L_CS, L_OBJC, L_JAVA, L_RC,\
 			   L_REGISTRY, L_RUST, L_SPICE, L_TXT2TAGS, L_VISUALPROLOG, L_TYPESCRIPT,\
 			   // Don't use L_JS, use L_JAVASCRIPT instead
 			   // The end of enumated language type, so it should be always at the end
-			   L_END};
+			   L_EXTERNAL};
 enum class ExternalLexerAutoIndentMode { Standard, C_Like, Custom };
 enum class MacroStatus { Idle, RecordInProgress, RecordingStopped, PlayingBack };
 
@@ -456,10 +456,6 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 		HICON	hToolbarIconDarkMode;
 	};
 
-	// Due to Scintilla 5 doesn't support external lexer, the following 2 messages are deprecated - they do nothing and return always FALSE
-	#define NPPM_GETEXTERNALLEXERAUTOINDENTMODE_DEPRECATED  (NPPMSG + 103)
-	#define NPPM_SETEXTERNALLEXERAUTOINDENTMODE_DEPRECATED  (NPPMSG + 104)
-	/*
 	#define NPPM_GETEXTERNALLEXERAUTOINDENTMODE  (NPPMSG + 103)
 	// BOOL NPPM_GETEXTERNALLEXERAUTOINDENTMODE(const TCHAR *languageName, ExternalLexerAutoIndentMode &autoIndentMode)
 	// Get ExternalLexerAutoIndentMode for an installed external programming language.
@@ -475,7 +471,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// - C_Like means Notepad++ will perform a C-Language style indentation for the selected external language;
 	// - Custom means a Plugin will be controlling auto-indentation for the current language.
 	// returned value: TRUE if function call was successful, otherwise FALSE.
-	*/
+
 	#define NPPM_ISAUTOINDENTON  (NPPMSG + 105)
 	// BOOL NPPM_ISAUTOINDENTON(0, 0)
 	// Returns the current Use Auto-Indentation setting in Notepad++ Preferences.

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -173,17 +173,82 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath)
 		// it's a lexer plugin
 		if (GetLexerCount)
 		{
-			// Lexer library (.dll) is not supported in Scintilla 5
+			GetLexerNameFn GetLexerName = (GetLexerNameFn)::GetProcAddress(pi->_hLib, "GetLexerName");
+			if (!GetLexerName)
+				throw generic_string(TEXT("Loading GetLexerName function failed."));
 
-			generic_string s = pluginFileName;
-			s += TEXT(" is a Lexer library.\n");
-			s += TEXT("Lexer library is not supported in Scintilla 5.\nIt'll be loaded as only a normal plugin, the external language part won't work with this version of Notepad++.");
-			::MessageBox(_nppData._nppHandle, s.c_str(), pluginFilePath, MB_OK);
+			GetLexerStatusTextFn GetLexerStatusText = (GetLexerStatusTextFn)::GetProcAddress(pi->_hLib, "GetLexerStatusText");
+
+			if (!GetLexerStatusText)
+				throw generic_string(TEXT("Loading GetLexerStatusText function failed."));
+
+			// Assign a buffer for the lexer name.
+			char lexName[MAX_EXTERNAL_LEXER_NAME_LEN];
+			lexName[0] = '\0';
+			TCHAR lexDesc[MAX_EXTERNAL_LEXER_DESC_LEN];
+			lexDesc[0] = '\0';
+
+			int numLexers = GetLexerCount();
+
+			ExternalLangContainer *containers[30];
+
+			WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+			for (int x = 0; x < numLexers; ++x)
+			{
+				GetLexerName(x, lexName, MAX_EXTERNAL_LEXER_NAME_LEN);
+				GetLexerStatusText(x, lexDesc, MAX_EXTERNAL_LEXER_DESC_LEN);
+				const TCHAR *pLexerName = wmc.char2wchar(lexName, CP_ACP);
+				if (!nppParams.isExistingExternalLangName(pLexerName) && nppParams.ExternalLangHasRoom())
+					containers[x] = new ExternalLangContainer(pLexerName, lexDesc);
+				else
+					containers[x] = NULL;
+			}
+
+			TCHAR xmlPath[MAX_PATH];
+			wcscpy_s(xmlPath, nppParams.getNppPath().c_str());
+			PathAppend(xmlPath, TEXT("plugins\\Config"));
+            PathAppend(xmlPath, pi->_moduleName.c_str());
+			PathRemoveExtension(xmlPath);
+			PathAddExtension(xmlPath, TEXT(".xml"));
+
+			if (!PathFileExists(xmlPath))
+			{
+				lstrcpyn(xmlPath, TEXT("\0"), MAX_PATH );
+				wcscpy_s(xmlPath, nppParams.getAppDataNppDir() );
+				PathAppend(xmlPath, TEXT("plugins\\Config"));
+                PathAppend(xmlPath, pi->_moduleName.c_str());
+				PathRemoveExtension( xmlPath );
+				PathAddExtension( xmlPath, TEXT(".xml") );
+
+				if (! PathFileExists( xmlPath ) )
+				{
+					throw generic_string(generic_string(xmlPath) + TEXT(" is missing."));
+				}
+			}
+
+			TiXmlDocument *pXmlDoc = new TiXmlDocument(xmlPath);
+
+			if (!pXmlDoc->LoadFile())
+			{
+				delete pXmlDoc;
+				pXmlDoc = NULL;
+				throw generic_string(generic_string(xmlPath) + TEXT(" failed to load."));
+			}
+
+			for (int x = 0; x < numLexers; ++x) // postpone adding in case the xml is missing/corrupt
+			{
+				if (containers[x] != NULL)
+					nppParams.addExternalLangToEnd(containers[x]);
+			}
+
+			nppParams.getExternalLexerFromXmlTree(pXmlDoc);
+			nppParams.getExternalLexerDoc()->push_back(pXmlDoc);
+			//const char *pDllName = wmc.wchar2char(pluginFilePath, CP_ACP);
+			//::SendMessage(_nppData._scintillaMainHandle, SCI_LOADLEXERLIBRARY, 0, reinterpret_cast<LPARAM>(pDllName));
+
 		}
-
 		addInLoadedDlls(pluginFilePath, pluginFileName);
 		_pluginInfos.push_back(pi);
-
 		return static_cast<int32_t>(_pluginInfos.size() - 1);
 	}
 	catch (std::exception& e)
@@ -193,19 +258,17 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath)
 	}
 	catch (generic_string& s)
 	{
-		if (pi && pi->_hLib)
-		{
-			::FreeLibrary(pi->_hLib);
-		}
-
 		s += TEXT("\n\n");
 		s += pluginFileName;
 		s += USERMSG;
-		if (::MessageBox(_nppData._nppHandle, s.c_str(), pluginFilePath, MB_YESNO) == IDYES)
+		if (::MessageBox(NULL, s.c_str(), pluginFilePath, MB_YESNO) == IDYES)
 		{
+			if (pi && pi->_hLib)
+			{
+				::FreeLibrary(pi->_hLib);
+			}
 			::DeleteFile(pluginFilePath);
 		}
-
 		delete pi;
 		return -1;
 	}
@@ -215,7 +278,7 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath)
 		msg += TEXT("\n\n");
 		msg += pluginFileName;
 		msg += USERMSG;
-		if (::MessageBox(_nppData._nppHandle, msg.c_str(), pluginFilePath, MB_YESNO) == IDYES)
+		if (::MessageBox(NULL, msg.c_str(), pluginFilePath, MB_YESNO) == IDYES)
 		{
 			if (pi && pi->_hLib)
 			{
@@ -228,7 +291,7 @@ int PluginsManager::loadPlugin(const TCHAR *pluginFilePath)
 	}
 }
 
-bool PluginsManager::loadPluginsFromItsOwnFolder(const TCHAR* dir, const PluginViewList* pluginUpdateInfoList)
+bool PluginsManager::loadPluginsV2(const TCHAR* dir, const PluginViewList* pluginUpdateInfoList)
 {
 	if (_isDisabled)
 		return false;

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -86,7 +86,8 @@ public:
 		_nppData = nppData;
 	}
 
-	bool loadPluginsFromItsOwnFolder(const TCHAR *dir = NULL, const PluginViewList* pluginUpdateInfoList = nullptr);
+    int loadPlugin(const TCHAR *pluginFilePath);
+	bool loadPluginsV2(const TCHAR *dir = NULL, const PluginViewList* pluginUpdateInfoList = nullptr);
 
     bool unloadPlugin(int index, HWND nppHandle);
 
@@ -126,8 +127,6 @@ private:
 	IDAllocator _markerAlloc;
 	bool _noMoreNotification = false;
 
-	int loadPlugin(const TCHAR* pluginFilePath);
-
 	void pluginCrashAlert(const TCHAR *pluginName, const TCHAR *funcSignature)
 	{
 		generic_string msg = pluginName;
@@ -163,3 +162,5 @@ private:
 
 // External Lexer function definitions...
 typedef int (EXT_LEXER_DECL *GetLexerCountFn)();
+typedef void (EXT_LEXER_DECL *GetLexerNameFn)(unsigned int Index, char *name, int buflength);
+typedef void (EXT_LEXER_DECL *GetLexerStatusTextFn)(unsigned int Index, TCHAR *desc, int buflength);

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -157,10 +157,3 @@ private:
 		_loadedDlls.push_back(LoadedDllInfo(fullPath, fn));
 	}
 };
-
-#define EXT_LEXER_DECL __stdcall
-
-// External Lexer function definitions...
-typedef int (EXT_LEXER_DECL *GetLexerCountFn)();
-typedef void (EXT_LEXER_DECL *GetLexerNameFn)(unsigned int Index, char *name, int buflength);
-typedef void (EXT_LEXER_DECL *GetLexerStatusTextFn)(unsigned int Index, TCHAR *desc, int buflength);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6121,7 +6121,7 @@ std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * co
 		{
 			pBuf->setLangType(L_USER, udl.c_str());
 		}
-		else if (lt < L_END)
+		else
 		{
 			pBuf->setLangType(lt);
 		}

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -467,6 +467,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	//Languages Menu
 	HMENU hLangMenu = ::GetSubMenu(_mainMenuHandle, MENUINDEX_LANGUAGE);
 
+	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	// Add external languages to menu
 	for (int i = 0; i < nppParam.getNbExternalLang(); ++i)
 	{
@@ -475,14 +476,15 @@ LRESULT Notepad_plus::init(HWND hwnd)
 		int numLangs = ::GetMenuItemCount(hLangMenu);
 		const int bufferSize = 100;
 		TCHAR buffer[bufferSize];
+		const TCHAR* lexerNameW = wmc.char2wchar(externalLangContainer._name.c_str(), CP_ACP);
 
-		int x;
-		for (x = 0; (x == 0 || lstrcmp(externalLangContainer._name, buffer) > 0) && x < numLangs; ++x)
+		int x = 0;
+		for (; (x == 0 || lstrcmp(lexerNameW, buffer) > 0) && x < numLangs; ++x)
 		{
 			::GetMenuString(hLangMenu, x, buffer, bufferSize, MF_BYPOSITION);
 		}
 
-		::InsertMenu(hLangMenu, x - 1, MF_BYPOSITION, IDM_LANG_EXTERNAL + i, externalLangContainer._name);
+		::InsertMenu(hLangMenu, x - 1, MF_BYPOSITION, IDM_LANG_EXTERNAL + i, lexerNameW);
 	}
 
 	if (nppGUI._excludedLangList.size() > 0)
@@ -2363,10 +2365,9 @@ generic_string Notepad_plus::getLangDesc(LangType langType, bool getName)
 	if ((langType >= L_EXTERNAL) && (langType < nppParams.L_END))
 	{
 		ExternalLangContainer & elc = nppParams.getELCFromIndex(langType - L_EXTERNAL);
-		if (getName)
-			return generic_string(elc._name);
-		else
-			return generic_string(elc._desc);
+		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+		const TCHAR* lexerNameW = wmc.char2wchar(elc._name.c_str(), CP_ACP);
+		return generic_string(lexerNameW);
 	}
 
 	if (langType > L_EXTERNAL)

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -415,7 +415,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		{
 			if (!wParam)
 				return FALSE;
-			if (lParam < L_TEXT || lParam >= L_END || lParam == L_USER)
+			if (lParam < L_TEXT || lParam >= L_EXTERNAL || lParam == L_USER)
 				return FALSE;
 
 			BufferID id = (BufferID)wParam;
@@ -2555,14 +2555,24 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return langDesc.length();
 		}
 
-		case NPPM_GETEXTERNALLEXERAUTOINDENTMODE_DEPRECATED:
+		case NPPM_GETEXTERNALLEXERAUTOINDENTMODE:
 		{
-			return FALSE;
+			int index = nppParam.getExternalLangIndexFromName(reinterpret_cast<TCHAR*>(wParam));
+			if (index < 0)
+				return FALSE;
+
+			*(reinterpret_cast<ExternalLexerAutoIndentMode*>(lParam)) = nppParam.getELCFromIndex(index)._autoIndentMode;
+			return TRUE;
 		}
 
-		case NPPM_SETEXTERNALLEXERAUTOINDENTMODE_DEPRECATED:
+		case NPPM_SETEXTERNALLEXERAUTOINDENTMODE:
 		{
-			return FALSE;
+			int index = nppParam.getExternalLangIndexFromName(reinterpret_cast<TCHAR*>(wParam));
+			if (index < 0)
+				return FALSE;
+
+			nppParam.getELCFromIndex(index)._autoIndentMode = static_cast<ExternalLexerAutoIndentMode>(lParam);
+			return TRUE;
 		}
 
 		case NPPM_ISAUTOINDENTON:

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3777,6 +3777,14 @@ void Notepad_plus::command(int id)
 					_pDocMap->setSyntaxHiliting();
 				}
 			}
+			else if ((id >= IDM_LANG_EXTERNAL) && (id <= IDM_LANG_EXTERNAL_LIMIT))
+			{
+				setLanguage((LangType)(id - IDM_LANG_EXTERNAL + L_EXTERNAL));
+				if (_pDocMap)
+				{
+					_pDocMap->setSyntaxHiliting();
+				}
+			}
 			else if ((id >= ID_MACRO) && (id < ID_MACRO_LIMIT))
 			{
 				int i = id - ID_MACRO;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2047,6 +2047,8 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, bool shou
 			LangType typeToSet = L_TEXT;
 			if (id != 0 && id != IDM_LANG_USER)
 				typeToSet = menuID2LangType(id);
+			if (typeToSet == L_EXTERNAL )
+				typeToSet = (LangType)(id - IDM_LANG_EXTERNAL + L_EXTERNAL);
 
 			Buffer *buf = MainFileManager.getBufferByID(lastOpened);
 
@@ -2156,6 +2158,8 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, bool shou
 
 			if (id != 0)
 				typeToSet = menuID2LangType(id);
+			if (typeToSet == L_EXTERNAL )
+				typeToSet = (LangType)(id - IDM_LANG_EXTERNAL + L_EXTERNAL);
 
 			Buffer * buf = MainFileManager.getBufferByID(lastOpened);
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -934,6 +934,11 @@ NppParameters::~NppParameters()
 		delete _userLangArray[i];
 	if (_hUXTheme)
 		FreeLibrary(_hUXTheme);
+
+	for (std::vector<TiXmlDocument *>::iterator it = _pXmlExternalLexerDoc.begin(), end = _pXmlExternalLexerDoc.end(); it != end; ++it )
+		delete (*it);
+
+	_pXmlExternalLexerDoc.clear();
 }
 
 
@@ -970,6 +975,11 @@ bool NppParameters::reloadStylers(const TCHAR* stylePath)
 
 	getUserStylersFromXmlTree();
 
+	//  Reload plugin styles.
+	for ( size_t i = 0; i < getExternalLexerDoc()->size(); ++i)
+	{
+		getExternalLexerFromXmlTree( getExternalLexerDoc()->at(i) );
+	}
 	return true;
 }
 
@@ -1032,6 +1042,7 @@ generic_string NppParameters::getSettingsFolder()
 
 bool NppParameters::load()
 {
+	L_END = L_EXTERNAL;
 	bool isAllLaoded = true;
 
 	_isx64 = sizeof(void *) == 8;
@@ -1470,6 +1481,10 @@ bool NppParameters::load()
 			getSessionFromXmlTree(pXmlSessionDoc, _session);
 
 		delete pXmlSessionDoc;
+
+		for (size_t i = 0, len = _pXmlExternalLexerDoc.size() ; i < len ; ++i)
+			if (_pXmlExternalLexerDoc[i])
+				delete _pXmlExternalLexerDoc[i];
 	}
 
 	//-------------------------------------------------------------//
@@ -1575,6 +1590,21 @@ void NppParameters::SetTransparent(HWND hwnd, int percent)
 	}
 }
 
+
+bool NppParameters::isExistingExternalLangName(const TCHAR *newName) const
+{
+	if ((!newName) || (!newName[0]))
+		return true;
+
+	for (int i = 0 ; i < _nbExternalLang ; ++i)
+	{
+		if (!lstrcmp(_externalLangArray[i]->_name, newName))
+			return true;
+	}
+	return false;
+}
+
+
 const TCHAR* NppParameters::getUserDefinedLangNameFromExt(TCHAR *ext, TCHAR *fullName) const
 {
 	if ((!ext) || (!ext[0]))
@@ -1611,6 +1641,18 @@ const TCHAR* NppParameters::getUserDefinedLangNameFromExt(TCHAR *ext, TCHAR *ful
 
 	return nullptr;
 }
+
+
+int NppParameters::getExternalLangIndexFromName(const TCHAR* externalLangName) const
+{
+	for (int i = 0 ; i < _nbExternalLang ; ++i)
+	{
+		if (!lstrcmp(externalLangName, _externalLangArray[i]->_name))
+			return i;
+	}
+	return -1;
+}
+
 
 UserLangContainer* NppParameters::getULCFromName(const TCHAR *userLangName)
 {
@@ -1713,6 +1755,25 @@ void NppParameters::getLangKeywordsFromXmlTree()
 		if (!root) return;
 	feedKeyWordsParameters(root);
 }
+
+
+void NppParameters::getExternalLexerFromXmlTree(TiXmlDocument *doc)
+{
+	TiXmlNode *root = doc->FirstChild(TEXT("NotepadPlus"));
+		if (!root) return;
+	feedKeyWordsParameters(root);
+	feedStylerArray(root);
+}
+
+
+int NppParameters::addExternalLangToEnd(ExternalLangContainer * externalLang)
+{
+	_externalLangArray[_nbExternalLang] = externalLang;
+	++_nbExternalLang;
+	++L_END;
+	return _nbExternalLang-1;
+}
+
 
 bool NppParameters::getUserStylersFromXmlTree()
 {
@@ -2813,7 +2874,7 @@ std::pair<unsigned char, unsigned char> NppParameters::feedUserLang(TiXmlNode *n
 			}
 
 		}
-		catch (const std::exception&)
+		catch (const std::exception& /*e*/)
 		{
 			delete _userLangArray[--_nbUserLang];
 		}
@@ -3603,9 +3664,16 @@ bool NppParameters::feedStylerArray(TiXmlNode *node)
 		const TCHAR *lexerName = element->Attribute(TEXT("name"));
 		const TCHAR *lexerDesc = element->Attribute(TEXT("desc"));
 		const TCHAR *lexerUserExt = element->Attribute(TEXT("ext"));
+		const TCHAR *lexerExcluded = element->Attribute(TEXT("excluded"));
 		if (lexerName)
 		{
 			_lexerStylerVect.addLexerStyler(lexerName, lexerDesc, lexerUserExt, childNode);
+			if (lexerExcluded != NULL && (lstrcmp(lexerExcluded, TEXT("yes")) == 0))
+			{
+				int index = getExternalLangIndexFromName(lexerName);
+				if (index != -1)
+					_nppGUI._excludedLangList.push_back(LangMenuItem((LangType)(index + L_EXTERNAL)));
+			}
 		}
 	}
 
@@ -3888,13 +3956,22 @@ TiXmlNode * NppParameters::getChildElementByAttribut(TiXmlNode *pere, const TCHA
 LangType NppParameters::getLangIDFromStr(const TCHAR *langName)
 {
 	int lang = static_cast<int32_t>(L_TEXT);
-	for (; lang < L_END; ++lang)
+	for (; lang < L_EXTERNAL; ++lang)
 	{
-		const TCHAR * name = ScintillaEditView::_langNames[lang].lexerName;
+		const TCHAR * name = ScintillaEditView::langNames[lang].lexerName;
 		if (!lstrcmp(name, langName)) //found lang?
 		{
 			return (LangType)lang;
 		}
+	}
+
+	//Cannot find language, check if its an external one
+
+	LangType l = (LangType)lang;
+	if (l == L_EXTERNAL) //try find external lexer
+	{
+		int id = NppParameters::getInstance().getExternalLangIndexFromName(langName);
+		if (id != -1) return (LangType)(id + L_EXTERNAL);
 	}
 
 	return L_TEXT;
@@ -6747,7 +6824,7 @@ void NppParameters::writeExcludedLangList(TiXmlElement *element)
 	for (size_t i = 0, len = _nppGUI._excludedLangList.size(); i < len ; ++i)
 	{
 		LangType langType = _nppGUI._excludedLangList[i]._langType;
-		if (langType >= L_END)
+		if (langType >= L_EXTERNAL && langType < L_END)
 			continue;
 
 		int nGrp = langType / groupNbMember;
@@ -7047,7 +7124,10 @@ int NppParameters::langTypeToCommandID(LangType lt) const
 
 
 		default :
-			id = IDM_LANG_TEXT;
+			if (lt >= L_EXTERNAL && lt < L_END)
+				id = lt - L_EXTERNAL + IDM_LANG_EXTERNAL;
+			else
+				id = IDM_LANG_TEXT;
 	}
 	return id;
 }
@@ -7122,6 +7202,42 @@ generic_string NppParameters::writeStyles(LexerStylerArray & lexersStylers, Styl
 				}
 			}
 		}
+	}
+
+	for (size_t x = 0; x < _pXmlExternalLexerDoc.size(); ++x)
+	{
+		TiXmlNode* lexersRoot2 = ( _pXmlExternalLexerDoc[x]->FirstChild(TEXT("NotepadPlus")))->FirstChildElement(TEXT("LexerStyles"));
+		for (TiXmlNode* childNode = lexersRoot2->FirstChildElement(TEXT("LexerType"));
+			childNode ;
+			childNode = childNode->NextSibling(TEXT("LexerType")))
+		{
+			TiXmlElement *element = childNode->ToElement();
+			const TCHAR *nm = element->Attribute(TEXT("name"));
+
+			LexerStyler *pLs = _lexerStylerVect.getLexerStylerByName(nm);
+			LexerStyler *pLs2 = lexersStylers.getLexerStylerByName(nm);
+
+			if (pLs)
+			{
+				const TCHAR *extStr = pLs->getLexerUserExt();
+				element->SetAttribute(TEXT("ext"), extStr);
+
+				for (TiXmlNode *grChildNode = childNode->FirstChildElement(TEXT("WordsStyle"));
+						grChildNode ;
+						grChildNode = grChildNode->NextSibling(TEXT("WordsStyle")))
+				{
+					TiXmlElement *grElement = grChildNode->ToElement();
+					const TCHAR *styleName = grElement->Attribute(TEXT("name"));
+					const Style * pStyle = pLs->findByName(styleName);
+					Style * pStyle2Sync = pLs2 ? pLs2->findByName(styleName) : nullptr;
+					if (pStyle && pStyle2Sync)
+					{
+						writeStyle2Element(*pStyle, *pStyle2Sync, grElement);
+					}
+				}
+			}
+		}
+		_pXmlExternalLexerDoc[x]->SaveFile();
 	}
 
 	TiXmlNode *globalStylesRoot = (_pXmlUserStylerDoc->FirstChild(TEXT("NotepadPlus")))->FirstChildElement(TEXT("GlobalStyles"));

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1591,14 +1591,14 @@ void NppParameters::SetTransparent(HWND hwnd, int percent)
 }
 
 
-bool NppParameters::isExistingExternalLangName(const TCHAR *newName) const
+bool NppParameters::isExistingExternalLangName(const char* newName) const
 {
 	if ((!newName) || (!newName[0]))
 		return true;
 
 	for (int i = 0 ; i < _nbExternalLang ; ++i)
 	{
-		if (!lstrcmp(_externalLangArray[i]->_name, newName))
+		if (_externalLangArray[i]->_name == newName)
 			return true;
 	}
 	return false;
@@ -1645,9 +1645,10 @@ const TCHAR* NppParameters::getUserDefinedLangNameFromExt(TCHAR *ext, TCHAR *ful
 
 int NppParameters::getExternalLangIndexFromName(const TCHAR* externalLangName) const
 {
+	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	for (int i = 0 ; i < _nbExternalLang ; ++i)
 	{
-		if (!lstrcmp(externalLangName, _externalLangArray[i]->_name))
+		if (!lstrcmp(externalLangName, wmc.char2wchar(_externalLangArray[i]->_name.c_str(), CP_ACP)))
 			return i;
 	}
 	return -1;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -30,6 +30,8 @@
 #include <assert.h>
 #include <tchar.h>
 #include <map>
+#include "ILexer.h"
+#include "Lexilla.h"
 
 #ifdef _WIN64
 
@@ -1072,23 +1074,21 @@ private:
 	friend class StylerDlg;
 };
 
-#define MAX_EXTERNAL_LEXER_NAME_LEN 16
-#define MAX_EXTERNAL_LEXER_DESC_LEN 32
+#define MAX_EXTERNAL_LEXER_NAME_LEN 128
 
 
 
 class ExternalLangContainer final
 {
 public:
-	TCHAR _name[MAX_EXTERNAL_LEXER_NAME_LEN];
-	TCHAR _desc[MAX_EXTERNAL_LEXER_DESC_LEN];
-	ExternalLexerAutoIndentMode _autoIndentMode = ExternalLexerAutoIndentMode::Standard;
+	// Mandatory for Lexilla
+	std::string _name;
+	Lexilla::CreateLexerFn fnCL = nullptr;
+	//Lexilla::GetLibraryPropertyNamesFn fnGLPN = nullptr;
+	//Lexilla::SetLibraryPropertyFn fnSLP = nullptr;
 
-	ExternalLangContainer(const TCHAR* name, const TCHAR* desc)
-	{
-		generic_strncpy(_name, name, MAX_EXTERNAL_LEXER_NAME_LEN);
-		generic_strncpy(_desc, desc, MAX_EXTERNAL_LEXER_DESC_LEN);
-	}
+	// For Notepad++
+	ExternalLexerAutoIndentMode _autoIndentMode = ExternalLexerAutoIndentMode::Standard;
 };
 
 
@@ -1437,7 +1437,7 @@ public:
 	int addUserLangToEnd(const UserLangContainer & userLang, const TCHAR *newName);
 	void removeUserLang(size_t index);
 
-	bool isExistingExternalLangName(const TCHAR *newName) const;
+	bool isExistingExternalLangName(const char* newName) const;
 
 	int addExternalLangToEnd(ExternalLangContainer * externalLang);
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -241,7 +241,7 @@ struct CmdLineParams
 	bool _isRecursive = false;
 	bool _openFoldersAsWorkspace = false;
 
-	LangType _langType = L_END;
+	LangType _langType = L_EXTERNAL;
 	generic_string _localizationPath;
 	generic_string _udlName;
 
@@ -274,7 +274,7 @@ struct CmdLineParamsDTO
 	intptr_t _column2go = 0;
 	intptr_t _pos2go = 0;
 
-	LangType _langType = L_END;
+	LangType _langType = L_EXTERNAL;
 	generic_string _udlName;
 
 	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
@@ -1072,6 +1072,25 @@ private:
 	friend class StylerDlg;
 };
 
+#define MAX_EXTERNAL_LEXER_NAME_LEN 16
+#define MAX_EXTERNAL_LEXER_DESC_LEN 32
+
+
+
+class ExternalLangContainer final
+{
+public:
+	TCHAR _name[MAX_EXTERNAL_LEXER_NAME_LEN];
+	TCHAR _desc[MAX_EXTERNAL_LEXER_DESC_LEN];
+	ExternalLexerAutoIndentMode _autoIndentMode = ExternalLexerAutoIndentMode::Standard;
+
+	ExternalLangContainer(const TCHAR* name, const TCHAR* desc)
+	{
+		generic_strncpy(_name, name, MAX_EXTERNAL_LEXER_NAME_LEN);
+		generic_strncpy(_desc, desc, MAX_EXTERNAL_LEXER_DESC_LEN);
+	}
+};
+
 
 struct FindHistory final
 {
@@ -1268,6 +1287,7 @@ public:
 	generic_string getSettingsFolder();
 
 	bool _isTaskListRBUTTONUP_Active = false;
+	int L_END;
 
 	NppGUI & getNppGUI() {
 		return _nppGUI;
@@ -1382,6 +1402,16 @@ public:
 	UserLangContainer & getULCFromIndex(size_t i) {return *_userLangArray[i];};
 	UserLangContainer * getULCFromName(const TCHAR *userLangName);
 
+	int getNbExternalLang() const {return _nbExternalLang;};
+	int getExternalLangIndexFromName(const TCHAR *externalLangName) const;
+
+	ExternalLangContainer & getELCFromIndex(int i) {return *_externalLangArray[i];};
+
+	bool ExternalLangHasRoom() const {return _nbExternalLang < NB_MAX_EXTERNAL_LANG;};
+
+	void getExternalLexerFromXmlTree(TiXmlDocument *doc);
+	std::vector<TiXmlDocument *> * getExternalLexerDoc() { return &_pXmlExternalLexerDoc; };
+
 	void writeDefaultUDL();
 	void writeNonDefaultUDL();
 	void writeNeed2SaveUDL();
@@ -1406,6 +1436,10 @@ public:
 
 	int addUserLangToEnd(const UserLangContainer & userLang, const TCHAR *newName);
 	void removeUserLang(size_t index);
+
+	bool isExistingExternalLangName(const TCHAR *newName) const;
+
+	int addExternalLangToEnd(ExternalLangContainer * externalLang);
 
 	TiXmlDocumentA * getNativeLangA() const {return _pXmlNativeLangDocA;};
 
@@ -1648,6 +1682,8 @@ private:
 	TiXmlDocumentA *_pXmlNativeLangDocA = nullptr;
 	TiXmlDocumentA *_pXmlContextMenuDocA = nullptr;
 
+	std::vector<TiXmlDocument *> _pXmlExternalLexerDoc;
+
 	NppGUI _nppGUI;
 	ScintillaViewParams _svp;
 	Lang* _langList[NB_LANG] = { nullptr };
@@ -1668,6 +1704,7 @@ private:
 	unsigned char _nbUserLang = 0; // won't be exceeded to 255;
 	generic_string _userDefineLangsFolderPath;
 	generic_string _userDefineLangPath;
+	ExternalLangContainer* _externalLangArray[NB_MAX_EXTERNAL_LANG] = { nullptr };
 	int _nbExternalLang = 0;
 
 	CmdLineParamsDTO _cmdLineParams;

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -1065,12 +1065,15 @@ const TCHAR * AutoCompletion::getApiFileName()
 		}
 	}
 
-	if (_curLang > L_END)
+	if (_curLang >= L_EXTERNAL && _curLang < NppParameters::getInstance().L_END)
+		return NppParameters::getInstance().getELCFromIndex(_curLang - L_EXTERNAL)._name;
+
+	if (_curLang > L_EXTERNAL)
         _curLang = L_TEXT;
 
 	if (_curLang == L_JAVASCRIPT)
         _curLang = L_JS;
 
-	return ScintillaEditView::_langNames[_curLang].lexerName;
+	return ScintillaEditView::langNames[_curLang].lexerName;
 
 }

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -1066,7 +1066,10 @@ const TCHAR * AutoCompletion::getApiFileName()
 	}
 
 	if (_curLang >= L_EXTERNAL && _curLang < NppParameters::getInstance().L_END)
-		return NppParameters::getInstance().getELCFromIndex(_curLang - L_EXTERNAL)._name;
+	{
+		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+		return wmc.char2wchar(NppParameters::getInstance().getELCFromIndex(_curLang - L_EXTERNAL)._name.c_str(), CP_ACP);
+	}
 
 	if (_curLang > L_EXTERNAL)
         _curLang = L_TEXT;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1444,13 +1444,23 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const TCHAR * fil
 	}
 	_pscratchTilla->execute(SCI_CLEARALL);
 
-	int lexerID = SCLEX_NULL;
-	if (fileFormat._language < L_END)
-	{
-		lexerID = ScintillaEditView::_langNames[fileFormat._language].lexerID;
-	}
 
-	_pscratchTilla->setLexerFromID(lexerID);
+	if (fileFormat._language < L_EXTERNAL)
+	{
+#pragma warning( push )
+#pragma warning( disable : 4996)
+	const char* pName = LexerNameFromID(ScintillaEditView::langNames[fileFormat._language].lexerID); //deprecated, therefore disabled warning
+#pragma warning( pop ) 
+		_pscratchTilla->execute(SCI_SETILEXER, 0, reinterpret_cast<LPARAM>(CreateLexer(pName)));
+	}
+	else
+	{
+		int id = fileFormat._language - L_EXTERNAL;
+		TCHAR * name = nppParam.getELCFromIndex(id)._name;
+		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+		const char *pName = wmc.wchar2char(name, CP_ACP);
+		_pscratchTilla->execute(SCI_SETILEXER, 0, reinterpret_cast<LPARAM>(CreateLexer(pName)));
+	}
 
 	if (fileFormat._encoding != -1)
 		_pscratchTilla->execute(SCI_SETCODEPAGE, SC_CP_UTF8);

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1456,10 +1456,10 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const TCHAR * fil
 	else
 	{
 		int id = fileFormat._language - L_EXTERNAL;
-		TCHAR * name = nppParam.getELCFromIndex(id)._name;
-		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-		const char *pName = wmc.wchar2char(name, CP_ACP);
-		_pscratchTilla->execute(SCI_SETILEXER, 0, reinterpret_cast<LPARAM>(CreateLexer(pName)));
+		ExternalLangContainer& externalLexer = nppParam.getELCFromIndex(id);
+		const char* lexerName = externalLexer._name.c_str();
+		if (externalLexer.fnCL)
+			_pscratchTilla->execute(SCI_SETILEXER, 0, reinterpret_cast<LPARAM>(externalLexer.fnCL(lexerName)));
 	}
 
 	if (fileFormat._encoding != -1)

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -18,8 +18,8 @@
 #include <shlwapi.h>
 #include "FindReplaceDlg.h"
 #include "ScintillaEditView.h"
-#include "ILexer.h"
-#include "Lexilla.h"
+#include <ILexer.h>
+#include <Lexilla.h>
 #include "Notepad_plus_msgs.h"
 #include "localization.h"
 #include "Utf8.h"
@@ -2314,9 +2314,6 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 	if (!isCreated() && !findReplaceInfo._txt2find)
 		return nbProcessed;
 
-	if (!_ppEditView)
-		return nbProcessed;
-
 	ScintillaEditView *pEditView = *_ppEditView;
 	if (view2Process)
 		pEditView = view2Process;
@@ -4314,7 +4311,7 @@ void Finder::setFinderStyle()
 	NppDarkMode::setBorder(_scintView.getHSelf());
 
 	// Set current line background color for the finder
-	const TCHAR * lexerName = ScintillaEditView::_langNames[L_SEARCHRESULT].lexerName;
+	const TCHAR * lexerName = ScintillaEditView::langNames[L_SEARCHRESULT].lexerName;
 	LexerStyler *pStyler = (NppParameters::getInstance().getLStylerArray()).getLexerStylerByName(lexerName);
 	if (pStyler)
 	{

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -880,14 +880,18 @@ void ScintillaEditView::setUserLexer(const TCHAR *userLangName)
 void ScintillaEditView::setExternalLexer(LangType typeDoc)
 {
 	int id = typeDoc - L_EXTERNAL;
-	TCHAR * name = NppParameters::getInstance().getELCFromIndex(id)._name;
+
+	ExternalLangContainer& externalLexer = NppParameters::getInstance().getELCFromIndex(id);
+	if (!externalLexer.fnCL)
+		return;
+	ILexer5* iLex5 = externalLexer.fnCL(externalLexer._name.c_str());
+	if (!iLex5)
+		return;
+	execute(SCI_SETILEXER, 0, reinterpret_cast<LPARAM>(iLex5));
 
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-	const char *pName = wmc.wchar2char(name, CP_ACP);
-
-	execute(SCI_SETILEXER, 0, reinterpret_cast<LPARAM>(CreateLexer(pName)));
-
-	LexerStyler *pStyler = (NppParameters::getInstance().getLStylerArray()).getLexerStylerByName(name);
+	const wchar_t* lexerNameW = wmc.char2wchar(externalLexer._name.c_str(), CP_ACP);
+	LexerStyler *pStyler = (NppParameters::getInstance().getLStylerArray()).getLexerStylerByName(lexerNameW);
 	if (pStyler)
 	{
 		for (const Style & style : *pStyler)

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -541,7 +541,7 @@ public:
 
 	bool getIndicatorRange(size_t indicatorNumber, size_t* from = NULL, size_t* to = NULL, size_t* cur = NULL);
 
-	static LanguageName _langNames[L_END + 1];
+	static LanguageName langNames[L_EXTERNAL+1];
 
 	void bufferUpdated(Buffer * buffer, int mask);
 	BufferID getCurrentBufferID() { return _currentBufferID; };
@@ -609,7 +609,6 @@ public:
 	void setPositionRestoreNeeded(bool val) { _positionRestoreNeeded = val; };
 	void markedTextToClipboard(int indiStyle, bool doAll = false);
 	void removeAnyDuplicateLines();
-	bool setLexerFromID(int lexerID);
 
 protected:
 	static bool _SciInit;
@@ -651,6 +650,7 @@ protected:
 	const char * getCompleteKeywordList(std::basic_string<char> & kwl, LangType langType, int keywordIndex);
 	void setKeywords(LangType langType, const char *keywords, int index);
 	void setLexer(int lexerID, LangType langType, int whichList);
+	bool setLexerFromID(int lexerID);
 	void makeStyle(LangType langType, const TCHAR **keywordArray = NULL);
 	void setStyle(Style styleToSet);			//NOT by reference	(style edited)
 	void setSpecialStyle(const Style & styleToSet);	//by reference
@@ -665,6 +665,7 @@ protected:
 	void setTclLexer();
     void setObjCLexer(LangType type);
 	void setUserLexer(const TCHAR *userLangName = NULL);
+	void setExternalLexer(LangType typeDoc);
 	void setEmbeddedJSLexer();
     void setEmbeddedPhpLexer();
     void setEmbeddedAspLexer();

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -23,7 +23,7 @@ using namespace std;
 
 FunctionParsersManager::~FunctionParsersManager()
 {
-	for (size_t i = 0, len = L_END + nbMaxUserDefined; i < len; ++i)
+	for (size_t i = 0, len = L_EXTERNAL + nbMaxUserDefined; i < len; ++i)
 	{
 		if (_parsers[i] != nullptr)
 			delete _parsers[i];
@@ -160,7 +160,7 @@ bool FunctionParsersManager::loadFuncListFromXmlTree(generic_string & xmlDirPath
 		index = lType;
 		if (overrideId.empty())
 		{
-			generic_string lexerName = ScintillaEditView::_langNames[lType].lexerName;
+			generic_string lexerName = ScintillaEditView::langNames[lType].lexerName;
 			funcListRulePath += lexerName;
 			funcListRulePath += TEXT(".xml");
 		}
@@ -281,7 +281,7 @@ bool FunctionParsersManager::getOverrideMapFromXmlTree(generic_string & xmlDirPa
 			}
 			else if (userDefinedLangName && userDefinedLangName[0])
 			{
-				if (_currentUDIndex < L_END + nbMaxUserDefined)
+				if (_currentUDIndex < L_EXTERNAL + nbMaxUserDefined)
 				{
 					++_currentUDIndex;
 					_parsers[_currentUDIndex] = new ParserInfo(id, userDefinedLangName);
@@ -343,10 +343,10 @@ FunctionParser * FunctionParsersManager::getParser(const AssociationInfo & assoI
 
 		case checkUserDefined:
 		{
-			if (_currentUDIndex == L_END) // no User Defined Language parser
+			if (_currentUDIndex == L_EXTERNAL) // no User Defined Language parser
 				return nullptr;
 
-			for (int i = L_END + 1; i <= _currentUDIndex; ++i)
+			for (int i = L_EXTERNAL + 1; i <= _currentUDIndex; ++i)
 			{
 				if (_parsers[i]->_userDefinedLangName == assoInfo._userDefinedLangName)
 				{

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.h
@@ -156,8 +156,8 @@ private:
 	generic_string _xmlDirPath; // The 1st place to load function list files. Usually it's "%APPDATA%\Notepad++\functionList\"
 	generic_string _xmlDirInstalledPath; // Where Notepad++ is installed. The 2nd place to load function list files. Usually it's "%PROGRAMFILES%\Notepad++\functionList\" 
 
-	ParserInfo* _parsers[L_END + nbMaxUserDefined] = {nullptr};
-	int _currentUDIndex = L_END;
+	ParserInfo* _parsers[L_EXTERNAL + nbMaxUserDefined] = {nullptr};
+	int _currentUDIndex = L_EXTERNAL;
 
 	bool getOverrideMapFromXmlTree(generic_string & xmlDirPath);
 	bool loadFuncListFromXmlTree(generic_string & xmlDirPath, LangType lType, const generic_string& overrideId, int udlIndex = -1);

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -1933,7 +1933,7 @@ intptr_t CALLBACK NewDocumentSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 			::SendDlgItemMessage(_hSelf, IDC_CHECK_OPENANSIASUTF8, BM_SETCHECK, (ID2Check == IDC_RADIO_UTF8SANSBOM && ndds._openAnsiAsUtf8)?BST_CHECKED:BST_UNCHECKED, 0);
 			::EnableWindow(::GetDlgItem(_hSelf, IDC_CHECK_OPENANSIASUTF8), ID2Check == IDC_RADIO_UTF8SANSBOM);
 
-			for (int i = L_TEXT + 1 ; i < L_END ; ++i) // Skip L_TEXT
+			for (int i = L_TEXT + 1 ; i < nppParam.L_END ; ++i) // Skip L_TEXT
 			{
 				LangType lt = static_cast<LangType>(i);
 				str.clear();
@@ -2372,7 +2372,7 @@ intptr_t CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			//
 			// Lang Menu
 			//
-			for (int i = L_TEXT ; i < L_END ; ++i)
+			for (int i = L_TEXT ; i < nppParam.L_END ; ++i)
 			{
 				generic_string str;
 				if (static_cast<LangType>(i) != L_USER)
@@ -2625,6 +2625,29 @@ intptr_t CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 					::SendDlgItemMessage(_hSelf, list2Remove, LB_SETCURSEL, static_cast<WPARAM>(-1), 0);
 					::EnableWindow(::GetDlgItem(_hSelf, idButton2Enable), TRUE);
 					::EnableWindow(::GetDlgItem(_hSelf, idButton2Disable), FALSE);
+
+					if ((lmi._langType >= L_EXTERNAL) && (lmi._langType < nppParam.L_END))
+					{
+						bool found(false);
+						for (size_t x = 0; x < nppParam.getExternalLexerDoc()->size() && !found; ++x)
+						{
+							TiXmlNode *lexersRoot = nppParam.getExternalLexerDoc()->at(x)->FirstChild(TEXT("NotepadPlus"))->FirstChildElement(TEXT("LexerStyles"));
+							for (TiXmlNode *childNode = lexersRoot->FirstChildElement(TEXT("LexerType"));
+								childNode ;
+								childNode = childNode->NextSibling(TEXT("LexerType")))
+							{
+								TiXmlElement *element = childNode->ToElement();
+
+								if (generic_string(element->Attribute(TEXT("name"))) == lmi._langName)
+								{
+									element->SetAttribute(TEXT("excluded"), (LOWORD(wParam)==IDC_BUTTON_REMOVE)?TEXT("yes"):TEXT("no"));
+									nppParam.getExternalLexerDoc()->at(x)->SaveFile();
+									found = true;
+									break;
+								}
+							}
+						}
+					}
 
 					HWND grandParent = ::GetParent(_hParent);
 

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -526,8 +526,8 @@
     #define    IDM_LANG_VISUALPROLOG       (IDM_LANG + 83)
     #define    IDM_LANG_TYPESCRIPT         (IDM_LANG + 84)
 
-    //#define    IDM_LANG_EXTERNAL           (IDM_LANG + 165)
-    //#define    IDM_LANG_EXTERNAL_LIMIT     (IDM_LANG + 179)
+    #define    IDM_LANG_EXTERNAL           (IDM_LANG + 165)
+    #define    IDM_LANG_EXTERNAL_LIMIT     (IDM_LANG + 179)
 
     #define    IDM_LANG_USER               (IDM_LANG + 180)     //46180: Used for translation
     #define    IDM_LANG_USER_LIMIT         (IDM_LANG + 210)     //46210: Ajust with IDM_LANG_USER

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -226,7 +226,7 @@ LangType getLangTypeFromParam(ParamVector & params)
 {
 	generic_string langStr;
 	if (!getParamVal('l', params, langStr))
-		return L_TEXT;
+		return L_EXTERNAL;
 	return NppParameters::getLangIDFromStr(langStr.c_str());
 }
 

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -226,7 +226,7 @@ LangType getLangTypeFromParam(ParamVector & params)
 {
 	generic_string langStr;
 	if (!getParamVal('l', params, langStr))
-		return L_END;
+		return L_TEXT;
 	return NppParameters::getLangIDFromStr(langStr.c_str());
 }
 


### PR DESCRIPTION
Make external lexer library work again after upgrading to Scintilla5.
Old external lexer libraries needs to add `CreateLexer` export function.

Tested with papyrus lexer plugin, the plugin modification is done in the PR:
https://github.com/blu3mania/npp-papyrus/pull/24