### PR TITLE
toggle collapsing command

### DIFF
--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -706,6 +706,7 @@ BEGIN
         MENUITEM "Unfold All",                  IDM_VIEW_TOGGLE_UNFOLDALL
         MENUITEM "Collapse Current Level",      IDM_VIEW_FOLD_CURRENT
         MENUITEM "Uncollapse Current Level",    IDM_VIEW_UNFOLD_CURRENT
+        MENUITEM "Toggle Collapse Cur Level",   IDM_VIEW_TOGGLE_CURRENT
         POPUP "Collapse Level"
         BEGIN
             MENUITEM "1",   IDM_VIEW_FOLD_1

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1980,6 +1980,10 @@ void Notepad_plus::command(int id)
 			_pEditView->foldCurrentPos((id==IDM_VIEW_FOLD_CURRENT)?fold_collapse:fold_uncollapse);
 			break;
 
+		case IDM_VIEW_TOGGLE_CURRENT:
+			_pEditView->toggleCurrentFold();
+			break;
+
 		case IDM_VIEW_TOGGLE_FOLDALL:
 		case IDM_VIEW_TOGGLE_UNFOLDALL:
 		{
@@ -3928,6 +3932,7 @@ void Notepad_plus::command(int id)
 			case IDM_VIEW_WRAP :
 			case IDM_VIEW_FOLD_CURRENT :
 			case IDM_VIEW_UNFOLD_CURRENT :
+			case IDM_VIEW_TOGGLE_CURRENT :
 			case IDM_VIEW_TOGGLE_FOLDALL:
 			case IDM_VIEW_TOGGLE_UNFOLDALL:
 			case IDM_VIEW_FOLD_1:

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -287,6 +287,7 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{ VK_0,       IDM_VIEW_TOGGLE_FOLDALL,                      false, true,  false, nullptr },
 	{ VK_0,       IDM_VIEW_TOGGLE_UNFOLDALL,                    false, true,  true,  nullptr },
 	{ VK_F,       IDM_VIEW_FOLD_CURRENT,                        true,  true,  false, nullptr },
+	{ VK_9,       IDM_VIEW_TOGGLE_CURRENT,                      false, true,  false, nullptr },
 	{ VK_F,       IDM_VIEW_UNFOLD_CURRENT,                      true,  true,  true,  nullptr },
 	{ VK_1,       IDM_VIEW_FOLD_1,                              false, true,  false, TEXT("Collapse Level 1") },
 	{ VK_2,       IDM_VIEW_FOLD_2,                              false, true,  false, TEXT("Collapse Level 2") },

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -512,6 +512,8 @@ public:
 		return (execute(SCI_GETFOLDEXPANDED, line) != 0);
 	};
 	void foldCurrentPos(bool mode);
+	void toggleCurrentFold();
+	void toggleFold(size_t line);
 	int getCodepage() const {return _codepage;};
 
 	ColumnModeInfos getColumnModeSelectInfo();

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -364,6 +364,7 @@
     #define    IDM_VIEW_SWITCHTO_FILEBROWSER      (IDM_VIEW + 107)
     #define    IDM_VIEW_SWITCHTO_FUNC_LIST        (IDM_VIEW + 108)
     #define    IDM_VIEW_SWITCHTO_DOCLIST          (IDM_VIEW + 109)
+    #define    IDM_VIEW_TOGGLE_CURRENT            (IDM_VIEW + 110)
 
     #define    IDM_VIEW_GOTO_ANOTHER_VIEW        10001
     #define    IDM_VIEW_CLONE_TO_ANOTHER_VIEW    10002


### PR DESCRIPTION
Created a command that is a toggle collapse. In current version there are separate commands for collapsing and uncollapsing. I have seen this feature request several times so I implemented it. Keyboard short cut is alt+9.

https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11529