### PR TITLE
boost 1.80.0

### DIFF
--- a/boostregex/boost/assert/source_location.hpp
+++ b/boostregex/boost/assert/source_location.hpp
@@ -9,10 +9,16 @@
 
 #include <boost/current_function.hpp>
 #include <boost/config.hpp>
+#include <boost/config/workaround.hpp>
 #include <boost/cstdint.hpp>
 #include <iosfwd>
 #include <string>
 #include <cstdio>
+#include <cstring>
+
+#if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
+# include <source_location>
+#endif
 
 namespace boost
 {
@@ -28,13 +34,21 @@ private:
 
 public:
 
-    BOOST_CONSTEXPR source_location() BOOST_NOEXCEPT: file_( "(unknown)" ), function_( "(unknown)" ), line_( 0 ), column_( 0 )
+    BOOST_CONSTEXPR source_location() BOOST_NOEXCEPT: file_( "" ), function_( "" ), line_( 0 ), column_( 0 )
     {
     }
 
     BOOST_CONSTEXPR source_location( char const * file, boost::uint_least32_t ln, char const * function, boost::uint_least32_t col = 0 ) BOOST_NOEXCEPT: file_( file ), function_( function ), line_( ln ), column_( col )
     {
     }
+
+#if defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
+
+    BOOST_CONSTEXPR source_location( std::source_location const& loc ) BOOST_NOEXCEPT: file_( loc.file_name() ), function_( loc.function_name() ), line_( loc.line() ), column_( loc.column() )
+    {
+    }
+
+#endif
 
     BOOST_CONSTEXPR char const * file_name() const BOOST_NOEXCEPT
     {
@@ -61,9 +75,17 @@ public:
 # pragma warning( disable: 4996 )
 #endif
 
+#if ( defined(_MSC_VER) && _MSC_VER < 1900 ) || ( defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) )
+# define BOOST_ASSERT_SNPRINTF(buffer, format, arg) std::sprintf(buffer, format, arg)
+#else
+# define BOOST_ASSERT_SNPRINTF(buffer, format, arg) std::snprintf(buffer, sizeof(buffer)/sizeof(buffer[0]), format, arg)
+#endif
+
     std::string to_string() const
     {
-        if( line() == 0 )
+        unsigned long ln = line();
+
+        if( ln == 0 )
         {
             return "(unknown source location)";
         }
@@ -72,26 +94,44 @@ public:
 
         char buffer[ 16 ];
 
-        std::sprintf( buffer, ":%ld", static_cast<long>( line() ) );
+        BOOST_ASSERT_SNPRINTF( buffer, ":%lu", ln );
         r += buffer;
 
-        if( column() )
+        unsigned long co = column();
+
+        if( co )
         {
-            std::sprintf( buffer, ":%ld", static_cast<long>( column() ) );
+            BOOST_ASSERT_SNPRINTF( buffer, ":%lu", co );
             r += buffer;
         }
 
-        r += " in function '";
-        r += function_name();
-        r += '\'';
+        char const* fn = function_name();
+
+        if( *fn != 0 )
+        {
+            r += " in function '";
+            r += fn;
+            r += '\'';
+        }
 
         return r;
     }
+
+#undef BOOST_ASSERT_SNPRINTF
 
 #if defined(BOOST_MSVC)
 # pragma warning( pop )
 #endif
 
+    inline friend bool operator==( source_location const& s1, source_location const& s2 ) BOOST_NOEXCEPT
+    {
+        return std::strcmp( s1.file_, s2.file_ ) == 0 && std::strcmp( s1.function_, s2.function_ ) == 0 && s1.line_ == s2.line_ && s1.column_ == s2.column_;
+    }
+
+    inline friend bool operator!=( source_location const& s1, source_location const& s2 ) BOOST_NOEXCEPT
+    {
+        return !( s1 == s2 );
+    }
 };
 
 template<class E, class T> std::basic_ostream<E, T> & operator<<( std::basic_ostream<E, T> & os, source_location const & loc )
@@ -102,19 +142,47 @@ template<class E, class T> std::basic_ostream<E, T> & operator<<( std::basic_ost
 
 } // namespace boost
 
-#if defined( BOOST_DISABLE_CURRENT_LOCATION )
+#if defined(BOOST_DISABLE_CURRENT_LOCATION)
 
-#  define BOOST_CURRENT_LOCATION ::boost::source_location()
+# define BOOST_CURRENT_LOCATION ::boost::source_location()
 
-#elif defined(__clang_analyzer__)
+#elif defined(BOOST_MSVC) && BOOST_MSVC >= 1926
 
-// Cast to char const* to placate clang-tidy
-// https://bugs.llvm.org/show_bug.cgi?id=28480
-#  define BOOST_CURRENT_LOCATION ::boost::source_location(__FILE__, __LINE__, static_cast<char const*>(BOOST_CURRENT_FUNCTION))
+// std::source_location::current() is available in -std:c++20, but fails with consteval errors before 19.31, and doesn't produce
+// the correct result under 19.31, so prefer the built-ins
+# define BOOST_CURRENT_LOCATION ::boost::source_location(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION(), __builtin_COLUMN())
+
+#elif defined(BOOST_MSVC)
+
+// __LINE__ is not a constant expression under /ZI (edit and continue) for 1925 and before
+
+# define BOOST_CURRENT_LOCATION_IMPL_1(x) BOOST_CURRENT_LOCATION_IMPL_2(x)
+# define BOOST_CURRENT_LOCATION_IMPL_2(x) (x##0 / 10)
+
+# define BOOST_CURRENT_LOCATION ::boost::source_location(__FILE__, BOOST_CURRENT_LOCATION_IMPL_1(__LINE__), "")
+
+#elif defined(__cpp_lib_source_location) && __cpp_lib_source_location >= 201907L
+
+# define BOOST_CURRENT_LOCATION ::boost::source_location(::std::source_location::current())
+
+#elif defined(BOOST_CLANG) && BOOST_CLANG_VERSION >= 90000
+
+# define BOOST_CURRENT_LOCATION ::boost::source_location(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION(), __builtin_COLUMN())
+
+#elif defined(BOOST_GCC) && BOOST_GCC >= 70000
+
+// The built-ins are available in 4.8+, but are not constant expressions until 7
+# define BOOST_CURRENT_LOCATION ::boost::source_location(__builtin_FILE(), __builtin_LINE(), __builtin_FUNCTION())
+
+#elif defined(BOOST_GCC) && BOOST_GCC >= 50000
+
+// __PRETTY_FUNCTION__ is allowed outside functions under GCC, but 4.x suffers from codegen bugs
+# define BOOST_CURRENT_LOCATION ::boost::source_location(__FILE__, __LINE__, __PRETTY_FUNCTION__)
 
 #else
 
-#  define BOOST_CURRENT_LOCATION ::boost::source_location(__FILE__, __LINE__, BOOST_CURRENT_FUNCTION)
+// __func__ macros aren't allowed outside functions, but BOOST_CURRENT_LOCATION is
+# define BOOST_CURRENT_LOCATION ::boost::source_location(__FILE__, __LINE__, "")
 
 #endif
 

--- a/boostregex/boost/config/assert_cxx03.hpp
+++ b/boostregex/boost/config/assert_cxx03.hpp
@@ -1,4 +1,4 @@
-//  This file was automatically generated on Tue Aug 17 16:27:31 2021
+//  This file was automatically generated on Sun Jun  5 16:50:18 2022
 //  by libs/config/tools/generate.cpp
 //  Copyright John Maddock 2002-21.
 //  Use, modification and distribution are subject to the 

--- a/boostregex/boost/config/assert_cxx11.hpp
+++ b/boostregex/boost/config/assert_cxx11.hpp
@@ -1,4 +1,4 @@
-//  This file was automatically generated on Tue Aug 17 16:27:31 2021
+//  This file was automatically generated on Sun Jun  5 16:50:18 2022
 //  by libs/config/tools/generate.cpp
 //  Copyright John Maddock 2002-21.
 //  Use, modification and distribution are subject to the 

--- a/boostregex/boost/config/assert_cxx14.hpp
+++ b/boostregex/boost/config/assert_cxx14.hpp
@@ -1,4 +1,4 @@
-//  This file was automatically generated on Tue Aug 17 16:27:31 2021
+//  This file was automatically generated on Sun Jun  5 16:50:18 2022
 //  by libs/config/tools/generate.cpp
 //  Copyright John Maddock 2002-21.
 //  Use, modification and distribution are subject to the 

--- a/boostregex/boost/config/assert_cxx17.hpp
+++ b/boostregex/boost/config/assert_cxx17.hpp
@@ -1,4 +1,4 @@
-//  This file was automatically generated on Tue Aug 17 16:27:31 2021
+//  This file was automatically generated on Sun Jun  5 16:50:18 2022
 //  by libs/config/tools/generate.cpp
 //  Copyright John Maddock 2002-21.
 //  Use, modification and distribution are subject to the 
@@ -12,6 +12,9 @@
 #include <boost/config.hpp>
 #include <boost/config/assert_cxx14.hpp>
 
+#ifdef BOOST_NO_CXX17_DEDUCTION_GUIDES
+#  error "Your compiler appears not to be fully C++17 compliant.  Detected via defect macro BOOST_NO_CXX17_DEDUCTION_GUIDES."
+#endif
 #ifdef BOOST_NO_CXX17_FOLD_EXPRESSIONS
 #  error "Your compiler appears not to be fully C++17 compliant.  Detected via defect macro BOOST_NO_CXX17_FOLD_EXPRESSIONS."
 #endif

--- a/boostregex/boost/config/assert_cxx20.hpp
+++ b/boostregex/boost/config/assert_cxx20.hpp
@@ -1,4 +1,4 @@
-//  This file was automatically generated on Tue Aug 17 16:27:31 2021
+//  This file was automatically generated on Sun Jun  5 16:50:18 2022
 //  by libs/config/tools/generate.cpp
 //  Copyright John Maddock 2002-21.
 //  Use, modification and distribution are subject to the 
@@ -53,4 +53,7 @@
 #endif
 #ifdef BOOST_NO_CXX20_HDR_SYNCSTREAM
 #  error "Your compiler appears not to be fully C++20 compliant.  Detected via defect macro BOOST_NO_CXX20_HDR_SYNCSTREAM."
+#endif
+#ifdef BOOST_NO_CXX20_HDR_VERSION
+#  error "Your compiler appears not to be fully C++20 compliant.  Detected via defect macro BOOST_NO_CXX20_HDR_VERSION."
 #endif

--- a/boostregex/boost/config/detail/cxx_composite.hpp
+++ b/boostregex/boost/config/detail/cxx_composite.hpp
@@ -1,4 +1,4 @@
-//  This file was automatically generated on Tue Aug 17 16:27:31 2021
+//  This file was automatically generated on Sun Jun  5 16:50:18 2022
 //  by libs/config/tools/generate.cpp
 //  Copyright John Maddock 2002-21.
 //  Use, modification and distribution are subject to the 
@@ -163,6 +163,7 @@
 #endif
 
 #if defined(BOOST_NO_CXX14)\
+   || defined(BOOST_NO_CXX17_DEDUCTION_GUIDES)\
    || defined(BOOST_NO_CXX17_FOLD_EXPRESSIONS)\
    || defined(BOOST_NO_CXX17_HDR_ANY)\
    || defined(BOOST_NO_CXX17_HDR_CHARCONV)\
@@ -195,7 +196,8 @@
    || defined(BOOST_NO_CXX20_HDR_SOURCE_LOCATION)\
    || defined(BOOST_NO_CXX20_HDR_SPAN)\
    || defined(BOOST_NO_CXX20_HDR_STOP_TOKEN)\
-   || defined(BOOST_NO_CXX20_HDR_SYNCSTREAM)
+   || defined(BOOST_NO_CXX20_HDR_SYNCSTREAM)\
+   || defined(BOOST_NO_CXX20_HDR_VERSION)
 #    define BOOST_NO_CXX20
 #endif
 

--- a/boostregex/boost/config/detail/suffix.hpp
+++ b/boostregex/boost/config/detail/suffix.hpp
@@ -632,7 +632,7 @@ namespace std{ using ::type_info; }
        // nvcc doesn't always parse __noinline__,
        // see: https://svn.boost.org/trac/boost/ticket/9392
 #      define BOOST_NOINLINE __attribute__ ((noinline))
-#    elif defined(HIP_VERSION)
+#    elif defined(__HIP__)
        // See https://github.com/boostorg/config/issues/392
 #      define BOOST_NOINLINE __attribute__ ((noinline))
 #    else
@@ -1069,6 +1069,12 @@ namespace std{ using ::type_info; }
 
 #define BOOST_STATIC_CONSTEXPR  static BOOST_CONSTEXPR_OR_CONST
 
+#if !defined(BOOST_NO_CXX11_NULLPTR)
+# define BOOST_NULLPTR nullptr
+#else
+# define BOOST_NULLPTR 0
+#endif
+
 //
 // Set BOOST_HAS_STATIC_ASSERT when BOOST_NO_CXX11_STATIC_ASSERT is not defined
 //
@@ -1135,9 +1141,14 @@ namespace std{ using ::type_info; }
 #endif
 #endif
 #endif
+//
+// Define the std level that the compiler claims to support:
+//
+#ifndef BOOST_CXX_VERSION
+#  define BOOST_CXX_VERSION __cplusplus
+#endif
 
-#if !defined(_YVALS) && !defined(_CPPLIB_VER)  // msvc std lib already configured
-#if (!defined(__has_include) || (__cplusplus < 201704))
+#if (!defined(__has_include) || (BOOST_CXX_VERSION < 201704))
 #  define BOOST_NO_CXX20_HDR_BARRIER
 #  define BOOST_NO_CXX20_HDR_FORMAT
 #  define BOOST_NO_CXX20_HDR_SOURCE_LOCATION
@@ -1153,74 +1164,73 @@ namespace std{ using ::type_info; }
 #  define BOOST_NO_CXX20_HDR_COROUTINE
 #  define BOOST_NO_CXX20_HDR_SEMAPHORE
 #else
-#if !__has_include(<barrier>)
+#if (!__has_include(<barrier>) || !defined(__cpp_lib_barrier) || (__cpp_lib_barrier < 201907L)) && !defined(BOOST_NO_CXX20_HDR_BARRIER)
 #  define BOOST_NO_CXX20_HDR_BARRIER
 #endif
-#if !__has_include(<format>)
+#if (!__has_include(<format>) || !defined(__cpp_lib_format) || (__cpp_lib_format < 201907L)) && !defined(BOOST_NO_CXX20_HDR_FORMAT)
 #  define BOOST_NO_CXX20_HDR_FORMAT
 #endif
-#if !__has_include(<source_Location>)
+#if (!__has_include(<source_location>) || !defined(__cpp_lib_source_location) || (__cpp_lib_source_location < 201907L)) && !defined(BOOST_NO_CXX20_HDR_SOURCE_LOCATION)
 #  define BOOST_NO_CXX20_HDR_SOURCE_LOCATION
 #endif
-#if !__has_include(<bit>)
+#if (!__has_include(<bit>) || !defined(__cpp_lib_bit_cast) || (__cpp_lib_bit_cast < 201806L) || !defined(__cpp_lib_bitops) || (__cpp_lib_bitops < 201907L) || !defined(__cpp_lib_endian) || (__cpp_lib_endian < 201907L)) && !defined(BOOST_NO_CXX20_HDR_BIT)
 #  define BOOST_NO_CXX20_HDR_BIT
 #endif
-#if !__has_include(<latch>)
+#if (!__has_include(<latch>) || !defined(__cpp_lib_latch) || (__cpp_lib_latch < 201907L)) && !defined(BOOST_NO_CXX20_HDR_LATCH)
 #  define BOOST_NO_CXX20_HDR_LATCH
 #endif
-#if !__has_include(<span>)
+#if (!__has_include(<span>) || !defined(__cpp_lib_span) || (__cpp_lib_span < 202002L)) && !defined(BOOST_NO_CXX20_HDR_SPAN)
 #  define BOOST_NO_CXX20_HDR_SPAN
 #endif
-#if !__has_include(<compare>)
+#if (!__has_include(<compare>) || !defined(__cpp_lib_three_way_comparison) || (__cpp_lib_three_way_comparison < 201907L)) && !defined(BOOST_NO_CXX20_HDR_COMPARE)
 #  define BOOST_NO_CXX20_HDR_COMPARE
 #endif
-#if !__has_include(<numbers>)
+#if (!__has_include(<numbers>) || !defined(__cpp_lib_math_constants) || (__cpp_lib_math_constants < 201907L)) && !defined(BOOST_NO_CXX20_HDR_NUMBERS)
 #  define BOOST_NO_CXX20_HDR_NUMBERS
 #endif
-#if !__has_include(<stop_token>)
+#if (!__has_include(<stop_token>) || !defined(__cpp_lib_jthread) || (__cpp_lib_jthread < 201911L)) && !defined(BOOST_NO_CXX20_HDR_STOP_TOKEN)
 #  define BOOST_NO_CXX20_HDR_STOP_TOKEN
 #endif
-#if !__has_include(<concepts>)
+#if (!__has_include(<concepts>) || !defined(__cpp_lib_concepts) || (__cpp_lib_concepts < 202002L)) && !defined(_YVALS) && !defined(_CPPLIB_VER) && !defined(BOOST_NO_CXX20_HDR_CONCEPTS)
 #  define BOOST_NO_CXX20_HDR_CONCEPTS
 #endif
-#if !__has_include(<ranges>)
+#if (!__has_include(<ranges>) || !defined(__cpp_lib_ranges) || (__cpp_lib_ranges < 201911L)) && !defined(BOOST_NO_CXX20_HDR_RANGES)
 #  define BOOST_NO_CXX20_HDR_RANGES
 #endif
-#if !__has_include(<syncstream>)
+#if (!__has_include(<syncstream>) || !defined(__cpp_lib_syncbuf) || (__cpp_lib_syncbuf < 201803L)) && !defined(BOOST_NO_CXX20_HDR_SYNCSTREAM)
 #  define BOOST_NO_CXX20_HDR_SYNCSTREAM
 #endif
-#if !__has_include(<coroutine>)
+#if (!__has_include(<coroutine>) || !defined(__cpp_lib_coroutine) || (__cpp_lib_coroutine < 201902L)) && !defined(BOOST_NO_CXX20_HDR_COROUTINE)
 #  define BOOST_NO_CXX20_HDR_COROUTINE
 #endif
-#if !__has_include(<semaphore>)
+#if (!__has_include(<semaphore>) || !defined(__cpp_lib_semaphore) || (__cpp_lib_semaphore < 201907L)) && !defined(BOOST_NO_CXX20_HDR_SEMAPHORE)
 #  define BOOST_NO_CXX20_HDR_SEMAPHORE
 #endif
 #endif
+
+#if defined(__cplusplus) && defined(__has_include)
+#if !__has_include(<version>)
+#  define BOOST_NO_CXX20_HDR_VERSION
+#else
+// For convenience, this is always included:
+#  include <version>
+#endif
+#else
+#  define BOOST_NO_CXX20_HDR_VERSION
+#endif
+
+#if defined(BOOST_MSVC)
+#if (BOOST_MSVC < 1914) || (_MSVC_LANG < 201703)
+#  define BOOST_NO_CXX17_DEDUCTION_GUIDES
+#endif
+#elif !defined(__cpp_deduction_guides) || (__cpp_deduction_guides < 201606)
+#  define BOOST_NO_CXX17_DEDUCTION_GUIDES
 #endif
 
 //
 // Define composite agregate macros:
 //
 #include <boost/config/detail/cxx_composite.hpp>
-
-//
-// Define the std level that the compiler claims to support:
-//
-#ifndef BOOST_CXX_VERSION
-#  define BOOST_CXX_VERSION __cplusplus
-#endif
-
-//
-// Define composite agregate macros:
-//
-#include <boost/config/detail/cxx_composite.hpp>
-
-//
-// Define the std level that the compiler claims to support:
-//
-#ifndef BOOST_CXX_VERSION
-#  define BOOST_CXX_VERSION __cplusplus
-#endif
 
 //
 // Finish off with checks for macros that are depricated / no longer supported,

--- a/boostregex/boost/config/stdlib/dinkumware.hpp
+++ b/boostregex/boost/config/stdlib/dinkumware.hpp
@@ -176,7 +176,9 @@
 #endif
 
 // C++17 features
-#if !defined(_CPPLIB_VER) || (_CPPLIB_VER < 650) || !defined(BOOST_MSVC) || (BOOST_MSVC < 1910) || !defined(_HAS_CXX17) || (_HAS_CXX17 == 0)
+#if !defined(_CPPLIB_VER) || (_CPPLIB_VER < 650) \
+ || ((!defined(BOOST_MSVC) || (BOOST_MSVC < 1910))) && (!defined(__clang__) || !defined(_MSC_VER) || (_MSC_VER < 1929))\
+ || !defined(_HAS_CXX17) || (_HAS_CXX17 == 0)
 #  define BOOST_NO_CXX17_STD_APPLY
 #  define BOOST_NO_CXX17_ITERATOR_TRAITS
 #  define BOOST_NO_CXX17_HDR_STRING_VIEW
@@ -192,29 +194,10 @@
 #  define BOOST_NO_CXX17_STD_INVOKE
 #endif
 
-// C++20 features
+// C++20 features which aren't configured in suffix.hpp correctly:
 #if !defined(_MSVC_STL_UPDATE) || (_MSVC_STL_UPDATE < 202008L) || !defined(_HAS_CXX20) || (_HAS_CXX20 == 0)
-#  define BOOST_NO_CXX20_HDR_BARRIER
-#  define BOOST_NO_CXX20_HDR_BIT
-#  define BOOST_NO_CXX20_HDR_LATCH
-#  define BOOST_NO_CXX20_HDR_SPAN
-#  define BOOST_NO_CXX20_HDR_COMPARE
-#  define BOOST_NO_CXX20_HDR_NUMBERS
 #  define BOOST_NO_CXX20_HDR_CONCEPTS
-#  define BOOST_NO_CXX20_HDR_COROUTINE
-#  define BOOST_NO_CXX20_HDR_SEMAPHORE
 #endif
-#if !defined(_MSVC_STL_UPDATE) || (_MSVC_STL_UPDATE < 202011L) || !defined(_HAS_CXX20) || (_HAS_CXX20 == 0)
-#  define BOOST_NO_CXX20_HDR_STOP_TOKEN
-#endif
-// C++20 features not yet implemented:
-#  define BOOST_NO_CXX20_HDR_FORMAT
-#if !defined(_MSVC_STL_UPDATE) || (_MSVC_STL_UPDATE < 202108L) || !defined(_HAS_CXX20) || (_HAS_CXX20 == 0)
-#  define BOOST_NO_CXX20_HDR_SOURCE_LOCATION
-#  define BOOST_NO_CXX20_HDR_SYNCSTREAM
-#endif
-// Incomplete:
-#  define BOOST_NO_CXX20_HDR_RANGES
 
 #if !(!defined(_CPPLIB_VER) || (_CPPLIB_VER < 650) || !defined(BOOST_MSVC) || (BOOST_MSVC < 1912) || !defined(_HAS_CXX17) || (_HAS_CXX17 == 0))
 // Deprecated std::iterator:

--- a/boostregex/boost/config/stdlib/libcpp.hpp
+++ b/boostregex/boost/config/stdlib/libcpp.hpp
@@ -104,7 +104,7 @@
 #  define BOOST_NO_CXX98_BINDERS
 #endif
 
-#ifdef __has_include
+#if defined(__cplusplus) && defined(__has_include)
 #if __has_include(<version>)
 #include <version>
 
@@ -115,53 +115,7 @@
 #define BOOST_NO_CXX17_STD_INVOKE
 #endif
 
-#if !defined(__cpp_lib_bit_cast) || (__cpp_lib_bit_cast < 201806L) || !defined(__cpp_lib_bitops) || (__cpp_lib_bitops < 201907L) || !defined(__cpp_lib_endian) || (__cpp_lib_endian < 201907L)
-#  define BOOST_NO_CXX20_HDR_BIT
-#endif
-#if !defined(__cpp_lib_three_way_comparison) || (__cpp_lib_three_way_comparison < 201907L)
-#  define BOOST_NO_CXX20_HDR_COMPARE
-#endif
-#if !defined(__cpp_lib_ranges) || (__cpp_lib_ranges < 201911L)
-#  define BOOST_NO_CXX20_HDR_RANGES
-#endif
-#if !defined(__cpp_lib_barrier) || (__cpp_lib_barrier < 201907L)
-#  define BOOST_NO_CXX20_HDR_BARRIER
-#endif
-#if !defined(__cpp_lib_format) || (__cpp_lib_format < 201907L)
-#  define BOOST_NO_CXX20_HDR_FORMAT
-#endif
-#if !defined(__cpp_lib_source_location) || (__cpp_lib_source_location < 201907L)
-#  define BOOST_NO_CXX20_HDR_SOURCE_LOCATION
-#endif
-#if !defined(__cpp_lib_latch) || (__cpp_lib_latch < 201907L)
-#  define BOOST_NO_CXX20_HDR_SOURCE_LATCH
-#endif
-#if !defined(__cpp_lib_span) || (__cpp_lib_span < 202002L)
-#  define BOOST_NO_CXX20_HDR_SOURCE_SPAN
-#endif
-#if !defined(__cpp_lib_math_constants) || (__cpp_lib_math_constants < 201907L)
-#  define BOOST_NO_CXX20_HDR_SOURCE_NUMBERS
-#endif
-#if !defined(__cpp_lib_jthread) || (__cpp_lib_jthread < 201911L)
-#  define BOOST_NO_CXX20_HDR_SOURCE_STOP_TOKEN
-#endif
-#if !defined(__cpp_lib_concepts) || (__cpp_lib_concepts < 202002L)
-#  define BOOST_NO_CXX20_HDR_SOURCE_STOP_CONCEPTS
-#endif
-#if !defined(__cpp_lib_syncbuf) || (__cpp_lib_syncbuf < 201803L)
-#  define BOOST_NO_CXX20_HDR_SYNCSTREAM
-#endif
-#if !defined(__cpp_lib_coroutine) || (__cpp_lib_coroutine < 201902L)
-#  define BOOST_NO_CXX20_HDR_COROUTINE
-#endif
-#if !defined(__cpp_lib_semaphore) || (__cpp_lib_semaphore < 201907L)
-#  define BOOST_NO_CXX20_HDR_SEMAPHORE
-#endif
-#if !defined(__cpp_lib_concepts) || (__cpp_lib_concepts < 202002L)
-#  define BOOST_NO_CXX20_HDR_CONCEPTS
-#endif
-
-#if(_LIBCPP_VERSION < 9000) && !defined(BOOST_NO_CXX20_HDR_SPAN)
+#if(_LIBCPP_VERSION < 9000)
 // as_writable_bytes is missing.
 #  define BOOST_NO_CXX20_HDR_SPAN
 #endif

--- a/boostregex/boost/config/stdlib/libstdcpp3.hpp
+++ b/boostregex/boost/config/stdlib/libstdcpp3.hpp
@@ -139,7 +139,9 @@
 //
 #ifdef __clang__
 
-#if __has_include(<compare>)
+#if __has_include(<source_location>)
+#  define BOOST_LIBSTDCXX_VERSION 110100
+#elif __has_include(<compare>)
 #  define BOOST_LIBSTDCXX_VERSION 100100
 #elif __has_include(<memory_resource>)
 #  define BOOST_LIBSTDCXX_VERSION 90100
@@ -385,6 +387,15 @@ extern "C" char *gets (char *__s);
 #define BOOST_NO_CXX20_HDR_BIT
 #endif
 
+#if BOOST_LIBSTDCXX_VERSION >= 120000
+//
+// Unary function is now deprecated in C++11 and later:
+//
+#if __cplusplus >= 201103L
+#define BOOST_NO_CXX98_FUNCTION_BASE
+#endif
+#endif
+
 #ifndef __cpp_impl_coroutine
 #  define BOOST_NO_CXX20_HDR_COROUTINE
 #endif
@@ -404,6 +415,17 @@ extern "C" char *gets (char *__s);
 #endif
 #if !defined(BOOST_NO_CXX20_HDR_RANGES)
 #  define BOOST_NO_CXX20_HDR_RANGES
+#endif
+#endif
+
+#if defined(__clang__)
+#if (__clang_major__ < 11) && !defined(BOOST_NO_CXX20_HDR_RANGES)
+#  define BOOST_NO_CXX20_HDR_RANGES
+#endif
+#if (__clang_major__ < 10) && (BOOST_LIBSTDCXX_VERSION >= 110000) && !defined(BOOST_NO_CXX11_HDR_CHRONO)
+// Old clang can't parse <chrono>:
+#  define BOOST_NO_CXX11_HDR_CHRONO
+#  define BOOST_NO_CXX11_HDR_CONDITION_VARIABLE
 #endif
 #endif
 

--- a/boostregex/boost/exception/exception.hpp
+++ b/boostregex/boost/exception/exception.hpp
@@ -6,6 +6,7 @@
 #ifndef BOOST_EXCEPTION_274DA366004E11DCB1DDFE2E56D89593
 #define BOOST_EXCEPTION_274DA366004E11DCB1DDFE2E56D89593
 
+#include <boost/assert/source_location.hpp>
 #include <boost/config.hpp>
 #include <exception>
 
@@ -107,6 +108,7 @@ boost
     typedef error_info<struct throw_function_,char const *> throw_function;
     typedef error_info<struct throw_file_,char const *> throw_file;
     typedef error_info<struct throw_line_,int> throw_line;
+    typedef error_info<struct throw_column_,int> throw_column;
 
     template <>
     class
@@ -139,6 +141,20 @@ boost
     template <>
     class
     error_info<throw_line_,int>
+        {
+        public:
+        typedef int value_type;
+        value_type v_;
+        explicit
+        error_info( value_type v ):
+            v_(v)
+            {
+            }
+        };
+
+    template <>
+    class
+    error_info<throw_column_,int>
         {
         public:
         typedef int value_type;
@@ -189,6 +205,9 @@ boost
         template <>
         struct get_info<throw_line>;
 
+        template <>
+        struct get_info<throw_column>;
+
         template <class>
         struct set_info_rv;
 
@@ -200,6 +219,9 @@ boost
 
         template <>
         struct set_info_rv<throw_line>;
+
+        template <>
+        struct set_info_rv<throw_column>;
 
         char const * get_diagnostic_information( exception const &, char const * );
 
@@ -216,6 +238,11 @@ boost
 
         template <class E>
         E const & set_info( E const &, throw_line const & );
+
+        template <class E>
+        E const & set_info( E const &, throw_column const & );
+
+        boost::source_location get_exception_throw_location( exception const & );
         }
 
     class
@@ -233,7 +260,8 @@ boost
         exception():
             throw_function_(0),
             throw_file_(0),
-            throw_line_(-1)
+            throw_line_(-1),
+            throw_column_(-1)
             {
             }
 
@@ -244,7 +272,8 @@ boost
             data_(x.data_),
             throw_function_(x.throw_function_),
             throw_file_(x.throw_file_),
-            throw_line_(x.throw_line_)
+            throw_line_(x.throw_line_),
+            throw_column_(x.throw_column_)
             {
             }
 #endif
@@ -269,27 +298,35 @@ boost
         template <class E>
         friend E const & exception_detail::set_info( E const &, throw_line const & );
 
+        template <class E>
+        friend E const & exception_detail::set_info( E const &, throw_column const & );
+
         template <class E,class Tag,class T>
         friend E const & exception_detail::set_info( E const &, error_info<Tag,T> const & );
 
         friend char const * exception_detail::get_diagnostic_information( exception const &, char const * );
+
+        friend boost::source_location exception_detail::get_exception_throw_location( exception const & );
 
         template <class>
         friend struct exception_detail::get_info;
         friend struct exception_detail::get_info<throw_function>;
         friend struct exception_detail::get_info<throw_file>;
         friend struct exception_detail::get_info<throw_line>;
+        friend struct exception_detail::get_info<throw_column>;
         template <class>
         friend struct exception_detail::set_info_rv;
         friend struct exception_detail::set_info_rv<throw_function>;
         friend struct exception_detail::set_info_rv<throw_file>;
         friend struct exception_detail::set_info_rv<throw_line>;
+        friend struct exception_detail::set_info_rv<throw_column>;
         friend void exception_detail::copy_boost_exception( exception *, exception const * );
 #endif
         mutable exception_detail::refcount_ptr<exception_detail::error_info_container> data_;
         mutable char const * throw_function_;
         mutable char const * throw_file_;
         mutable int throw_line_;
+        mutable int throw_column_;
         };
 
     inline
@@ -323,6 +360,42 @@ boost
             {
             x.throw_line_=y.v_;
             return x;
+            }
+
+        template <class E>
+        E const &
+        set_info( E const & x, throw_column const & y )
+            {
+            x.throw_column_=y.v_;
+            return x;
+            }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+        template <>
+        struct
+        set_info_rv<throw_column>
+            {
+            template <class E>
+            static
+            E const &
+            set( E const & x, throw_column && y )
+                {
+                x.throw_column_=y.v_;
+                return x;
+                }
+            };
+
+#endif
+
+        inline boost::source_location get_exception_throw_location( exception const & x )
+            {
+            return boost::source_location(
+                x.throw_file_? x.throw_file_: "",
+                x.throw_line_ >= 0? x.throw_line_: 0,
+                x.throw_function_? x.throw_function_: "",
+                x.throw_column_ >= 0? x.throw_column_: 0
+                );
             }
         }
 
@@ -423,6 +496,7 @@ boost
             a->throw_file_ = b->throw_file_;
             a->throw_line_ = b->throw_line_;
             a->throw_function_ = b->throw_function_;
+            a->throw_column_ = b->throw_column_;
             a->data_ = data;
             }
 

--- a/boostregex/boost/regex/v5/basic_regex_creator.hpp
+++ b/boostregex/boost/regex/v5/basic_regex_creator.hpp
@@ -1019,6 +1019,8 @@ int basic_regex_creator<charT, traits>::calculate_backstep(re_syntax_base* state
             {
                if(rep->max != rep->min)
                   return -1;
+               if (static_cast<std::size_t>((std::numeric_limits<int>::max)() - result) < rep->min)
+                  return -1; // protection against overflow, we can't calculate a backstep in this case and the expression is probably ill-formed.
                result += static_cast<int>(rep->min);
                state = rep->alt.p;
                continue;

--- a/boostregex/boost/regex/v5/mem_block_cache.hpp
+++ b/boostregex/boost/regex/v5/mem_block_cache.hpp
@@ -34,6 +34,7 @@
 namespace boost{
 namespace BOOST_REGEX_DETAIL_NS{
 
+#if BOOST_REGEX_MAX_CACHE_BLOCKS != 0
 #ifdef BOOST_REGEX_MEM_BLOCK_CACHE_LOCK_FREE /* lock free implementation */
 struct mem_block_cache
 {
@@ -137,6 +138,7 @@ struct mem_block_cache
       return block_cache;
    }
 };
+#endif
 #endif
 
 #if BOOST_REGEX_MAX_CACHE_BLOCKS == 0

--- a/boostregex/boost/throw_exception.hpp
+++ b/boostregex/boost/throw_exception.hpp
@@ -7,10 +7,9 @@
 # pragma once
 #endif
 
-//
 //  boost/throw_exception.hpp
 //
-//  Copyright (c) 2002, 2018, 2019 Peter Dimov
+//  Copyright (c) 2002, 2018-2022 Peter Dimov
 //  Copyright (c) 2008-2009 Emil Dotchevski and Reverge Studios, Inc.
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
@@ -18,14 +17,17 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 //  http://www.boost.org/libs/throw_exception
-//
 
 #include <boost/exception/exception.hpp>
 #include <boost/assert/source_location.hpp>
 #include <boost/config.hpp>
 #include <boost/config/workaround.hpp>
 #include <exception>
+#include <utility>
 #include <cstddef>
+#if !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+#include <type_traits>
+#endif
 
 #if !defined( BOOST_EXCEPTION_DISABLE ) && defined( BOOST_BORLANDC ) && BOOST_WORKAROUND( BOOST_BORLANDC, BOOST_TESTED_AT(0x593) )
 # define BOOST_EXCEPTION_DISABLE
@@ -104,6 +106,7 @@ public:
         set_info( *this, throw_file( loc.file_name() ) );
         set_info( *this, throw_line( loc.line() ) );
         set_info( *this, throw_function( loc.function_name() ) );
+        set_info( *this, throw_column( loc.column() ) );
     }
 
     virtual boost::exception_detail::clone_base const * clone() const BOOST_OVERRIDE
@@ -113,7 +116,7 @@ public:
 
         boost::exception_detail::copy_boost_exception( p, this );
 
-        del.p_ = 0;
+        del.p_ = BOOST_NULLPTR;
         return p;
     }
 
@@ -177,5 +180,99 @@ template<class E> BOOST_NORETURN void throw_exception( E const & e, boost::sourc
 // BOOST_THROW_EXCEPTION
 
 #define BOOST_THROW_EXCEPTION(x) ::boost::throw_exception(x, BOOST_CURRENT_LOCATION)
+
+namespace boost
+{
+
+// throw_with_location
+
+namespace detail
+{
+
+struct BOOST_SYMBOL_VISIBLE throw_location
+{
+    boost::source_location location_;
+
+    explicit throw_location( boost::source_location const & loc ): location_( loc )
+    {
+    }
+};
+
+template<class E> class BOOST_SYMBOL_VISIBLE with_throw_location: public E, public throw_location
+{
+public:
+
+    with_throw_location( E const & e, boost::source_location const & loc ): E( e ), throw_location( loc )
+    {
+    }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+
+    with_throw_location( E && e, boost::source_location const & loc ): E( std::move( e ) ), throw_location( loc )
+    {
+    }
+
+#endif
+};
+
+} // namespace detail
+
+#if !defined(BOOST_NO_EXCEPTIONS)
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS)
+
+template<class E> BOOST_NORETURN void throw_with_location( E && e, boost::source_location const & loc = BOOST_CURRENT_LOCATION )
+{
+    throw_exception_assert_compatibility( e );
+    throw detail::with_throw_location<typename std::decay<E>::type>( std::forward<E>( e ), loc );
+}
+
+#else
+
+template<class E> BOOST_NORETURN void throw_with_location( E const & e, boost::source_location const & loc = BOOST_CURRENT_LOCATION )
+{
+    throw_exception_assert_compatibility( e );
+    throw detail::with_throw_location<E>( e, loc );
+}
+
+#endif
+
+#else
+
+template<class E> BOOST_NORETURN void throw_with_location( E const & e, boost::source_location const & loc = BOOST_CURRENT_LOCATION )
+{
+    boost::throw_exception( e, loc );
+}
+
+#endif
+
+// get_throw_location
+
+template<class E> boost::source_location get_throw_location( E const & e )
+{
+#if defined(BOOST_NO_RTTI)
+
+    (void)e;
+    return boost::source_location();
+
+#else
+
+    if( detail::throw_location const* pl = dynamic_cast< detail::throw_location const* >( &e ) )
+    {
+        return pl->location_;
+    }
+    else if( boost::exception const* px = dynamic_cast< boost::exception const* >( &e ) )
+    {
+        return exception_detail::get_exception_throw_location( *px );
+    }
+    else
+    {
+        return boost::source_location();
+    }
+
+#endif
+}
+
+} // namespace boost
 
 #endif // #ifndef BOOST_THROW_EXCEPTION_HPP_INCLUDED


### PR DESCRIPTION
- update with boost 1.80.0 from https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.7z containing a overflow check for regex