### PR TITLE
Add location indicator to find window

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4147,9 +4147,9 @@ void Finder::add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline)
 		len = cut + lenEndOfLongLine;
 	}
 
-	setFinderReadOnly(false);
+	Finder::setFinderReadOnly(false);
 	_scintView.execute(SCI_ADDTEXT, len, reinterpret_cast<LPARAM>(text2AddUtf8));
-	setFinderReadOnly(true);
+	Finder::setFinderReadOnly(true);
 	_pMainMarkings->push_back(mi);
 }
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -119,7 +119,7 @@ public:
 	void addFileNameTitle(const TCHAR * fileName);
 	void addFileHitCount(int count);
 	void addSearchHitCount(int count, int countSearched, bool isMatchLines, bool searchedEntireNotSelection);
-	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline, size_t totalLineNumber);
+	void add(FoundInfo fi, SearchResultMarking mi, const TCHAR* foundline);
 	void setFinderStyle();
 	void removeAll();
 	void openAll();


### PR DESCRIPTION
Issue #11118 
Added a relative location each time find replace is clicked. This gives users the ability to see more information about what match they are at and how many matches there are in an easy to view way.
The indicator is in the text in the bottom portion of the screen, and updates when a user clicks "Find Next".
![ManualTest2](https://user-images.githubusercontent.com/66501558/164781268-80fac690-373e-4219-b773-daf6d251bf17.PNG)
![ManualTest1](https://user-images.githubusercontent.com/66501558/164781271-bdbedc64-1112-4ffc-b4b4-fff912e204f6.PNG)
