### PR TITLE
Fix "Reload from disk" loosing syntax highlighting regression

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4399,7 +4399,7 @@ void Notepad_plus::docGotoAnotherEditView(FileTransferMode mode)
 	}
 }
 
-bool Notepad_plus::activateBuffer(BufferID id, int whichOne)
+bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHilite)
 {
 	NppGUI& nppGui = NppParameters::getInstance().getNppGUI();
 	bool isSnapshotMode = nppGui.isSnapshotMode();
@@ -4420,7 +4420,7 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne)
 		if (_mainDocTab.activateBuffer(id))	//only activate if possible
 		{
 			_isFolding = true;
-			_mainEditView.activateBuffer(id);
+			_mainEditView.activateBuffer(id, forceApplyHilite);
 			_isFolding = false;
 		}
 		else
@@ -4431,7 +4431,7 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne)
 		if (_subDocTab.activateBuffer(id))
 		{
 			_isFolding = true;
-			_subEditView.activateBuffer(id);
+			_subEditView.activateBuffer(id, forceApplyHilite);
 			_isFolding = false;
 		}
 		else

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -451,7 +451,7 @@ private:
 	void loadBufferIntoView(BufferID id, int whichOne, bool dontClose = false);		//Doesnt _activate_ the buffer
 	bool removeBufferFromView(BufferID id, int whichOne);	//Activates alternative of possible, or creates clean document if not clean already
 
-	bool activateBuffer(BufferID id, int whichOne);			//activate buffer in that view if found
+	bool activateBuffer(BufferID id, int whichOne, bool forceApplyHilite = false);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);
 	void performPostReload(int whichOne);
 //END: Document management

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -522,7 +522,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 
 	// Once reload is complete, activate buffer which will take care of
 	// many settings such as update status bar, clickable link etc.
-	activateBuffer(id, currentView());
+	activateBuffer(id, currentView(), true);
 	return res;
 }
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -64,7 +64,6 @@ class FileManager final {
 public:
 	void init(Notepad_plus* pNotepadPlus, ScintillaEditView* pscratchTilla);
 
-	//void activateBuffer(int index);
 	void checkFilesystemChanges(bool bCheckOnlyCurrentBuffer);
 
 	size_t getNbBuffers() const { return _nbBufs; };

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -1903,11 +1903,11 @@ bool ScintillaEditView::setLexerFromLangID(int langID) // Internal lexer only
 }
 
 
-void ScintillaEditView::activateBuffer(BufferID buffer)
+void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 {
 	if (buffer == BUFFER_INVALID)
 		return;
-	if (buffer == _currentBuffer)
+	if (!force && buffer == _currentBuffer)
 		return;
 	Buffer * newBuf = MainFileManager.getBufferByID(buffer);
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -222,7 +222,7 @@ public:
 		}
 	};
 
-	void activateBuffer(BufferID buffer);
+	void activateBuffer(BufferID buffer, bool force = false);
 
 	void getCurrentFoldStates(std::vector<size_t> & lineStateVector);
 	void syncFoldStateWith(const std::vector<size_t> & lineStateVectorNew);


### PR DESCRIPTION
In Scintilla4 reloaded document keeps its syntax highlighting without re-applying the lexer for its syntax highlighting.
It seems the behaviour has been changed in Scintilla5. Hence this workaround to force to apply syntax highlighting after reloading.

Fix #11606