### PR TITLE
Fixing: The entire DebugInfo text is not being selected with May 16 or later builds of NPP.

### DIFF
--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -400,7 +400,7 @@ void DebugInfoDlg::refreshDebugInfo()
 
 	// Set Debug Info text and leave the text in selected state
 	::SetDlgItemText(_hSelf, IDC_DEBUGINFO_EDIT, debugInfoDisplay.c_str());
-	::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, _debugInfoStr.length() - 1);
+	::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, debugInfoDisplay.length() - 1);
 	::SetFocus(::GetDlgItem(_hSelf, IDC_DEBUGINFO_EDIT));
 }
 


### PR DESCRIPTION
This PR is a minor fix for an issue resulting from the last-minute changes in commit [Add command line argument for plugin, a related notification and an API](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/0f8d5724afb0a540e8b4024252945ab60bc88c71).

### Issue
The entire DebugInfo text is not being selected with May 16 or later builds of NPP.

### Steps to Reproduce:
1. Launch Notepad++ with one of the recent builds dated May 16 or later (i.e., after the [0f8d572](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/0f8d5724afb0a540e8b4024252945ab60bc88c71) commit). Leave the Notepad++ instance running.
2.  Then from the command prompt re-invoke NPP with one or more file names and any other optional command line parameters.
3.  In NPP, view the entire Debug Info text by scolling all the way down if necessary. Note that the full Debug Info will not be selected. Like so:
![image](https://user-images.githubusercontent.com/45252729/169158989-0debf549-2ef3-4f07-ab9f-afcb6646291d.png)
