### PR TITLE
Make it possible to compile Plugins Admin with MinGW in debug mode

### DIFF
--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -60,7 +60,7 @@ else
 BUILD_TYPE := debug
 BUILD_SUFFIX := -debug
 CXXFLAGS += -Og -g -Wall -Wpedantic -Wconversion-null
-#CPP_DEFINE += DEBUG
+CPP_DEFINE += DEBUG
 endif
 
 #

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -706,7 +706,11 @@ bool PluginsAdminDlg::initFromJson()
 #ifdef DEBUG // if not debug, then it's release
 	
 	// load from nppPluginList.json instead of nppPluginList.dll
+#ifdef __MINGW32__
 	ifstream nppPluginListJson(wstring2string(_pluginListFullPath, CP_UTF8));
+#else // MSVC supports UTF-16 path names in file stream constructors 
+	ifstream nppPluginListJson(_pluginListFullPath);
+#endif
 	nppPluginListJson >> j;
 
 #else //RELEASE

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -706,7 +706,7 @@ bool PluginsAdminDlg::initFromJson()
 #ifdef DEBUG // if not debug, then it's release
 	
 	// load from nppPluginList.json instead of nppPluginList.dll
-	ifstream nppPluginListJson(_pluginListFullPath);
+	ifstream nppPluginListJson(wstring2string(_pluginListFullPath, CP_UTF8));
 	nppPluginListJson >> j;
 
 #else //RELEASE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,11 +27,6 @@ configuration:
     - Release
     - Debug
 
-matrix:
-  exclude:
-    - compiler: GCC
-      configuration: Debug
-
 before_build:
     - ps: |
         Write-Output "Compiler : $env:compiler"
@@ -98,6 +93,7 @@ for:
     only:
       - compiler: GCC
   install:
+    - if "%configuration%" EQU "Debug" set DEBUG=1
     - if "%platform%" EQU "i686" set PATH=C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32\bin;%PATH:C:\Program Files\Git\usr\bin;=%
     - if "%platform%" EQU "x86_64" set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
   build_script:


### PR DESCRIPTION
Since [f428fba][0], the MinGW makefile *does not* pass the `DEBUG` compiler definition to GCC during a debug build. This is contrary to [Scintilla][1] and [Lexilla][2], which are built from their own makefiles and *do* pass the appropriate definition in debug mode.

The missing compiler def makes GCC skip the JSON loading feature in the Plugins Admin module:

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/10f48e36ad34195adb02acbf9acbc77fdef8a842/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp#L706-L711

This means a manually edited plugin list can't be tested with GCC builds, as first reported in notepad-plus-plus/nppPluginList#454.

By sheer accident, this was preventing a compiler failure, as the debug code path currently breaks GCC builds:

<details>
<summary>* compiling ../src/WinControls/PluginsAdmin/pluginsAdmin.cpp</summary>
<pre><code>
../src/WinControls/PluginsAdmin/pluginsAdmin.cpp: In member function 'bool PluginsAdminDlg::initFromJson()':
../src/WinControls/PluginsAdmin/pluginsAdmin.cpp:709:55: error: no matching function for call to 'std::basic_ifstream<char>::basic_ifstream(generic_string&)'
  709 |         ifstream nppPluginListJson(_pluginListFullPath);
    |                                                       ^
In file included from ../src/WinControls/PluginsAdmin/pluginsAdmin.cpp:20:
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:584:9: note: candidate: 'template<class _Path, class _Require> std::basic_ifstream<_CharT, _Traits>::basic_ifstream(const _Path&, std::ios_base::openmode) [with _Path = _Path; _Require = _Require; _CharT = char; _Traits = std::char_traits<char>]'
  584 |         basic_ifstream(const _Path& __s,
    |         ^~~~~~~~~~~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:584:9: note:   template argument deduction/substitution failed:
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:583:32: error: 'class std::__cxx11::basic_string<wchar_t>' has no member named 'make_preferred'
  583 |       template<typename _Path, typename _Require = _If_fs_path<_Path>>
    |                                ^~~~~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:592:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream(std::basic_ifstream<_CharT, _Traits>&&) [with _CharT = char; _Traits = std::char_traits<char>]'
  592 |       basic_ifstream(basic_ifstream&& __rhs)
    |       ^~~~~~~~~~~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:592:39: note:   no known conversion for argument 1 from 'generic_string' {aka 'std::__cxx11::basic_string<wchar_t>'} to 'std::basic_ifstream<char>&&'
  592 |       basic_ifstream(basic_ifstream&& __rhs)
    |                      ~~~~~~~~~~~~~~~~~^~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:567:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream(const string&, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::string = std::__cxx11::basic_string<char>; std::ios_base::openmode = std::ios_base::openmode]'
  567 |       basic_ifstream(const std::string& __s,
    |       ^~~~~~~~~~~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:567:41: note:   no known conversion for argument 1 from 'generic_string' {aka 'std::__cxx11::basic_string<wchar_t>'} to 'const string&' {aka 'const std::__cxx11::basic_string<char>&'}
  567 |       basic_ifstream(const std::string& __s,
    |                      ~~~~~~~~~~~~~~~~~~~^~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:549:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream(const wchar_t*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]'
  549 |       basic_ifstream(const wchar_t* __s,
    |       ^~~~~~~~~~~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:549:37: note:   no known conversion for argument 1 from 'generic_string' {aka 'std::__cxx11::basic_string<wchar_t>'} to 'const wchar_t*'
  549 |       basic_ifstream(const wchar_t* __s,
    |                      ~~~~~~~~~~~~~~~^~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:534:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream(const char*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]'
  534 |       basic_ifstream(const char* __s, ios_base::openmode __mode = ios_base::in)
    |       ^~~~~~~~~~~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:534:34: note:   no known conversion for argument 1 from 'generic_string' {aka 'std::__cxx11::basic_string<wchar_t>'} to 'const char*'
  534 |       basic_ifstream(const char* __s, ios_base::openmode __mode = ios_base::in)
    |                      ~~~~~~~~~~~~^~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:523:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream() [with _CharT = char; _Traits = std::char_traits<char>]'
  523 |       basic_ifstream() : __istream_type(), _M_filebuf()
    |       ^~~~~~~~~~~~~~
c:\winlibs-mingw-msvcrt\current\include\c++\11.2.0\fstream:523:7: note:   candidate expects 0 arguments, 1 provided
mingw32-make[1]: *** [makefile:239: bin.x86_64-debug.build/WinControls/PluginsAdmin/pluginsAdmin.o] Error 1
mingw32-make[1]: *** Waiting for unfinished jobs....
</code></pre>
</details>

This patch allows GCC to successfully compile the debug code path, so that contributors without Visual Studio can dynamically load plugin manifests from a GCC debug build:

![nppPluginList/issues/454#issuecomment-1131306721](https://user-images.githubusercontent.com/47723516/169230402-b823c312-5b41-47de-9998-b1a6ed41cf8c.png)

Fixes #11687

[0]: https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f428fbab13c6bbea673b57457b35d9a4a9aa1f09#diff-81078873c7192ded6b5a93da2d62b0e6f86a5516905529f465fa5b7c33bb2df4R47
[1]: https://github.com/notepad-plus-plus/notepad-plus-plus/blob/10f48e36ad34195adb02acbf9acbc77fdef8a842/scintilla/win32/makefile#L59
[2]: https://github.com/notepad-plus-plus/notepad-plus-plus/blob/10f48e36ad34195adb02acbf9acbc77fdef8a842/lexilla/src/makefile#L81