### PR TITLE
exclude "Search result" from sorting of languages in Style Configurator 

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -508,6 +508,10 @@ private :
 
 struct SortLexersInAlphabeticalOrder {
 	bool operator() (LexerStyler& l, LexerStyler& r) {
+		if (!lstrcmp(l.getLexerDesc(), TEXT("Search result")))
+			return false;
+		if (!lstrcmp(r.getLexerDesc(), TEXT("Search result")))
+			return true;
 		return lstrcmp(l.getLexerDesc(), r.getLexerDesc()) < 0;
 	}
 };


### PR DESCRIPTION
With https://github.com/notepad-plus-plus/notepad-plus-plus/commit/2474cbeafd2db6483bfacd50768ec7ec07aa0be3 the listing of languages in Style Configurator was sorted in alphabetic order. In this process "Search Result" was sorted too, before it was placed at the bottom. This PR excludes "Search Results" from the sorting of languages and places it at the bottom as @donho wanted to do here: https://github.com/notepad-plus-plus/notepad-plus-plus/commit/2474cbeafd2db6483bfacd50768ec7ec07aa0be3#commitcomment-70894280