### PR TITLE
Add incompatible (unloaded) plugin list in Plugin Admin

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -317,7 +317,7 @@ int PluginsManager::loadPluginFromPath(const TCHAR *pluginFilePath)
 	}
 }
 
-bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginUpdateInfoList)
+bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginUpdateInfoList, PluginViewList* pluginImcompatibleList)
 {
 	if (_isDisabled)
 		return false;
@@ -349,6 +349,9 @@ bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginU
 	GetModuleFileName(NULL, nppFullPathName, MAX_PATH);
 	Version nppVer;
 	nppVer.setVersionFrom(nppFullPathName);
+
+	const TCHAR* incompatibleWarning = L"%s's version %s is not compatible to this version of Notepad++ (v%s).\r\nAs a result the plugin cannot be loaded.";
+	const TCHAR* incompatibleWarningWithSolution = L"%s's version %s is not compatible to this version of Notepad++ (v%s).\r\nAs a result the plugin cannot be loaded.\r\n\r\nGo to Updates section and update your plugin to %s for solving the compatibility issue.";
 
 	// get plugin folder
 	if (hFindFolder != INVALID_HANDLE_VALUE && (foundData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
@@ -385,6 +388,16 @@ bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginU
 						{
 							// Find compatible Notepad++ versions
 							isCompatible = nppVer.isCompatibleTo(pui->_nppCompatibleVersions.first, pui->_nppCompatibleVersions.second);
+
+							if (!isCompatible && pluginImcompatibleList)
+							{
+								PluginUpdateInfo* incompatiblePlg = new PluginUpdateInfo(*pui);
+								incompatiblePlg->_version = v;
+								TCHAR msg[1024];
+								wsprintf(msg, incompatibleWarning, incompatiblePlg->_displayName.c_str(), v.toString().c_str(), nppVer.toString().c_str());
+								incompatiblePlg->_description = msg;
+								pluginImcompatibleList->pushBack(incompatiblePlg);
+							}
 						}
 						else if (v < pui->_version && // If dll version is older, and _oldVersionCompatibility is valid (not empty), we search in "_oldVersionCompatibility"
 							!(pui->_oldVersionCompatibility.first.first.empty() && pui->_oldVersionCompatibility.first.second.empty()) && // first version interval is valid
@@ -393,6 +406,16 @@ bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginU
 							if (v.isCompatibleTo(pui->_oldVersionCompatibility.first.first, pui->_oldVersionCompatibility.first.second)) // dll older version found
 							{
 								isCompatible = nppVer.isCompatibleTo(pui->_oldVersionCompatibility.second.first, pui->_oldVersionCompatibility.second.second);
+
+								if (!isCompatible && pluginImcompatibleList)
+								{
+									PluginUpdateInfo* incompatiblePlg = new PluginUpdateInfo(*pui);
+									incompatiblePlg->_version = v;
+									TCHAR msg[1024];
+									wsprintf(msg, incompatibleWarningWithSolution, incompatiblePlg->_displayName.c_str(), v.toString().c_str(), nppVer.toString().c_str(), pui->_version.toString().c_str());
+									incompatiblePlg->_description = msg;
+									pluginImcompatibleList->pushBack(incompatiblePlg);
+								}
 							}
 						}
 					}
@@ -443,6 +466,16 @@ bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginU
 							{
 								// Find compatible Notepad++ versions
 								isCompatible2 = nppVer.isCompatibleTo(pui2->_nppCompatibleVersions.first, pui2->_nppCompatibleVersions.second);
+
+								if (!isCompatible2 && pluginImcompatibleList)
+								{
+									PluginUpdateInfo* incompatiblePlg = new PluginUpdateInfo(*pui2);
+									incompatiblePlg->_version = v2;
+									TCHAR msg[1024];
+									wsprintf(msg, incompatibleWarning, incompatiblePlg->_displayName.c_str(), v2.toString().c_str(), nppVer.toString().c_str());
+									incompatiblePlg->_description = msg;
+									pluginImcompatibleList->pushBack(incompatiblePlg);
+								}
 							}
 							else if (v2 < pui2->_version && // If dll version is older, and _oldVersionCompatibility is valid (not empty), we search in "_oldVersionCompatibility"
 								!(pui2->_oldVersionCompatibility.first.first.empty() && pui2->_oldVersionCompatibility.first.second.empty()) && // first version interval is valid
@@ -451,6 +484,16 @@ bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginU
 								if (v2.isCompatibleTo(pui2->_oldVersionCompatibility.first.first, pui2->_oldVersionCompatibility.first.second)) // dll older version found
 								{
 									isCompatible2 = nppVer.isCompatibleTo(pui2->_oldVersionCompatibility.second.first, pui2->_oldVersionCompatibility.second.second);
+
+									if (!isCompatible2 && pluginImcompatibleList)
+									{
+										PluginUpdateInfo* incompatiblePlg = new PluginUpdateInfo(*pui2);
+										incompatiblePlg->_version = v2;
+										TCHAR msg[1024];
+										wsprintf(msg, incompatibleWarningWithSolution, incompatiblePlg->_displayName.c_str(), v2.toString().c_str(), nppVer.toString().c_str(), pui2->_version.toString().c_str());
+										incompatiblePlg->_description = msg;
+										pluginImcompatibleList->pushBack(incompatiblePlg);
+									}
 								}
 							}
 						}

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -91,7 +91,7 @@ public:
 		_nppData = nppData;
 	}
 
-	bool loadPlugins(const TCHAR *dir = NULL, const PluginViewList* pluginUpdateInfoList = nullptr);
+	bool loadPlugins(const TCHAR *dir = NULL, const PluginViewList* pluginUpdateInfoList = nullptr, PluginViewList* pluginImcompatibleList = nullptr);
 
     bool unloadPlugin(int index, HWND nppHandle);
 
@@ -133,16 +133,14 @@ private:
 
 	int loadPluginFromPath(const TCHAR* pluginFilePath);
 
-	void pluginCrashAlert(const TCHAR *pluginName, const TCHAR *funcSignature)
-	{
+	void pluginCrashAlert(const TCHAR *pluginName, const TCHAR *funcSignature) {
 		generic_string msg = pluginName;
 		msg += TEXT(" just crashed in\r");
 		msg += funcSignature;
 		::MessageBox(NULL, msg.c_str(), TEXT("Plugin Crash"), MB_OK|MB_ICONSTOP);
 	}
 
-	void pluginExceptionAlert(const TCHAR *pluginName, const std::exception& e)
-	{
+	void pluginExceptionAlert(const TCHAR *pluginName, const std::exception& e) {
 		generic_string msg = TEXT("An exception occurred due to plugin: ");
 		msg += pluginName;
 		msg += TEXT("\r\n\r\nException reason: ");
@@ -151,8 +149,7 @@ private:
 		::MessageBox(NULL, msg.c_str(), TEXT("Plugin Exception"), MB_OK);
 	}
 
-	bool isInLoadedDlls(const TCHAR *fn) const
-	{
+	bool isInLoadedDlls(const TCHAR *fn) const {
 		for (size_t i = 0; i < _loadedDlls.size(); ++i)
 			if (generic_stricmp(fn, _loadedDlls[i]._fileName.c_str()) == 0)
 				return true;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -425,7 +425,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_pluginsManager.init(nppData);
 
 	bool enablePluginAdmin = _pluginsAdminDlg.initFromJson();
-	_pluginsManager.loadPlugins(nppParam.getPluginRootDir(), enablePluginAdmin ? &_pluginsAdminDlg.getAvailablePluginUpdateInfoList() : nullptr);
+	_pluginsManager.loadPlugins(nppParam.getPluginRootDir(), enablePluginAdmin ? &_pluginsAdminDlg.getAvailablePluginUpdateInfoList() : nullptr, enablePluginAdmin ? &_pluginsAdminDlg.getIncompatibleList() : nullptr);
 	_restoreButton.init(_pPublicInterface->getHinst(), hwnd);
 
 	// ------------ //

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.h
@@ -128,6 +128,7 @@ public:
 	void changeColumnName(COLUMN_TYPE index, const TCHAR *name2change);
 
 private:
+	// _list & _ui should keep being synchronized
 	std::vector<PluginUpdateInfo*> _list;
 	ListView _ui;
 
@@ -180,6 +181,10 @@ public :
 	const PluginViewList & getAvailablePluginUpdateInfoList() const {
 		return _availableList;
 	};
+	
+	PluginViewList & getIncompatibleList() {
+		return _incompatibleList;
+	};
 
 protected:
 	virtual intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
@@ -191,9 +196,10 @@ private :
 
 	TabBar _tab;
 
-	PluginViewList _availableList; // A permanent list, once it's loaded (no removal - only hide or show) 
-	PluginViewList _updateList;    // A dynamical list, items are removable
-	PluginViewList _installedList; // A dynamical list, items are removable
+	PluginViewList _availableList;    // A permanent list, once it's loaded (no removal - only hide or show) 
+	PluginViewList _updateList;       // A dynamical list, items are removable
+	PluginViewList _installedList;    // A dynamical list, items are removable
+	PluginViewList _incompatibleList; // A permanent list, once it's loaded (no removal - only hide or show) 
 
 	PluginsManager *_pPluginsManager = nullptr;
 	NppCurrentStatus _nppCurrentStatus;
@@ -213,6 +219,7 @@ private :
 	};
 	
 	bool initAvailablePluginsViewFromList();
+	bool initIncompatiblePluginList();
 	bool loadFromPluginInfos();
 	bool checkUpdates();
 


### PR DESCRIPTION
The plugins which are not compatible but their newer versions are available are not only on the incompatible list, but also on the Updates list.

Fix #12069