### PR TITLE
Honour foreground selection style when window loses focus

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2617,7 +2617,10 @@ void ScintillaEditView::performGlobalStyles()
 	execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_SELECTION_INACTIVE_BACK, selectColorBack);
 
 	if (nppParams.isSelectFgColorEnabled())
+	{
 		execute(SCI_SETSELFORE, 1, selectColorFore);
+		execute(SCI_SETELEMENTCOLOUR, SC_ELEMENT_SELECTION_INACTIVE_TEXT, selectColorFore);
+	}
 
 	COLORREF caretColor = black;
 	pStyle = stylers.findByID(SCI_SETCARETFORE);


### PR DESCRIPTION
### Acknowledgements

- [@Yaron10](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11743#issuecomment-1140510622) identified the required [Scintilla message](https://www.scintilla.org/ScintillaDoc.html#SC_ELEMENT_SELECTION_INACTIVE_TEXT)
- [@vinsworldcom](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11595#issuecomment-1111293326) explained [how Scintilla 5 applies inactive styles](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/3b0d5242acd23b4a727560ea98139cc5f4a8b88a)

Fixes #11743