### PR TITLE
Update Corsican translation for Notepad++ 8.4.3

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,6 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
+		- Updated on June 13th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
 		- Updated on May 25th, 2022 for version 8.4.2 by Patriccollu di Santa Maria è Sichè
 		- Updated on April 27th, 2022 for version 8.4.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on April 7nd, 2022 for version 8.3.4 by Patriccollu di Santa Maria è Sichè
@@ -35,7 +36,7 @@ The comments are here for explanation, it's not necessary to translate them.
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 -->
 <NotepadPlus>
-    <Native-Langue name="Corsu" filename="corsican.xml" version="8.4.2">
+    <Native-Langue name="Corsu" filename="corsican.xml" version="8.4.3">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -919,6 +920,10 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="6653" name="Culurisce u sfondulu"/>
                     <Item id="6654" name="Quadru"/>
                     <Item id="6655" name="Larghezza :"/>
+                    <Item id="6247" name="Fine di linea (CRLF)"/> <!-- Don't translate "(CRLF)" -->
+                    <Item id="6248" name="Predefinitu"/>
+                    <Item id="6249" name="Testu in chjaru"/>
+                    <Item id="6250" name="Culore persunalizatu"/>
                 </Scintillas>
 
                 <DarkMode title="Modu scuru">
@@ -942,6 +947,7 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="7124" name="Bordu"/>
                     <Item id="7125" name="Liame"/>
                     <Item id="7126" name="Bordu zeppu"/>
+                    <Item id="7127" name="Bordu disattivatu"/>
                     <Item id="7130" name="Reinizià"/>
                     <Item id="7135" name="Toni"/>
                 </DarkMode>
@@ -1460,6 +1466,9 @@ Cuntinuà ?"/>
         <MiscStrings>
             <!-- $INT_REPLACE$  and $STR_REPLACE$ are a place holders, don't translate these place holders -->
             <word-chars-list-tip value="Què permette d’include caratteri addiziunali in i caratteri di parolle currente quandu ci hè un doppiu cliccu per selezziunà o una ricerca cù l’ozzione « Parolla sana deve currisponde » selezziunata."/> <!-- HowToReproduce: In "Delimiter" section of Preferences dialog, hover your mouse on the "?" button. -->
+
+            <!-- Don't translate "(&quot;EOL custom color&quot;)" -->
+            <eol-custom-color-tip value="Accede à u Cunfiguratore di stilu per persunalizà u culore predefinitu di fine di linea (&quot;EOL custom color&quot;)."/>
 
             <word-chars-list-warning-begin value="Fate casu : "/>
             <word-chars-list-space-warning value="$INT_REPLACE$ spaziu(i)"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on June 13th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
+		- Updated on June 27th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
 		- Updated on May 25th, 2022 for version 8.4.2 by Patriccollu di Santa Maria è Sichè
 		- Updated on April 27th, 2022 for version 8.4.1 by Patriccollu di Santa Maria è Sichè
 		- Updated on April 7nd, 2022 for version 8.3.4 by Patriccollu di Santa Maria è Sichè
@@ -1078,6 +1078,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                     <Item id="6903" name="U dialogu di ricerca sta apertu dopu una ricerca chì s’affisseghja in a finestra di risultati"/>
                     <Item id="6904" name="Cunfirmà tutti i rimpiazzamenti in tutti i ducumenti aperti"/>
                     <Item id="6905" name="Rimpiazzà : ùn movesi micca à a prossima occurrenza"/>
+                    <Item id="6906" name="Risultati di ricerca : affissà un elementu unicu à a linea trova (ùn s’appieca micca à u modu RTL)"/>
                 </Searching>
 
                 <RecentFilesHistory title="Schedarii recenti">


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/d3b026bfeb96eb39e0402673d68dd04e640e2e1e Add dark mode support for plugins
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/33ab652395f9cf9b47dc9927f54d56c01f770951 Make dark mode support for plugin by default
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/d65967deabaff17069e789019e060c9a87f5f076 Use edge colors in dark mode for listbox border
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/79e766755d9d466704c535f99eb3ce99ffbbb1bf Make EOL (CRLF) display customizable

Updated on June 27th for this commit:

  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/2258274780ce18be0406183bf7b9619202c3c06e Update localization files

Cheers,
Patriccollu.