### PR TITLE
Fix cutting off 4GB+ files during saving

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.h
+++ b/PowerEditor/src/MISC/Common/FileInterface.h
@@ -45,10 +45,10 @@ public:
 	//int_fast64_t getSize();
 	//unsigned long read(void *rbuf, unsigned long buf_size);
 
-	bool write(const void *wbuf, unsigned long buf_size);
+	bool write(const void *wbuf, size_t buf_size);
 
 	bool writeStr(const std::string& str) {
-		return write(str.c_str(), static_cast<unsigned long>(str.length()));
+		return write(str.c_str(), str.length());
 	};
 
 private:

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1036,7 +1036,7 @@ bool FileManager::backupCurrentBuffer()
 
 				if (encoding == -1) //no special encoding; can be handled directly by Utf8_16_Write
 				{
-					isWrittenSuccessful = UnicodeConvertor.writeFile(buf, static_cast<unsigned long>(lengthDoc));
+					isWrittenSuccessful = UnicodeConvertor.writeFile(buf, lengthDoc);
 					if (lengthDoc == 0)
 						isWrittenSuccessful = true;
 				}
@@ -1054,7 +1054,7 @@ bool FileManager::backupCurrentBuffer()
 						int incompleteMultibyteChar = 0;
 						const char *newData = wmc.encode(SC_CP_UTF8, encoding, buf+i, static_cast<int>(grabSize), &newDataLen, &incompleteMultibyteChar);
 						grabSize -= incompleteMultibyteChar;
-						isWrittenSuccessful = UnicodeConvertor.writeFile(newData, static_cast<unsigned long>(newDataLen));
+						isWrittenSuccessful = UnicodeConvertor.writeFile(newData, newDataLen);
 					}
 					if (lengthDoc == 0)
 						isWrittenSuccessful = true;
@@ -1170,7 +1170,7 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 
 		if (encoding == -1) //no special encoding; can be handled directly by Utf8_16_Write
 		{
-			isWrittenSuccessful = UnicodeConvertor.writeFile(buf, static_cast<unsigned long>(lengthDoc));
+			isWrittenSuccessful = UnicodeConvertor.writeFile(buf, lengthDoc);
 			if (lengthDoc == 0)
 				isWrittenSuccessful = true;
 		}
@@ -1194,7 +1194,7 @@ SavingStatus FileManager::saveBuffer(BufferID id, const TCHAR * filename, bool i
 					int incompleteMultibyteChar = 0;
 					const char* newData = wmc.encode(SC_CP_UTF8, encoding, buf + i, static_cast<int>(grabSize), &newDataLen, &incompleteMultibyteChar);
 					grabSize -= incompleteMultibyteChar;
-					isWrittenSuccessful = UnicodeConvertor.writeFile(newData, static_cast<unsigned long>(newDataLen));
+					isWrittenSuccessful = UnicodeConvertor.writeFile(newData, newDataLen);
 				}
 			}
 		}

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -299,7 +299,7 @@ bool Utf8_16_Write::openFile(const TCHAR *name)
 	return true;
 }
 
-bool Utf8_16_Write::writeFile(const void* p, unsigned long _size)
+bool Utf8_16_Write::writeFile(const void* p, size_t _size)
 {
     // no file open
 	if (!m_pFile)

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -140,7 +140,7 @@ public:
 	void setEncoding(UniMode eType);
 
 	bool openFile(const TCHAR *name);
-	bool writeFile(const void* p, unsigned long _size);
+	bool writeFile(const void* p, size_t _size);
 	void closeFile();
 
 	size_t convert(char* p, size_t _size);


### PR DESCRIPTION
Fixes #12526 and similar [Community report](https://community.notepad-plus-plus.org/topic/23407/large-file-being-truncated-on-save).

There were invalid 64-bit -> 32-bit castings of filesize integers.

(I found the culprit, @pnedev wrote the fix for his WIN32 FileInterface and I did the final necessary tests.)

