### PR TITLE
Update sql.xml (2)

### DIFF
--- a/PowerEditor/installer/functionList/sql.xml
+++ b/PowerEditor/installer/functionList/sql.xml
@@ -11,12 +11,12 @@
 		<!-- ========================================================= [ PL/SQL ] -->
 		<parser id="plsql_function" displayName="PL/SQL" commentExpr="((/\*.*?\*)/|(//.*?$))">
 				<function
-				mainExpr="((PROCEDURE)|(FUNCTION))[\s]+[A-Za-z][\w_]*([\s]*\([^\)]*\)[\s]*)?(([\s]*;)|([\s]*([ia]s))|([\s]+(RETURN)([\s]+[\w%\.]+)+(([\s]*;)|([\s]+([ia]s)))))"
+				mainExpr="^[ \t]*((PROCEDURE)|(FUNCTION))[\s]+[A-Za-z][\w_]*([\s]*(?'open'\().*?(\)))?(([\s]*;)|([\s]*([ia]s)\s)|([\s]+(RETURN)([\s]+[\w%\.]+)+(([\s]*;)|([\s]+([ia]s)\s))))"
 				displayMode="$className->$functionName"
 			>
-				<functionName>
-					<nameExpr expr="[\s]+[A-Za-z][\w_]*([\s]*\([^\)]*\))?(([\s]*;)|([\s]*([ia]s))|([\s]+(RETURN)([\s]+[\w%\.]+)+(([\s]*;)|([\s]+([ia]s)))))"/>
-					<nameExpr expr="[A-Za-z][\w_]*([\s]*\([^\)]*\))?(([\s]*;)|([\s]*([ia]s))|([\s]+(RETURN)([\s]+[\w%\.]+)+(([\s]*;)|([\s]+([ia]s)))))"/>
+        <functionName>
+					<nameExpr expr="[\s]+[A-Za-z][\w_]*([\s]*(?'open'\().*?(\)))?(([\s]*;)|([\s]*([ia]s)\s)|([\s]+(RETURN)([\s]+[\w%\.]+)+(([\s]*;)|([\s]+([ia]s)\s))))"/>
+					<nameExpr expr="[A-Za-z][\w_]*([\s]*(?'open'\().*?(\)))?(([\s]*;)|([\s]*([ia]s)\s)|([\s]+(RETURN)([\s]+[\w%\.]+)+(([\s]*;)|([\s]+([ia]s)\s))))"/>
 					<nameExpr expr="[A-Za-z][\w_]*([\s]*\([^\)]*\))?(([\s]+(RETURN)([\s]+[\w%\.]+)+))*"/>
 				</functionName>
 			</function>


### PR DESCRIPTION
### Description of the Issue
SQL functionList does not catch all procedure and function signatures

### Steps to Reproduce the Issue
Open an sql file and check that functionList contains all the signatures

### Solution
I change the sql.xml attached here and this one seems to work better than the one provided with Notepad++. Evaluate yourself if you want to use my version.

I provide the test_re.sql ([test_re.txt](https://github.com/notepad-plus-plus/notepad-plus-plus/files/10181753/test_re.txt) to be renamed) that I used for verification and the screenshot showing different result for default sql.xml and my customized version

FunctionList with my customized version, more function are catched by new RE
![sql_custom](https://user-images.githubusercontent.com/4454252/206346186-76adaa27-b606-4360-83e1-1c945069521b.png)

FunctionList with default sql.xml provided with the installer
![sql_default](https://user-images.githubusercontent.com/4454252/206346437-72580294-cd8d-4c7a-bc9c-a71d3ff21b23.png)
