### PR TITLE
Fix auto-detection of UTF-16-encoded files

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1307,16 +1307,26 @@ LangType FileManager::detectLanguageFromTextBegining(const unsigned char *data, 
 		LangType lang;
 	};
 
+	enum class ByteOrder { none, utf8, utf16_be, utf16_le };
+
 	// Is the buffer at least the size of a BOM?
 	if (dataLen <= 3)
 		return L_TEXT;
 
 	// Eliminate BOM if present
 	size_t i = 0;
+	ByteOrder bom = ByteOrder::none;
 	if ((data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) || // UTF8 BOM
-		(data[0] == 0xFE && data[1] == 0xFF && data[2] == 0x00) || // UTF16 BE BOM
-		(data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00))   // UTF16 LE BOM
+		(data[0] == 0xFE && data[1] == 0xFF && data[2] == 0x00))   // UTF16 BE BOM
+	{
 		i += 3;
+		bom = (*data == 0xFE) ? ByteOrder::utf16_be : ByteOrder::utf8;
+	}
+	else if (data[0] == 0xFF && data[1] == 0xFE && data[3] == 0x00) // UTF16 LE BOM
+	{
+		i += 2;
+		bom = ByteOrder::utf16_le;
+	}
 
 	// Skip any space-like char
 	for (; i < dataLen; ++i)
@@ -1327,14 +1337,27 @@ LangType FileManager::detectLanguageFromTextBegining(const unsigned char *data, 
 
 	// Create the buffer to need to test
 	const size_t longestLength = 40; // shebangs can be large
-	std::string buf2Test = std::string((const char *)data + i, longestLength);
+	std::string buf2Test(longestLength, '\0');
+	if (bom > ByteOrder::utf8)
+	{
+		std::vector<unsigned char> bytes;
+		for (size_t j = 0; j < longestLength; j++)
+		{
+			// Skip every other byte
+			if (j % 2 == 0)
+				bytes.push_back(*(data + i + j));
+		}
+		buf2Test = std::string(bytes.begin(), bytes.end());
+	}
+	else
+		buf2Test = std::string((const char *)data + i, longestLength);
 
 	// Is there a \r or \n in the buffer? If so, truncate it
 	auto cr = buf2Test.find("\r");
 	auto nl = buf2Test.find("\n");
 	auto crnl = min(cr, nl);
 	if (crnl != std::string::npos && crnl < longestLength)
-		buf2Test = std::string((const char *)data + i, crnl);
+		buf2Test = buf2Test.substr(0, crnl);
 
 	// First test for a Unix-like Shebang
 	// See https://en.wikipedia.org/wiki/Shebang_%28Unix%29 for more details about Shebang


### PR DESCRIPTION
### Problem

1. Create a new file with only a document type declaration at the top:

	`<?xml version="1.0" encoding="UTF-8" ?>`

*Note.* The value of the "encoding" attribute makes no difference; the opening `<?xml` tag is the only significant part

2. From the menu, select "Encoding > Convert to UTF-16 BE *or* LE BOM"

*Note.* UTF-8 BOM is *not* affected by this issue

3. Save the file *with no extension*
4. Close and reopen the file
5. The detected file type is "Normal text file"
6. Repeat with any another auto-detected file type. e.g., HTML, PHP, bash, perl, python, NodeJs script
7. Same result


### Analysis

The input to `FileManager::detectLanguageFromTextBeginin()` is always a character string (`const unsigned char *`), regardless of encoding. The file header patterns are likewise hard-coded as character strings, e.g., `<?xml`:

     3C 3F 78 6D 6C
     <  ?  x  m  l

UTF-16 devotes 2 bytes to every character; in little-endian mode, XML file headers look like this (after stripping the BOM):

     3C 00 3F 00 78 00 6D 00 6C 00
     <     ?     x     m     l

This doesn't match with `3C 3F 78 6D 6C`, so file type detection fails.

In big-endian mode (after stripping the BOM), the file header is:

     00 3C 00 3F 00 78 00 6D 00 6C
        <     ?     x     m     l

which also doesn't match.

We can't simply use `::WideCharToMultiByte` to convert between encodings: the function's input is *already* a single-byte character string.

### Patch 

This PR ensures a fair comparison of UTF-16 strings by stripping the interleaved `NULL` bytes from the input.

It also addresses one other problem with little-endian encoding. Currently, this line checks the wrong index:

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/70660eb608eea7a9c85a4bfb08761ffd6bfbc887/PowerEditor/src/ScintillaComponent/Buffer.cpp#L1318

In little-endian mode, it's the *odd-numbered* bytes that are `NULL` for characters in the ASCII set.
The sequence `FF FE 00` will never match the prelude of a real file, unless the first character of that file's content is actually `NULL`. For files in little-endian mode, the pointer should be moved 2 places instead of 3.

Fixes #11505
