### PR TITLE
Add patch to colorized theme dark mode buttons.

### DIFF
--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -87,6 +87,7 @@ namespace NppDarkMode
 
 	COLORREF invertLightness(COLORREF c);
 	COLORREF invertLightnessSofter(COLORREF c);
+	COLORREF lightColor(COLORREF color, WORD luminance);
 	double calculatePerceivedLighness(COLORREF c);
 
 	void setDarkTone(ColorTone colorToneChoice);


### PR DESCRIPTION
Hello @donho,

I've added a patch to fix the dialog buttons, so they won't draw black everytime on custom colored Dark Themes.

Original look:

![image](https://user-images.githubusercontent.com/99574879/165865540-8629038f-7033-46e9-b557-540cb4be460b.png)

Patched:

![image](https://user-images.githubusercontent.com/99574879/165865587-ab3a1df9-99fb-453f-bd40-bcff3dba2fc4.png)

I also have a ready patch that can do the same with the recently added Tab UpDown.

Original unthemed version:

![image](https://user-images.githubusercontent.com/99574879/165865724-37a2df79-2849-4a13-90ff-95d4bb992d59.png)

The current version:

![image](https://user-images.githubusercontent.com/99574879/165865820-88f098e5-1ee6-4b5f-aca1-d4718b1de8c4.png)

My version:

![image](https://user-images.githubusercontent.com/99574879/165866475-f508f2aa-e04d-4d25-a7ca-0c189218324e.png)

Remark: the spin control (Tab UpDown) is NOT included on this pull yet, but if you also want it, I can add (it's already on code, but I did not commit).

What do you think?

