### PR TITLE
Check for a negative language id in `Notepad_plus::getLangDesc`

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2406,7 +2406,7 @@ generic_string Notepad_plus::getLangDesc(LangType langType, bool getName)
 		return generic_string(lexerNameW);
 	}
 
-	if (langType > L_EXTERNAL)
+	if (langType < L_TEXT || langType > L_EXTERNAL)
         langType = L_TEXT;
 
 	generic_string str2Show;


### PR DESCRIPTION
### Problem

* Call `Notepad_plus::getLangDesc()` with a negative `langType` argument, e.g. -1

* `-1 < L_EXTERNAL`, so this won't execute:

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/2e66fe000765d7923f731ef8f1e524a27ddc0912/PowerEditor/src/Notepad_plus.cpp#L2409-L2410

* But *this* does: `ScintillaEditView::_langNameInfoArray[-1]`

    
Fixes #12009