### PR TITLE
Update pascal.xml to fix issue with Pascal units

### DIFF
--- a/PowerEditor/installer/functionList/pascal.xml
+++ b/PowerEditor/installer/functionList/pascal.xml
@@ -16,6 +16,7 @@
 			commentExpr="(?x)                                                                      # Utilize inline comments (see `RegEx - Pattern Modifiers`)
 						   (?s:\x7B.*?\x7D)                                                        # Multi Line Comment 1st variant
 						 | (?s:\x28\x2A.*?\x2A\x29)                                                # Multi Line Comment 2nd variant
+						 | (?is:Interface.*?Implementation)                                        # Multi Line Comment 3nd variant Ignore function definition for Units
 						 | (?m-s:\x2F{2}.*$)                                                       # Single Line Comment
 						 "
 		>


### PR DESCRIPTION
Pascal Units require a definition of each function and procedure as a header of the unit.  This causes the function list to have duplicates of each function and procedure in the definition.  To solve this duplication and make the list only take you to the actual functions, I've added another comment definition that uses the keywords Interface which must always be before the function definitions and implementation which always must be after the definitions and before the actual functions.  so everything between Interface and Implementation is ignored the way it should be.  If someone wants the duplicates for some strange reason, they can always comment that line out.