### PR TITLE
Initial & current command line parameters query API & Debug Info text refresh

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -709,8 +709,8 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
 	//scnNotification->nmhdr.idFrom = 0;
 
-	#define NPPN_CMDLINECHANGED (NPPN_FIRST + 28)  // To notify plugins that current command line string has changed
-	//scnNotification->nmhdr.code = NPPN_CMDLINECHANGED;
+	#define NPPN_CMDLINEPLUGINMSG (NPPN_FIRST + 28)  // To notify plugins that current command line string has changed
+	//scnNotification->nmhdr.code = NPPN_CMDLINEPLUGINMSG;
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
-	//scnNotification->nmhdr.idFrom = 0;
+	//scnNotification->nmhdr.idFrom = pluginMessage; //where pluginMessage is pointer of type TCHAR
 

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -511,14 +511,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// Note: in the case of calling failure ("false" is returned), you may need to change NppDarkMode::Colors structure to:
 	// https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppDarkMode.h#L32
 
-	#define NPPM_GETINITIALCMDLINE (NPPMSG + 109)
-	// INT NPPM_GETINITIALCMDLINE(size_t strLen, TCHAR *commandLineStr)
-	// Get the Initial Command Line string.
-	// Returns the number of TCHAR copied/to copy.
-	// Users should call it with commandLineStr as NULL to get the required number of TCHAR (not including the terminating nul character),
-	// allocate commandLineStr buffer with the return value + 1, then call it again to get the initial command line string.
-
-	#define NPPM_GETCURRENTCMDLINE (NPPMSG + 110)
+	#define NPPM_GETCURRENTCMDLINE (NPPMSG + 109)
 	// INT NPPM_GETCURRENTCMDLINE(size_t strLen, TCHAR *commandLineStr)
 	// Get the Current Command Line string.
 	// Returns the number of TCHAR copied/to copy.

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -709,8 +709,8 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
 	//scnNotification->nmhdr.idFrom = 0;
 
-	#define NPPN_CMDLINEPLUGINMSG (NPPN_FIRST + 28)  // To notify plugins that current command line string has changed
+	#define NPPN_CMDLINEPLUGINMSG (NPPN_FIRST + 28)  // To notify plugins that the new argument for plugins (via '-pluginMessage="YOUR_PLUGIN_ARGUMENT"' in command line) is available
 	//scnNotification->nmhdr.code = NPPN_CMDLINEPLUGINMSG;
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
-	//scnNotification->nmhdr.idFrom = pluginMessage; //where pluginMessage is pointer of type TCHAR
+	//scnNotification->nmhdr.idFrom = pluginMessage; //where pluginMessage is pointer of type wchar_t
 

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -511,6 +511,20 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// Note: in the case of calling failure ("false" is returned), you may need to change NppDarkMode::Colors structure to:
 	// https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/NppDarkMode.h#L32
 
+	#define NPPM_GETINITIALCMDLINE (NPPMSG + 109)
+	// INT NPPM_GETINITIALCMDLINE(size_t strLen, TCHAR *commandLineStr)
+	// Get the Initial Command Line string.
+	// Returns the number of TCHAR copied/to copy.
+	// Users should call it with commandLineStr as NULL to get the required number of TCHAR (not including the terminating nul character),
+	// allocate commandLineStr buffer with the return value + 1, then call it again to get the initial command line string.
+
+	#define NPPM_GETCURRENTCMDLINE (NPPMSG + 110)
+	// INT NPPM_GETCURRENTCMDLINE(size_t strLen, TCHAR *commandLineStr)
+	// Get the Current Command Line string.
+	// Returns the number of TCHAR copied/to copy.
+	// Users should call it with commandLineStr as NULL to get the required number of TCHAR (not including the terminating nul character),
+	// allocate commandLineStr buffer with the return value + 1, then call it again to get the current command line string.
+
 
 #define VAR_NOT_RECOGNIZED 0
 #define FULL_CURRENT_PATH 1
@@ -699,6 +713,11 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 
 	#define NPPN_DARKMODECHANGED (NPPN_FIRST + 27) // To notify plugins that Dark Mode was enabled/disabled
 	//scnNotification->nmhdr.code = NPPN_DARKMODECHANGED;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp;
+	//scnNotification->nmhdr.idFrom = 0;
+
+	#define NPPN_CMDLINECHANGED (NPPN_FIRST + 28)  // To notify plugins that current command line string has changed
+	//scnNotification->nmhdr.code = NPPN_CMDLINECHANGED;
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
 	//scnNotification->nmhdr.idFrom = 0;
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -675,12 +675,15 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					if (sizeof(CmdLineParamsDTO) == cmdLineParamsSize) // make sure the structure is the same
 					{
 						nppParam.setCmdlineParam(*cmdLineParam);
-						SCNotification scnN;
-						scnN.nmhdr.code = NPPN_CMDLINECHANGED;
-						generic_string pluginMessage{  };
-						scnN.nmhdr.hwndFrom = hwnd;
-						scnN.nmhdr.idFrom = reinterpret_cast<uptr_t>(nppParam.getCmdLineParams()._pluginMessage);
-						_pluginsManager.notify(&scnN);
+						generic_string pluginMessage { nppParam.getCmdLineParams()._pluginMessage };
+						if (!pluginMessage.empty())
+						{
+							SCNotification scnN;
+							scnN.nmhdr.code = NPPN_CMDLINEPLUGINMSG;
+							scnN.nmhdr.hwndFrom = hwnd;
+							scnN.nmhdr.idFrom = reinterpret_cast<uptr_t>(pluginMessage.c_str());
+							_pluginsManager.notify(&scnN);
+						}
 					}
 					else
 					{

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -699,6 +699,20 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					loadCommandlineParams(fileNamesW, &cmdLineParams);
 					break;
 				}
+
+				case COPYDATA_FULL_CMDLINE:
+				{
+					wchar_t* fullCmdLine = static_cast<wchar_t*>(pCopyData->lpData);
+					NppParameters::getInstance().setCmdLineStringCurrent(fullCmdLine);
+
+					SCNotification scnN;
+					scnN.nmhdr.code = NPPN_CMDLINECHANGED;
+					scnN.nmhdr.hwndFrom = hwnd;
+					scnN.nmhdr.idFrom = 0;
+					_pluginsManager.notify(&scnN);
+
+					break;
+				}
 			}
 
 			return TRUE;
@@ -1308,6 +1322,22 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			if (_playingBackMacro)
 				return static_cast<LRESULT>(MacroStatus::PlayingBack);
 			return (_macro.empty()) ? static_cast<LRESULT>(MacroStatus::Idle) : static_cast<LRESULT>(MacroStatus::RecordingStopped);
+		}
+
+		case NPPM_GETINITIALCMDLINE:
+		case NPPM_GETCURRENTCMDLINE:
+		{
+			generic_string cmdLineString = (message == NPPM_GETINITIALCMDLINE) ? nppParam.getCmdLineString() : nppParam.getCmdLineStringCurrent();
+
+			if (lParam != 0)
+			{
+				if (cmdLineString.length() >= static_cast<size_t>(wParam))
+				{
+					return 0;
+				}
+				lstrcpy(reinterpret_cast<TCHAR*>(lParam), cmdLineString.c_str());
+			}
+			return cmdLineString.length();
 		}
 
 		case WM_FRSAVE_INT:

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -281,8 +281,8 @@ struct CmdLineParamsDTO
 	intptr_t _pos2go = 0;
 
 	LangType _langType = L_EXTERNAL;
+	generic_string _udlName;
 
-	wchar_t _udlName[MAX_PATH];
 	wchar_t _pluginMessage[MAX_PATH];
 
 	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
@@ -300,7 +300,7 @@ struct CmdLineParamsDTO
 		dto._pos2go = params._pos2go;
 		
 		dto._langType = params._langType;
-		wcsncpy(dto._udlName, params._udlName.c_str(), MAX_PATH);
+		dto._udlName = params._udlName;
 		wcsncpy(dto._pluginMessage, params._pluginMessage.c_str(), MAX_PATH);
 		return dto;
 	}

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -248,6 +248,7 @@ struct CmdLineParams
 	LangType _langType = L_EXTERNAL;
 	generic_string _localizationPath;
 	generic_string _udlName;
+	generic_string _pluginMessage;
 
 	generic_string _easterEggName;
 	unsigned char _quoteType = 0;
@@ -280,7 +281,9 @@ struct CmdLineParamsDTO
 	intptr_t _pos2go = 0;
 
 	LangType _langType = L_EXTERNAL;
-	generic_string _udlName;
+
+	wchar_t _udlName[MAX_PATH];
+	wchar_t _pluginMessage[MAX_PATH];
 
 	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
 	{
@@ -297,7 +300,8 @@ struct CmdLineParamsDTO
 		dto._pos2go = params._pos2go;
 		
 		dto._langType = params._langType;
-		dto._udlName = params._udlName;
+		wcsncpy(dto._udlName, params._udlName.c_str(), MAX_PATH);
+		wcsncpy(dto._pluginMessage, params._pluginMessage.c_str(), MAX_PATH);
 		return dto;
 	}
 };
@@ -1481,13 +1485,11 @@ public:
 	{
 		_cmdLineParams = cmdLineParams;
 	}
+
 	const CmdLineParamsDTO & getCmdLineParams() const {return _cmdLineParams;};
 
 	const generic_string& getCmdLineString() const { return _cmdLineString; }
 	void setCmdLineString(const generic_string& str) { _cmdLineString = str; }
-
-	const generic_string& getCmdLineStringCurrent() const { return _cmdLineStringCurrent; }
-	void setCmdLineStringCurrent(const generic_string& str) { _cmdLineStringCurrent = str; }
 
 	void setFileSaveDlgFilterIndex(int ln) {_fileSaveDlgFilterIndex = ln;};
 	int getFileSaveDlgFilterIndex() const {return _fileSaveDlgFilterIndex;};
@@ -1734,7 +1736,6 @@ private:
 
 	CmdLineParamsDTO _cmdLineParams;
 	generic_string _cmdLineString;
-	generic_string _cmdLineStringCurrent;
 
 	int _fileSaveDlgFilterIndex = -1;
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -117,6 +117,7 @@ const int LANG_INDEX_TYPE7 = 8;
 const int COPYDATA_PARAMS = 0;
 const int COPYDATA_FILENAMESA = 1;
 const int COPYDATA_FILENAMESW = 2;
+const int COPYDATA_FULL_CMDLINE = 3;
 
 #define PURE_LC_NONE	0
 #define PURE_LC_BOL	 1
@@ -1485,6 +1486,9 @@ public:
 	const generic_string& getCmdLineString() const { return _cmdLineString; }
 	void setCmdLineString(const generic_string& str) { _cmdLineString = str; }
 
+	const generic_string& getCmdLineStringCurrent() const { return _cmdLineStringCurrent; }
+	void setCmdLineStringCurrent(const generic_string& str) { _cmdLineStringCurrent = str; }
+
 	void setFileSaveDlgFilterIndex(int ln) {_fileSaveDlgFilterIndex = ln;};
 	int getFileSaveDlgFilterIndex() const {return _fileSaveDlgFilterIndex;};
 
@@ -1730,6 +1734,7 @@ private:
 
 	CmdLineParamsDTO _cmdLineParams;
 	generic_string _cmdLineString;
+	generic_string _cmdLineStringCurrent;
 
 	int _fileSaveDlgFilterIndex = -1;
 

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -145,170 +145,7 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 	{
 		case WM_INITDIALOG:
 		{
-			NppParameters& nppParam = NppParameters::getInstance();
-
 			NppDarkMode::autoSubclassAndThemeChildControls(_hSelf);
-
-			// Notepad++ version
-			_debugInfoStr = NOTEPAD_PLUS_VERSION;
-			_debugInfoStr += nppParam.archType() == IMAGE_FILE_MACHINE_I386 ? TEXT("   (32-bit)") : (nppParam.archType() == IMAGE_FILE_MACHINE_AMD64 ? TEXT("   (64-bit)") : TEXT("   (ARM 64-bit)"));
-			_debugInfoStr += TEXT("\r\n");
-
-			// Build time
-			_debugInfoStr += TEXT("Build time : ");
-			generic_string buildTime;
-			WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-			buildTime += wmc.char2wchar(__DATE__, CP_ACP);
-			buildTime += TEXT(" - ");
-			buildTime += wmc.char2wchar(__TIME__, CP_ACP);
-			_debugInfoStr += buildTime;
-			_debugInfoStr += TEXT("\r\n");
-
-#if defined(__GNUC__)
-			_debugInfoStr += TEXT("Built with : GCC ");
-			_debugInfoStr += wmc.char2wchar(__VERSION__, CP_ACP);
-			_debugInfoStr += TEXT("\r\n");
-#elif !defined(_MSC_VER)
-			_debugInfoStr += TEXT("Built with : (unknown)\r\n");
-#endif
-
-			// Binary path
-			_debugInfoStr += TEXT("Path : ");
-			TCHAR nppFullPath[MAX_PATH];
-			::GetModuleFileName(NULL, nppFullPath, MAX_PATH);
-			_debugInfoStr += nppFullPath;
-			_debugInfoStr += TEXT("\r\n");
-
-			// Command line as specified for program launch
-			_debugInfoStr += TEXT("Command Line : ");
-			_debugInfoStr += nppParam.getCmdLineString();
-			_debugInfoStr += TEXT("\r\n");
-
-			// Administrator mode
-			_debugInfoStr += TEXT("Admin mode : ");
-			_debugInfoStr += (_isAdmin ? TEXT("ON") : TEXT("OFF"));
-			_debugInfoStr += TEXT("\r\n");
-
-			// local conf
-			_debugInfoStr += TEXT("Local Conf mode : ");
-			bool doLocalConf = (NppParameters::getInstance()).isLocal();
-			_debugInfoStr += (doLocalConf ? TEXT("ON") : TEXT("OFF"));
-			_debugInfoStr += TEXT("\r\n");
-
-			// Cloud config directory
-			_debugInfoStr += TEXT("Cloud Config : ");
-			const generic_string& cloudPath = nppParam.getNppGUI()._cloudPath;
-			_debugInfoStr += cloudPath.empty() ? _T("OFF") : cloudPath;
-			_debugInfoStr += TEXT("\r\n");
-
-			// OS information
-			HKEY hKey;
-			DWORD dataSize = 0;
-			
-			TCHAR szProductName[96] = {'\0'};
-			TCHAR szCurrentBuildNumber[32] = {'\0'};
-			TCHAR szReleaseId[32] = {'\0'};
-			DWORD dwUBR = 0;
-			TCHAR szUBR[12] = TEXT("0");
-
-			// NOTE: RegQueryValueExW is not guaranteed to return null-terminated strings
-			if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
-			{
-				dataSize = sizeof(szProductName);
-				RegQueryValueExW(hKey, TEXT("ProductName"), NULL, NULL, reinterpret_cast<LPBYTE>(szProductName), &dataSize);
-				szProductName[sizeof(szProductName) / sizeof(TCHAR) - 1] = '\0';
-
-				dataSize = sizeof(szReleaseId);
-				RegQueryValueExW(hKey, TEXT("ReleaseId"), NULL, NULL, reinterpret_cast<LPBYTE>(szReleaseId), &dataSize);
-				szReleaseId[sizeof(szReleaseId) / sizeof(TCHAR) - 1] = '\0';
-				
-				dataSize = sizeof(szCurrentBuildNumber);
-				RegQueryValueExW(hKey, TEXT("CurrentBuildNumber"), NULL, NULL, reinterpret_cast<LPBYTE>(szCurrentBuildNumber), &dataSize);
-				szCurrentBuildNumber[sizeof(szCurrentBuildNumber) / sizeof(TCHAR) - 1] = '\0';
-				
-				dataSize = sizeof(DWORD);
-				if (RegQueryValueExW(hKey, TEXT("UBR"), NULL, NULL, reinterpret_cast<LPBYTE>(&dwUBR), &dataSize) == ERROR_SUCCESS)
-				{
-					generic_sprintf(szUBR, TEXT("%u"), dwUBR);
-				}
-				
-				RegCloseKey(hKey);
-			}
-
-			// Get alternative OS information
-			if (szProductName[0] == '\0')
-			{
-				generic_sprintf(szProductName, TEXT("%s"), (NppParameters::getInstance()).getWinVersionStr().c_str());
-			}
-
-			// Override ProductName if it's Windows 11
-			if (NppDarkMode::isWindows11())
-				generic_sprintf(szProductName, TEXT("%s"), TEXT("Windows 11"));
-
-			if (szCurrentBuildNumber[0] == '\0')
-			{
-				DWORD dwVersion = GetVersion();
-				if (dwVersion < 0x80000000)
-				{
-					generic_sprintf(szCurrentBuildNumber, TEXT("%u"), HIWORD(dwVersion));
-				}
-			}
-			
-			_debugInfoStr += TEXT("OS Name : ");
-			_debugInfoStr += szProductName;
-			_debugInfoStr += TEXT(" (");
-			_debugInfoStr += (NppParameters::getInstance()).getWinVerBitStr();
-			_debugInfoStr += TEXT(") ");
-			_debugInfoStr += TEXT("\r\n");
-			
-			if (szReleaseId[0] != '\0')
-			{
-				_debugInfoStr += TEXT("OS Version : ");
-				_debugInfoStr += szReleaseId;
-				_debugInfoStr += TEXT("\r\n");
-			}
-
-			if (szCurrentBuildNumber[0] != '\0')
-			{
-				_debugInfoStr += TEXT("OS Build : ");
-				_debugInfoStr += szCurrentBuildNumber;
-				_debugInfoStr += TEXT(".");
-				_debugInfoStr += szUBR;
-				_debugInfoStr += TEXT("\r\n");
-			}
-
-			{
-				TCHAR szACP[32];
-				generic_sprintf(szACP, TEXT("%u"), ::GetACP());
-				_debugInfoStr += TEXT("Current ANSI codepage : ");
- 				_debugInfoStr += szACP;
-				_debugInfoStr += TEXT("\r\n");
-			}
-
-			// Detect WINE
-			PWINEGETVERSION pWGV = nullptr;
-			HMODULE hNtdllModule = GetModuleHandle(L"ntdll.dll");
-			if (hNtdllModule)
-			{
-				pWGV = (PWINEGETVERSION)GetProcAddress(hNtdllModule, "wine_get_version");
-			}
-
-			if (pWGV != nullptr)
-			{
-				TCHAR szWINEVersion[32];
-				generic_sprintf(szWINEVersion, TEXT("%hs"), pWGV());
-
-				_debugInfoStr += TEXT("WINE : ");
-				_debugInfoStr += szWINEVersion;
-				_debugInfoStr += TEXT("\r\n");
-			}
-
-			// Plugins
-			_debugInfoStr += TEXT("Plugins : ");
-			_debugInfoStr += _loadedPlugins.length() == 0 ? TEXT("none") : _loadedPlugins;
-			_debugInfoStr += TEXT("\r\n");
-
-			::SetDlgItemText(_hSelf, IDC_DEBUGINFO_EDIT, _debugInfoStr.c_str());
 
 			_copyToClipboardLink.init(_hInst, _hSelf);
 			_copyToClipboardLink.create(::GetDlgItem(_hSelf, IDC_DEBUGINFO_COPYLINK), IDC_DEBUGINFO_COPYLINK);
@@ -381,8 +218,189 @@ void DebugInfoDlg::doDialog()
 	if (!isCreated())
 		create(IDD_DEBUGINFOBOX);
 
+	// Refresh the Debug Information.
+	// For example, the command line parameters may have changed since this dialog was last opened during this session.
+	refreshDebugInfo();
+
 	// Adjust the position of AboutBox
 	goToCenter();
+}
+
+void DebugInfoDlg::refreshDebugInfo()
+{
+	NppParameters& nppParam = NppParameters::getInstance();
+
+	// Notepad++ version
+	_debugInfoStr = NOTEPAD_PLUS_VERSION;
+	_debugInfoStr += nppParam.archType() == IMAGE_FILE_MACHINE_I386 ? TEXT("   (32-bit)") : (nppParam.archType() == IMAGE_FILE_MACHINE_AMD64 ? TEXT("   (64-bit)") : TEXT("   (ARM 64-bit)"));
+	_debugInfoStr += TEXT("\r\n");
+
+	// Build time
+	_debugInfoStr += TEXT("Build time : ");
+	generic_string buildTime;
+	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+	buildTime += wmc.char2wchar(__DATE__, CP_ACP);
+	buildTime += TEXT(" - ");
+	buildTime += wmc.char2wchar(__TIME__, CP_ACP);
+	_debugInfoStr += buildTime;
+	_debugInfoStr += TEXT("\r\n");
+
+#if defined(__GNUC__)
+	_debugInfoStr += TEXT("Built with : GCC ");
+	_debugInfoStr += wmc.char2wchar(__VERSION__, CP_ACP);
+	_debugInfoStr += TEXT("\r\n");
+#elif !defined(_MSC_VER)
+	_debugInfoStr += TEXT("Built with : (unknown)\r\n");
+#endif
+
+	// Binary path
+	_debugInfoStr += TEXT("Path : ");
+	TCHAR nppFullPath[MAX_PATH];
+	::GetModuleFileName(NULL, nppFullPath, MAX_PATH);
+	_debugInfoStr += nppFullPath;
+	_debugInfoStr += TEXT("\r\n");
+
+	// Command line as specified for program launch
+	generic_string commandLine{ nppParam.getCmdLineString() };
+	generic_string commandLineCurrent{ nppParam.getCmdLineStringCurrent() };
+
+	if (commandLineCurrent.length() < 1)
+	{
+		_debugInfoStr += TEXT("Command Line : ") + commandLine + TEXT("\r\n");
+	}
+	else
+	{
+		_debugInfoStr += TEXT("Initial Command Line : ") + commandLine + TEXT("\r\n");
+		_debugInfoStr += TEXT("Current Command Line : ") + commandLineCurrent + TEXT("\r\n");
+	}
+
+	// Administrator mode
+	_debugInfoStr += TEXT("Admin mode : ");
+	_debugInfoStr += (_isAdmin ? TEXT("ON") : TEXT("OFF"));
+	_debugInfoStr += TEXT("\r\n");
+
+	// local conf
+	_debugInfoStr += TEXT("Local Conf mode : ");
+	bool doLocalConf = (NppParameters::getInstance()).isLocal();
+	_debugInfoStr += (doLocalConf ? TEXT("ON") : TEXT("OFF"));
+	_debugInfoStr += TEXT("\r\n");
+
+	// Cloud config directory
+	_debugInfoStr += TEXT("Cloud Config : ");
+	const generic_string& cloudPath = nppParam.getNppGUI()._cloudPath;
+	_debugInfoStr += cloudPath.empty() ? _T("OFF") : cloudPath;
+	_debugInfoStr += TEXT("\r\n");
+
+	// OS information
+	HKEY hKey;
+	DWORD dataSize = 0;
+
+	TCHAR szProductName[96] = {'\0'};
+	TCHAR szCurrentBuildNumber[32] = {'\0'};
+	TCHAR szReleaseId[32] = {'\0'};
+	DWORD dwUBR = 0;
+	TCHAR szUBR[12] = TEXT("0");
+
+	// NOTE: RegQueryValueExW is not guaranteed to return null-terminated strings
+	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+	{
+		dataSize = sizeof(szProductName);
+		RegQueryValueExW(hKey, TEXT("ProductName"), NULL, NULL, reinterpret_cast<LPBYTE>(szProductName), &dataSize);
+		szProductName[sizeof(szProductName) / sizeof(TCHAR) - 1] = '\0';
+
+		dataSize = sizeof(szReleaseId);
+		RegQueryValueExW(hKey, TEXT("ReleaseId"), NULL, NULL, reinterpret_cast<LPBYTE>(szReleaseId), &dataSize);
+		szReleaseId[sizeof(szReleaseId) / sizeof(TCHAR) - 1] = '\0';
+
+		dataSize = sizeof(szCurrentBuildNumber);
+		RegQueryValueExW(hKey, TEXT("CurrentBuildNumber"), NULL, NULL, reinterpret_cast<LPBYTE>(szCurrentBuildNumber), &dataSize);
+		szCurrentBuildNumber[sizeof(szCurrentBuildNumber) / sizeof(TCHAR) - 1] = '\0';
+
+		dataSize = sizeof(DWORD);
+		if (RegQueryValueExW(hKey, TEXT("UBR"), NULL, NULL, reinterpret_cast<LPBYTE>(&dwUBR), &dataSize) == ERROR_SUCCESS)
+		{
+			generic_sprintf(szUBR, TEXT("%u"), dwUBR);
+		}
+
+		RegCloseKey(hKey);
+	}
+
+	// Get alternative OS information
+	if (szProductName[0] == '\0')
+	{
+		generic_sprintf(szProductName, TEXT("%s"), (NppParameters::getInstance()).getWinVersionStr().c_str());
+	}
+
+	// Override ProductName if it's Windows 11
+	if (NppDarkMode::isWindows11())
+		generic_sprintf(szProductName, TEXT("%s"), TEXT("Windows 11"));
+
+	if (szCurrentBuildNumber[0] == '\0')
+	{
+		DWORD dwVersion = GetVersion();
+		if (dwVersion < 0x80000000)
+		{
+			generic_sprintf(szCurrentBuildNumber, TEXT("%u"), HIWORD(dwVersion));
+		}
+	}
+
+	_debugInfoStr += TEXT("OS Name : ");
+	_debugInfoStr += szProductName;
+	_debugInfoStr += TEXT(" (");
+	_debugInfoStr += (NppParameters::getInstance()).getWinVerBitStr();
+	_debugInfoStr += TEXT(") ");
+	_debugInfoStr += TEXT("\r\n");
+
+	if (szReleaseId[0] != '\0')
+	{
+		_debugInfoStr += TEXT("OS Version : ");
+		_debugInfoStr += szReleaseId;
+		_debugInfoStr += TEXT("\r\n");
+	}
+
+	if (szCurrentBuildNumber[0] != '\0')
+	{
+		_debugInfoStr += TEXT("OS Build : ");
+		_debugInfoStr += szCurrentBuildNumber;
+		_debugInfoStr += TEXT(".");
+		_debugInfoStr += szUBR;
+		_debugInfoStr += TEXT("\r\n");
+	}
+
+	{
+		TCHAR szACP[32];
+		generic_sprintf(szACP, TEXT("%u"), ::GetACP());
+		_debugInfoStr += TEXT("Current ANSI codepage : ");
+		_debugInfoStr += szACP;
+		_debugInfoStr += TEXT("\r\n");
+	}
+
+	// Detect WINE
+	PWINEGETVERSION pWGV = nullptr;
+	HMODULE hNtdllModule = GetModuleHandle(L"ntdll.dll");
+	if (hNtdllModule)
+	{
+		pWGV = (PWINEGETVERSION)GetProcAddress(hNtdllModule, "wine_get_version");
+	}
+
+	if (pWGV != nullptr)
+	{
+		TCHAR szWINEVersion[32];
+		generic_sprintf(szWINEVersion, TEXT("%hs"), pWGV());
+
+		_debugInfoStr += TEXT("WINE : ");
+		_debugInfoStr += szWINEVersion;
+		_debugInfoStr += TEXT("\r\n");
+	}
+
+	// Plugins
+	_debugInfoStr += TEXT("Plugins : ");
+	_debugInfoStr += _loadedPlugins.length() == 0 ? TEXT("none") : _loadedPlugins;
+	_debugInfoStr += TEXT("\r\n");
+
+	// Set Debug Info text and leave the text in selected state
+	::SetDlgItemText(_hSelf, IDC_DEBUGINFO_EDIT, _debugInfoStr.c_str());
+	::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, _debugInfoStr.length() - 1);
 }
 
 void DoSaveOrNotBox::doDialog(bool isRTL)

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -261,18 +261,7 @@ void DebugInfoDlg::refreshDebugInfo()
 	_debugInfoStr += TEXT("\r\n");
 
 	// Command line as specified for program launch
-	generic_string commandLine{ nppParam.getCmdLineString() };
-	generic_string commandLineCurrent{ nppParam.getCmdLineStringCurrent() };
-
-	if (commandLineCurrent.length() < 1)
-	{
-		_debugInfoStr += TEXT("Command Line : ") + commandLine + TEXT("\r\n");
-	}
-	else
-	{
-		_debugInfoStr += TEXT("Initial Command Line : ") + commandLine + TEXT("\r\n");
-		_debugInfoStr += TEXT("Current Command Line : ") + commandLineCurrent + TEXT("\r\n");
-	}
+	_debugInfoStr += TEXT("Command Line : ") + nppParam.getCmdLineString() + TEXT("\r\n");
 
 	// Administrator mode
 	_debugInfoStr += TEXT("Admin mode : ");
@@ -401,6 +390,7 @@ void DebugInfoDlg::refreshDebugInfo()
 	// Set Debug Info text and leave the text in selected state
 	::SetDlgItemText(_hSelf, IDC_DEBUGINFO_EDIT, _debugInfoStr.c_str());
 	::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, _debugInfoStr.length() - 1);
+	::SetFocus(::GetDlgItem(_hSelf, IDC_DEBUGINFO_EDIT));
 }
 
 void DoSaveOrNotBox::doDialog(bool isRTL)

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
@@ -70,6 +70,8 @@ public:
 
 	void doDialog();
 
+	void refreshDebugInfo();
+
 	virtual void destroy() {
 		_copyToClipboardLink.destroy();
 	};

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
@@ -82,6 +82,7 @@ protected:
 private:
 	typedef const CHAR * (__cdecl * PWINEGETVERSION)();
 	generic_string _debugInfoStr;
+	const generic_string _cmdLinePlaceHolder { L"$COMMAND_LINE_PLACEHOLDER$" };
 	bool _isAdmin = false;
 	generic_string _loadedPlugins;
 	URLCtrl _copyToClipboardLink;

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -434,9 +434,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 	bool doFunctionListExport = isInList(FLAG_FUNCLSTEXPORT, params);
 	bool doPrintAndQuit = isInList(FLAG_PRINTANDQUIT, params);
 
-	NppParameters& nppParameters = NppParameters::getInstance();
-	nppParameters.setCmdLineString(cmdLineString);
-
 	CmdLineParams cmdLineParams;
 	cmdLineParams._isNoTab = isInList(FLAG_NOTABBAR, params);
 	cmdLineParams._isNoPlugin = isInList(FLAG_NO_PLUGIN, params);
@@ -474,6 +471,10 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
     cmdLineParams._pos2go = getNumberFromParam('p', params, isParamePresent);
 	cmdLineParams._point.x = static_cast<LONG>(getNumberFromParam('x', params, cmdLineParams._isPointXValid));
 	cmdLineParams._point.y = static_cast<LONG>(getNumberFromParam('y', params, cmdLineParams._isPointYValid));
+
+	NppParameters& nppParameters = NppParameters::getInstance();
+
+	nppParameters.setCmdLineString(cmdLineString);
 
 	generic_string path;
 	if (getParamValFromString(FLAG_SETTINGS_DIR, params, path))

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -593,6 +593,11 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 
 			if (params.size() > 0)	//if there are files to open, use the WM_COPYDATA system
 			{
+				COPYDATASTRUCT cmdLineData;
+				cmdLineData.dwData = COPYDATA_FULL_CMDLINE;
+				cmdLineData.lpData = (void*)cmdLineString.c_str();
+				cmdLineData.cbData = long(cmdLineString.length() + 1) * (sizeof(TCHAR));
+
 				CmdLineParamsDTO dto = CmdLineParamsDTO::FromCmdLineParams(cmdLineParams);
 
 				COPYDATASTRUCT paramData;
@@ -603,8 +608,9 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int)
 				COPYDATASTRUCT fileNamesData;
 				fileNamesData.dwData = COPYDATA_FILENAMES;
 				fileNamesData.lpData = (void *)quotFileName.c_str();
-				fileNamesData.cbData = long(quotFileName.length() + 1)*(sizeof(TCHAR));
+				fileNamesData.cbData = long(quotFileName.length() + 1) * (sizeof(TCHAR));
 
+				::SendMessage(hNotepad_plus, WM_COPYDATA, reinterpret_cast<WPARAM>(hInstance), reinterpret_cast<LPARAM>(&cmdLineData));
 				::SendMessage(hNotepad_plus, WM_COPYDATA, reinterpret_cast<WPARAM>(hInstance), reinterpret_cast<LPARAM>(&paramData));
 				::SendMessage(hNotepad_plus, WM_COPYDATA, reinterpret_cast<WPARAM>(hInstance), reinterpret_cast<LPARAM>(&fileNamesData));
 			}


### PR DESCRIPTION
Fixes: #11576 (Re-invoking a mono-instance NPP using new command line parameters issue with plugin query & Debug Info display) 
Fixes: #11633 (NPP crashes when re-invoked with -udl command line parameter with more than 7 characters as its value)

Additionally, this PR may also allow closing of issue #10602. With the additions to NPP messaging & notification API in this PR, GotoLineCol plugin will be able to meet the user's requirement. See [here](https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/issues/11#issuecomment-935639520).

### Screenshots with this PR implementation:

1. When a fresh command line param string is not an empty string, _Debug Info..._ will display both the initial and current command lines.
![image](https://user-images.githubusercontent.com/45252729/165011605-cf31c674-46e7-4400-be95-0e7d6118e687.png)

2. When a fresh command line param string is either not available or empty, _Debug Info..._ will display just a command line (keeping current behavior for this use case).
![image](https://user-images.githubusercontent.com/45252729/165011964-94cab438-50af-4c58-97f7-a27a29b2e7a1.png)

