### PR TITLE
Serialized _udlName from generic_string to wchar_t _udlName[MAX_PATH]

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -281,8 +281,7 @@ struct CmdLineParamsDTO
 	intptr_t _pos2go = 0;
 
 	LangType _langType = L_EXTERNAL;
-	generic_string _udlName;
-
+	wchar_t _udlName[MAX_PATH];
 	wchar_t _pluginMessage[MAX_PATH];
 
 	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
@@ -298,9 +297,9 @@ struct CmdLineParamsDTO
 		dto._line2go = params._line2go;
 		dto._column2go = params._column2go;
 		dto._pos2go = params._pos2go;
-		
+
 		dto._langType = params._langType;
-		dto._udlName = params._udlName;
+		wcsncpy(dto._udlName, params._udlName.c_str(), MAX_PATH);
 		wcsncpy(dto._pluginMessage, params._pluginMessage.c_str(), MAX_PATH);
 		return dto;
 	}


### PR DESCRIPTION
Fixes: #11633 

Previously, `_udlName` was declared as a generic_string inside `struct CmdLineParamsDTO`. The size for this member will always evaluate as a pointer, regardless of the string value assigned to it. So, the WM_COPYDATA used for re-invoking an already running instance of NPP will have no way of properly assigning a buffer for the contents being passed in via `struct CmdLineParamsDTO`.

Changing `_udlName` to `wchar_t _udlName[MAX_PATH]` will fix the size evaluation issue.