### PR TITLE
rebol syntax quote issue

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -272,7 +272,7 @@ public:
 	};
 
 	Sci_CharacterRange getSelection() const {
-		Sci_CharacterRange crange;
+		Sci_CharacterRange crange{};
 		crange.cpMin = static_cast<Sci_PositionCR>(execute(SCI_GETSELECTIONSTART));
 		crange.cpMax = static_cast<Sci_PositionCR>(execute(SCI_GETSELECTIONEND));
 		return crange;
@@ -917,7 +917,7 @@ protected:
 
 	void setREBOLLexer() {
 		setLexer(L_REBOL, LIST_0 | LIST_1 | LIST_2 | LIST_3 | LIST_4 | LIST_5 | LIST_6);
-		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?!.’+-*&|=_~"));
+		execute(SCI_SETWORDCHARS, 0, reinterpret_cast<LPARAM>("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?!.'+-*&|=_~"));
 	};
 
 	void setRegistryLexer() {


### PR DESCRIPTION
- see http://www.rebol.com/r3/docs/guide/code-syntax.html#section-3
setREBOLLexer seems to use wrong, non ASCII single quote, see also https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/lexilla/lexers/LexRebol.cxx#L38 found by clang tidy(https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170, https://learn.microsoft.com/en-us/cpp/code-quality/clang-tidy?source=recommendations&view=msvc-170) warning, see https://github.com/chcg/notepad-plus-plus/actions/runs/3112910176/jobs/5046875133

`..\src\ScintillaComponent\ScintillaEditView.h(920,123): warning : illegal character encoding in string literal [-Winvalid-source-encoding] [D:\a\notepad-plus-plus\notepad-plus-plus\PowerEditor\visual.net\notepadPlus.vcxproj]
`
- default init struct