### PR TITLE
Revert "Set PKGBUILD and APKBUILD syntax highlighting as shell script"

### DIFF
--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -17,7 +17,7 @@
 #
 # definitions
 #
-
+SHELL = bash.exe
 GCC_DIRECTORY := ../gcc
 GCC_EXCLUDE := $(GCC_DIRECTORY)/gcc-%
 SRC_DIRECTORY := ../src

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -222,7 +222,7 @@ void Buffer::setFileName(const TCHAR *fn)
 			determinatedLang = L_PYTHON;
 		else if ((OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("Rakefile")) == 0) || (OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("Vagrantfile")) == 0))
 			determinatedLang = L_RUBY;
-		else if ((OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("crontab")) == 0) || (OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("PKGBUILD")) == 0) || (OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("APKBUILD")) == 0))
+		else if ((OrdinalIgnoreCaseCompareStrings(_fileName, TEXT("crontab")) == 0))
 			determinatedLang = L_BASH;
 	}
 


### PR DESCRIPTION
This reverts commit f3f615d52252439b56dd62446a29e2ea5af456ca due to build fail in GCC.