### PR TITLE
Implement support for raw Win32-filenames in Notepad++

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -232,6 +232,11 @@ generic_string getDateTimeStrFrom(const generic_string& dateTimeFormat, const SY
 
 HFONT createFont(const TCHAR* fontName, int fontSize, bool isBold, HWND hDestParent);
 
+bool isRawWin32FileName(const generic_string& fileName);
+bool isRawWin32FileName(const TCHAR* szFileName);
+bool isUnsupportedFileName(const generic_string& fileName);
+bool isUnsupportedFileName(const TCHAR* szFileName);
+
 class Version final
 {
 public:

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -717,17 +717,25 @@ BufferID FileManager::loadFile(const TCHAR* filename, Document doc, int encoding
 		ownDoc = true;
 	}
 
-	TCHAR fullpath[MAX_PATH];
-	::GetFullPathName(filename, MAX_PATH, fullpath, NULL);
-	if (_tcschr(fullpath, '~'))
+	TCHAR fullpath[MAX_PATH] = { 0 };
+	if (isRawWin32FileName(filename))
 	{
-		::GetLongPathName(fullpath, fullpath, MAX_PATH);
+		// use directly the raw file name, skip the GetFullPathName WINAPI
+		_tcsncpy_s(fullpath, _countof(fullpath), filename, _TRUNCATE);
+	}
+	else
+	{
+		::GetFullPathName(filename, MAX_PATH, fullpath, NULL);
+		if (_tcschr(fullpath, '~'))
+		{
+			::GetLongPathName(fullpath, fullpath, MAX_PATH);
+		}
 	}
 
 	bool isSnapshotMode = backupFileName != NULL && PathFileExists(backupFileName);
 	if (isSnapshotMode && !PathFileExists(fullpath)) // if backup mode and fullpath doesn't exist, we guess is UNTITLED
 	{
-		wcscpy_s(fullpath, MAX_PATH, filename); // we restore fullpath with filename, in our case is "new  #"
+		_tcscpy_s(fullpath, MAX_PATH, filename); // we restore fullpath with filename, in our case is "new  #"
 	}
 
 	Utf8_16_Read UnicodeConvertor;	//declare here so we can get information after loading is done
@@ -1116,11 +1124,19 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 	bool isHiddenOrSys = false;
 	DWORD attrib = 0;
 
-	TCHAR fullpath[MAX_PATH];
-	::GetFullPathName(filename, MAX_PATH, fullpath, NULL);
-	if (_tcschr(fullpath, '~'))
+	TCHAR fullpath[MAX_PATH] = { 0 };
+	if (isRawWin32FileName(filename))
 	{
-		::GetLongPathName(fullpath, fullpath, MAX_PATH);
+		// use directly the raw file name, skip the GetFullPathName WINAPI
+		_tcsncpy_s(fullpath, _countof(fullpath), filename, _TRUNCATE);
+	}
+	else
+	{
+		::GetFullPathName(filename, MAX_PATH, fullpath, NULL);
+		if (_tcschr(fullpath, '~'))
+		{
+			::GetLongPathName(fullpath, fullpath, MAX_PATH);
+		}
 	}
 
 	if (PathFileExists(fullpath))


### PR DESCRIPTION
Support the Win32-filenames escaped by \\\\?\\ or \\\\?\UNC\\ ([Ref.](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces)), possible globbing in filenames (\\\\?\\C:\\fil?.txt) and shell links (\\\\?\\C:\\file.txt.lnk) included.

Unsupported (temporarily - it needs further patches for N++):
- any raw filename with length exceeding the MAX_PATH
- any nonstandard Windows OS filename: with 'dot' or 'space' char(s) at the name end, WinOS reserved ones: AUX, CON, PRN, NUL, COM1-9, LPT1-9 and the ones with invalid ASCII chars in it (0-31, <, >, | , ")

Fixes #12453 .