### PR TITLE
Fix inconsistencies at OS-forced Notepad++ (v8.4.7) exit - 2nd part

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2171,8 +2171,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			{
 				if (MainFileManager.getNbDirtyBuffers() > 0)
 				{
-					// we have unsaved filebuffer(s), give the user a chance to respond (non-critical shutdown only)
-					if (!isForcedShuttingDown && isFirstQueryEndSession)
+					// we have unsaved filebuffer(s), give the user a chance to respond
+					// (but only for a non-critical OS restart/shutdown and while the N++ backup mode is OFF)
+					if (!isForcedShuttingDown && isFirstQueryEndSession && !nppParam.getNppGUI().isSnapshotMode())
 					{
 						// if N++ has been minimized or invisible, we need to show it 1st
 						if (::IsIconic(hwnd))


### PR DESCRIPTION
Fixes 2nd part of the  #12541 (when N++ backup mode is ON).

This fixes users reported inconsistency, in between the usual N++ exit initiated manually by a user and the Windows OS forced one, in case that the N++ backup mode is ON.