### PR TITLE
Reconcile the two SCI_GETSELTEXT queries in NPP source to the changed return value in Scintilla5

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -140,7 +140,7 @@ void Notepad_plus::command(int id)
 			TCHAR currentDir[CURRENTWORD_MAXLENGTH];
 			::SendMessage(_pPublicInterface->getHSelf(), NPPM_GETFULLCURRENTPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentFile));
 			::SendMessage(_pPublicInterface->getHSelf(), NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir));
-	
+
 			if (!_pFileBrowser)
 			{
 				command(IDM_VIEW_FILEBROWSER);
@@ -148,14 +148,14 @@ void Notepad_plus::command(int id)
 
 			vector<generic_string> folders;
 			folders.push_back(currentDir);
-			
+
 			launchFileBrowser(folders, currentFile);
 		}
 		break;
 
 		case IDM_FILE_OPEN_DEFAULT_VIEWER:
 		{
-			// Opens file in its default viewer. 
+			// Opens file in its default viewer.
             // Has the same effect as double–clicking this file in Windows Explorer.
             BufferID buf = _pEditView->getCurrentBufferID();
 			HINSTANCE res = ::ShellExecute(NULL, TEXT("open"), buf->getFullPathName(), NULL, NULL, SW_SHOW);
@@ -175,7 +175,7 @@ void Notepad_plus::command(int id)
 				errorMsg += TEXT("\nError Code: ");
 				errorMsg += intToString(retResult);
 				errorMsg += TEXT("\n----------------------------------------------------------");
-				
+
 				::MessageBox(_pPublicInterface->getHSelf(), errorMsg.c_str(), TEXT("ShellExecute - ERROR"), MB_ICONINFORMATION | MB_APPLMODAL);
 			}
 		}
@@ -373,8 +373,8 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_COPY_BINARY:
 		case IDM_EDIT_CUT_BINARY:
 		{
-			size_t textLen = _pEditView->execute(SCI_GETSELTEXT, 0, 0) - 1;
-			if (!textLen)
+			size_t textLen = _pEditView->execute(SCI_GETSELTEXT, 0, 0);
+			if (textLen < 1)
 				return;
 
 			char *pBinText = new char[textLen + 1];
@@ -490,7 +490,7 @@ void Notepad_plus::command(int id)
 			HWND hwnd = _pPublicInterface->getHSelf();
 			TCHAR curentWord[CURRENTWORD_MAXLENGTH];
 			::SendMessage(hwnd, NPPM_GETFILENAMEATCURSOR, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(curentWord));
-			
+
 			TCHAR cmd2Exec[CURRENTWORD_MAXLENGTH];
 			if (id == IDM_EDIT_OPENINFOLDER)
 			{
@@ -579,7 +579,7 @@ void Notepad_plus::command(int id)
 			}
 
 			Command cmd(url.c_str());
-			cmd.run(_pPublicInterface->getHSelf());	
+			cmd.run(_pPublicInterface->getHSelf());
 		}
 		break;
 
@@ -1506,7 +1506,7 @@ void Notepad_plus::command(int id)
 			else // (id == IDM_SEARCH_GOPREVMARKER_DEF)
 				styleID = SCE_UNIVERSAL_FOUND_STYLE;
 
-			goToPreviousIndicator(styleID);	
+			goToPreviousIndicator(styleID);
 		}
 		break;
 
@@ -2243,8 +2243,8 @@ void Notepad_plus::command(int id)
 					//fullCurrentPath += TEXT("\"");
 
 					::ShellExecute(NULL, TEXT("open"), TEXT("shell:Appsfolder\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge"), fullCurrentPath.c_str(), NULL, SW_SHOW);
-				} 
-				else 
+				}
+				else
 				{
 					_nativeLangSpeaker.messageBox("ViewInBrowser",
 						_pPublicInterface->getHSelf(),
@@ -3096,7 +3096,7 @@ void Notepad_plus::command(int id)
 					std::string md5ResultA = md5.digestString(selectedStr);
 					std::wstring md5ResultW(md5ResultA.begin(), md5ResultA.end());
 					str2Clipboard(md5ResultW, _pPublicInterface->getHSelf());
-					
+
 					delete [] selectedStr;
 				}
 			}
@@ -3160,8 +3160,8 @@ void Notepad_plus::command(int id)
 		{
 			bool doAboutDlg = false;
 			const int maxSelLen = 32;
-			auto textLen = _pEditView->execute(SCI_GETSELTEXT, 0, 0) - 1;
-			if (!textLen)
+			auto textLen = _pEditView->execute(SCI_GETSELTEXT, 0, 0);
+			if (textLen < 1)
 				doAboutDlg = true;
 			if (textLen > maxSelLen)
 				doAboutDlg = true;
@@ -3441,7 +3441,7 @@ void Notepad_plus::command(int id)
 			}
 		}
         break;
-		
+
 		case IDM_LANG_OPENUDLDIR:
 		{
 			generic_string userDefineLangFolderPath = NppParameters::getInstance().getUserDefineLangFolderPath();

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -374,7 +374,7 @@ void Notepad_plus::command(int id)
 		case IDM_EDIT_CUT_BINARY:
 		{
 			size_t textLen = _pEditView->execute(SCI_GETSELTEXT, 0, 0);
-			if (textLen < 1)
+			if (!textLen)
 				return;
 
 			char *pBinText = new char[textLen + 1];

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -140,7 +140,7 @@ void Notepad_plus::command(int id)
 			TCHAR currentDir[CURRENTWORD_MAXLENGTH];
 			::SendMessage(_pPublicInterface->getHSelf(), NPPM_GETFULLCURRENTPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentFile));
 			::SendMessage(_pPublicInterface->getHSelf(), NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir));
-
+	
 			if (!_pFileBrowser)
 			{
 				command(IDM_VIEW_FILEBROWSER);
@@ -148,14 +148,14 @@ void Notepad_plus::command(int id)
 
 			vector<generic_string> folders;
 			folders.push_back(currentDir);
-
+			
 			launchFileBrowser(folders, currentFile);
 		}
 		break;
 
 		case IDM_FILE_OPEN_DEFAULT_VIEWER:
 		{
-			// Opens file in its default viewer.
+			// Opens file in its default viewer. 
             // Has the same effect as double–clicking this file in Windows Explorer.
             BufferID buf = _pEditView->getCurrentBufferID();
 			HINSTANCE res = ::ShellExecute(NULL, TEXT("open"), buf->getFullPathName(), NULL, NULL, SW_SHOW);
@@ -175,7 +175,7 @@ void Notepad_plus::command(int id)
 				errorMsg += TEXT("\nError Code: ");
 				errorMsg += intToString(retResult);
 				errorMsg += TEXT("\n----------------------------------------------------------");
-
+				
 				::MessageBox(_pPublicInterface->getHSelf(), errorMsg.c_str(), TEXT("ShellExecute - ERROR"), MB_ICONINFORMATION | MB_APPLMODAL);
 			}
 		}
@@ -490,7 +490,7 @@ void Notepad_plus::command(int id)
 			HWND hwnd = _pPublicInterface->getHSelf();
 			TCHAR curentWord[CURRENTWORD_MAXLENGTH];
 			::SendMessage(hwnd, NPPM_GETFILENAMEATCURSOR, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(curentWord));
-
+			
 			TCHAR cmd2Exec[CURRENTWORD_MAXLENGTH];
 			if (id == IDM_EDIT_OPENINFOLDER)
 			{
@@ -579,7 +579,7 @@ void Notepad_plus::command(int id)
 			}
 
 			Command cmd(url.c_str());
-			cmd.run(_pPublicInterface->getHSelf());
+			cmd.run(_pPublicInterface->getHSelf());	
 		}
 		break;
 
@@ -1506,7 +1506,7 @@ void Notepad_plus::command(int id)
 			else // (id == IDM_SEARCH_GOPREVMARKER_DEF)
 				styleID = SCE_UNIVERSAL_FOUND_STYLE;
 
-			goToPreviousIndicator(styleID);
+			goToPreviousIndicator(styleID);	
 		}
 		break;
 
@@ -2243,8 +2243,8 @@ void Notepad_plus::command(int id)
 					//fullCurrentPath += TEXT("\"");
 
 					::ShellExecute(NULL, TEXT("open"), TEXT("shell:Appsfolder\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge"), fullCurrentPath.c_str(), NULL, SW_SHOW);
-				}
-				else
+				} 
+				else 
 				{
 					_nativeLangSpeaker.messageBox("ViewInBrowser",
 						_pPublicInterface->getHSelf(),
@@ -3096,7 +3096,7 @@ void Notepad_plus::command(int id)
 					std::string md5ResultA = md5.digestString(selectedStr);
 					std::wstring md5ResultW(md5ResultA.begin(), md5ResultA.end());
 					str2Clipboard(md5ResultW, _pPublicInterface->getHSelf());
-
+					
 					delete [] selectedStr;
 				}
 			}
@@ -3161,7 +3161,7 @@ void Notepad_plus::command(int id)
 			bool doAboutDlg = false;
 			const int maxSelLen = 32;
 			auto textLen = _pEditView->execute(SCI_GETSELTEXT, 0, 0);
-			if (textLen < 1)
+			if (textLen <= 0)
 				doAboutDlg = true;
 			if (textLen > maxSelLen)
 				doAboutDlg = true;
@@ -3441,7 +3441,7 @@ void Notepad_plus::command(int id)
 			}
 		}
         break;
-
+		
 		case IDM_LANG_OPENUDLDIR:
 		{
 			generic_string userDefineLangFolderPath = NppParameters::getInstance().getUserDefineLangFolderPath();


### PR DESCRIPTION
Fixes: #11639 - [NotePad++ 8.4 Highlights every Instance of the first word in the document after clicking HELP | ABOUT](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11639)
Fixes: #11671 - [[Regression] "Copy Binary Content" crashes NPP if there is no selection](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11671)

The following change is [documented ](https://sourceforge.net/p/scintilla/code/ci/483efdbe6facf2d9a4f10a8ec1f049bfae7723ae/tree/doc/ScintillaHistory.html?diff=2a700fc24c59a47fa6b29b0bb6c556dcc39c5b31)for Scintilla5:
>When calling SCI_GETTEXT, SCI_GETSELTEXT, and SCI_GETCURLINE with a NULL buffer argument to discover the length that should be allocated, do not include the terminating NUL in the returned value. The value returned is 1 less than previous versions of Scintilla. Applications should allocate a buffer 1 more than this to accommodate the NUL. The wParam (length) argument to SCI_GETTEXT and SCI_GETCURLINE also omits the NUL. This is more consistent with other APIs.

This change accounts for the issues reported in #11639 & #11671. This PR makes the identical minor changes needed to fix both these issues.