### PR TITLE
Set PKGBUILD and APKBUILD syntax highlighting as shell script

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -222,7 +222,7 @@ void Buffer::setFileName(const TCHAR *fn, LangType defaultLang)
 			newLang = L_PYTHON;
 		else if ((OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("Rakefile")) == 0) || (OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("Vagrantfile")) == 0))
 			newLang = L_RUBY;
-		else if ((OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("crontab")) == 0))
+		else if ((OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("crontab")) == 0) || (OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("PKGBUILD")) == 0) || (OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("APKBUILD")) == 0))
 			newLang = L_BASH;
 	}
 


### PR DESCRIPTION
Both PKGBUILD and APKBUILD files are actually shell script. See
* https://wiki.archlinux.org/title/PKGBUILD
* https://wiki.alpinelinux.org/wiki/APKBUILD_Reference