### PR TITLE
fix for drag&drop crash between different N++ instances

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -282,8 +282,8 @@ struct CmdLineParamsDTO
 	intptr_t _pos2go = 0;
 
 	LangType _langType = L_EXTERNAL;
-	wchar_t _udlName[MAX_PATH];
-	wchar_t _pluginMessage[MAX_PATH];
+	wchar_t _udlName[MAX_PATH] = {'\0'};
+	wchar_t _pluginMessage[MAX_PATH] = {'\0'};
 
 	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
 	{


### PR DESCRIPTION
Fixes #11976 .

Uninitialized _udlName forced N++ to think that there is an UDL...

Easily spotted in DEBUG version because of the `wchar_t _udlName[MAX_PATH] ` has been full of the 0xCD bytes (aka the compiler allocated but never written memory by the app).
![_udlName_uninitialized](https://user-images.githubusercontent.com/13075183/182615283-a86f6d87-49ce-4f3e-96c5-a00ef74fde04.png)
