### PR TITLE
Scintilla interface FULL for plugin proposal

### DIFF
--- a/scintilla/include/Sci_Position.h
+++ b/scintilla/include/Sci_Position.h
@@ -18,7 +18,9 @@ typedef ptrdiff_t Sci_Position;
 typedef size_t Sci_PositionU;
 
 // For Sci_CharacterRange  which is defined as long to be compatible with Win32 CHARRANGE
-typedef long Sci_PositionCR;
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//typedef long Sci_PositionCR;
 
 #ifdef _WIN32
 	#define SCI_METHOD __stdcall

--- a/scintilla/include/Scintilla.h
+++ b/scintilla/include/Scintilla.h
@@ -490,9 +490,13 @@ typedef sptr_t (*SciFnDirectStatus)(sptr_t ptr, unsigned int iMessage, uptr_t wP
 #define SCFIND_REGEXP 0x00200000
 #define SCFIND_POSIX 0x00400000
 #define SCFIND_CXX11REGEX 0x00800000
-#define SCI_FINDTEXT 2150
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//#define SCI_FINDTEXT 2150
 #define SCI_FINDTEXTFULL 2196
-#define SCI_FORMATRANGE 2151
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//#define SCI_FORMATRANGE 2151
 #define SCI_FORMATRANGEFULL 2777
 #define SC_CHANGE_HISTORY_DISABLED 0
 #define SC_CHANGE_HISTORY_ENABLED 1
@@ -511,7 +515,9 @@ typedef sptr_t (*SciFnDirectStatus)(sptr_t ptr, unsigned int iMessage, uptr_t wP
 #define SCI_GETMODIFY 2159
 #define SCI_SETSEL 2160
 #define SCI_GETSELTEXT 2161
-#define SCI_GETTEXTRANGE 2162
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//#define SCI_GETTEXTRANGE 2162
 #define SCI_GETTEXTRANGEFULL 2039
 #define SCI_HIDESELECTION 2163
 #define SCI_GETSELECTIONHIDDEN 2088
@@ -1294,31 +1300,37 @@ typedef sptr_t (*SciFnDirectStatus)(sptr_t ptr, unsigned int iMessage, uptr_t wP
  * CHARRANGE, TEXTRANGE, FINDTEXTEX, FORMATRANGE, and NMHDR structs.
  * So older code that treats Scintilla as a RichEdit will work. */
 
-struct Sci_CharacterRange {
-	Sci_PositionCR cpMin;
-	Sci_PositionCR cpMax;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_CharacterRange {
+//	Sci_PositionCR cpMin;
+//	Sci_PositionCR cpMax;
+//};
 
 struct Sci_CharacterRangeFull {
 	Sci_Position cpMin;
 	Sci_Position cpMax;
 };
 
-struct Sci_TextRange {
-	struct Sci_CharacterRange chrg;
-	char *lpstrText;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_TextRange {
+//	struct Sci_CharacterRange chrg;
+//	char *lpstrText;
+//};
 
 struct Sci_TextRangeFull {
 	struct Sci_CharacterRangeFull chrg;
 	char *lpstrText;
 };
 
-struct Sci_TextToFind {
-	struct Sci_CharacterRange chrg;
-	const char *lpstrText;
-	struct Sci_CharacterRange chrgText;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_TextToFind {
+//	struct Sci_CharacterRange chrg;
+//	const char *lpstrText;
+//	struct Sci_CharacterRange chrgText;
+//};
 
 struct Sci_TextToFindFull {
 	struct Sci_CharacterRangeFull chrg;
@@ -1338,13 +1350,15 @@ struct Sci_Rectangle {
 /* This structure is used in printing and requires some of the graphics types
  * from Platform.h.  Not needed by most client code. */
 
-struct Sci_RangeToFormat {
-	Sci_SurfaceID hdc;
-	Sci_SurfaceID hdcTarget;
-	struct Sci_Rectangle rc;
-	struct Sci_Rectangle rcPage;
-	struct Sci_CharacterRange chrg;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_RangeToFormat {
+//	Sci_SurfaceID hdc;
+//	Sci_SurfaceID hdcTarget;
+//	struct Sci_Rectangle rc;
+//	struct Sci_Rectangle rcPage;
+//	struct Sci_CharacterRange chrg;
+//};
 
 struct Sci_RangeToFormatFull {
 	Sci_SurfaceID hdc;

--- a/scintilla/src/Editor.cxx
+++ b/scintilla/src/Editor.cxx
@@ -4118,8 +4118,8 @@ Sci::Position Editor::FindText(
 			static_cast<FindOption>(wParam),
 			&lengthFound);
 		if (pos != -1) {
-			ft->chrgText.cpMin = static_cast<Sci_PositionCR>(pos);
-			ft->chrgText.cpMax = static_cast<Sci_PositionCR>(pos + lengthFound);
+			ft->chrgText.cpMin = static_cast<PositionCR>(pos);
+			ft->chrgText.cpMax = static_cast<PositionCR>(pos + lengthFound);
 		}
 		return pos;
 	} catch (RegexError &) {
@@ -4149,8 +4149,8 @@ Sci::Position Editor::FindTextFull(
 			static_cast<FindOption>(wParam),
 			&lengthFound);
 		if (pos != -1) {
-			ft->chrgText.cpMin = static_cast<Sci_PositionCR>(pos);
-			ft->chrgText.cpMax = static_cast<Sci_PositionCR>(pos + lengthFound);
+			ft->chrgText.cpMin = static_cast<Sci::Position>(pos);
+			ft->chrgText.cpMax = static_cast<Sci::Position>(pos + lengthFound);
 		}
 		return pos;
 	} catch (RegexError &) {


### PR DESCRIPTION
See discussion at #12327:

- disabled versions with usage of Sci_PositionCR restricted to 2GB files on windows
- fixed wrong cast for Editor::FindTextFull
- removed dependency to Sci_PositionCR from Editor::FindText
- didn't adapt ScintillaStructures.h yet to avoid disabling/patching of functions for SCI_GETTEXTRANGE, SCI_FINDTEXT, and SCI_FORMATRANGE already now
- seems a full equivalent for https://www.scintilla.org/ScintillaDoc.html#SCI_GETSTYLEDTEXT is still missing

Assumption:
- ScintillaStructures.h is yet not/not widely used by plugins 