### PR TITLE
Don't override detected file type with default language

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -742,7 +742,7 @@ BufferID FileManager::loadFile(const TCHAR* filename, Document doc, int encoding
 		buf->setEncoding(-1);
 
 		// if no file extension, and the language has been detected,  we use the detected value
-		if (!newBuf->_isLargeFile && ((buf->getLangType() == L_TEXT) && (loadedFileFormat._language != L_TEXT)))
+		if (!newBuf->_isLargeFile && loadedFileFormat._language != L_TEXT)
 			buf->setLangType(loadedFileFormat._language);
 
 		setLoadedBufferEncodingAndEol(buf, UnicodeConvertor, loadedFileFormat._encoding, loadedFileFormat._eolFormat);


### PR DESCRIPTION
 ### Problem

 1. Go to "Settings > Preferences > New Document" and change the "Default language" option, e.g. "C++"

 2. Create a new file with only a document type declaration at the top:

    `<?xml version="1.0" encoding="UTF-8" ?`

 3. Save the file _with no extension_

 4. Close and reopen the file

 5. The detected file type is "C++" (or whatever default language was chosen in step 1.)


 ### Analysis

 The logic of this condition is flawed:

 https://github.com/notepad-plus-plus/notepad-plus-plus/blob/2e66fe000765d7923f731ef8f1e524a27ddc0912/PowerEditor/src/ScintillaComponent/Buffer.cpp#L744-L746

 When a default language has been set, and the file has no extension, a new `Buffer` instance will be constructed with *the default language*:

 https://github.com/notepad-plus-plus/notepad-plus-plus/blob/2e66fe000765d7923f731ef8f1e524a27ddc0912/PowerEditor/src/ScintillaComponent/Buffer.cpp#L178-L181

So the condition `buf->getLangType() == L_TEXT` is *always* false, and the *detected* file type is *never* applied. The default language is intended for __*new, empty*__ files, not __*saved*__ files with existing content, especially if the content matches a pattern that can be inferred by `FileManager::detectLanguageFromTextBegining()`.

 ### Patch

 This PR prevents the default language from overriding the detected one by checking that a file is brand new (i.e. untitled) before deciding to skip the detected file type.

 Fixes #11504
