### PR TITLE
Update Corsican translation for Notepad++ 8.4.7

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on October 20th, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
+		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
 		- Updated on September 21st, 2022 for version 8.4.6 by Patriccollu di Santa Maria è Sichè
 		- Updated on August 24th, 2022 for version 8.4.5 by Patriccollu di Santa Maria è Sichè
 		- Updated on June 27th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
@@ -1192,15 +1192,15 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                 </Delimiter>
 
                 <Performance title="Perfurmenze">
-                    <Item id="7141" name="Ristrizzione di i schedarii maiò"/>
-                    <Item id="7142" name="À l’apertura d’un schedariu maiò, certe funzioni sò disattivate per migliurà e perfurmenze. Pudete persunalizalle quì."/>
-                    <Item id="7143" name="Attivà a ristrizzione di i schedarii maiò (senza messa in evidenza di a sintassa)"/>
-                    <Item id="7144" name="Definisce a dimensione d’un schedariu maiò :"/>
+                    <Item id="7141" name="Ristrizzione di i schedarii tamanti"/>
+                    <Item id="7143" name="Attivà a ristrizzione di i schedarii tamanti (senza messa in evidenza di a sintassa)"/>
+                    <Item id="7144" name="Definisce a dimensione d’un schedariu tamantu :"/>
                     <Item id="7146" name="Mo   (1 - 4096)"/>
                     <Item id="7147" name="Permette d’attivà a currispundenza trà e parentesi"/>
                     <Item id="7148" name="Permette d’attivà di l’empiimentu autumaticu"/>
                     <Item id="7149" name="Permette d’attivà u sopralineamentu astutu"/>
                     <Item id="7150" name="Disattivà di manera glubale u ritornu autumaticu à a linea"/>
+                    <Item id="7151" name="Permette d’attivà u liame clicchevule"/>
                 </Performance>
 
                 <Cloud title="Nivulu è liame">
@@ -1641,9 +1641,10 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <contextMenu-styleOneToken value="Stilizà l’occurenza unica di testu" />
             <contextMenu-clearStyle value="Spurgulà certi stili" />
             <contextMenu-PluginCommands value="Cumande d’estensione" />
-            <enable-disable-largeFileRestriction-tip value="U cambiamentu di l’ozzione « Attivà a ristrizzione di i schedarii maiò » serà pigliatu in contu solu dopu a chjusura è a riapertura di u schedariu maiò" />
-            <change-largeFileRestriction_fileLength-tip value="A mudificazione di u valore di a dimensione di u schedariu serà pigliata in contu solu dopu a chjusura è a riapertura di u schedariu maiò" />
-            <largeFileRestriction_wordWrap-tip value="L’attivazione di l’ozzione « Disattivà di manera glubale u ritornu autumaticu à a linea » disattiverà u ritornu autumaticu à a linea per tutti i ducumenti aperti dopu l’apertura d’un schedariu maiò. Pudete attivà torna sta funzione manualmente." />
+            <largeFileRestriction-tip value="Certe funzioni ponu rallentà e perfurmenze durante l¹apertura di i schedarii tamanti. Quelle funzioni ponu esse disattivate autumaticamente à l’apertura d’un schedariu tamantu. Pudete persunalizalle quì.
+NOTA :
+1. Per funziunà bè, a mudificazione di quelle ozzioni richiede d’apre torna i schedarii tamanti chì sò dighjà aperti.
+2. S’è l’ozzione « Disattivà di manera glubale u ritornu autumaticu à a linea » hè attiva è chì un schedariu tamantu hè apertu, tandu u ritornu autumaticu à a linea serà disattivatu per tutti i schedarii. Pudete attivallu torna via l’ozzione di listinu Affissera > Ritornu autumaticu à a linea." />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on October 16th, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
+		- Updated on October 18th, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
 		- Updated on September 21st, 2022 for version 8.4.6 by Patriccollu di Santa Maria è Sichè
 		- Updated on August 24th, 2022 for version 8.4.5 by Patriccollu di Santa Maria è Sichè
 		- Updated on June 27th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
@@ -1641,6 +1641,8 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <contextMenu-styleOneToken value="Stilizà l’occurenza unica di testu" />
             <contextMenu-clearStyle value="Spurgulà certi stili" />
             <contextMenu-PluginCommands value="Cumande d’estensione" />
+            <enable-disable-largeFileRestriction-tip value="U cambiamentu di l’ozzione « Attivà a ristrizzione di i schedarii maiò » serà pigliatu in contu solu dopu a chjusura è a riapertura di u schedariu maiò" />
+            <change-largeFileRestriction_fileLength-tip value="A mudificazione di u valore di a dimensione di u schedariu serà pigliata in contu solu dopu a chjusura è a riapertura di u schedariu maiò" />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on October 18th, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
+		- Updated on October 20th, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
 		- Updated on September 21st, 2022 for version 8.4.6 by Patriccollu di Santa Maria è Sichè
 		- Updated on August 24th, 2022 for version 8.4.5 by Patriccollu di Santa Maria è Sichè
 		- Updated on June 27th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
@@ -1194,13 +1194,13 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                 <Performance title="Perfurmenze">
                     <Item id="7141" name="Ristrizzione di i schedarii maiò"/>
                     <Item id="7142" name="À l’apertura d’un schedariu maiò, certe funzioni sò disattivate per migliurà e perfurmenze. Pudete persunalizalle quì."/>
-                    <Item id="7143" name="Attivà a ristrizzione di i schedarii maiò"/>
+                    <Item id="7143" name="Attivà a ristrizzione di i schedarii maiò (senza messa in evidenza di a sintassa)"/>
                     <Item id="7144" name="Definisce a dimensione d’un schedariu maiò :"/>
                     <Item id="7146" name="Mo   (1 - 4096)"/>
                     <Item id="7147" name="Permette d’attivà a currispundenza trà e parentesi"/>
                     <Item id="7148" name="Permette d’attivà di l’empiimentu autumaticu"/>
                     <Item id="7149" name="Permette d’attivà u sopralineamentu astutu"/>
-                    <Item id="7150" name="Permette d’attivà u ritornu autumaticu à a linea"/>
+                    <Item id="7150" name="Disattivà di manera glubale u ritornu autumaticu à a linea"/>
                 </Performance>
 
                 <Cloud title="Nivulu è liame">
@@ -1643,6 +1643,7 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <contextMenu-PluginCommands value="Cumande d’estensione" />
             <enable-disable-largeFileRestriction-tip value="U cambiamentu di l’ozzione « Attivà a ristrizzione di i schedarii maiò » serà pigliatu in contu solu dopu a chjusura è a riapertura di u schedariu maiò" />
             <change-largeFileRestriction_fileLength-tip value="A mudificazione di u valore di a dimensione di u schedariu serà pigliata in contu solu dopu a chjusura è a riapertura di u schedariu maiò" />
+            <largeFileRestriction_wordWrap-tip value="L’attivazione di l’ozzione « Disattivà di manera glubale u ritornu autumaticu à a linea » disattiverà u ritornu autumaticu à a linea per tutti i ducumenti aperti dopu l’apertura d’un schedariu maiò. Pudete attivà torna sta funzione manualmente." />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,6 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
+		- Updated on October 16th, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
 		- Updated on September 21st, 2022 for version 8.4.6 by Patriccollu di Santa Maria è Sichè
 		- Updated on August 24th, 2022 for version 8.4.5 by Patriccollu di Santa Maria è Sichè
 		- Updated on June 27th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
@@ -38,7 +39,7 @@ The comments are here for explanation, it's not necessary to translate them.
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 -->
 <NotepadPlus>
-    <Native-Langue name="Corsu" filename="corsican.xml" version="8.4.6">
+    <Native-Langue name="Corsu" filename="corsican.xml" version="8.4.7">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -1189,6 +1190,18 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                     <Item id="6163" name="Aghjunghje u vostru caratteru cum’è una parte di parolla
 (solu s’è voi site sicuri di ciò chì voi fate)"/>
                 </Delimiter>
+
+                <Performance title="Perfurmenze">
+                    <Item id="7141" name="Ristrizzione di i schedarii maiò"/>
+                    <Item id="7142" name="À l’apertura d’un schedariu maiò, certe funzioni sò disattivate per migliurà e perfurmenze. Pudete persunalizalle quì."/>
+                    <Item id="7143" name="Attivà a ristrizzione di i schedarii maiò"/>
+                    <Item id="7144" name="Definisce a dimensione d’un schedariu maiò :"/>
+                    <Item id="7146" name="Mo   (1 - 4096)"/>
+                    <Item id="7147" name="Permette d’attivà a currispundenza trà e parentesi"/>
+                    <Item id="7148" name="Permette d’attivà di l’empiimentu autumaticu"/>
+                    <Item id="7149" name="Permette d’attivà u sopralineamentu astutu"/>
+                    <Item id="7150" name="Permette d’attivà u ritornu autumaticu à a linea"/>
+                </Performance>
 
                 <Cloud title="Nivulu è liame">
                     <Item id="6262" name="Preferenze di nivulu"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/8ff003412acc9b55413040b27110bf7ef887300b Make large file limit (for styling) configurable"Fold/unfold" on menu

Updated on October 18<sup>th</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/c02c23b7d431fe27ebad41619df4c2b4f1ea3a9a Add tooltips in performance section to make features more explicit

Updated on October 20<sup>th</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/6755daf223299ffcd49a8b6ca233c79627578f05 Enhance Large File Restriction UI

Updated on October 22<sup>nd</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/cd6a6ac3bb4d46a9ddd53e3bde2002db00ac00f5 Add "Allow clickable link" option in large file restriction

Cheers,
Patriccollu.