### PR TITLE
Send NPPN_DARKMODECHANGED notification with hwndNpp as hwndFrom

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -205,7 +205,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			// Notify plugins that Dark Mode changed
 			SCNotification scnN;
 			scnN.nmhdr.code = NPPN_DARKMODECHANGED;
-			scnN.nmhdr.hwndFrom = reinterpret_cast<void*>(lParam);
+			scnN.nmhdr.hwndFrom = hwnd;
 			scnN.nmhdr.idFrom = 0;
 			_pluginsManager.notify(&scnN);
 			return TRUE;


### PR DESCRIPTION
So it matches the documented API info on https://npp-user-manual.org/docs/plugin-communication/#nppn-darkmodechanged. Previously it sends 0 which is of no use to plugin authors.

This fixes #12144