### PR TITLE
Don't enable "show only one entry per found line" by default

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -6335,7 +6335,7 @@ void NppParameters::createXmlTreeFromGUIParams()
 		GUIConfigElement->SetAttribute(TEXT("isLessModeOn"), _nppGUI._findWindowLessMode ? TEXT("yes") : TEXT("no"));
 	}
 
-	// <GUIConfig name="FinderConfig" wrappedLines="no" purgeBeforeEverySearch="no" showOnlyOneEntryPerFoundLine="yes"/>
+	// <GUIConfig name="FinderConfig" wrappedLines="no" purgeBeforeEverySearch="no" showOnlyOneEntryPerFoundLine="no"/>
 	{
 		TiXmlElement* GUIConfigElement = (newGUIRoot->InsertEndChild(TiXmlElement(TEXT("GUIConfig"))))->ToElement();
 		GUIConfigElement->SetAttribute(TEXT("name"), TEXT("FinderConfig"));

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -760,7 +760,7 @@ struct NppGUI final
 
 	bool _finderLinesAreCurrentlyWrapped = false;
 	bool _finderPurgeBeforeEverySearch = false;
-	bool _finderShowOnlyOneEntryPerFoundLine = true;
+	bool _finderShowOnlyOneEntryPerFoundLine = false;
 
 	int _fileAutoDetection = cdEnabledNew;
 


### PR DESCRIPTION
Per https://github.com/notepad-plus-plus/notepad-plus-plus/pull/11808#issuecomment-1212701012:

> Although this new mode can be useful, I think the setting shouldn't be enabled by default.
> 
> It makes very easy to overlook that an entry occurs several times on a same line. There is no hint that a line contains several matches, apart from the highlights that the user has to look for. Actually, for long lines that don't fit on screen width, there is no hint at all, unless the user horizontally scrolls the results pane while looking for the highlights...