### PR TITLE
[xml][force xml] Switch to Python311-x64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ image: Visual Studio 2022
 #    - PowerEditor/installer/*/*.xml
 
 environment:
+  python_ver: Python311-x64
   matrix:
     - compiler: MSC
       platform: Win32
@@ -50,7 +51,7 @@ before_build:
                     Write-Output "XML validation mode`n"
                     if ("$env:platform/$env:configuration" -eq "Win32/Debug") {
                         if (@($files_modified | Where-Object {$_ -match $folders_onejob}).length -eq 0) {
-                            $env:Path = "C:\Python311-x64;C:\Python311-x64\Scripts;" + $env:Path
+                            $env:Path = "C:\$env:python_ver;C:\$env:python_ver\Scripts;" + $env:Path
                             python -m pip install requests rfc3987 pywin32 lxml
                             python PowerEditor\Test\xmlValidator\validator_xml.py
                             if ($LastExitCode -eq 0) {
@@ -106,7 +107,7 @@ for:
         $nppFileName = "Notepad++.$env:platform.$env:configuration.exe"
         Push-AppveyorArtifact "PowerEditor\visual.net\Debug\Notepad++.exe" -FileName "$nppFileName"
     # xml files syntax checks
-    - set PATH=C:\Python311-x64;C:\Python311-x64\Scripts;%PATH%
+    - set PATH=C:\%python_ver%;C:\%python_ver%\Scripts;%PATH%
     - python -m pip install requests rfc3987 pywin32 lxml
     - python PowerEditor\Test\xmlValidator\validator_xml.py
     # tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,8 @@ before_build:
                     Write-Output "XML validation mode`n"
                     if ("$env:platform/$env:configuration" -eq "Win32/Debug") {
                         if (@($files_modified | Where-Object {$_ -match $folders_onejob}).length -eq 0) {
-                            $env:Path = "C:\Python310;C:\Python310\Scripts;" + $env:Path
-                            python -m pip install requests rfc3987 pywin32 lxml
+                            $env:Path = "C:\Python311-x64;C:\Python311-x64\Scripts;" + $env:Path
+                            python -m pip install requests rfc3987 pywin32 https://download.lfd.uci.edu/pythonlibs/archived/lxml-4.9.0-cp311-cp311-win_amd64.whl
                             python PowerEditor\Test\xmlValidator\validator_xml.py
                             if ($LastExitCode -eq 0) {
                                 Write-Output "`nAll XML files are valid.`n"
@@ -106,8 +106,8 @@ for:
         $nppFileName = "Notepad++.$env:platform.$env:configuration.exe"
         Push-AppveyorArtifact "PowerEditor\visual.net\Debug\Notepad++.exe" -FileName "$nppFileName"
     # xml files syntax checks
-    - set PATH=C:\Python310;C:\Python310\Scripts;%PATH%
-    - python -m pip install requests rfc3987 pywin32 lxml
+    - set PATH=C:\Python311-x64;C:\Python311-x64\Scripts;%PATH%
+    - python -m pip install requests rfc3987 pywin32 https://download.lfd.uci.edu/pythonlibs/archived/lxml-4.9.0-cp311-cp311-win_amd64.whl
     - python PowerEditor\Test\xmlValidator\validator_xml.py
     # tests
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,8 @@ before_build:
                     Write-Output "XML validation mode`n"
                     if ("$env:platform/$env:configuration" -eq "Win32/Debug") {
                         if (@($files_modified | Where-Object {$_ -match $folders_onejob}).length -eq 0) {
-                            $env:Path = "C:\Python311-x64;C:\Python311-x64\Scripts;" + $env:Path
-                            python -m pip install requests rfc3987 pywin32 https://download.lfd.uci.edu/pythonlibs/archived/lxml-4.9.0-cp311-cp311-win_amd64.whl
+                            $env:Path = "C:\Python311;C:\Python311\Scripts;" + $env:Path
+                            python -m pip install requests rfc3987 pywin32 lxml==4.9.1
                             python PowerEditor\Test\xmlValidator\validator_xml.py
                             if ($LastExitCode -eq 0) {
                                 Write-Output "`nAll XML files are valid.`n"
@@ -106,8 +106,8 @@ for:
         $nppFileName = "Notepad++.$env:platform.$env:configuration.exe"
         Push-AppveyorArtifact "PowerEditor\visual.net\Debug\Notepad++.exe" -FileName "$nppFileName"
     # xml files syntax checks
-    - set PATH=C:\Python311-x64;C:\Python311-x64\Scripts;%PATH%
-    - python -m pip install requests rfc3987 pywin32 https://download.lfd.uci.edu/pythonlibs/archived/lxml-4.9.0-cp311-cp311-win_amd64.whl
+    - set PATH=C:\Python311;C:\Python311\Scripts;%PATH%
+    - python -m pip install requests rfc3987 pywin32 lxml==4.9.1
     - python PowerEditor\Test\xmlValidator\validator_xml.py
     # tests
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ image: Visual Studio 2022
 #    - PowerEditor/installer/*/*.xml
 
 environment:
-  python_ver: Python311-x64
+  python_dir: C:\Python311-x64
   matrix:
     - compiler: MSC
       platform: Win32
@@ -51,7 +51,7 @@ before_build:
                     Write-Output "XML validation mode`n"
                     if ("$env:platform/$env:configuration" -eq "Win32/Debug") {
                         if (@($files_modified | Where-Object {$_ -match $folders_onejob}).length -eq 0) {
-                            $env:Path = "C:\$env:python_ver;C:\$env:python_ver\Scripts;" + $env:Path
+                            $env:Path = "$env:python_dir;$env:python_dir\Scripts;" + $env:Path
                             python -m pip install requests rfc3987 pywin32 lxml
                             python PowerEditor\Test\xmlValidator\validator_xml.py
                             if ($LastExitCode -eq 0) {
@@ -107,7 +107,7 @@ for:
         $nppFileName = "Notepad++.$env:platform.$env:configuration.exe"
         Push-AppveyorArtifact "PowerEditor\visual.net\Debug\Notepad++.exe" -FileName "$nppFileName"
     # xml files syntax checks
-    - set PATH=C:\%python_ver%;C:\%python_ver%\Scripts;%PATH%
+    - set PATH=%python_dir%;%python_dir%\Scripts;%PATH%
     - python -m pip install requests rfc3987 pywin32 lxml
     - python PowerEditor\Test\xmlValidator\validator_xml.py
     # tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ before_build:
                     Write-Output "XML validation mode`n"
                     if ("$env:platform/$env:configuration" -eq "Win32/Debug") {
                         if (@($files_modified | Where-Object {$_ -match $folders_onejob}).length -eq 0) {
-                            $env:Path = "C:\Python311;C:\Python311\Scripts;" + $env:Path
+                            $env:Path = "C:\Python310;C:\Python310\Scripts;" + $env:Path
                             python -m pip install requests rfc3987 pywin32 lxml==4.9.1
                             python PowerEditor\Test\xmlValidator\validator_xml.py
                             if ($LastExitCode -eq 0) {
@@ -106,7 +106,7 @@ for:
         $nppFileName = "Notepad++.$env:platform.$env:configuration.exe"
         Push-AppveyorArtifact "PowerEditor\visual.net\Debug\Notepad++.exe" -FileName "$nppFileName"
     # xml files syntax checks
-    - set PATH=C:\Python311;C:\Python311\Scripts;%PATH%
+    - set PATH=C:\Python310;C:\Python310\Scripts;%PATH%
     - python -m pip install requests rfc3987 pywin32 lxml==4.9.1
     - python PowerEditor\Test\xmlValidator\validator_xml.py
     # tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,8 @@ before_build:
                     Write-Output "XML validation mode`n"
                     if ("$env:platform/$env:configuration" -eq "Win32/Debug") {
                         if (@($files_modified | Where-Object {$_ -match $folders_onejob}).length -eq 0) {
-                            $env:Path = "C:\Python310;C:\Python310\Scripts;" + $env:Path
-                            python -m pip install requests rfc3987 pywin32 lxml==4.9.1
+                            $env:Path = "C:\Python311-x64;C:\Python311-x64\Scripts;" + $env:Path
+                            python -m pip install requests rfc3987 pywin32 lxml
                             python PowerEditor\Test\xmlValidator\validator_xml.py
                             if ($LastExitCode -eq 0) {
                                 Write-Output "`nAll XML files are valid.`n"
@@ -106,8 +106,8 @@ for:
         $nppFileName = "Notepad++.$env:platform.$env:configuration.exe"
         Push-AppveyorArtifact "PowerEditor\visual.net\Debug\Notepad++.exe" -FileName "$nppFileName"
     # xml files syntax checks
-    - set PATH=C:\Python310;C:\Python310\Scripts;%PATH%
-    - python -m pip install requests rfc3987 pywin32 lxml==4.9.1
+    - set PATH=C:\Python311-x64;C:\Python311-x64\Scripts;%PATH%
+    - python -m pip install requests rfc3987 pywin32 lxml
     - python PowerEditor\Test\xmlValidator\validator_xml.py
     # tests
     - ps: |


### PR DESCRIPTION
Looks like Python was update and we have a problem with `lxml` package:
https://ci.appveyor.com/project/donho/notepad-plus-plus/builds/45673917
Or maybe `lxml` was update? We are using a specific version `Python310`. 

I use `--use-pep517` but still build faild:
https://ci.appveyor.com/project/donho/notepad-plus-plus/builds/45674624

On this PR I use prebuild `lxml` provided on the website project (anyway it's marked as unofficial):
https://lxml.de/installation.html
https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml

Something like this works, but...

@alankilborn @pryrt 
Any tips how to do a proper build via pip? What's missing here?

