### PR TITLE
Fixes in PHP autocompletion

### DIFF
--- a/PowerEditor/installer/APIs/php.xml
+++ b/PowerEditor/installer/APIs/php.xml
@@ -9698,7 +9698,7 @@
 		<KeyWord name="pcntl_signal" func="yes">
 			<Overload retVal="bool">
 				<Param name="int signo"/>
-				<Param name="callback handle"/>
+				<Param name="callback handler"/>
 				<Param name="[bool restart_syscalls]"/>
 			</Overload>
 		</KeyWord>

--- a/PowerEditor/installer/APIs/php.xml
+++ b/PowerEditor/installer/APIs/php.xml
@@ -2804,18 +2804,18 @@
 		<KeyWord name="file_get_contents" func="yes">
 			<Overload retVal="string|false">
 				<Param name="string filename"/>
-				<Param name="[int flags=0"/>
-				<Param name="[resource context"/>
-				<Param name="[int offset=-1"/>
-				<Param name="[int maxlen=-1]]]]"/>
+				<Param name="[bool use_include_path=false"/>
+				<Param name="[resource context=NULL"/>
+				<Param name="[int offset=0"/>
+				<Param name="[int length]]]]"/>
 			</Overload>
 		</KeyWord>
 		<KeyWord name="file_put_contents" func="yes">
 			<Overload retVal="int|false">
-				<Param name="string file"/>
+				<Param name="string filename"/>
 				<Param name="mixed data"/>
 				<Param name="[int flags=0"/>
-				<Param name="[resource context]]"/>
+				<Param name="[resource context=NULL]]"/>
 			</Overload>
 		</KeyWord>
 		<KeyWord name="file_register_wrapper" func="yes">
@@ -12221,10 +12221,10 @@
 			</Overload>
 		</KeyWord>
 		<KeyWord name="stream_get_contents" func="yes">
-			<Overload retVal="string">
-				<Param name="resource handle"/>
-				<Param name="[int maxlength=-1"/>
-				<Param name="[int offset=0]]"/>
+			<Overload retVal="string|false">
+				<Param name="resource stream"/>
+				<Param name="[int length=-1"/>
+				<Param name="[int offset=-1]]"/>
 			</Overload>
 		</KeyWord>
 		<KeyWord name="stream_get_filters" func="yes">


### PR DESCRIPTION
* [`file_get_contents()`](https://www.php.net/manual/en/function.file-get-contents.php):
    * `use_include_path` argument expects a boolean, and this is enforced when strict typing is enabled. See [note on the parameter](https://www.php.net/manual/en/function.file-get-contents.php#refsect1-function.file-get-contents-parameters).
    * `context` argument can be skipped using `null`.
    * `offset` argument default value is `0`. Using `-1` would count from the end of the stream (since PHP 7.1).
    * `length` argument produces a [warning](https://www.php.net/manual/en/function.file-get-contents.php#refsect1-function.file-get-contents-errors) if it is negative. It is nullable but only starting from PHP 8.
* [`file_put_contents()`](https://www.php.net/manual/en/function.file-put-contents.php):
    * `context` argument can be discarded using `null`.
* [`stream_get_contents()`](https://www.php.net/manual/en/function.stream-get-contents.php):
    * returns `false` on failure.
    * [documentation example](https://www.php.net/manual/en/function.stream-get-contents.php#example-3856) confirms the `length` argument can be skipped using `-1`. It is nullable but only starting from PHP 8.
    * `offset` argument default value is `-1`. Documentation states that no seeking occurs with a negative value.