### PR TITLE
Add toolbarIcons.xml to the build process

### DIFF
--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -26,7 +26,7 @@ BIN_DIRECTORY := ../bin
 INSTALLER_DIRECTORY := ../installer
 
 TARGET_BINARY := notepad++.exe
-SRC_DATA := contextMenu.xml langs.model.xml shortcuts.xml stylers.model.xml tabContextMenu_example.xml
+SRC_DATA := contextMenu.xml langs.model.xml shortcuts.xml stylers.model.xml tabContextMenu_example.xml toolbarIcons.xml
 BIN_DATA := change.log doLocalConf.xml nppLogNulContentCorruptionIssue.xml readme.txt userDefineLangs/
 INSTALLER_DATA := autoCompletion/ functionList/ localization/ themes/
 

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -75,13 +75,13 @@ Function copyCommonFiles
 	SetOutPath "$UPDATE_PATH\"
 	File "..\bin\contextMenu.xml"
 	File "..\src\tabContextMenu_example.xml"
-	
+	File "..\src\toolbarIcons.xml"
+
 	SetOverwrite on
 	SetOutPath "$INSTDIR\"
 	File "..\bin\langs.model.xml"
 	File "..\bin\stylers.model.xml"
 	File "..\bin\contextMenu.xml"
-	File "..\bin\toolbarIcons.xml"
 
 	SetOverwrite off
 	File "..\bin\shortcuts.xml"

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -81,6 +81,7 @@ Function copyCommonFiles
 	File "..\bin\langs.model.xml"
 	File "..\bin\stylers.model.xml"
 	File "..\bin\contextMenu.xml"
+	File "..\bin\toolbarIcons.xml"
 
 	SetOverwrite off
 	File "..\bin\shortcuts.xml"

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -230,6 +230,7 @@ Section Uninstall
 		Delete "$INSTDIR\nativeLang.xml"
 		Delete "$INSTDIR\userDefineLang.xml"
 		Delete "$INSTDIR\nppLogNulContentCorruptionIssue.xml"
+		Delete "$INSTDIR\toolbarIcons.xml"
 	${endIf}
 	
 	Delete "$INSTDIR\config.model.xml"
@@ -269,6 +270,7 @@ Section Uninstall
 		Delete "$APPDATA\${APPNAME}\userDefineLang.xml"
 		Delete "$APPDATA\${APPNAME}\insertExt.ini"
 		Delete "$APPDATA\${APPNAME}\nppLogNulContentCorruptionIssue.log"
+		Delete "$APPDATA\${APPNAME}\toolbarIcons.xml"
 		Delete "$APPDATA\${APPNAME}\userDefineLangs\userDefinedLang-markdown.default.modern.xml"
 		Delete "$APPDATA\${APPNAME}\userDefineLangs\markdown._preinstalled.udl.xml"
 		Delete "$APPDATA\${APPNAME}\userDefineLangs\markdown._preinstalled_DM.udl.xml"

--- a/PowerEditor/installer/packageAll.bat
+++ b/PowerEditor/installer/packageAll.bat
@@ -113,6 +113,8 @@ copy /Y ..\bin\"notepad++.exe" .\minimalist\
 If ErrorLevel 1 goto End
 copy /Y ".\themes\DarkModeDefault.xml" .\minimalist\themes\
 If ErrorLevel 1 goto End
+copy /Y ..\src\toolbarIcons.xml .\minimalist\
+If ErrorLevel 1 goto End
 
 
 rmdir /S /Q .\minimalist64
@@ -146,6 +148,8 @@ copy /Y ..\bin64\"notepad++.exe" .\minimalist64\
 If ErrorLevel 1 goto End
 copy /Y ".\themes\DarkModeDefault.xml" .\minimalist64\themes\
 If ErrorLevel 1 goto End
+copy /Y ..\src\toolbarIcons.xml .\minimalist64\
+If ErrorLevel 1 goto End
 
 
 rmdir /S /Q .\minimalistArm64
@@ -178,6 +182,8 @@ If ErrorLevel 1 goto End
 copy /Y ..\binarm64\"notepad++.exe" .\minimalistArm64\
 If ErrorLevel 1 goto End
 copy /Y ".\themes\DarkModeDefault.xml" .\minimalistArm64\themes\
+If ErrorLevel 1 goto End
+copy /Y ..\src\toolbarIcons.xml .\minimalistArm64\
 If ErrorLevel 1 goto End
 
 
@@ -261,6 +267,9 @@ copy /Y ..\bin\nppLogNulContentCorruptionIssue.xml .\zipped.package.release\
 If ErrorLevel 1 goto End
 copy /Y ..\bin\"notepad++.exe" .\zipped.package.release\
 If ErrorLevel 1 goto End
+copy /Y ..\src\toolbarIcons.xml .\zipped.package.release\
+If ErrorLevel 1 goto End
+
 
 
 rem Basic Copy needed files into Notepad++ 64-bit package folders
@@ -286,6 +295,8 @@ copy /Y ..\bin\nppLogNulContentCorruptionIssue.xml .\zipped.package.release64\
 If ErrorLevel 1 goto End
 copy /Y ..\bin64\"notepad++.exe" .\zipped.package.release64\
 If ErrorLevel 1 goto End
+copy /Y ..\src\toolbarIcons.xml .\zipped.package.release64\
+If ErrorLevel 1 goto End
 
 
 rem Basic Copy needed files into Notepad++ ARM64 package folders
@@ -310,6 +321,8 @@ If ErrorLevel 1 goto End
 copy /Y ..\bin\nppLogNulContentCorruptionIssue.xml .\zipped.package.releaseArm64\
 If ErrorLevel 1 goto End
 copy /Y ..\binarm64\"notepad++.exe" .\zipped.package.releaseArm64\
+If ErrorLevel 1 goto End
+copy /Y ..\src\toolbarIcons.xml .\zipped.package.releaseArm64\
 If ErrorLevel 1 goto End
 
 


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12682#issuecomment-1365151173.

@donho I don't know exactly how this should be added to `copyCommonFiles` (if it should):
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/58416114da14536dcc7a8ad36010da3382366ba6/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh#L73 



