### PR TITLE
More performance optimization for the Remove Empty Lines command

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1461,11 +1461,11 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	FindOption env;
 	if (isBlankContained)
 	{
-		env._str2Search = TEXT("^([\\t ]*$(\\r?\\n|\\r))(\\1)*");
+		env._str2Search = TEXT("^(?>[\\t ]*[\\r\\n]+)+");
 	}
 	else
 	{
-		env._str2Search = TEXT("^$(\\r?\\n|\\r)(\\1)*");
+		env._str2Search = TEXT("^[\\r\\n]+");
 	}
 	env._str4Replace = TEXT("");
 	env._searchType = FindRegex;
@@ -1477,15 +1477,22 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	_findReplaceDlg.processAll(ProcessReplaceAll, &env, isEntireDoc);
 
 	// remove the last line if it's an empty line.
-	if (isBlankContained)
+	auto lastLineDoc = _pEditView->execute(SCI_GETLINECOUNT) - 1;
+	auto str2Search = isBlankContained ? TEXT("[\\r\\n]+^[\\t ]*$|^[\\t ]+$") : TEXT("[\\r\\n]+^$");
+	auto startPos = _pEditView->execute(SCI_POSITIONFROMLINE, lastLineDoc - 1);
+	auto endPos = _pEditView->execute(SCI_GETLENGTH);
+	if (!isEntireDoc)
 	{
-		env._str2Search = TEXT("(\\r?\\n|\\r)^[\\t ]*$");
+		startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
+		endPos = _pEditView->execute(SCI_GETSELECTIONEND);
+		auto endLine = _pEditView->execute(SCI_LINEFROMPOSITION, endPos);
+		if (endPos != (_pEditView->execute(SCI_POSITIONFROMLINE, endLine) + _pEditView->execute(SCI_LINELENGTH, endLine)))
+			return;
 	}
-	else
-	{
-		env._str2Search = TEXT("(\\r?\\n|\\r)^$");
-	}
-	_findReplaceDlg.processAll(ProcessReplaceAll, &env, isEntireDoc);
+	_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
+	auto posFound = _pEditView->searchInTarget(str2Search, lstrlen(str2Search), startPos, endPos);
+	if (posFound >= 0)
+		_pEditView->replaceTarget(TEXT(""), posFound, endPos);
 }
 
 void Notepad_plus::removeDuplicateLines()


### PR DESCRIPTION
I found regular expressions even more efficient than the [last ones ](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12512)(and simpler).
```
^[\r\n]+

^(?>[\t ]*[\r\n]+)+
```
This can be checked with https://regex101.com/ (PCRE) and file for test  [regex.txt](https://github.com/notepad-plus-plus/notepad-plus-plus/files/10025169/regex.txt).

I also play with this `// remove the last line if it's an empty line.` with some big file. There is no point to checking the entire file when we want to remove the last blank line. We need only check the last two (or one) lines, which can be done directly with Scintilla commands. From now on, this last empty line removal will not slow as the multi-line document grows.

This PR also cover two more cases:
- also works with one empty line [#12512 (comment)](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12512#issuecomment-1317940411)
- add some condition for selection to avoid some unexpected situations ([like this](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12535#issuecomment-1319497990))

This is just a performance improvement. In particular, it doesn't change the behavior of how to treat the last EOL with or without selection. It works as it has been until now. I suggest discussing changing this behavior elsewhere (https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12545, https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12535).
