### PR TITLE
Fix Go to settings for URL hovered style

### DIFF
--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -971,7 +971,7 @@ std::pair<intptr_t, intptr_t> WordStyleDlg::goToPreferencesSettings()
 	}
 	else if (style._styleDesc == TEXT("URL hovered"))
 	{
-		result.first = 16;
+		result.first = 17;
 		result.second = IDC_CHECK_CLICKABLELINK_ENABLE;
 	}
 	else if (style._styleDesc == TEXT("EOL custom color"))


### PR DESCRIPTION
After adding the Performance tab, the link below goes to the wrong place:
![image](https://user-images.githubusercontent.com/2730894/207198230-9605b830-75fc-464a-a835-b1aef294ef23.png)
