### PR TITLE
Fix behavior when using notepad image hijack with npp

### DIFF
--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -162,9 +162,9 @@ ParamVector convertParamsToNotepadStyle(PWSTR pCmdLine)
 	if ( *pCmdLine != '\0' )
 	{
 		generic_string str(pCmdLine);
-		if ( *PathFindExtension(str.c_str()) == '\0' )
+		if ( *PathFindExtension(str.c_str()) == '\0' && !PathFileExists(str.c_str()) )
 		{
-			str.append(TEXT(".txt")); // If joined path has no extension, Notepad adds a .txt extension
+			str.append(TEXT(".txt")); // If joined path has no extension and there is no file without an extension, Notepad adds a .txt extension
 		}
 		params.push_back(std::move(str));
 	}


### PR DESCRIPTION
This change aligns the behavior of the original notepad.exe with notepad++.exe when it's used as image hijack for notepad.exe.

Fixes #7902

#### New behavior:
*Important: This affects the notepad.exe image hijack with notepad++.exe, not notepad++.exe directly*  

1. File without extension exists:  
    The file will now be opened as expected

2. File without extension doesn't exist:  
    Notepad++ tries to open the file with a `.txt` extension  
    If this file also doesn't exist, it asks to create a file with the `.txt` extension

