### PR TITLE
better specify the cmdline interpreter

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -6690,7 +6690,7 @@ void NppParameters::createXmlTreeFromGUIParams()
 	}
 
 	// <GUIConfig name="commandLineInterpreter">powershell</GUIConfig>
-	if (_nppGUI._commandLineInterpreter.compare(TEXT("cmd")))
+	if (_nppGUI._commandLineInterpreter.compare(CMD_INTERPRETER))
 	{
 		TiXmlElement *GUIConfigElement = (newGUIRoot->InsertEndChild(TiXmlElement(TEXT("GUIConfig"))))->ToElement();
 		GUIConfigElement->SetAttribute(TEXT("name"), TEXT("commandLineInterpreter"));

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -841,7 +841,7 @@ struct NppGUI final
 	generic_string _definedSessionExt;
 	generic_string _definedWorkspaceExt;
 
-	generic_string _commandLineInterpreter = TEXT("cmd");
+	generic_string _commandLineInterpreter = TEXT("cmd.exe");
 
 	struct AutoUpdateOptions
 	{

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -46,6 +46,7 @@
 
 #endif
 
+#define CMD_INTERPRETER TEXT("%WINDIR%\\System32\\cmd.exe")
 
 class NativeLangSpeaker;
 
@@ -841,7 +842,7 @@ struct NppGUI final
 	generic_string _definedSessionExt;
 	generic_string _definedWorkspaceExt;
 
-	generic_string _commandLineInterpreter = TEXT("cmd.exe");
+	generic_string _commandLineInterpreter = CMD_INTERPRETER;
 
 	struct AutoUpdateOptions
 	{

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -46,7 +46,7 @@
 
 #endif
 
-#define CMD_INTERPRETER TEXT("%WINDIR%\\System32\\cmd.exe")
+#define CMD_INTERPRETER TEXT("%COMSPEC%")
 
 class NativeLangSpeaker;
 


### PR DESCRIPTION
Fixes #11818 .

This solves a possible confusion between the cmdline interpreter and the possible folder named "cmd"' for the ShellExecute WINAPI.