### PR TITLE
Disable CI 32 build in GCC temporarily

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ environment:
     - compiler: MSC
       platform: arm64
 
-    - compiler: GCC
-      platform: i686
+#    - compiler: GCC
+#      platform: i686
 
     - compiler: GCC
       platform: x86_64


### PR DESCRIPTION
AppVeyor has updated Msys2 and that causes GCC 32 bits build faillure. The investigation of this issue is in progress, in the meantime GCC 32 bits build is disable temporarily.

ref: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12481