### PR TITLE
Change for Remove Empty Lines command how operate on selection and last empty line

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1487,7 +1487,8 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	nbTotal = _findReplaceDlg.processAll(ProcessReplaceAll, &env, isEntireDoc);
 
 	// remove the last line if it's an empty line.
-	auto lastLineDoc = _pEditView->execute(SCI_GETLINECOUNT) - 1;
+	auto lineCount = _pEditView->execute(SCI_GETLINECOUNT);
+	auto lastLineDoc = lineCount - 1;
 	auto str2Search = isBlankContained ? TEXT("[\\r\\n]+^[\\t ]*$|^[\\t ]+$") : TEXT("[\\r\\n]+^$");
 	auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, lastLineDoc - 1);
 	auto endPos = _pEditView->execute(SCI_GETLENGTH);
@@ -1496,13 +1497,18 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 		pair<size_t, size_t> lineRange = _pEditView->getSelectionLinesRange();
 		startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
 		endPos = _pEditView->execute(SCI_GETSELECTIONEND);
-		if (lineRange.second != static_cast<size_t>(lastLineDoc)){
+		if (lineRange.second != static_cast<size_t>(lastLineDoc))
+		{
 			if (nbTotal == 0)
 			{
 				_pEditView->execute(SCI_SETANCHOR, mainSelAnchor);
 				_pEditView->execute(SCI_SETCURRENTPOS, mainSelCaretPos);
 			}
 			return;
+		}
+		else if (lineCount > 1 && (endPos - startPos > 0))
+		{
+			startPos = _pEditView->execute(SCI_GETLINEENDPOSITION, lineRange.first - 1);
 		}
 	}
 	_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1477,14 +1477,19 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	_findReplaceDlg.processAll(ProcessReplaceAll, &env, isEntireDoc);
 
 	// remove the last line if it's an empty line.
-	auto lastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1;
+	auto lastLineDoc = _pEditView->execute(SCI_GETLINECOUNT) - 1;
 	auto str2Search = isBlankContained ? TEXT("[\\r\\n]+^[\\t ]*$|^[\\t ]+$") : TEXT("[\\r\\n]+^$");
-	auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, lastLine - 1);
-	auto endPos = _pEditView->execute(SCI_POSITIONFROMLINE, lastLine) + _pEditView->execute(SCI_LINELENGTH, lastLine);
+	auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, lastLineDoc - 1);
+	auto endPos = _pEditView->execute(SCI_GETLENGTH);
 	if (!isEntireDoc)
 	{
 		startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
-		endPos  = _pEditView->execute(SCI_GETSELECTIONEND);
+		endPos = _pEditView->execute(SCI_GETSELECTIONEND);
+		auto endLine = _pEditView->execute(SCI_LINEFROMPOSITION, endPos);
+		if (endPos != (_pEditView->execute(SCI_POSITIONFROMLINE, endLine) + _pEditView->execute(SCI_LINELENGTH, endLine)))
+		{
+			return;
+		}
 	}
 	_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
 	auto posFound = _pEditView->searchInTarget(str2Search, lstrlen(str2Search), startPos, endPos);


### PR DESCRIPTION
For https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12545.

I looked at all operations from `Edit>Line Operations` how they work with and without selection (`Sort`, `Reverse`, `Randomize` and `Remove empty`). And all except (`Remove empty`):
1. Without selection they include the last empty line.
2. With selection they omit the last empty line.
3. For partially selected lines they automatically extend the selection to the entire lines. For sorting it's obvious. But for other cases it also makes sense because we operate on the lines and we do not have to worry about the full (correct) line selecting.

\* `Join lines` command fit only to points 2 and 3 (not work without selection, maybe should).

Taking the above into account, I also made `Remove empty` consistent with this behavior (https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12535/commits/4b5369e8483521c7363c614ed4aa6611505c785c). 

It needs to be clearly stated that these listed sort commands are basically a variant of one command, so other commands should not necessarily behave the same.

This PR is for testing purposes to produce different behavior variants for this `Remove Empty Lines` command.

