### PR TITLE
Installer - ARM64 CPU check for arm64-installer

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -172,7 +172,7 @@ updaterDone:
 
 	Call SetRoughEstimation		; This is rough estimation of files present in function copyCommonFiles
 	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
-	Call preventInstallInWin9x
+	Call preventInstall		; check unsupported OSes and CPUs
 		
 	; look for previously selected language
 	ClearErrors

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -172,7 +172,7 @@ updaterDone:
 
 	Call SetRoughEstimation		; This is rough estimation of files present in function copyCommonFiles
 	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
-	Call preventInstall		; check unsupported OSes and CPUs
+	Call checkCompatibility		; check unsupported OSes and CPUs
 		
 	; look for previously selected language
 	ClearErrors

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -172,7 +172,7 @@ updaterDone:
 
 	Call SetRoughEstimation		; This is rough estimation of files present in function copyCommonFiles
 	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
-	Call checkCompability		; check unsupported OSes and CPUs
+	Call preventInstall		; check unsupported OSes and CPUs
 		
 	; look for previously selected language
 	ClearErrors

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -172,7 +172,7 @@ updaterDone:
 
 	Call SetRoughEstimation		; This is rough estimation of files present in function copyCommonFiles
 	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
-	Call preventInstall		; check unsupported OSes and CPUs
+	Call checkCompability		; check unsupported OSes and CPUs
 		
 	; look for previously selected language
 	ClearErrors

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -107,7 +107,7 @@ Function ExtraOptions
 	nsDialogs::Show
 FunctionEnd
 
-Function preventInstall
+Function checkCompatibility
 
 	${GetWindowsVersion} $WinVer
 	

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -107,7 +107,7 @@ Function ExtraOptions
 	nsDialogs::Show
 FunctionEnd
 
-Function preventInstall
+Function checkCompability
 
 	${GetWindowsVersion} $WinVer
 	

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -107,28 +107,28 @@ Function ExtraOptions
 	nsDialogs::Show
 FunctionEnd
 
-Function preventInstallInWin9x
-	;Test if window9x
+Function preventInstall
+
 	${GetWindowsVersion} $WinVer
 	
 	StrCmp $WinVer "95" 0 +3
-		MessageBox MB_OK "Notepad++ does not support your OS. The installation will be aborted."
+		MessageBox MB_OK|MB_ICONSTOP "Notepad++ does not support your OS. The installation will be aborted."
 		Abort
 		
 	StrCmp $WinVer "98" 0 +3
-		MessageBox MB_OK "Notepad++ does not support your OS. The installation will be aborted."
+		MessageBox MB_OK|MB_ICONSTOP "Notepad++ does not support your OS. The installation will be aborted."
 		Abort
 		
 	StrCmp $WinVer "ME" 0 +3
-		MessageBox MB_OK "Notepad++ does not support your OS. The installation will be aborted."
+		MessageBox MB_OK|MB_ICONSTOP "Notepad++ does not support your OS. The installation will be aborted."
 		Abort
 		
 	StrCmp $WinVer "2000" 0 +3 ; Windows 2000
-		MessageBox MB_OK "Notepad++ does not support your OS. The installation will be aborted."
+		MessageBox MB_OK|MB_ICONSTOP "Notepad++ does not support your OS. The installation will be aborted."
 		Abort
 		
 	StrCmp $WinVer "XP" 0 xp_endTest ; XP
-		MessageBox MB_YESNO "This version of Notepad++ doesn't support Windows XP. The installation will be aborted.$\nDo you want to go to Notepad++ download page for downloading the last version which supports XP (v7.9.2)?" IDYES xp_openDlPage IDNO xp_goQuit
+		MessageBox MB_YESNO|MB_ICONSTOP "This version of Notepad++ doesn't support Windows XP. The installation will be aborted.$\n$\nDo you want to go to Notepad++ download page for downloading the last version which supports XP (v7.9.2)?" IDYES xp_openDlPage IDNO xp_goQuit
 xp_openDlPage:
 		ExecShell "open" "https://notepad-plus-plus.org/downloads/v7.9.2/"
 xp_goQuit:
@@ -136,12 +136,26 @@ xp_goQuit:
 xp_endTest:
 		
 	StrCmp $WinVer "2003" 0 ws2003_endTest ; Windows Server 2003
-		MessageBox MB_YESNO "This version of Notepad++ doesn't support Windows Server 2003. The installation will be aborted.$\nDo you want to go to Notepad++ download page for downloading the last version which supports this OS?" IDYES ws2003_openDlPage IDNO ws2003_goQuit
+		MessageBox MB_YESNO|MB_ICONSTOP "This version of Notepad++ doesn't support Windows Server 2003. The installation will be aborted.$\n$\nDo you want to go to Notepad++ download page for downloading the last version which supports this OS?" IDYES ws2003_openDlPage IDNO ws2003_goQuit
 ws2003_openDlPage:
 		ExecShell "open" "https://notepad-plus-plus.org/downloads/v7.9.2/"
 ws2003_goQuit:
 		Abort
 ws2003_endTest:
+
+!ifdef ARCHARM64
+	${If} ${IsNativeARM64}
+		; OK
+	${Else}
+		; we cannot run ARM64 binaries on a x86/x64 CPU (the other way around is possible - x86 on ARM64 CPU)
+		MessageBox MB_YESNO|MB_ICONSTOP "This installer contains ARM64 version of Notepad++ incompatible with your computer processor running, so the installation will be aborted.$\n$\nDo you want to go to the Notepad++ site to download a compatible (x86/x64) installer instead?" IDYES arm64_openDlPage IDNO arm64_goQuit
+arm64_openDlPage:
+		ExecShell "open" "https://notepad-plus-plus.org/downloads/"
+arm64_goQuit:
+		Abort
+	${EndIf}
+!endif
+
 FunctionEnd
 
 Var noUserDataChecked

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -107,7 +107,7 @@ Function ExtraOptions
 	nsDialogs::Show
 FunctionEnd
 
-Function checkCompability
+Function preventInstall
 
 	${GetWindowsVersion} $WinVer
 	


### PR DESCRIPTION
Fixes #12320 .

To detect ARM64 CPU running, as we cannot run ARM64 binaries on a x86/x64 CPU  (the other way around is possible - x86 on ARM64 CPU, like we use the N++ x86 NSIS installer there...).

A patched arm64-installer for testing and how it looks like in action in the issue.

Also improved a little bit the visual look of the other abort-messages (MB_ICONSTOP and newline separator).