### PR TITLE
Scrolling Document List automatically to make the selected item visible

### DIFF
--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.cpp
@@ -330,6 +330,12 @@ void VerticalFileSwitcher::popupMenuCmd(int cmdID)
 	}
 }
 
+void VerticalFileSwitcher::display(bool toShow) const
+{
+	DockingDlgInterface::display(toShow);
+	_fileListView.ensureVisibleCurrentItem();	// without this call the current item may stay above visible area after the program startup
+};
+
 void VerticalFileSwitcher::activateDoc(TaskLstFnStatus *tlfs) const
 {
 	int view = tlfs->_iView;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcher.h
@@ -38,9 +38,7 @@ public:
 		_hImaLst = hImaLst;
 	};
 
-    virtual void display(bool toShow = true) const {
-        DockingDlgInterface::display(toShow);
-    };
+	virtual void display(bool toShow = true) const; 
 
     void setParent(HWND parent2set){
         _hParent = parent2set;

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
@@ -70,6 +70,9 @@ public:
 
 	std::vector<SwitcherFileInfo> getSelectedFiles(bool reverse = false) const;
 	void reload();
+	void ensureVisibleCurrentItem() const {
+		ListView_EnsureVisible(_hSelf, _currentIndex, false);
+	};
 
 	void setBackgroundColor(COLORREF bgColour) {
 		ListView_SetBkColor(_hSelf, bgColour);
@@ -85,6 +88,9 @@ public:
 protected:
 	HIMAGELIST _hImaLst = nullptr;
 	WNDPROC _defaultProc = nullptr;
+
+	int _currentIndex = 0;
+
 	LRESULT runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
 
 	static LRESULT CALLBACK staticProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam) {
@@ -95,4 +101,7 @@ protected:
 	int add(BufferID bufferID, int iView);
 	void remove(int index);
 	void removeAll();
+	void selectCurrentItem() const {
+		ListView_SetItemState(_hSelf, _currentIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+	};
 };


### PR DESCRIPTION
Scrolling "Document List" to make the selected item visible after:
- selecting;
- opening a file or files;
- the program startup;
- adding/removing columns.
This commit doesn't cover the case of the selected item becoming invisible after resizing of the window.

Fix #11204