### PR TITLE
Fix crash on Wine,

### DIFF
--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -52,6 +52,13 @@ namespace NppDarkMode
 		bool enablePlugin = false;
 	};
 
+	struct NppDarkModeParams
+	{
+		const wchar_t* _themeClassName = nullptr;
+		bool _subclass = false;
+		bool _theme = false;
+	};
+
 	enum class ToolTipsType
 	{
 		tooltip,
@@ -166,6 +173,14 @@ namespace NppDarkMode
 	void subclassGroupboxControl(HWND hwnd);
 	void subclassTabControl(HWND hwnd);
 	void subclassComboBoxControl(HWND hwnd);
+
+	void subclassAndThemeButton(HWND hwnd, NppDarkModeParams p);
+	void subclassAndThemeComboBox(HWND hwnd, NppDarkModeParams p);
+	void subclassAndThemeListBoxOrEditControl(HWND hwnd, NppDarkModeParams p, bool isListBox);
+	void subclassAndThemeListView(HWND hwnd, NppDarkModeParams p);
+	void themeTreeView(HWND hwnd, NppDarkModeParams p);
+	void themeToolbar(HWND hwnd, NppDarkModeParams p);
+	void themeRichEdit(HWND hwnd, NppDarkModeParams p);
 
 	void autoSubclassAndThemeChildControls(HWND hwndParent, bool subclass = true, bool theme = true);
 	void autoThemeChildControls(HWND hwndParent);


### PR DESCRIPTION
create functions for every classes in `EnumChildWindows` lambda,
and reorder class detection to improve stability,
add checks to improve stability on older OS and wine

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11941

I am currently away so I cannot test it properly, but it should fix crash with wine.
Issue seems to be `subclassCustomBorderForListBoxAndEditControls` but I am not sure why.

@xomx 
if you have time could you find out why?
