### PR TITLE
Fix issue with custom theme when changing dark/light mode

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7932,8 +7932,18 @@ void Notepad_plus::refreshDarkMode(bool resetStyle)
 		generic_string xmlFileName = NppDarkMode::getThemeName();
 		if (!xmlFileName.empty())
 		{
-			themePath = themeSwitcher.getThemeDirPath();
-			pathAppend(themePath, xmlFileName);
+			if (!nppParams.isLocal() || nppParams.isCloud())
+			{
+				themePath = nppParams.getUserPath();
+				pathAppend(themePath, TEXT("themes\\"));
+				pathAppend(themePath, xmlFileName);
+			}
+
+			if (::PathFileExists(themePath.c_str()) == FALSE || themePath.empty())
+			{
+				themePath = themeSwitcher.getThemeDirPath();
+				pathAppend(themePath, xmlFileName);
+			}
 
 			themeName = themeSwitcher.getThemeFromXmlFileName(themePath.c_str());
 		}
@@ -7946,7 +7956,7 @@ void Notepad_plus::refreshDarkMode(bool resetStyle)
 			themeName = themeSwitcher.getDefaultThemeLabel();
 		}
 
-		if (::PathFileExists(themePath.c_str()))
+		if (::PathFileExists(themePath.c_str()) == TRUE)
 		{
 			nppParams.getNppGUI()._themeName = themePath;
 

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -100,8 +100,8 @@ namespace NppDarkMode
 	{
 		bool _enableWindowsMode = false;
 
-		NppDarkMode::AdvOptDefaults _darkDefaults{};
-		NppDarkMode::AdvOptDefaults _lightDefaults{};
+		NppDarkMode::AdvOptDefaults _darkDefaults{ L"DarkModeDefault.xml", 0, 2, false };
+		NppDarkMode::AdvOptDefaults _lightDefaults{ L"", 4, 0, true };
 	};
 
 	void initDarkMode();				// pulls options from NppParameters

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1180,7 +1180,8 @@ bool NppParameters::load()
 	//
 	// the 2nd priority: cloud Choice Path
 	//
-	if (::PathFileExists(cloudChoicePath.c_str()))
+	_isCloud = (::PathFileExists(cloudChoicePath.c_str()) == TRUE);
+	if (_isCloud)
 	{
 		// Read cloud choice
 		std::string cloudChoiceStr = getFileContent(cloudChoicePath.c_str());
@@ -1192,6 +1193,10 @@ bool NppParameters::load()
 			_userPath = cloudChoiceStrW;
 			_nppGUI._cloudPath = cloudChoiceStrW;
 			_initialCloudChoice = _nppGUI._cloudPath;
+		}
+		else
+		{
+			_isCloud = false;
 		}
 	}
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1704,6 +1704,10 @@ public:
 		return _isLocal;
 	}
 
+	bool isCloud() const {
+		return _isCloud;
+	}
+
 	void saveConfig_xml();
 
 	generic_string getUserPath() const {
@@ -1831,6 +1835,7 @@ private:
 	WNDPROC _enableThemeDialogTextureFuncAddr = nullptr;
 	bool _isLocal = false;
 	bool _isx64 = false; // by default 32-bit
+	bool _isCloud = false;
 
 	generic_string _cmdSettingsDir;
 	generic_string _titleBarAdditional;


### PR DESCRIPTION
fix issue from https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12466

@donho 
When changing dark/light mode, only default themes (in "themes" folder in folder with notepad++.exe) will be used.

This PR will fix it.

Allows cloud setting to redirect themes folder, currently it uses `%AppData%\Notepad++\Themes\` or `Themes\` with `doLocalConf.xml` file.

Also use relative path for themes with `doLocalConf.xml` file.

should fix or improve issues below and maybe more issues with portable config and themes
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/6092
partially fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9409
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10801
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12296
partially fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12583
