### PR TITLE
CustomFileDialog: Restore the selection after SetFileName

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -303,11 +303,10 @@ public:
 		generic_string name = getDialogFileName(_dialog);
 		if (changeExt(name, dialogIndex - 1))
 		{
-			// Set file name and restore the previous selection in the edit box.
-			// The selection is modified by SetFileName().
+			// Set the file name and clear the selection in the edit box.
+			// The selection is implicitly modified by SetFileName().
 			DWORD selStart = 0;
 			DWORD selEnd = 0;
-			SendMessage(_hwndNameEdit, EM_GETSEL, reinterpret_cast<WPARAM>(&selStart), reinterpret_cast<LPARAM>(&selEnd));
 			bool ok = SUCCEEDED(_dialog->SetFileName(name.c_str()));
 			if (ok)
 				SendMessage(_hwndNameEdit, EM_SETSEL, selStart, selEnd);

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -302,7 +302,17 @@ public:
 		_currentType = dialogIndex;
 		generic_string name = getDialogFileName(_dialog);
 		if (changeExt(name, dialogIndex - 1))
-			return SUCCEEDED(_dialog->SetFileName(name.c_str()));
+		{
+			// Set file name and restore the previous selection in the edit box.
+			// The selection is modified by SetFileName().
+			DWORD selStart = 0;
+			DWORD selEnd = 0;
+			SendMessage(_hwndNameEdit, EM_GETSEL, reinterpret_cast<WPARAM>(&selStart), reinterpret_cast<LPARAM>(&selEnd));
+			bool ok = SUCCEEDED(_dialog->SetFileName(name.c_str()));
+			if (ok)
+				SendMessage(_hwndNameEdit, EM_SETSEL, selStart, selEnd);
+			return ok;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
The selection is modified indirectly by SetFileName().
So it has to be restored to avoid confusion.

Fix #11517