### PR TITLE
Remove `$COMMAND_LINE_PLACEHOLDER$` from the copied DebugInfo text

### DIFF
--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -359,10 +359,10 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 					if ((GetKeyState(VK_LBUTTON) & 0x100) != 0)
 					{
 						// Visual effect
-						::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, _debugInfoStr.length() - 1);
+						::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, _debugInfoDisplay.length() - 1);
 
 						// Copy to clipboard
-						str2Clipboard(_debugInfoStr, _hSelf);
+						str2Clipboard(_debugInfoDisplay, _hSelf);
 					}
 					return TRUE;
 				}
@@ -394,17 +394,17 @@ void DebugInfoDlg::doDialog()
 
 void DebugInfoDlg::refreshDebugInfo()
 {
-	generic_string debugInfoDisplay { _debugInfoStr };
+	_debugInfoDisplay = _debugInfoStr;
 
-	size_t replacePos = debugInfoDisplay.find(_cmdLinePlaceHolder);
+	size_t replacePos = _debugInfoDisplay.find(_cmdLinePlaceHolder);
 	if (replacePos != std::string::npos)
 	{
-		debugInfoDisplay.replace(replacePos, _cmdLinePlaceHolder.length(), NppParameters::getInstance().getCmdLineString());
+		_debugInfoDisplay.replace(replacePos, _cmdLinePlaceHolder.length(), NppParameters::getInstance().getCmdLineString());
 	}
 
 	// Set Debug Info text and leave the text in selected state
-	::SetDlgItemText(_hSelf, IDC_DEBUGINFO_EDIT, debugInfoDisplay.c_str());
-	::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, debugInfoDisplay.length() - 1);
+	::SetDlgItemText(_hSelf, IDC_DEBUGINFO_EDIT, _debugInfoDisplay.c_str());
+	::SendDlgItemMessage(_hSelf, IDC_DEBUGINFO_EDIT, EM_SETSEL, 0, _debugInfoDisplay.length() - 1);
 	::SetFocus(::GetDlgItem(_hSelf, IDC_DEBUGINFO_EDIT));
 }
 

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
@@ -82,6 +82,7 @@ protected:
 private:
 	typedef const CHAR * (__cdecl * PWINEGETVERSION)();
 	generic_string _debugInfoStr;
+	generic_string _debugInfoDisplay;
 	const generic_string _cmdLinePlaceHolder { L"$COMMAND_LINE_PLACEHOLDER$" };
 	bool _isAdmin = false;
 	generic_string _loadedPlugins;


### PR DESCRIPTION
Fix: #11752

### Issue Summary

The placeholder string `$COMMAND_LINE_PLACEHOLDER$` is getting copied as the `Command Line:` value when the **_Copy debug info into clipboard_** hyperlink is clicked in the DebugInfo dialog.

The placeholder `$COMMAND_LINE_PLACEHOLDER$` should be removed from the copied text.

Note that:
1. The placeholder string is not visible in the DebugInfo dialog. This is fine and how it should be.
2. It is also not in the copied text when you press CTRL+C to copy the string. This is fine and how it should be.