### PR TITLE
Add a new message NPPM_GETBUFFERIDFROMLEXER

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -548,6 +548,10 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// void* NPPM_GETBOOKMARKID(0, 0)
 	// Returns the bookmark ID
 
+	#define NPPM_GETBUFFERIDFROMLEXER (NPPMSG + 112)
+	// LRESULT NPPM_GETBUFFERIDFROMLEXER(void* pExternalLexer)
+	// wParam: Pointer to external lexer instance
+	// Returns Buffer ID if a buffer is lexed by given lexer instance, or 0 if invalid
 
 
 	// For RUNCOMMAND_USER

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -495,6 +495,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return reinterpret_cast<LRESULT>(BUFFER_INVALID);
 		}
 
+		case NPPM_GETBUFFERIDFROMLEXER:
+		{
+			return reinterpret_cast<LRESULT>(MainFileManager.getBufferByExternalLexer(reinterpret_cast<void*>(wParam)));
+		}
+
 		case NPPM_GETCURRENTBUFFERID:
 		{
 			return reinterpret_cast<LRESULT>(_pEditView->getCurrentBufferID());

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -70,6 +70,7 @@ public:
 	int getBufferIndexByID(BufferID id);
 	Buffer * getBufferByIndex(size_t index);
 	Buffer * getBufferByID(BufferID id) {return static_cast<Buffer*>(id);}
+	Buffer * getBufferByExternalLexer(void* pExternalLexer);
 
 	void beNotifiedOfBufferChange(Buffer * theBuf, int mask);
 
@@ -124,7 +125,7 @@ private:
 	FileManager& operator=(FileManager&&) = delete;
 
 	int detectCodepage(char* buf, size_t len);
-	bool loadFileData(Document doc, int64_t fileSize, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat);
+	std::pair<bool, void*> loadFileData(Document doc, int64_t fileSize, const TCHAR* filename, char* buffer, Utf8_16_Read* UnicodeConvertor, LoadedFileFormat& fileFormat);
 	LangType detectLanguageFromTextBegining(const unsigned char *data, size_t dataLen);
 
 	Notepad_plus* _pNotepadPlus = nullptr;
@@ -188,6 +189,9 @@ public:
 		_isUserReadOnly = ro;
 		doNotify(BufferChangeReadonly);
 	}
+
+	void* getExternalLexer() const { return _pExternalLexer; }
+	void setExternalLexer(void* pExternalLexer) { _pExternalLexer = pExternalLexer; }
 
 	EolType getEolFormat() const { return _eolFormat; }
 
@@ -345,6 +349,7 @@ private:
 	int _encoding = -1;
 	bool _isUserReadOnly = false;
 	bool _needLexer = false; // new buffers do not need lexing, Scintilla takes care of that
+	void* _pExternalLexer{nullptr}; // when this buffer is lexed by an external lexer
 	//these properties have to be duplicated because of multiple references
 
 	//All the vectors must have the same size at all times

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -900,6 +900,9 @@ void ScintillaEditView::setExternalLexer(LangType typeDoc)
 		return;
 	execute(SCI_SETILEXER, 0, reinterpret_cast<LPARAM>(iLex5));
 
+	Buffer* buf = MainFileManager.getBufferByID(_currentBufferID);
+	buf->setExternalLexer(iLex5);
+
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	const wchar_t* lexerNameW = wmc.char2wchar(externalLexer._name.c_str(), CP_ACP);
 	LexerStyler *pStyler = (NppParameters::getInstance().getLStylerArray()).getLexerStylerByName(lexerNameW);


### PR DESCRIPTION
Add a new message NPPM_GETBUFFERIDFROMLEXER for external lexer to query for buffer ID by providing lexer instance pointer. Enhanced Buffer to cache associated external lexer pointer, and FileManager to provide a lookup method to find the buffer in its list that is associated with the given lexer instance.

Without such a mechanism, it is impossible for lexer to know which instance should be used to handle messages received from Scintilla.

This closes #12351.