### PR TITLE
Make XML and XHTML tag matching case-sensitive

### DIFF
--- a/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -22,6 +22,7 @@
 
 #include "xmlMatchedTagsHighlighter.h"
 #include "ScintillaEditView.h"
+#include <shlwapi.h>
 
 using namespace std;
 
@@ -563,11 +564,16 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findCloseTag(co
 XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findText(const char *text, intptr_t start, intptr_t end, int flags)
 {
 	FindResult returnValue;
-	
+
 	Sci_TextToFindFull search{};
 	search.lpstrText = const_cast<char *>(text); // Grrrrrr
 	search.chrg.cpMin = static_cast<Sci_Position>(start);
 	search.chrg.cpMax = static_cast<Sci_Position>(end);
+
+	LangType lang = (_pEditView->getCurrentBuffer())->getLangType();
+	if (lang == L_XML || (lang == L_HTML && generic_stricmp(PathFindExtension((_pEditView->getCurrentBuffer())->getFileName()), TEXT(".xhtml")) == 0))
+		flags = flags | SCFIND_MATCHCASE;
+
 	intptr_t result = _pEditView->execute(SCI_FINDTEXTFULL, flags, reinterpret_cast<LPARAM>(&search));
 	if (-1 == result)
 	{


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10011. This fix works for:
- XML lang (detect from extension or manually select)
- HTML lang (detect from extension or manually select) when file has `.xhtml` extension. In this case we are dealing with XHTML language, and it must/should also comply with the XML syntax (like case-sensitive).

I'm not sure whether to do the second case. We don't really have a separate XHTML language (it's covered by HTML). But fact is that the real XHTML (treated as XML, not as HTML) is case sensitive.