### PR TITLE
Update Corsican translation for Notepad++ 8.3.4

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,6 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
+		- Updated on April 7nd, 2022 for version 8.3.4 by Patriccollu di Santa Maria è Sichè
 		- Updated on February 21st, 2022 for version 8.3.2 by Patriccollu di Santa Maria è Sichè
 		- Updated on February 8th, 2022 for version 8.3.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on January 11th, 2022 for version 8.2.1 by Patriccollu di Santa Maria è Sichè
@@ -32,7 +33,7 @@ The comments are here for explanation, it's not necessary to translate them.
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 -->
 <NotepadPlus>
-    <Native-Langue name="Corsu" filename="corsican.xml" version="8.3.2">
+    <Native-Langue name="Corsu" filename="corsican.xml" version="8.3.4">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -393,12 +394,13 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="48016" name="Ghjestione di l’accurtatoghji di tastera per e macro…"/>
                     <Item id="48017" name="Ghjestione di l’accurtatoghji di tastera per e cumande…"/>
 
+                    <Item id="11001" name="&amp;Ducumenti…"/>
                     <Item id="11002" name="Nome da A à Z"/>
                     <Item id="11003" name="Nome da Z à A"/>
                     <Item id="11004" name="Chjassu d’accessu da A à Z"/>
                     <Item id="11005" name="Chjassu d’accessu da Z à A"/>
-                    <Item id="11006" name="Typu da A à Z"/>
-                    <Item id="11007" name="Typu da Z à A"/>
+                    <Item id="11006" name="Tipu da A à Z"/>
+                    <Item id="11007" name="Tipu da Z à A"/>
                     <Item id="11008" name="Dimensione da chjuca à maiò"/>
                     <Item id="11009" name="Dimensione da maiò à chjuca"/>
                 </Commands>
@@ -592,8 +594,8 @@ The comments are here for explanation, it's not necessary to translate them.
                 <RunCommandsTab name="Cumande d’esecuzione"/>
                 <PluginCommandsTab name="Cumande d’estensione"/>
                 <ScintillaCommandsTab name="Cumande Scintilla"/>
-                <ConflictInfoOk name="Alcunu cunflittu d’accurtatoghju per st’elementu."/>
-                <ConflictInfoEditing name="Alcunu cunflittu . . ."/>
+                <ConflictInfoOk name="Nisunu cunflittu d’accurtatoghju per st’elementu."/>
+                <ConflictInfoEditing name="Nisunu cunflittu . . ."/>
                 <MainCommandNames>
                     <Item id="41019" name="Apre cù l’espluratore u cartulare cuntenendu u schedariu"/>
                     <Item id="41020" name="Apre cù l’invitu di cumanda u cartulare cuntenendu u schedariu"/>
@@ -909,6 +911,7 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="6215" name="Permette una grafia allisciata"/>
                     <Item id="6236" name="Permette l’affissera dopu à l’ultima linea"/>
                     <Item id="6239" name="Cunservà a selezzione in casu di cliccu dirittu fora di a selezzione"/>
+                    <Item id="6245" name="Attivà u spaziu virtuale"/>
                 </Scintillas>
 
                 <DarkMode title="Modu scuru">
@@ -1133,7 +1136,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                     <Item id="6161" name="Lista di caratteri delimitatori di parolla"/>
                     <Item id="6162" name="Impiegà a lista predefinita di caratteri delimitatori di parolla tale è quale"/>
                     <Item id="6163" name="Aghjunghje u vostru caratteru cum’è una parte di parolla
-(solu s’è voi site sicuru di ciò chì voi fate)"/>
+(solu s’è voi site sicuri di ciò chì voi fate)"/>
                 </Delimiter>
 
                 <Cloud title="Nivulu è liame">
@@ -1236,7 +1239,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                 <Item id="5" name="Nò &amp;per tutti"/>
             </DoSaveOrNot>
             <DoSaveAll title="Cunfirmazione di l’arregistramentu di tutti i schedarii">
-                <Item id="1766" name="Site sicuru di vulè arregistrà tutti i ducumenti mudificati ?
+                <Item id="1766" name="Site sicuri di vulè arregistrà tutti i ducumenti mudificati ?
 
 Sciglite « Sempre sì » s’è ùn vulete più risponde à sta dumanda.
 Pudete attivà torna st’ozzione in u dialogu di e preferenze."/>
@@ -1257,14 +1260,14 @@ Tutte e mudificazioni arregistrate ùn pudenu micca esse disfatte.
 
 Cuntinuà ?"/> <!-- HowToReproduce: when you openned file is modified and saved, then you are changing file encoding. -->
             <CannotMoveDoc title="Dispiazzà in una nova finestra Notepad++" message="U ducumentu hè mudificatu, arregistratelu è pruvate torna."/> <!-- HowToReproduce: From your Notepad++ drag & drop a clean (not dirty) file to outside of Notepad++, another instance of Notepad++ will be created. Then from your first Notepad++ drag & drop an unsaved file to the new instance. -->
-            <DocReloadWarning title="Ricaricà" message="Site sicuru di vulè ricaricà u schedariu currente è perde cusì i cambiamenti fatti cù Notepad++ ?"/>
+            <DocReloadWarning title="Ricaricà" message="Site sicuri di vulè ricaricà u schedariu currente è perde cusì i cambiamenti fatti cù Notepad++ ?"/>
             <FileLockedWarning title="Arregistramentu fiascatu" message="Ci vole à verificà s’è stu schedariu hè dighjà apertu in un altru prugramma"/>
             <FileAlreadyOpenedInNpp title="" message="U schedariu hè dighjà apertu in Notepad++."/> <!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
             <RenameTabTemporaryNameAlreadyInUse title="Rinuminazione fiascata" message="U nome specificatu hè dighjà impiegatu in un’altra unghjetta."/> <!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
             <DeleteFileFailed title="Squassatura di schedariu" message="Fiascu di a squassatura di u schedariu"/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
             <NbFileToOpenImportantWarning title="A quantità di schedarii à apre hè troppu maiò" message="$INT_REPLACE$ schedarii devenu esse aperti.
-Site sicuru di vulè apreli ?"/> <!-- HowToReproduce: Check "Open all files of folder instead of launching Folder as Workspace on folder dropping" in "Default Directory" of Preferences dialog, then drop a folder which contains more then 200 files into Notepad++. -->
+Site sicuri di vulè apreli ?"/> <!-- HowToReproduce: Check "Open all files of folder instead of launching Folder as Workspace on folder dropping" in "Default Directory" of Preferences dialog, then drop a folder which contains more then 200 files into Notepad++. -->
             <SettingsOnCloudError title="Preferenze di nivulu" message="Pare chì u chjassu di e preferenze di nivulu hè definitu nant’à un lettore in
 lettura sola, o in un cartulare chì richiede diritti d’accessu di scrittura.
 E vostre preferenze di nivulu anu da esse abbandunate. Ci vole à rimette un valore accetevule via u dialogu di Preferenze."/>
@@ -1322,15 +1325,15 @@ U vostru spaziu di travagliu ùn hè micca statu arregistratu."/> <!-- HowToRepr
             <ProjectPanelOpenFailed title="Apre u spaziu di travagliu" message="U spaziu di travagliu ùn pò micca esse apertu.
 Pare chì u schedariu à apre ùn hè micca un schedariu di prughjettu accettevule."/>
             <ProjectPanelRemoveFolderFromProject title="Caccià u cartulare da u prughjettu" message="Tutti i sottu-elementi seranu cacciati.
-Site sicuru di vulè caccià stu cartulare da u prughjettu ?"/>
-            <ProjectPanelRemoveFileFromProject title="Caccià u schedariu da u prughjettu" message="Site sicuru di vulè caccià stu schedariu da u prughjettu ?"/>
+Site sicuri di vulè caccià stu cartulare da u prughjettu ?"/>
+            <ProjectPanelRemoveFileFromProject title="Caccià u schedariu da u prughjettu" message="Site sicuri di vulè caccià stu schedariu da u prughjettu ?"/>
             <ProjectPanelReloadError title="Ricaricà u spaziu di travagliu" message="Ùn pò micca truvà u schedariu à ricaricà."/>
             <ProjectPanelReloadDirty title="Ricaricà u spaziu di travagliu" message="U spaziu di travagliu attuale hè statu mudificatu. Un ricaricamentu scarterà tutte e mudificazioni.
 Vulete cuntinuà ?"/>
             <UDLNewNameError title="Sbagliu UDL" message="Stu nome hè impiegatu da un altru linguaghju,
 ci vole à dà un altru."/>
-            <UDLRemoveCurrentLang title="Caccià u linguaghju attuale" message="Site sicuru ?"/>
-            <SCMapperDoDeleteOrNot title="Cunfirmazione" message="Site sicuru di vulè squassà st’accurtatoghju ?"/>
+            <UDLRemoveCurrentLang title="Caccià u linguaghju attuale" message="Site sicuri ?"/>
+            <SCMapperDoDeleteOrNot title="Cunfirmazione" message="Site sicuri di vulè squassà st’accurtatoghju ?"/>
             <FindCharRangeValueError title="Penseru di valore di stesa" message="Ci vole à stampittà trà 0 è 255."/>
             <OpenInAdminMode title="Arregistramentu fiascatu" message="U schedariu ùn pò micca esse arregistratu, forse hè prutettu.
 Vulete dimarrà Notepad++ in modu Amministratore ?"/>
@@ -1338,7 +1341,7 @@ Vulete dimarrà Notepad++ in modu Amministratore ?"/>
 Vulete dimarrà Notepad++ in modu Amministratore ?"/>
             <OpenInAdminModeFailed title="Apertura fiascata in modu Amministratore" message="Notepad++ ùn pò micca esse apertu in modu Amministratore."/> <!-- HowToReproduce: When you have no Admin privilege and you try to save a modified file in a protected location (for example: any file in sub-folder of "C:\Program Files\". This message will appear after replying "Yes" to "Open in Admin mode" dialog. -->
             <ViewInBrowser title="Fighjà u schedariu attuale in u navigatore" message="L’appiecazione ùn si trova micca in u sistema."/>
-            <ExitToUpdatePlugins title="Notepad++ hè prontu à esce" message="S’è vo cliccate Sì, Notepad++ hà da piantà per cuntinuà l’operazioni.
+            <ExitToUpdatePlugins title="Notepad++ hè prontu à esce" message="S’è vo fate un cliccu nant’à « Sì », Notepad++ hà da piantà per cuntinuà l’operazioni.
 Notepad++ serà rilanciatu quandu st’operazioni seranu compie.
 Cuntinuà ?"/>
             <NeedToRestartToLoadPlugins title="Notepad++ hà bisognu d’esse rilanciatu" message="Ci vole à rilancià Notepad++ per caricà l’estensioni chì sò state installate."/> <!-- HowToReproduce: Import a plugin via menu "Settings->Import->Import Plugin(s)...". -->
@@ -1374,8 +1377,10 @@ Cuntinuà ?"/>
         </DocumentMap>
         <FunctionList>
             <PanelTitle name="Lista di e funzioni"/>
-            <SortTip name="Classificà"/>
+            <SortTip name="Ordinà"/>
             <ReloadTip name="Ricaricà"/>
+            <PreferencesTip name="Preferenze"/>
+            <PreferencesInitialSort name="Ordine predefinitu di e funzioni (da A à Z)"/>
         </FunctionList>
         <FolderAsWorkspace>
             <PanelTitle name="Cartulare cum’è spaziu di travagliu"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/ee765135be97808d68d04700a349abb9ac0ad41d Add "Windows..." localization entry
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/64bfa72bd0693344b81017cece1f52a28511e42a Add default sorting ability in Function list
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/88ed851478b3426e9cca365b67a1ceb4cd4f92e2 Add virtual space ability

Cheers,
Patriccollu.