### PR TITLE
Fix squarish artifacts around rounded button corners

### DIFF
--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -51,6 +51,7 @@ intptr_t CALLBACK HashFromFilesDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 		}
 		return TRUE;
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		{
 			if (NppDarkMode::isEnabled())
@@ -371,6 +372,7 @@ intptr_t CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 			break;
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		{
 			if (NppDarkMode::isEnabled())
@@ -393,15 +395,6 @@ intptr_t CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 				{
 					return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 				}
-			}
-			break;
-		}
-
-		case WM_PRINTCLIENT:
-		{
-			if (NppDarkMode::isEnabled())
-			{
-				return TRUE;
 			}
 			break;
 		}

--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -51,7 +51,6 @@ intptr_t CALLBACK HashFromFilesDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 		}
 		return TRUE;
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		{
 			if (NppDarkMode::isEnabled())
@@ -74,6 +73,15 @@ intptr_t CALLBACK HashFromFilesDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 				{
 					return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 				}
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
 			}
 			break;
 		}
@@ -372,7 +380,6 @@ intptr_t CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 			break;
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		{
 			if (NppDarkMode::isEnabled())
@@ -395,6 +402,15 @@ intptr_t CALLBACK HashFromTextDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 				{
 					return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 				}
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
 			}
 			break;
 		}

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4605,6 +4605,7 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 			return reinterpret_cast<LRESULT>(hBrushBackground);
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
@@ -5095,6 +5096,7 @@ LRESULT APIENTRY Progress::wndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM l
 			return 0;
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4605,7 +4605,6 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 			return reinterpret_cast<LRESULT>(hBrushBackground);
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
@@ -4615,6 +4614,15 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 			}
 
 			return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
 		}
 
 		case NPPM_INTERNAL_REFRESHDARKMODE:
@@ -5096,7 +5104,6 @@ LRESULT APIENTRY Progress::wndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM l
 			return 0;
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
@@ -5105,6 +5112,15 @@ LRESULT APIENTRY Progress::wndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM l
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wparam));
 			}
 
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
 			break;
 		}
 

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -61,6 +61,7 @@ intptr_t CALLBACK AboutDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
 			return TRUE;
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
@@ -308,6 +309,7 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			return TRUE;
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
@@ -417,6 +419,7 @@ intptr_t CALLBACK DoSaveOrNotBox::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			return TRUE;
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
@@ -521,6 +524,7 @@ intptr_t CALLBACK DoSaveAllBox::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 		return TRUE;
 	}
 
+	case WM_CTLCOLORBTN:
 	case WM_CTLCOLORDLG:
 	case WM_CTLCOLORSTATIC:
 	{

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -61,13 +61,21 @@ intptr_t CALLBACK AboutDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
 			return TRUE;
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
 			if (NppDarkMode::isEnabled())
 			{
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
 			}
 			break;
 		}
@@ -309,13 +317,21 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			return TRUE;
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
 			if (NppDarkMode::isEnabled())
 			{
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
 			}
 			break;
 		}
@@ -419,13 +435,21 @@ intptr_t CALLBACK DoSaveOrNotBox::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			return TRUE;
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
 			if (NppDarkMode::isEnabled())
 			{
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
 			}
 			break;
 		}
@@ -524,13 +548,21 @@ intptr_t CALLBACK DoSaveAllBox::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 		return TRUE;
 	}
 
-	case WM_CTLCOLORBTN:
 	case WM_CTLCOLORDLG:
 	case WM_CTLCOLORSTATIC:
 	{
 		if (NppDarkMode::isEnabled())
 		{
 			return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+		}
+		break;
+	}
+
+	case WM_PRINTCLIENT:
+	{
+		if (NppDarkMode::isEnabled())
+		{
+			return TRUE;
 		}
 		break;
 	}

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
@@ -103,13 +103,21 @@ intptr_t CALLBACK ColourPopup::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			return reinterpret_cast<LRESULT>(::GetStockObject(NULL_BRUSH));
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
 			if (NppDarkMode::isEnabled())
 			{
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
 			}
 			break;
 		}

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
@@ -103,6 +103,7 @@ intptr_t CALLBACK ColourPopup::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			return reinterpret_cast<LRESULT>(::GetStockObject(NULL_BRUSH));
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -94,13 +94,21 @@ intptr_t CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 			return FALSE;
 		}
 
-		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{
 			if (NppDarkMode::isEnabled())
 			{
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+			}
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
 			}
 			break;
 		}

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -94,6 +94,7 @@ intptr_t CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 			return FALSE;
 		}
 
+		case WM_CTLCOLORBTN:
 		case WM_CTLCOLORDLG:
 		case WM_CTLCOLORSTATIC:
 		{


### PR DESCRIPTION
Related to fixes for: #10171, #10255, #10264, #10269

These squarish artifacts are visible in dark mode only in Window 7 & Windows 11 OS versions. But NOT in Windows 10 since the buttons in this OS version have inherently squarish corners.

Sample screenshot with this issue, before the fix:
![image](https://user-images.githubusercontent.com/45252729/161826073-ddde7ac5-7991-4c72-a765-0cdbaf080296.png)

Fixed in the following dialogs:
1. About Notepad++
2. Debug Info
3. Save All Files prompt
4. Save or Not Save Files prompt
5. MD5/SHA Generate (in both from text and From Files)
6. Incremental Search
7. Colour Chooser popup

Also, fixed in the following but could not test yet (since I am not aware of a path to invoke these dialogs in NPP):
1. Progress dialog (code in FindReplaceDlg.cpp)
2. TaskListDlg.cpp

