### PR TITLE
Fix session.xml emptying by forced Windows Update restart

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -39,7 +39,7 @@ Win32_IO_File::Win32_IO_File(const wchar_t *fname)
 		_hFile = ::CreateFileW(fname, _accessParam, _shareParam, NULL, _dispParam, _attribParam, NULL);
 
 		NppParameters& nppParam = NppParameters::getInstance();
-		if (nppParam.isQueryEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");
@@ -69,7 +69,7 @@ void Win32_IO_File::close()
 
 
 		NppParameters& nppParam = NppParameters::getInstance();
-		if (nppParam.isQueryEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");
@@ -132,7 +132,7 @@ bool Win32_IO_File::write(const void *wbuf, unsigned long buf_size)
 	NppParameters& nppParam = NppParameters::getInstance();
 	if (::WriteFile(_hFile, wbuf, buf_size, &bytes_written, NULL) == FALSE)
 	{
-		if (nppParam.isQueryEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");
@@ -151,7 +151,7 @@ bool Win32_IO_File::write(const void *wbuf, unsigned long buf_size)
 	}
 	else
 	{
-		if (nppParam.isQueryEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2051,6 +2051,9 @@ void Notepad_plus::filePrint(bool showDialog)
 
 int Notepad_plus::doSaveOrNot(const TCHAR* fn, bool isMulti)
 {
+	if ((NppParameters::getInstance()).isEndSessionCritical())
+		return IDCANCEL; // simulate Esc-key or Cancel-button as there should not be any big delay / code-flow block
+
 	// In case Notepad++ is iconized into notification zone
 	if (!::IsWindowVisible(_pPublicInterface->getHSelf()))
 	{

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -382,11 +382,8 @@ private:
 	bool _isFileOpening = false;
 	bool _isAdministrator = false;
 
-	bool _isEndingSessionButNotReady = false; // If Windows 10 update needs to restart 
-                                              // and Notepad++ has one (some) dirty document(s)
-                                              // and "Enable session snapshot and periodic backup" is not enabled
-                                              // then WM_ENDSESSION is send with wParam == FALSE
-                                              // in this case this boolean is set true, so Notepad++ will quit and its current session will be saved 
+	bool _isNppSessionSavedAtExit = false; // guard flag, it prevents emptying of the N++ session.xml in case of multiple WM_ENDSESSION or WM_CLOSE messages
+
 	ScintillaCtrls _scintillaCtrls4Plugins;
 
 	std::vector<std::pair<int, int> > _hideLinesMarks;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1879,7 +1879,7 @@ public:
 	bool doNppLogNulContentCorruptionIssue() { return _doNppLogNulContentCorruptionIssue; };
 	void endSessionStart() { _isEndSessionStarted = true; };
 	bool isEndSessionStarted() { return _isEndSessionStarted; };
-	void endSessionCritical() { _isEndSessionCritical = true; };
+	void makeEndSessionCritical() { _isEndSessionCritical = true; };
 	bool isEndSessionCritical() { return _isEndSessionCritical; };
 
 private:

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1862,7 +1862,8 @@ private:
 	bool _doNppLogNetworkDriveIssue = false;
 
 	bool _doNppLogNulContentCorruptionIssue = false;
-	bool _isQueryEndSessionStarted = false;
+	bool _isEndSessionStarted = false;
+	bool _isEndSessionCritical = false;
 
 public:
 	generic_string getWingupFullPath() const { return _wingupFullPath; };
@@ -1876,8 +1877,10 @@ public:
 
 	bool doNppLogNetworkDriveIssue() { return _doNppLogNetworkDriveIssue; };
 	bool doNppLogNulContentCorruptionIssue() { return _doNppLogNulContentCorruptionIssue; };
-	void queryEndSessionStart() { _isQueryEndSessionStarted = true; };
-	bool isQueryEndSessionStarted() { return _isQueryEndSessionStarted; };
+	void endSessionStart() { _isEndSessionStarted = true; };
+	bool isEndSessionStarted() { return _isEndSessionStarted; };
+	void endSessionCritical() { _isEndSessionCritical = true; };
+	bool isEndSessionCritical() { return _isEndSessionCritical; };
 
 private:
 	void getLangKeywordsFromXmlTree();

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -1365,6 +1365,9 @@ generic_string NativeLangSpeaker::getAttrNameStr(const TCHAR *defaultStr, const 
 
 int NativeLangSpeaker::messageBox(const char *msgBoxTagName, HWND hWnd, const TCHAR *defaultMessage, const TCHAR *defaultTitle, int msgBoxType, int intInfo, const TCHAR *strInfo)
 {
+	if ((NppParameters::getInstance()).isEndSessionCritical())
+		return IDCANCEL; // simulate Esc-key or Cancel-button as there should not be any big delay / code-flow block
+
 	generic_string msg, title;
 	if (!getMsgBoxLang(msgBoxTagName, title, msg))
 	{


### PR DESCRIPTION
Fixes: #9850  (main issue, I will link here all the others if this PR will be accepted)

This fixes both the long standing problem with the emptying of the session.xml file by forced Windows Update restart/shutdown and also some potential N++ crashes caused by possible main N++ wnd blocking at exit (I experienced these during my debugging sessions).

Two main changes to the previous N++ design:
- WM_QUERYENDSESSION is not used anymore for the N++ tidy-up ops and it always quickly returns TRUE/FALSE to the system as it should and postpone any cleanup activities until processing the WM_ENDSESSION with WPARAM TRUE ([Ref](https://learn.microsoft.com/en-us/windows/win32/shutdown/shutdown-changes-for-windows-vista#best-practices))
- there is now a safe-guard flag for the session.xml saving at N++ exit, which prevents otherwise possible incorrect overwriting in case of multiple "endsession" messages

Enhanced N++ log from a real forced WU-restart, resulting in the emptied session.xml, in the issue [here](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9850#issuecomment-1279734621).

Custom test-tool for the problem reproduction without the real forced WU-restart, together with a detailed description, in the issue [here](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9850#issuecomment-1287888101).

I intentionally left many (perhaps not so essential) comments in the new code, as it is otherwise difficult to explain here at one place all the details of implementation. These can be removed, of course.

At the end I confirmed functionality of this fix also with the help of another real forced WU in a Win11 WM. I tested also one at my Win10. It seems to me that the Win11 WU is more aggressive than the Win10 one (maybe, IDK, there is also interesting [report](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9850#issuecomment-1278928010)). But it will depend of course on many factors like Windows edition, user settings, etc.