### PR TITLE
Make dark mode groupbox edge to use edge color

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -375,7 +375,6 @@ void FindReplaceDlg::fillFindHistory()
 
 		if (findHistory._transparencyMode == FindHistory::none)
 		{
-			enableFindDlgItem(IDC_TRANSPARENT_GRPBOX, false);
 			enableFindDlgItem(IDC_TRANSPARENT_LOSSFOCUS_RADIO, false);
 			enableFindDlgItem(IDC_TRANSPARENT_ALWAYS_RADIO, false);
 			enableFindDlgItem(IDC_PERCENTAGE_SLIDER, false);
@@ -1771,7 +1770,6 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 				{
 					bool isChecked = isCheckedOrNot(IDC_TRANSPARENT_CHECK);
 
-					enableFindDlgItem(IDC_TRANSPARENT_GRPBOX, isChecked);
 					enableFindDlgItem(IDC_TRANSPARENT_LOSSFOCUS_RADIO, isChecked);
 					enableFindDlgItem(IDC_TRANSPARENT_ALWAYS_RADIO, isChecked);
 					enableFindDlgItem(IDC_PERCENTAGE_SLIDER, isChecked);


### PR DESCRIPTION
make combobox border round on Windows 11 to match style,
fix visual glitch with transparency groupbox in Find dialog

![image](https://user-images.githubusercontent.com/55940305/169094068-f4bced50-6395-4312-be4d-f6d6f8b21cc0.png)

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11693

related https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11207, https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11376
