### PR TITLE
Allow "Go To" dialog to update when switching file tabs

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3873,6 +3873,9 @@ void Notepad_plus::updateStatusBar()
 	_statusBar.setText(strLnColSel, STATUSBAR_CUR_POS);
 
 	_statusBar.setText(_pEditView->execute(SCI_GETOVERTYPE) ? TEXT("OVR") : TEXT("INS"), STATUSBAR_TYPING_MODE);
+	
+	//updating "Go To" dialog
+	_goToLineDlg.updateLinesNumbers();
 }
 
 void Notepad_plus::dropFiles(HDROP hdrop)
@@ -6178,6 +6181,9 @@ void Notepad_plus::notifyBufferActivated(BufferID bufid, int view)
 	}
 
 	_linkTriggered = true;
+	
+	//updating "Go To" dialog
+	_goToLineDlg.updateLinesNumbers();
 }
 
 std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * commandLine, const CmdLineParamsDTO * pCmdParams)

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6181,9 +6181,6 @@ void Notepad_plus::notifyBufferActivated(BufferID bufid, int view)
 	}
 
 	_linkTriggered = true;
-	
-	//updating "Go To" dialog
-	_goToLineDlg.updateLinesNumbers();
 }
 
 std::vector<generic_string> Notepad_plus::loadCommandlineParams(const TCHAR * commandLine, const CmdLineParamsDTO * pCmdParams)

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3874,8 +3874,10 @@ void Notepad_plus::updateStatusBar()
 
 	_statusBar.setText(_pEditView->execute(SCI_GETOVERTYPE) ? TEXT("OVR") : TEXT("INS"), STATUSBAR_TYPING_MODE);
 	
-	//updating "Go To" dialog
-	_goToLineDlg.updateLinesNumbers();
+	if (_goToLineDlg.isCreated() && _goToLineDlg.isVisible())
+	{
+		_goToLineDlg.updateLinesNumbers();
+	}
 }
 
 void Notepad_plus::dropFiles(HDROP hdrop)

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.h
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.h
@@ -46,6 +46,8 @@ public :
         if (toShow)
             ::SetFocus(::GetDlgItem(_hSelf, ID_GOLINE_EDIT));
     };
+    
+    void updateLinesNumbers() const;
 
 protected :
 	enum mode {go2line, go2offsset};
@@ -54,8 +56,6 @@ protected :
 
 private :
     ScintillaEditView **_ppEditView = nullptr;
-
-    void updateLinesNumbers() const;
 
     void cleanLineEdit() const {
         ::SetDlgItemText(_hSelf, ID_GOLINE_EDIT, TEXT(""));


### PR DESCRIPTION
This allows the "Go To" dialog to update "You are here" and "You can't go further than" each time a different file tab is clicked or a different line of the current file tab is clicked. #12284 
FYI: This is my first pull request, feel free to give me some feedback!
