### PR TITLE
Change for Remove Empty Lines command how operate on selection and last empty line

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1506,7 +1506,7 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	auto recSelAnchorVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE);
 	auto recSelCaretVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE);
 	bool isRecSel = _pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE || _pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN;
-	bool isEntireDoc = mainSelAnchor == mainSelCaretPos && !isRecSel;
+	bool isEntireDoc = mainSelAnchor == mainSelCaretPos && recSelAnchorVirt == recSelCaretVirt;
 	auto docLength = _pEditView->execute(SCI_GETLENGTH);
 	bool checkLastLine = true;
 	bool isRecSelLastLine = false;
@@ -1542,7 +1542,7 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 		{
 			checkLastLine = false;
 		}
-		else if ((lineCount > 1 && (endPos - startPos > 0)) || isRecSelLastLine)
+		else if ((lineCount > 1 && startPos != endPos) || isRecSelLastLine)
 		{
 			startPos = _pEditView->execute(SCI_GETLINEENDPOSITION, lineRange.first - 1);
 		}

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1503,6 +1503,8 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	env._searchType = FindRegex;
 	auto mainSelAnchor = _pEditView->execute(SCI_GETANCHOR);
 	auto mainSelCaretPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	auto recSelAnchorVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE);
+	auto recSelCaretVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE);
 	bool isSelRec = _pEditView->execute(SCI_GETSELECTIONS) > 1 && _pEditView->execute(SCI_GETSELECTIONMODE) == 1;
 	bool isEntireDoc = mainSelAnchor == mainSelCaretPos;
 	int nbTotal = 0;
@@ -1534,7 +1536,9 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 				if (isSelRec)
 				{
 					_pEditView->execute(SCI_SETRECTANGULARSELECTIONANCHOR, mainSelAnchor);
+					_pEditView->execute(SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE, recSelAnchorVirt);
 					_pEditView->execute(SCI_SETRECTANGULARSELECTIONCARET, mainSelCaretPos);
+					_pEditView->execute(SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE, recSelCaretVirt);
 				}
 				else
 				{
@@ -1560,7 +1564,9 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 		if (isSelRec)
 		{
 			_pEditView->execute(SCI_SETRECTANGULARSELECTIONANCHOR, mainSelAnchor);
+			_pEditView->execute(SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE, recSelAnchorVirt);
 			_pEditView->execute(SCI_SETRECTANGULARSELECTIONCARET, mainSelCaretPos);
+			_pEditView->execute(SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE, recSelCaretVirt);
 		}
 		else
 		{

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1503,25 +1503,25 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	env._searchType = FindRegex;
 	auto mainSelAnchor = _pEditView->execute(SCI_GETANCHOR);
 	auto mainSelCaretPos = _pEditView->execute(SCI_GETCURRENTPOS);
-	auto recSelAnchorVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE);
-	auto recSelCaretVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE);
-	bool isRecSel = _pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE || _pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN;
-	bool isEntireDoc = mainSelAnchor == mainSelCaretPos && recSelAnchorVirt == recSelCaretVirt;
+	auto rectSelAnchorVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE);
+	auto rectSelCaretVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE);
+	bool isRectSel = (_pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE) || (_pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN);
+	bool isEntireDoc = (mainSelAnchor == mainSelCaretPos) && (rectSelAnchorVirt == rectSelCaretVirt);
 	auto docLength = _pEditView->execute(SCI_GETLENGTH);
 	bool checkLastLine = true;
-	bool isRecSelLastLine = false;
+	bool isRectSelLastLine = false;
 	if (!isEntireDoc)
 	{
 		env._isInSelection = !isEntireDoc;
 		pair<size_t, size_t> lineRange = _pEditView->getSelectionLinesRange();
 		auto newSelStart = _pEditView->execute(SCI_POSITIONFROMLINE, lineRange.first);
 		auto newSelEnd = _pEditView->execute(SCI_POSITIONFROMLINE, lineRange.second) + _pEditView->execute(SCI_LINELENGTH, lineRange.second);
-		if (isRecSel)
+		if (isRectSel)
 		{
 			auto newLineEnd = _pEditView->execute(SCI_LINEFROMPOSITION, _pEditView->execute(SCI_GETSELECTIONEND));
 			newSelEnd = _pEditView->execute(SCI_POSITIONFROMLINE, newLineEnd) + _pEditView->execute(SCI_LINELENGTH, newLineEnd);
 			if (newLineEnd == _pEditView->execute(SCI_GETLINECOUNT) - 1)
-				isRecSelLastLine = true;
+				isRectSelLastLine = true;
 		}
 		_pEditView->execute(SCI_SETSEL, newSelStart, newSelEnd);
 	}
@@ -1538,15 +1538,16 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 		pair<size_t, size_t> lineRange = _pEditView->getSelectionLinesRange();
 		startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
 		endPos = _pEditView->execute(SCI_GETSELECTIONEND);
-		if ((!isRecSel && lineRange.second != static_cast<size_t>(lastLineDoc)) || (isRecSel && !isRecSelLastLine))
+		if ((!isRectSel && (lineRange.second != static_cast<size_t>(lastLineDoc))) || (isRectSel && !isRectSelLastLine))
 		{
 			checkLastLine = false;
 		}
-		else if ((lineCount > 1 && startPos != endPos) || isRecSelLastLine)
+		else if ((lineCount > 1 && startPos != endPos) || isRectSelLastLine)
 		{
 			startPos = _pEditView->execute(SCI_GETLINEENDPOSITION, lineRange.first - 1);
 		}
 	}
+
 	if (checkLastLine)
 	{
 		_pEditView->execute(SCI_SETSEARCHFLAGS, SCFIND_REGEXP|SCFIND_POSIX);
@@ -1556,14 +1557,15 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 			_pEditView->replaceTarget(TEXT(""), posFound, endPos);
 		}
 	}
-	if (!isEntireDoc && docLength == _pEditView->execute(SCI_GETLENGTH))
+
+	if (!isEntireDoc && (docLength == _pEditView->execute(SCI_GETLENGTH)))
 	{
-		if (isRecSel)
+		if (isRectSel)
 		{
 			_pEditView->execute(SCI_SETRECTANGULARSELECTIONANCHOR, mainSelAnchor);
-			_pEditView->execute(SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE, recSelAnchorVirt);
+			_pEditView->execute(SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE, rectSelAnchorVirt);
 			_pEditView->execute(SCI_SETRECTANGULARSELECTIONCARET, mainSelCaretPos);
-			_pEditView->execute(SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE, recSelCaretVirt);
+			_pEditView->execute(SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE, rectSelCaretVirt);
 		}
 		else
 		{

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1505,8 +1505,8 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	auto mainSelCaretPos = _pEditView->execute(SCI_GETCURRENTPOS);
 	auto recSelAnchorVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE);
 	auto recSelCaretVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE);
-	bool isRecSel = _pEditView->execute(SCI_GETSELECTIONS) > 1 && _pEditView->execute(SCI_GETSELECTIONMODE) == 1;
-	bool isEntireDoc = mainSelAnchor == mainSelCaretPos;
+	bool isRecSel = _pEditView->execute(SCI_GETSELECTIONMODE) == 1;
+	bool isEntireDoc = mainSelAnchor == mainSelCaretPos && !isRecSel;
 	bool delRecSel = false;
 	int nbTotal = 0;
 	if (!isEntireDoc)
@@ -1555,7 +1555,7 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 			}
 			return;
 		}
-		else if (lineCount > 1 && (endPos - startPos > 0))
+		else if ((lineCount > 1 && (endPos - startPos > 0)) || delRecSel)
 		{
 			startPos = _pEditView->execute(SCI_GETLINEENDPOSITION, lineRange.first - 1);
 		}

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1505,7 +1505,7 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 	auto mainSelCaretPos = _pEditView->execute(SCI_GETCURRENTPOS);
 	auto recSelAnchorVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE);
 	auto recSelCaretVirt = _pEditView->execute(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE);
-	bool isRecSel = _pEditView->execute(SCI_GETSELECTIONMODE) == 1;
+	bool isRecSel = _pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE || _pEditView->execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN;
 	bool isEntireDoc = mainSelAnchor == mainSelCaretPos && !isRecSel;
 	bool delRecSel = false;
 	int nbTotal = 0;
@@ -1515,7 +1515,8 @@ void Notepad_plus::removeEmptyLine(bool isBlankContained)
 		pair<size_t, size_t> lineRange = _pEditView->getSelectionLinesRange();
 		auto newSelStart = _pEditView->execute(SCI_POSITIONFROMLINE, lineRange.first);
 		auto newSelEnd = _pEditView->execute(SCI_POSITIONFROMLINE, lineRange.second) + _pEditView->execute(SCI_LINELENGTH, lineRange.second);
-		if (isRecSel){
+		if (isRecSel)
+		{
 			auto newLineEnd = _pEditView->execute(SCI_LINEFROMPOSITION, _pEditView->execute(SCI_GETSELECTIONEND));
 			newSelEnd = _pEditView->execute(SCI_POSITIONFROMLINE, newLineEnd) + _pEditView->execute(SCI_LINELENGTH, newLineEnd);
 			if (newLineEnd == _pEditView->execute(SCI_GETLINECOUNT) - 1)


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12545.

I looked at all operations from `Edit>Line Operations` how they work with and without selection (`Sort`, `Reverse`, `Randomize` and `Remove empty`). And all except (`Remove empty`):
1. Without selection they include the last empty line.
2. With selection they omit the last empty line.
3. For partially selected lines they automatically extend the selection to the entire lines. For sorting it's obvious. But for other cases it also makes sense because we operate on the lines and we do not have to worry about the full (correct) line selecting.

\* `Join lines` command fit only to points 2 and 3 (not work without selection, maybe should).

Taking the above into account, I also made `Remove empty` consistent with this behavior.

It needs to be clearly stated that these listed sort commands are basically a variant of one command, so other commands should not necessarily behave the same.

This PR is for testing purposes to produce different behavior variants for this `Remove Empty Lines` command.

Continuation of https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12535.