### PR TITLE
Improve "Append extension" when save a file.

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -76,7 +76,8 @@ namespace // anonymous
 	{
 		std::unordered_set<generic_string> result;
 
-		for (const auto& filter : filterSpec) {
+		for (const auto& filter : filterSpec) 
+		{
 			char delimiter = ';';
 			size_t pos = filter.ext.find('.'), posEnd = 0;
 			generic_string token;


### PR DESCRIPTION
## Impove Append extension

https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10824

This PR enhances the "Append extension" feature.

Now :
If the file name contains a period, the extension will not be added even if the "Append extension" is checked.
If you change the file format from drop box, the file name after the period is replaced.

Changes :
Add extension if "Append extension" is checked and current extension is unkown extension.
If you change the file format from drop box, the file name after the period is not replace if it is unknown extension.
Custom extensions included in notepp's Style Configurator are excluded from this new rule. Those are kown extensions.