### PR TITLE
Fix #12226, #12253 and properly fix #11504

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -742,7 +742,7 @@ BufferID FileManager::loadFile(const TCHAR* filename, Document doc, int encoding
 		buf->setEncoding(-1);
 
 		// if no file extension, and the language has been detected,  we use the detected value
-		if (!newBuf->_isLargeFile && loadedFileFormat._language != L_TEXT)
+		if (!newBuf->_isLargeFile && ((buf->getLangType() == L_TEXT) && (loadedFileFormat._language != L_TEXT)))
 			buf->setLangType(loadedFileFormat._language);
 
 		setLoadedBufferEncodingAndEol(buf, UnicodeConvertor, loadedFileFormat._encoding, loadedFileFormat._eolFormat);

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -211,6 +211,8 @@ void Buffer::setFileName(const TCHAR *fn, LangType defaultLang)
 			newLang = nppParamInst.getLangFromExt(ext);
 		}
 	}
+	else if (!isUntitled()) // existing file with no extension
+		newLang = L_TEXT;
 
 	if (newLang == defaultLang || newLang == L_TEXT)	//language can probably be refined
 	{

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -741,19 +741,10 @@ BufferID FileManager::loadFile(const TCHAR* filename, Document doc, int encoding
 		// restore the encoding (ANSI based) while opening the existing file
 		buf->setEncoding(-1);
 
-		NppParameters& nppParamInst = NppParameters::getInstance();
-		const NewDocDefaultSettings& ndds = (nppParamInst.getNppGUI()).getNewDocDefaultSettings();
-
-		// if no file extension, or the file type is unknown, and the language has been detected, we use the detected value
-		if (!newBuf->_isLargeFile &&
-			// case 1: no file extension
-			(!_tcsrchr(newBuf->_fileName, '.') ||
-				// case 2: file extension found, but the file type is unknown (i.e. unchanged from the default)
-				(buf->_lang == L_TEXT || buf->_lang == ndds._lang)
-			&& loadedFileFormat._language != L_TEXT))
-		{
+		// if no file extension, and the language has been detected,  we use the detected value
+		if (!newBuf->_isLargeFile && loadedFileFormat._language != L_TEXT)
 			buf->setLangType(loadedFileFormat._language);
-		}
+
 		setLoadedBufferEncodingAndEol(buf, UnicodeConvertor, loadedFileFormat._encoding, loadedFileFormat._eolFormat);
 
 		//determine buffer properties

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -741,10 +741,19 @@ BufferID FileManager::loadFile(const TCHAR* filename, Document doc, int encoding
 		// restore the encoding (ANSI based) while opening the existing file
 		buf->setEncoding(-1);
 
-		// if no file extension, and the language has been detected,  we use the detected value
-		if (!newBuf->_isLargeFile && loadedFileFormat._language != L_TEXT)
-			buf->setLangType(loadedFileFormat._language);
+		NppParameters& nppParamInst = NppParameters::getInstance();
+		const NewDocDefaultSettings& ndds = (nppParamInst.getNppGUI()).getNewDocDefaultSettings();
 
+		// if no file extension, or the file type is unknown, and the language has been detected, we use the detected value
+		if (!newBuf->_isLargeFile &&
+			// case 1: no file extension
+			(!_tcsrchr(newBuf->_fileName, '.') ||
+				// case 2: file extension found, but the file type is unknown (i.e. unchanged from the default)
+				(buf->_lang == L_TEXT || buf->_lang == ndds._lang)
+			&& loadedFileFormat._language != L_TEXT))
+		{
+			buf->setLangType(loadedFileFormat._language);
+		}
 		setLoadedBufferEncodingAndEol(buf, UnicodeConvertor, loadedFileFormat._encoding, loadedFileFormat._eolFormat);
 
 		//determine buffer properties

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1086,7 +1086,6 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 	std::lock_guard<std::mutex> lock(save_mutex);
 
 	Buffer* buffer = getBufferByID(id);
-	LangType language = buffer->_lang;
 	bool isHiddenOrSys = false;
 	DWORD attrib = 0;
 
@@ -1157,11 +1156,8 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 			}
 		}
 
-		if (!_tcsrchr(buffer->_fileName, '.'))
-		{
-			// no extension -- check the language du fichier
-			language = detectLanguageFromTextBegining((unsigned char *)buf, lengthDoc);
-		}
+		// check the language du fichier
+		LangType language = detectLanguageFromTextBegining((unsigned char *)buf, lengthDoc);
 
 		UnicodeConvertor.closeFile();
 
@@ -1511,7 +1507,7 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const TCHAR * fil
 						fileFormat._encoding = detectCodepage(data, lenFile);
                 }
 
-				if (!_tcsrchr(filename, '.'))
+				if (fileFormat._language == L_TEXT)
 				{
 					// check the language du fichier
 					fileFormat._language = detectLanguageFromTextBegining((unsigned char *)data, lenFile);

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1086,6 +1086,7 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 	std::lock_guard<std::mutex> lock(save_mutex);
 
 	Buffer* buffer = getBufferByID(id);
+	LangType language = buffer->_lang;
 	bool isHiddenOrSys = false;
 	DWORD attrib = 0;
 
@@ -1156,8 +1157,11 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 			}
 		}
 
-		// check the language du fichier
-		LangType language = detectLanguageFromTextBegining((unsigned char *)buf, lengthDoc);
+		if (!_tcsrchr(buffer->_fileName, '.'))
+		{
+			// no extension -- check the language du fichier
+			language = detectLanguageFromTextBegining((unsigned char *)buf, lengthDoc);
+		}
 
 		UnicodeConvertor.closeFile();
 
@@ -1507,7 +1511,7 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const TCHAR * fil
 						fileFormat._encoding = detectCodepage(data, lenFile);
                 }
 
-				if (fileFormat._language == L_TEXT)
+				if (!_tcsrchr(filename, '.'))
 				{
 					// check the language du fichier
 					fileFormat._language = detectLanguageFromTextBegining((unsigned char *)data, lenFile);


### PR DESCRIPTION
Before 6263ce5, the user-preferred default language was being applied to files with _no extension_, but got _overwritten_ by `L_TEXT` when the extension was present _but unknown_. This was why the `buf->_lang == L_TEXT` condition failed _only for buffers with no extension_.

This fixes #11504 by handling the no-extension case, without causing regressions.
Also fixes #12226 and fixes #12253