### PR TITLE
Add Go to settings for Change History margin style

### DIFF
--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -943,6 +943,11 @@ std::pair<intptr_t, intptr_t> WordStyleDlg::goToPreferencesSettings()
 		result.first = 3;
 		result.second = IDC_CHECK_BOOKMARKMARGE;
 	}
+	else if (style._styleDesc == TEXT("Change History margin"))
+	{
+		result.first = 3;
+		result.second = IDC_CHECK_CHANGHISTORYMARGE;
+	}
 	else if (style._styleDesc == TEXT("Fold") || style._styleDesc == TEXT("Fold active") || style._styleDesc == TEXT("Fold margin"))
 	{
 		result.first = 3;


### PR DESCRIPTION
This one is missing:

![image](https://user-images.githubusercontent.com/2730894/207918808-f2a3b6bc-db56-41df-8bf6-e864b20e2e56.png)