### PR TITLE
Add file monitoring command line argument

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6177,6 +6177,7 @@ std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * co
 	bool recursive = pCmdParams->_isRecursive;
 	bool readOnly = pCmdParams->_isReadOnly;
 	bool openFoldersAsWorkspace = pCmdParams->_openFoldersAsWorkspace;
+	bool monitorFiles = pCmdParams->_monitorFiles;
 
 	if (openFoldersAsWorkspace)
 	{
@@ -6237,6 +6238,12 @@ std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * co
 			_pEditView->scrollPosToCenter(_pEditView->execute(SCI_GETCURRENTPOS));
 
 			switchEditViewTo(iView);	//restore view
+		}
+
+		if (monitorFiles)
+		{
+			monitoringStartOrStopAndUpdateUI(pBuf, true);
+			createMonitoringThread(pBuf);
 		}
 	}
 	if (lastOpened != BUFFER_INVALID)
@@ -8107,6 +8114,13 @@ void Notepad_plus::monitoringStartOrStopAndUpdateUI(Buffer* pBuf, bool isStartin
 		_toolBar.setCheck(IDM_VIEW_MONITORING, isStarting);
 		pBuf->setUserReadOnly(isStarting);
 	}
+}
+
+void Notepad_plus::createMonitoringThread(Buffer* pBuf)
+{
+	MonitorInfo *monitorInfo = new Notepad_plus::MonitorInfo(pBuf, _pPublicInterface->getHSelf());
+	HANDLE hThread = ::CreateThread(NULL, 0, monitorFileOnChange, (void *)monitorInfo, 0, NULL); // will be deallocated while quitting thread
+	::CloseHandle(hThread);
 }
 
 // Fill names into the shortcut list.

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -636,5 +636,6 @@ private:
 	};
 
 	void monitoringStartOrStopAndUpdateUI(Buffer* pBuf, bool isStarting);
+	void createMonitoringThread(Buffer* pBuf);
 	void updateCommandShortcuts();
 };

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2517,10 +2517,7 @@ void Notepad_plus::command(int id)
 					{
 						// Monitoring firstly for making monitoring icon
 						monitoringStartOrStopAndUpdateUI(curBuf, true);
-						
-						MonitorInfo *monitorInfo = new MonitorInfo(curBuf, _pPublicInterface->getHSelf());
-						HANDLE hThread = ::CreateThread(NULL, 0, monitorFileOnChange, (void *)monitorInfo, 0, NULL); // will be deallocated while quitting thread
-						::CloseHandle(hThread);
+						createMonitoringThread(curBuf);
 					}
 				}
 				else

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -242,6 +242,7 @@ struct CmdLineParams
 	bool _isSessionFile = false;
 	bool _isRecursive = false;
 	bool _openFoldersAsWorkspace = false;
+	bool _monitorFiles = false;
 
 	LangType _langType = L_EXTERNAL;
 	generic_string _localizationPath;
@@ -271,6 +272,7 @@ struct CmdLineParamsDTO
 	bool _isSessionFile = false;
 	bool _isRecursive = false;
 	bool _openFoldersAsWorkspace = false;
+	bool _monitorFiles = false;
 
 	intptr_t _line2go = 0;
 	intptr_t _column2go = 0;
@@ -287,6 +289,7 @@ struct CmdLineParamsDTO
 		dto._isSessionFile = params._isSessionFile;
 		dto._isRecursive = params._isRecursive;
 		dto._openFoldersAsWorkspace = params._openFoldersAsWorkspace;
+		dto._monitorFiles = params._monitorFiles;
 
 		dto._line2go = params._line2go;
 		dto._column2go = params._column2go;

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -312,6 +312,7 @@ const TCHAR FLAG_OPEN_FOLDERS_AS_WORKSPACE[] = TEXT("-openFoldersAsWorkspace");
 const TCHAR FLAG_SETTINGS_DIR[] = TEXT("-settingsDir=");
 const TCHAR FLAG_TITLEBAR_ADD[] = TEXT("-titleAdd=");
 const TCHAR FLAG_APPLY_UDL[] = TEXT("-udl=");
+const TCHAR FLAG_MONITOR_FILES[] = TEXT("-monitor");
 
 void doException(Notepad_plus_Window & notepad_plus_plus)
 {
@@ -443,6 +444,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 	cmdLineParams._isSessionFile = isInList(FLAG_OPENSESSIONFILE, params);
 	cmdLineParams._isRecursive = isInList(FLAG_RECURSIVE, params);
 	cmdLineParams._openFoldersAsWorkspace = isInList(FLAG_OPEN_FOLDERS_AS_WORKSPACE, params);
+	cmdLineParams._monitorFiles = isInList(FLAG_MONITOR_FILES, params);
 
 	cmdLineParams._langType = getLangTypeFromParam(params);
 	cmdLineParams._localizationPath = getLocalizationPathFromParam(params);


### PR DESCRIPTION
Completes feature request from [#10562](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10562).

Monitoring for a file can be activated through the command line using the `-monitor` argument:
`notepad++ -monitor filePath`

This works with multiple files, e.g.:
`notepad++ -monitor filePath1 filePath2 filepath3`

To avoid code duplication and promote maintainability, I abstracted away the code that [creates the file monitoring thread](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppCommands.cpp#L2521-L2523) into a function `createMonitoringThread` in the `Notepad_plus` class.