### PR TITLE
Fix option 3 for #11433 using SCI_SETELEMENTCOLOUR

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -273,9 +273,6 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_mainEditView.setWrapMode(svp._lineWrapMethod);
 	_subEditView.setWrapMode(svp._lineWrapMethod);
 
-	_mainEditView.execute(SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow);
-	_subEditView.execute(SCI_SETCARETLINEVISIBLE, svp._currentLineHilitingShow);
-
 	_mainEditView.execute(SCI_SETENDATLASTLINE, !svp._scrollBeyondLastLine);
 	_subEditView.execute(SCI_SETENDATLASTLINE, !svp._scrollBeyondLastLine);
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3745,8 +3745,8 @@ void Notepad_plus::command(int id)
 		case IDM_VIEW_CURLINE_HILITING:
 		{
 			COLORREF colour = (NppParameters::getInstance()).getCurLineHilitingColour();
-			_mainEditView.setCurrentLineHiLiting(!_pEditView->isCurrentLineHiLiting(), colour);
-			_subEditView.setCurrentLineHiLiting(!_pEditView->isCurrentLineHiLiting(), colour);
+			_mainEditView.setCurrentLineHiLiting(_pEditView->isCurrentLineHiLiting(), colour);
+			_subEditView.setCurrentLineHiLiting(_pEditView->isCurrentLineHiLiting(), colour);
 		}
 		break;
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3744,8 +3744,11 @@ void Notepad_plus::command(int id)
 
 		case IDM_VIEW_CURLINE_HILITING:
 		{
-			COLORREF colour = (NppParameters::getInstance()).getCurLineHilitingColour();
-			bool hilite{ NppParameters::getInstance().getSVP()._currentLineHilitingShow };
+			NppParameters& nppParams = NppParameters::getInstance();
+
+			COLORREF colour{ nppParams.getCurLineHilitingColour() };
+			bool hilite{ nppParams.getSVP()._currentLineHilitingShow };
+
 			_mainEditView.setCurrentLineHiLiting(hilite, colour);
 			_subEditView.setCurrentLineHiLiting(hilite, colour);
 		}

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3745,8 +3745,9 @@ void Notepad_plus::command(int id)
 		case IDM_VIEW_CURLINE_HILITING:
 		{
 			COLORREF colour = (NppParameters::getInstance()).getCurLineHilitingColour();
-			_mainEditView.setCurrentLineHiLiting(_pEditView->isCurrentLineHiLiting(), colour);
-			_subEditView.setCurrentLineHiLiting(_pEditView->isCurrentLineHiLiting(), colour);
+			bool hilite{ NppParameters::getInstance().getSVP()._currentLineHilitingShow };
+			_mainEditView.setCurrentLineHiLiting(hilite, colour);
+			_subEditView.setCurrentLineHiLiting(hilite, colour);
 		}
 		break;
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2570,9 +2570,9 @@ void ScintillaEditView::performGlobalStyles()
 	StyleArray & stylers = nppParams.getMiscStylerArray();
 
 	const Style * pStyle = stylers.findByName(TEXT("Current line background colour"));
-	if (pStyle)
+	if (pStyle && isCurrentLineHiLiting())
 	{
-		execute(SCI_SETCARETLINEBACK, pStyle->_bgColor);
+		execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, pStyle->_bgColor);
 	}
 
 	COLORREF selectColorBack = grey;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2567,12 +2567,16 @@ void ScintillaEditView::expand(size_t& line, bool doExpand, bool force, intptr_t
 void ScintillaEditView::performGlobalStyles()
 {
 	NppParameters& nppParams = NppParameters::getInstance();
-	StyleArray & stylers = nppParams.getMiscStylerArray();
+	StyleArray& stylers = nppParams.getMiscStylerArray();
+	const Style* pStyle{};
 
-	const Style * pStyle = stylers.findByName(TEXT("Current line background colour"));
-	if (pStyle && isCurrentLineHiLiting())
+	if (nppParams.getSVP()._currentLineHilitingShow)
 	{
-		execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, pStyle->_bgColor);
+		pStyle = stylers.findByName(TEXT("Current line background colour"));
+		if (pStyle)
+		{
+			execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, pStyle->_bgColor);
+		}
 	}
 
 	COLORREF selectColorBack = grey;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -475,10 +475,6 @@ public:
 			execute(SCI_RESETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, NULL);
 	};
 
-	bool isCurrentLineHiLiting() const {
-		return NppParameters::getInstance().getSVP()._currentLineHilitingShow;
-	};
-
 	void performGlobalStyles();
 
 	void expand(size_t& line, bool doExpand, bool force = false, intptr_t visLevels = 0, intptr_t level = -1);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -469,14 +469,14 @@ public:
 	
 
 	void setCurrentLineHiLiting(bool isHiliting, COLORREF bgColor) const {
-		execute(SCI_SETCARETLINEVISIBLE, isHiliting);
-		if (!isHiliting)
-			return;
-		execute(SCI_SETCARETLINEBACK, bgColor);
+		if (isHiliting)
+			execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, bgColor);
+		else
+			execute(SCI_RESETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, NULL);
 	};
 
 	bool isCurrentLineHiLiting() const {
-		return (execute(SCI_GETCARETLINEVISIBLE) != 0);
+		return NppParameters::getInstance().getSVP()._currentLineHilitingShow;
 	};
 
 	void performGlobalStyles();


### PR DESCRIPTION
### Note: This is the 3rd alternative way to fix #11433. For the other two methods, see PR #11511 & PR #11518.

This PR fix uses the **SCI_SETELEMENTCOLOUR** API recommended by Scintilla instead of the _discouraged_ **SCI_SETCARETLINEBACK** & **SCI_SETCARETLINEVISIBLE** API calls.