### PR TITLE
[TEMP] fix WINE crash caused by DarkMode stuff

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1769,6 +1769,11 @@ namespace NppDarkMode
 
 	void autoSubclassAndThemeChildControls(HWND hwndParent, bool subclass, bool theme)
 	{
+		UNREFERENCED_PARAMETER(hwndParent);
+		UNREFERENCED_PARAMETER(subclass);
+		UNREFERENCED_PARAMETER(theme);
+		
+		/*
 		struct Params
 		{
 			const wchar_t* themeClassName = nullptr;
@@ -2010,6 +2015,7 @@ namespace NppDarkMode
 
 			return TRUE;
 		}, reinterpret_cast<LPARAM>(&p));
+		*/
 	}
 
 	void autoThemeChildControls(HWND hwndParent)


### PR DESCRIPTION
Temporary fix for the #11941 . It should be replaced by a proper fix after testing.

Replacing the DM autoSubclassAndThemeChildControls func content with stub to prevent Linux WINE translation layer crashing in the COMCTL32 call.

The problem of the above func manifests itself in its EnumChildWindows(hwndParent, [](HWND hwnd, LPARAM lParam) WINAPI_LAMBDA {... part.