### PR TITLE
Fix option 2 for #11433 "Enable Current Line Highlighting"

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2570,7 +2570,7 @@ void ScintillaEditView::performGlobalStyles()
 	StyleArray & stylers = nppParams.getMiscStylerArray();
 
 	const Style * pStyle = stylers.findByName(TEXT("Current line background colour"));
-	if (pStyle)
+	if (pStyle && isCurrentLineHiLiting())
 	{
 		execute(SCI_SETCARETLINEBACK, pStyle->_bgColor);
 	}


### PR DESCRIPTION
Fix option 2 of 3 for issue #11433 

### Note: This is the 2nd alternative way to fix #11433. For the first method, see PR #11511.

#### Plus points for this approach
* This PR fix does **_NOT_** involve the use of an asynchronous message call that was used in PR #11511.
* The change involved with this fix is also much smaller than the first one. 

This method involves just adding the `isCurrentLineHiLiting()` check inside `ScintillaEditView::performGlobalStyles()`. So, the relevant lines of code after the change will be:

```C++
	const Style * pStyle = stylers.findByName(TEXT("Current line background colour"));
	if (pStyle && isCurrentLineHiLiting())
	{
		execute(SCI_SETCARETLINEBACK, pStyle->_bgColor);
	}
```