### PR TITLE
Fix for "Enable current line highlighting" may function incorrectly

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -273,8 +273,8 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.setWrapMode(svp._lineWrapMethod);
 	_subEditView.setWrapMode(svp._lineWrapMethod);
 
-	_mainEditView.execute(SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow);
-	_subEditView.execute(SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow);
+	PostMessage(_mainEditView.getHSelf(), SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow, NULL);
+	PostMessage(_subEditView.getHSelf(), SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow, NULL);
 
 	_mainEditView.execute(SCI_SETENDATLASTLINE, !svp._scrollBeyondLastLine);
 	_subEditView.execute(SCI_SETENDATLASTLINE, !svp._scrollBeyondLastLine);


### PR DESCRIPTION
Fix for #11433

This is being proposed as a quick & temporary fix.

The documentation for [SCI_SETCARETLINEVISIBLE](https://www.scintilla.org/ScintillaDoc.html#SCI_SETCARETLINEVISIBLE) states:
>You can choose to make the background colour of the line containing the caret different with these messages. To do this, set the desired background colour with SCI_SETCARETLINEBACK, then use SCI_SETCARETLINEVISIBLE(true) to enable the effect.

Based on this, I first tried setting a value with SCI_SETCARETLINEBACK before the **SCI_SETCARETLINEVISIBLE** call. No luck.

Therefore, I surmised that maybe the Scintilla5 control is not fully initialized and ready to be able to process the **SCI_SETCARETLINEVISIBLE** call during the time when NPP is still launching. So, I tried using **PostMessage** instead of the **SendMessage** that was being used for the **SCI_SETCARETLINEVISIBLE** call. That seems to have fixed the issue.

Effectively, this PR change is:
```C++
	//_mainEditView.execute(SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow);
	//_subEditView.execute(SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow);
	PostMessage(_mainEditView.getHSelf(), SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow, NULL);
	PostMessage(_subEditView.getHSelf(), SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow, NULL);
```

The **_execute_** function is using a Scintilla Direct Function pointer to process a **SendMessage** API call. Since **PostMessage** API call is not processed immediately, a direct function pointer is redundant for the SCI_SETCARETLINEVISIBLE calls on both views.

In any case, this PR is intended as a quick & temporary fix until a better, long term solution can be found.

