### PR TITLE
fix empty .NFO file crash

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1601,7 +1601,7 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const TCHAR * fil
 		fileFormat._eolFormat = ndds._format;
 
 		//for empty files, if the default for new files is UTF8, and "Apply to opened ANSI files" is set, apply it
-		if (fileSize == 0)
+		if ((fileSize == 0) && (fileFormat._encoding < 1))
 		{
 			if (ndds._unicodeMode == uniCookie && ndds._openAnsiAsUtf8)
 				fileFormat._encoding = SC_CP_UTF8;


### PR DESCRIPTION
Fixes #11820 .

The infinite recursion tour:
- an empty nfo-file has been loaded, at the end the `activateBuffer` has been called
- the code flow reached the `ScintillaEditView::defineDocType` (`case L_ASCII`), where the file encoding has been changed to `NPP_CP_DOS_437` and the `IDM_FILE_RELOAD` has been sent after
- during the reloading the `FileManager::loadFileData` was called and there is this important part:
```
	//for empty files, if the default for new files is UTF8, and "Apply to opened ANSI files" is set, apply it
	if (fileSize == 0)
	{
		if (ndds._unicodeMode == uniCookie && ndds._openAnsiAsUtf8)
			fileFormat._encoding = SC_CP_UTF8;
	}
```
- it means that in this constellation the `fileFormat._encoding` has been reset back to `SC_CP_UTF8`
- so in the following `activateBuffer` call we ended up on the exactly same place and the file encoding has been set back to `NPP_CP_DOS_437` again and another `IDM_FILE_RELOAD` has been sent ...
