### PR TITLE
Override with "Search result" style in "Search results" view

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -2680,8 +2680,6 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		_pFinder->_scintView.execute(SCI_SETCODEPAGE, SC_CP_UTF8);
 		_pFinder->_scintView.execute(SCI_USEPOPUP, FALSE);
 		_pFinder->_scintView.execute(SCI_SETUNDOCOLLECTION, false);	//dont store any undo information
-		_pFinder->_scintView.execute(SCI_SETCARETLINEVISIBLE, 1);
-		_pFinder->_scintView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
 		_pFinder->_scintView.execute(SCI_SETCARETWIDTH, 0);
 		_pFinder->_scintView.showMargin(ScintillaEditView::_SC_MARGE_FOLDER, true);
 
@@ -2814,8 +2812,6 @@ Finder * FindReplaceDlg::createFinder()
 	pFinder->_scintView.execute(SCI_SETCODEPAGE, SC_CP_UTF8);
 	pFinder->_scintView.execute(SCI_USEPOPUP, FALSE);
 	pFinder->_scintView.execute(SCI_SETUNDOCOLLECTION, false);	//dont store any undo information
-	pFinder->_scintView.execute(SCI_SETCARETLINEVISIBLE, 1);
-	pFinder->_scintView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
 	pFinder->_scintView.execute(SCI_SETCARETWIDTH, 0);
 	pFinder->_scintView.showMargin(ScintillaEditView::_SC_MARGE_FOLDER, true);
 
@@ -4331,6 +4327,7 @@ void Finder::setFinderStyle()
 		{
 			_scintView.execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, pStyle->_bgColor);
 			_scintView.execute(SCI_SETCARETLINEFRAME, 0);
+			_scintView.execute(SCI_SETCARETLINEVISIBLE, 1);
 			_scintView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
 		}
 	}

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4329,7 +4329,9 @@ void Finder::setFinderStyle()
 		const Style * pStyle = pStyler->findByID(SCE_SEARCHRESULT_CURRENT_LINE);
 		if (pStyle)
 		{
-			_scintView.execute(SCI_SETCARETLINEBACK, pStyle->_bgColor);
+			_scintView.execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, pStyle->_bgColor);
+			_scintView.execute(SCI_SETCARETLINEFRAME, 0);
+			_scintView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
 		}
 	}
 	_scintView.setSearchResultLexer();

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4327,7 +4327,6 @@ void Finder::setFinderStyle()
 		{
 			_scintView.execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_CARET_LINE_BACK, pStyle->_bgColor);
 			_scintView.execute(SCI_SETCARETLINEFRAME, 0);
-			_scintView.execute(SCI_SETCARETLINEVISIBLE, 1);
 			_scintView.execute(SCI_SETCARETLINEVISIBLEALWAYS, true);
 		}
 	}


### PR DESCRIPTION
Fixes: #11596

With this PR, "Search results" view will only use the _Current line background color_ to set a full highlight on the caret line, while suppressing the caret frame that could get applied on the main and sub edit views.