### PR TITLE
Fix button text in dark mode regression from Wine fix

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1797,10 +1797,7 @@ namespace NppDarkMode
 
 			if (wcscmp(className, WC_BUTTON) == 0)
 			{
-				if (g_isAtLeastWindows10)
-				{
-					NppDarkMode::subclassAndThemeButton(hwnd, p);
-				}
+				NppDarkMode::subclassAndThemeButton(hwnd, p);
 				return TRUE;
 			}
 


### PR DESCRIPTION
Fix regression from https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2c4ecd7e1bfd5d7d5c14c854438c02f2ba0909a

fix https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f2c4ecd7e1bfd5d7d5c14c854438c02f2ba0909a#commitcomment-82841877