### PR TITLE
Themes: Synchronise color of EOL and Whitespaces

### DIFF
--- a/PowerEditor/installer/themes/Bespin.xml
+++ b/PowerEditor/installer/themes/Bespin.xml
@@ -803,6 +803,6 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" bgColor="8000FF" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FCAF3E" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Black board.xml
+++ b/PowerEditor/installer/themes/Black board.xml
@@ -801,6 +801,6 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FCAF3E" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Choco.xml
+++ b/PowerEditor/installer/themes/Choco.xml
@@ -801,6 +801,6 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FCAF3E" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
+++ b/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
@@ -913,6 +913,6 @@ Installation : Copy this file to "%APPDATA%\Notepad++\themes" and in a portable 
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" bgColor="C0C0C0" fontStyle="0" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" fontStyle="0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="4D4D4D" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/DarkModeDefault.xml
+++ b/PowerEditor/installer/themes/DarkModeDefault.xml
@@ -1444,6 +1444,6 @@ License:             GPL2
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="A3DCA3" />
         <WidgetStyle name="Document map" styleID="0" fgColor="000000" bgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="5F5F5F" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Deep Black.xml
+++ b/PowerEditor/installer/themes/Deep Black.xml
@@ -806,6 +806,6 @@ https://notepad-plus-plus.org/donate/
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FF8000" bgColor="000000" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FF8080" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Hello Kitty.xml
+++ b/PowerEditor/installer/themes/Hello Kitty.xml
@@ -760,7 +760,7 @@ so your enhanced file can be included in Notepad++ future release.
         <WidgetStyle name="Fold" styleID="0" fgColor="FFFFFF" bgColor="FF80C0" fontSize="8" fontStyle="0" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="FF80C0" bgColor="FF80C0" fontSize="8" fontStyle="0" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="FFB56A" bgColor="EEEEEC" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="808080" bgColor="EEEEEC" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="00FF00" fgColor="555753" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="FF0000" fgColor="FCAF3E" />
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="00FFFF" />

--- a/PowerEditor/installer/themes/HotFudgeSundae.xml
+++ b/PowerEditor/installer/themes/HotFudgeSundae.xml
@@ -939,6 +939,6 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" fontStyle="0" bgColor="80FF00" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="43250B" bgColor="D5BC93" fontStyle="0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="CFBA28" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Mono Industrial.xml
+++ b/PowerEditor/installer/themes/Mono Industrial.xml
@@ -805,6 +805,6 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FCAF3E" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Monokai.xml
+++ b/PowerEditor/installer/themes/Monokai.xml
@@ -821,6 +821,6 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FCAF3E" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/MossyLawn.xml
+++ b/PowerEditor/installer/themes/MossyLawn.xml
@@ -924,7 +924,7 @@ Installation:
         <WidgetStyle name="Fold" styleID="0" fgColor="603d13" bgColor="7e8a28" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="FF0000" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="7e8a28" bgColor="7e8a28" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="ffc973" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="00a080" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="bf8830" />
         <WidgetStyle name="Find Mark Style" styleID="31" bgColor="6a1a01" />
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="fdd64a" />
@@ -940,6 +940,6 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="012001" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="162504" bgColor="BBCF60" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="00a080" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Navajo.xml
+++ b/PowerEditor/installer/themes/Navajo.xml
@@ -937,6 +937,6 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="181880" bgColor="BA9C80" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="106060" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Obsidian.xml
+++ b/PowerEditor/installer/themes/Obsidian.xml
@@ -806,6 +806,6 @@ Notepad++ Custom Style
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" bgColor="0080FF" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="343F43" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Plastic Code Wrap.xml
+++ b/PowerEditor/installer/themes/Plastic Code Wrap.xml
@@ -817,6 +817,6 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FCAF3E" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Ruby Blue.xml
+++ b/PowerEditor/installer/themes/Ruby Blue.xml
@@ -654,6 +654,6 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FF8080" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Solarized-light.xml
+++ b/PowerEditor/installer/themes/Solarized-light.xml
@@ -948,6 +948,6 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="073642" bgColor="93A1A1" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="808040" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="B58900" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Solarized.xml
+++ b/PowerEditor/installer/themes/Solarized.xml
@@ -948,6 +948,6 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="EEE8D5" bgColor="586E75" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="B58900" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Twilight.xml
+++ b/PowerEditor/installer/themes/Twilight.xml
@@ -806,6 +806,6 @@ Credits:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FCAF3E" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Vibrant Ink.xml
+++ b/PowerEditor/installer/themes/Vibrant Ink.xml
@@ -777,6 +777,6 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FF8080" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/Zenburn.xml
+++ b/PowerEditor/installer/themes/Zenburn.xml
@@ -1444,6 +1444,6 @@ License:             GPL2
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="A3DCA3" />
         <WidgetStyle name="Document map" styleID="0" fgColor="000000" bgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="5F5F5F" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/khaki.xml
+++ b/PowerEditor/installer/themes/khaki.xml
@@ -937,6 +937,6 @@ Installation:
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="5f5f00" bgColor="d7d7af" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="808040" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="005f00" />
     </GlobalStyles>
 </NotepadPlus>

--- a/PowerEditor/installer/themes/vim Dark Blue.xml
+++ b/PowerEditor/installer/themes/vim Dark Blue.xml
@@ -753,7 +753,7 @@
         <WidgetStyle name="Fold" styleID="0" fgColor="FFFFFF" bgColor="000040" />
         <WidgetStyle name="Fold active" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Fold margin" styleID="0" fgColor="000040" bgColor="000040" />
-        <WidgetStyle name="White space symbol" styleID="0" fgColor="004040" />
+        <WidgetStyle name="White space symbol" styleID="0" fgColor="808080" />
         <WidgetStyle name="Smart HighLighting" styleID="29" bgColor="2050D0" />
         <WidgetStyle name="Find Mark Style" styleID="31" fgColor="FFFF00" bgColor="000040" fontName="" fontStyle="1" fontSize="" />
         <WidgetStyle name="Mark Style 1" styleID="25" bgColor="00FFFF" />

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -1433,6 +1433,6 @@
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="0000FF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FF8000" bgColor="FFFFFF" />
-        <WidgetStyle name="EOL custom color" styleID="0" fgColor="DADADA" />
+        <WidgetStyle name="EOL custom color" styleID="0" fgColor="FFB56A" />
     </GlobalStyles>
 </NotepadPlus>


### PR DESCRIPTION
Fix #11840

Before:
![grafik](https://user-images.githubusercontent.com/82021174/175767068-bd7dd9f9-6fea-4af4-ac22-d7645c2b2fac.png)

After:
![grafik](https://user-images.githubusercontent.com/82021174/175767142-5195a590-007c-406d-a305-b4a2e8c9817e.png)

This synchronises the color of EOL and Whitespace as default, so all symbols have same color which is most likely user expectation. This is IMO a good choice, because it is individually adapted to each theme instead of grey everywhere.

Checked it with normal text and also some source code files, for example, xml, ini, c/c++/c#, md. It looks quite well.

What do others think on this approach? Suggestions?