### PR TITLE
Fix erasing part of content make hanging issue

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -64,15 +64,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				_pEditView->getCurrentBuffer()->setModifiedStatus(true);
 			}
 
-			if (notification->modificationType & SC_MOD_CHANGEFOLD)
-			{
-				if (prevWasEdit)
-				{
-					notifyView->foldChanged(notification->line, notification->foldLevelNow, notification->foldLevelPrev);
-					prevWasEdit = false;
-				}
-			}
-			else if (!(notification->modificationType & (SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT)))
+			if ((notification->modificationType & SC_MOD_CHANGEFOLD) || !(notification->modificationType & (SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT)))
 			{
 				prevWasEdit = false;
 			}

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -3373,38 +3373,6 @@ void ScintillaEditView::columnReplace(ColumnModeInfos & cmi, int initial, int in
 	}
 }
 
-
-void ScintillaEditView::foldChanged(size_t line, int levelNow, int levelPrev)
-{
-	if (levelNow & SC_FOLDLEVELHEADERFLAG)		//line can be folded
-	{
-		if (!(levelPrev & SC_FOLDLEVELHEADERFLAG))	//but previously couldnt
-		{
-			// Adding a fold point.
-			execute(SCI_SETFOLDEXPANDED, line, 1);
-			expand(line, true, false, 0, levelPrev);
-		}
-	}
-	else if (levelPrev & SC_FOLDLEVELHEADERFLAG)
-	{
-		if (isFolded(line))
-		{
-			// Removing the fold from one that has been contracted so should expand
-			// otherwise lines are left invisible with no way to make them visible
-			execute(SCI_SETFOLDEXPANDED, line, 1);
-			expand(line, true, false, 0, levelPrev);
-		}
-	}
-	else if (!(levelNow & SC_FOLDLEVELWHITEFLAG) &&
-	        ((levelPrev & SC_FOLDLEVELNUMBERMASK) > (levelNow & SC_FOLDLEVELNUMBERMASK)))
-	{
-		// See if should still be hidden
-		intptr_t parentLine = execute(SCI_GETFOLDPARENT, line);
-		if ((parentLine < 0) || !isFolded(parentLine && execute(SCI_GETLINEVISIBLE, parentLine)))
-			execute(SCI_SHOWLINES, line, line);
-	}
-}
-
 bool ScintillaEditView::getIndicatorRange(size_t indicatorNumber, size_t* from, size_t* to, size_t* cur)
 {
 	size_t curPos = execute(SCI_GETCURRENTPOS);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -520,7 +520,6 @@ public:
 	void columnReplace(ColumnModeInfos & cmi, const TCHAR *str);
 	void columnReplace(ColumnModeInfos & cmi, int initial, int incr, int repeat, UCHAR format);
 
-	void foldChanged(size_t line, int levelNow, int levelPrev);
 	void clearIndicator(int indicatorNumber) {
 		size_t docStart = 0;
 		size_t docEnd = getCurrentDocLen();


### PR DESCRIPTION
Deletion of one line where there's folding didn't show the hiden lines in the old version of Scitilla.
It's not anymore the case in the new (current used) version of Scintilla (which manages such situation correctly).
Therefore the redundant notification for the current used version of Scintilla can be removed, and it solves hanging problem.

Fix #10193