### PR TITLE
Fix autocomplete to sort case insensitive

### DIFF
--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -376,7 +376,13 @@ bool AutoCompletion::showApiAndWordComplete()
 
 	// Sort word array and convert it to a single string with space-separated words
 
-	sort(wordArray.begin(), wordArray.end());
+	if (_ignoreCase)
+		sort(wordArray.begin(), wordArray.end(), [](const generic_string &a, const generic_string &b)
+		{
+			return (generic_stricmp(a.c_str(), b.c_str()) < 0);
+		});
+	else
+		sort(wordArray.begin(), wordArray.end());
 
 	generic_string words;
 

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -667,7 +667,13 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 
 	// Sort word array and convert it to a single string with space-separated words
 
-	sort(wordArray.begin(), wordArray.end());
+	if (_ignoreCase)
+		sort(wordArray.begin(), wordArray.end(), [](const generic_string &a, const generic_string &b)
+		{
+			return (generic_stricmp(a.c_str(), b.c_str()) < 0);
+		});
+	else
+		sort(wordArray.begin(), wordArray.end());
 
 	generic_string words(TEXT(""));
 

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -268,6 +268,25 @@ static bool isAllDigits(const generic_string &str)
 	return true;
 }
 
+void sortInsensitive(vector<generic_string> &wordArray)
+{
+	sort(
+		wordArray.begin(),
+		wordArray.end(),
+		[](const generic_string &a, const generic_string &b)
+		{
+			return lexicographical_compare(
+				a.begin(), a.end(),
+				b.begin(), b.end(),
+				[](const char &ch1, const char &ch2)
+				{
+					return toupper(ch1) < toupper(ch2);
+				}
+			);
+		}
+	);
+}
+
 
 bool AutoCompletion::showApiComplete()
 {
@@ -378,10 +397,7 @@ bool AutoCompletion::showApiAndWordComplete()
 	// Sort word array and convert it to a single string with space-separated words
 
 	if (_ignoreCase)
-		sort(wordArray.begin(), wordArray.end(), [](const generic_string &a, const generic_string &b)
-		{
-			return (generic_stricmp(a.c_str(), b.c_str()) < 0);
-		});
+		sortInsensitive(wordArray);
 	else
 		sort(wordArray.begin(), wordArray.end());
 
@@ -668,10 +684,7 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 	// Sort word array and convert it to a single string with space-separated words
 
 	if (_ignoreCase)
-		sort(wordArray.begin(), wordArray.end(), [](const generic_string &a, const generic_string &b)
-		{
-			return (generic_stricmp(a.c_str(), b.c_str()) < 0);
-		});
+		sortInsensitive(wordArray);
 	else
 		sort(wordArray.begin(), wordArray.end());
 
@@ -1210,10 +1223,7 @@ bool AutoCompletion::setLanguage(LangType language)
 		}
 
 		if (_ignoreCase)
-			sort(_keyWordArray.begin(), _keyWordArray.end(), [](const generic_string &a, const generic_string &b)
-			{
-				return (generic_stricmp(a.c_str(), b.c_str()) < 0);
-			});
+			sortInsensitive(_keyWordArray);
 		else
 			sort(_keyWordArray.begin(), _keyWordArray.end());
 

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -312,8 +312,14 @@ bool AutoCompletion::showApiComplete()
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
 	_pEditView->execute(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, _ignoreCase);
+
+	if (_ignoreCase)
+		_pEditView->execute(SCI_AUTOCSETORDER, SC_ORDER_PERFORMSORT);
+
 	_pEditView->showAutoComletion(curPos - startPos, _keyWords.c_str());
 
+	if (_ignoreCase)
+		_pEditView->execute(SCI_AUTOCSETORDER, SC_ORDER_PRESORTED);
 	return true;
 }
 

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -312,14 +312,8 @@ bool AutoCompletion::showApiComplete()
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
 	_pEditView->execute(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, _ignoreCase);
-
-	if (_ignoreCase)
-		_pEditView->execute(SCI_AUTOCSETORDER, SC_ORDER_PERFORMSORT);
-
 	_pEditView->showAutoComletion(curPos - startPos, _keyWords.c_str());
 
-	if (_ignoreCase)
-		_pEditView->execute(SCI_AUTOCSETORDER, SC_ORDER_PRESORTED);
 	return true;
 }
 
@@ -1209,7 +1203,13 @@ bool AutoCompletion::setLanguage(LangType language)
 			}
 		}
 
-		sort(_keyWordArray.begin(), _keyWordArray.end());
+		if (_ignoreCase)
+			sort(_keyWordArray.begin(), _keyWordArray.end(), [](const generic_string &a, const generic_string &b)
+			{
+				return (generic_stricmp(a.c_str(), b.c_str()) < 0);
+			});
+		else
+			sort(_keyWordArray.begin(), _keyWordArray.end());
 
 		for (size_t i = 0, len = _keyWordArray.size(); i < len; ++i)
 		{

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -311,6 +311,7 @@ bool AutoCompletion::showApiComplete()
 	_pEditView->execute(SCI_AUTOCSETTYPESEPARATOR, WPARAM('\x1E'));
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
+	_pEditView->execute(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, _ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, _keyWords.c_str());
 
 	return true;
@@ -421,6 +422,7 @@ bool AutoCompletion::showApiAndWordComplete()
 	_pEditView->execute(SCI_AUTOCSETTYPESEPARATOR, WPARAM('\x1E'));
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
+	_pEditView->execute(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, _ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, words.c_str());
 	return true;
 }
@@ -616,6 +618,7 @@ void AutoCompletion::showPathCompletion()
 	// Show autocompletion box.
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM('\n'));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, true);
+	_pEditView->execute(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, true);
 	_pEditView->showAutoComletion(rawPath.length(), autoCompleteEntries.c_str());
 	return;
 }
@@ -679,6 +682,7 @@ bool AutoCompletion::showWordComplete(bool autoInsert)
 
 	_pEditView->execute(SCI_AUTOCSETSEPARATOR, WPARAM(' '));
 	_pEditView->execute(SCI_AUTOCSETIGNORECASE, _ignoreCase);
+	_pEditView->execute(SCI_AUTOCSETCASEINSENSITIVEBEHAVIOUR, _ignoreCase);
 	_pEditView->showAutoComletion(curPos - startPos, words.c_str());
 	return true;
 }

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -278,7 +278,7 @@ void sortInsensitive(vector<generic_string> &wordArray)
 			return lexicographical_compare(
 				a.begin(), a.end(),
 				b.begin(), b.end(),
-				[](const char &ch1, const char &ch2)
+				[](const wchar_t &ch1, const wchar_t &ch2)
 				{
 					return toupper(ch1) < toupper(ch2);
 				}


### PR DESCRIPTION
Fix #12495

Currently, case sensitive sort is done on the list items for autocomplete. This fix sorts the list items as case sensitive or case insensitive based on the value of `_ignoreCase`. This will improve the autocomplete list to operate better for case insensitive selections.