### PR TITLE
Add two missing xml files to makefile

### DIFF
--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -26,8 +26,8 @@ BIN_DIRECTORY := ../bin
 INSTALLER_DIRECTORY := ../installer
 
 TARGET_BINARY := notepad++.exe
-SRC_DATA := contextMenu.xml langs.model.xml shortcuts.xml stylers.model.xml
-BIN_DATA := change.log doLocalConf.xml readme.txt userDefineLangs/
+SRC_DATA := contextMenu.xml langs.model.xml shortcuts.xml stylers.model.xml tabContextMenu_example.xml
+BIN_DATA := change.log doLocalConf.xml nppLogNulContentCorruptionIssue.xml readme.txt userDefineLangs/
 INSTALLER_DATA := autoCompletion/ functionList/ localization/ themes/
 
 SCINTILLA_DIRECTORY := ../../scintilla


### PR DESCRIPTION
Two xml files `tabContextMenu_example.xml` and `nppLogNulContentCorruptionIssue.xml` are added to the official package but are missing in the `makefile`.

@donho 
[`toolbarIcons.xml`](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/src/toolbarIcons.xml) cannot be added to the official pack? Its default content will not affect the program, but it shows that Notepad++ offers the ability to change icons.

Edit: hmm `tabContextMenu_example.xml` is added only to `minimalist` ([packageAll.bat](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/packageAll.bat)), why not also to full?