### PR TITLE
Fix OS Version querying for Windows build 21H1 and greater

### DIFF
--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -220,7 +220,11 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 				szProductName[sizeof(szProductName) / sizeof(TCHAR) - 1] = '\0';
 
 				dataSize = sizeof(szReleaseId);
-				RegQueryValueExW(hKey, TEXT("ReleaseId"), NULL, NULL, reinterpret_cast<LPBYTE>(szReleaseId), &dataSize);
+				if(RegQueryValueExW(hKey, TEXT("DisplayVersion"), NULL, NULL, reinterpret_cast<LPBYTE>(szReleaseId), &dataSize) != ERROR_SUCCESS)
+				{
+					dataSize = sizeof(szReleaseId);
+					RegQueryValueExW(hKey, TEXT("ReleaseId"), NULL, NULL, reinterpret_cast<LPBYTE>(szReleaseId), &dataSize);
+				}
 				szReleaseId[sizeof(szReleaseId) / sizeof(TCHAR) - 1] = '\0';
 
 				dataSize = sizeof(szCurrentBuildNumber);


### PR DESCRIPTION
Windows deprecated the ``ReleaseID`` registry entry (now it is no longer updated and on newer Windows 10/11 builds will remain the same) and moved to use ``DisplayVersion``.
Attempt now to first query ``DisplayVersion`` and in case that is missing, fall back to ``ReleaseID`` for older Windows 10 builds.