### PR TITLE
Fix square edges around buttons in dark mode

### DIFF
--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -77,6 +77,15 @@ intptr_t CALLBACK HashFromFilesDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 			break;
 		}
 
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::autoThemeChildControls(_hSelf);

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4625,6 +4625,15 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 			return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
 		}
 
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::autoThemeChildControls(getHSelf());
@@ -5112,6 +5121,15 @@ LRESULT APIENTRY Progress::wndProc(HWND hwnd, UINT umsg, WPARAM wparam, LPARAM l
 				return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wparam));
 			}
 
+			break;
+		}
+
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
 			break;
 		}
 

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -71,6 +71,15 @@ intptr_t CALLBACK AboutDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lPar
 			break;
 		}
 
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::autoThemeChildControls(_hSelf);
@@ -318,6 +327,15 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			break;
 		}
 
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::autoThemeChildControls(_hSelf);
@@ -427,6 +445,15 @@ intptr_t CALLBACK DoSaveOrNotBox::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			break;
 		}
 
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case WM_COMMAND:
 		{
 			switch (LOWORD(wParam))
@@ -527,6 +554,15 @@ intptr_t CALLBACK DoSaveAllBox::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 		if (NppDarkMode::isEnabled())
 		{
 			return NppDarkMode::onCtlColorDarker(reinterpret_cast<HDC>(wParam));
+		}
+		break;
+	}
+
+	case WM_PRINTCLIENT:
+	{
+		if (NppDarkMode::isEnabled())
+		{
+			return TRUE;
 		}
 		break;
 	}

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
@@ -113,6 +113,15 @@ intptr_t CALLBACK ColourPopup::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			break;
 		}
 
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case NPPM_INTERNAL_REFRESHDARKMODE:
 		{
 			NppDarkMode::autoThemeChildControls(_hSelf);

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.cpp
@@ -104,6 +104,15 @@ intptr_t CALLBACK TaskListDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM l
 			break;
 		}
 
+		case WM_PRINTCLIENT:
+		{
+			if (NppDarkMode::isEnabled())
+			{
+				return TRUE;
+			}
+			break;
+		}
+
 		case WM_DESTROY :
 		{
 			_taskList.destroy();


### PR DESCRIPTION
Related to fixes for: #10171, #10255, #10264, #10269

These square edges in dark mode are more prominent in Windows 7 & Windows 11 OS versions which have rounded button corners. But not so much in Windows 10 since the buttons in this OS version have inherently squarish corners.

Sample screenshot with this issue, before the fix:
![image](https://user-images.githubusercontent.com/45252729/161826073-ddde7ac5-7991-4c72-a765-0cdbaf080296.png)

Fixed in the following dialogs:
1. About Notepad++
2. Debug Info
3. Save All Files prompt
4. Save or Not Save Files prompt
5. MD5/SHA Generate (in both from text and From Files)
6. Incremental Search
7. Colour Chooser popup

Additional background information on these fixes in the closed PR #11478 which failed to merge due to changes from other commits in the FindReplaceDlg.cpp.