### PR TITLE
Add selection support to TAB and Space conversion commands

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1350,7 +1350,8 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 		if (source == NULL)
 			continue;
 
-		_pEditView->execute(SCI_SETSEL, startPos, endPos);
+		_pEditView->execute(SCI_SETSELECTIONSTART, startPos);
+		_pEditView->execute(SCI_SETSELECTIONEND, endPos);
 		_pEditView->execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(source));
 
 		intptr_t count = 0;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1526,7 +1526,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 
 		_pEditView->execute(SCI_BEGINUNDOACTION);
 
-		for (int i = static_cast<int>startLine; i <= endLine; ++i)
+		for (int i = static_cast<int>(startLine); i <= endLine; ++i)
 		{
 			if (bookmarkPresent(i))
 			{

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1387,7 +1387,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 					{
 						*dest++ = ' ';
 						changeDataCount += 1;
-						if (i <= currentPos)
+						if (i < currentPos)
 							++newCurrentPos;
 					}
 					column += insertTabs;
@@ -1395,7 +1395,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 				else
 				{
 					*dest++ = source[i];
-					if (i <= currentPos)
+					if (i < currentPos)
 						++newCurrentPos;
 					if ((source[i] == '\n') || (source[i] == '\r'))
 						column = 0;
@@ -1511,7 +1511,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 					}
 				}
 
-				if (i <= currentPos)
+				if (i < currentPos)
 					++newCurrentPos;
 			}
 			*dest = '\0';

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1298,19 +1298,11 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 	intptr_t mainSelAnchor = _pEditView->execute(SCI_GETANCHOR);
 	bool isEntireDoc = (mainSelAnchor == currentPos);
 
-	auto restoreSelection = [this, mainSelAnchor, currentPos, isEntireDoc]()
+	auto restoreSelection = [this, mainSelAnchor, currentPos]()
 	{
 		// restore original selection if nothing has changed
-		if (!isEntireDoc)
-		{
 			_pEditView->execute(SCI_SETANCHOR, mainSelAnchor);
 			_pEditView->execute(SCI_SETCURRENTPOS, currentPos);
-		}
-		else
-		{
-			_pEditView->execute(SCI_SETANCHOR, mainSelAnchor);
-			_pEditView->execute(SCI_SETCURRENTPOS, currentPos);
-		}
 	};
 
 	// auto-expand of partially selected lines

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1306,6 +1306,11 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 			_pEditView->execute(SCI_SETANCHOR, mainSelAnchor);
 			_pEditView->execute(SCI_SETCURRENTPOS, currentPos);
 		}
+		else
+		{
+			_pEditView->execute(SCI_SETANCHOR, mainSelAnchor);
+			_pEditView->execute(SCI_SETCURRENTPOS, currentPos);
+		}
 	};
 
 	// auto-expand of partially selected lines

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1521,12 +1521,12 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 
 	if (changeDataCount)
 	{
-		vector<intptr_t> bookmarks;
-		vector<intptr_t> folding;
+		vector<int> bookmarks;
+		vector<int> folding;
 
 		_pEditView->execute(SCI_BEGINUNDOACTION);
 
-		for (intptr_t i = startLine; i <= endLine; ++i)
+		for (int i = static_cast<int>startLine; i <= endLine; ++i)
 		{
 			if (bookmarkPresent(i))
 			{
@@ -1552,10 +1552,10 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 			_pEditView->execute(SCI_GOTOPOS, newCurrentPos);
 		}
 
-		for (intptr_t i = 0; i < bookmarks.size(); ++i)
+		for (size_t i = 0; i < bookmarks.size(); ++i)
 			_pEditView->execute(SCI_MARKERADD, bookmarks[i], MARK_BOOKMARK);
 
-		for (intptr_t i = 0; i < folding.size(); ++i)
+		for (size_t i = 0; i < folding.size(); ++i)
 			_pEditView->fold(folding[i], false);
 
 		_pEditView->execute(SCI_ENDUNDOACTION);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1336,6 +1336,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 
 	intptr_t changeDataCount = 0;
 	intptr_t newCurrentPos = 0;
+	vector<intptr_t> folding;
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
 
@@ -1532,6 +1533,10 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 			}
 		}
 
+		if ((_pEditView->execute(SCI_GETFOLDLEVEL, idx) & SC_FOLDLEVELHEADERFLAG))
+			if (_pEditView->execute(SCI_GETFOLDEXPANDED, idx) == 0)
+				folding.push_back(idx);
+
 		if (changeDataLineCount)
 		{
 			_pEditView->execute(SCI_TARGETFROMSELECTION);
@@ -1552,6 +1557,9 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 			_pEditView->execute(SCI_SETSEL, _pEditView->execute(SCI_POSITIONFROMLINE, startLine), endLineCorrect != endLine ? _pEditView->execute(SCI_POSITIONFROMLINE, endLine) : _pEditView->execute(SCI_GETLINEENDPOSITION, endLine));
 		else
 			_pEditView->execute(SCI_GOTOPOS, _pEditView->execute(SCI_POSITIONFROMLINE, currentLine) + newCurrentPos);
+
+		for (size_t i = 0; i < folding.size(); ++i)
+			_pEditView->fold(folding[i], false);
 	}
 	else
 		restoreSelection();

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1521,12 +1521,12 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 
 	if (changeDataCount)
 	{
-		vector<int> bookmarks;
-		vector<int> folding;
+		vector<intptr_t> bookmarks;
+		vector<intptr_t> folding;
 
 		_pEditView->execute(SCI_BEGINUNDOACTION);
 
-		for (int i = startLine; i <= endLine; ++i)
+		for (intptr_t i = startLine; i <= endLine; ++i)
 		{
 			if (bookmarkPresent(i))
 			{
@@ -1552,10 +1552,10 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 			_pEditView->execute(SCI_GOTOPOS, newCurrentPos);
 		}
 
-		for (size_t i = 0; i < bookmarks.size(); ++i)
+		for (intptr_t i = 0; i < bookmarks.size(); ++i)
 			_pEditView->execute(SCI_MARKERADD, bookmarks[i], MARK_BOOKMARK);
 
-		for (size_t i = 0; i < folding.size(); ++i)
+		for (intptr_t i = 0; i < folding.size(); ++i)
 			_pEditView->fold(folding[i], false);
 
 		_pEditView->execute(SCI_ENDUNDOACTION);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1288,8 +1288,12 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 
 	intptr_t tabWidth = _pEditView->execute(SCI_GETTABWIDTH);
 	intptr_t currentPos = _pEditView->execute(SCI_GETCURRENTPOS);
+	intptr_t currentLine = _pEditView->execute(SCI_LINEFROMPOSITION, currentPos);
+	intptr_t currentPosInLine = currentPos - _pEditView->execute(SCI_POSITIONFROMLINE, currentLine);
+
 	intptr_t startLine = 0;
 	intptr_t endLine = _pEditView->lastZeroBasedLineNumber();
+	intptr_t endLineCorrect = endLine;
 	intptr_t dataLength = _pEditView->execute(SCI_GETLENGTH) + 1;
 	intptr_t mainSelAnchor = _pEditView->execute(SCI_GETANCHOR);
 	bool isEntireDoc = (mainSelAnchor == currentPos);
@@ -1310,14 +1314,16 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 		intptr_t startPos = _pEditView->execute(SCI_GETSELECTIONSTART);
 		startLine = _pEditView->execute(SCI_LINEFROMPOSITION, startPos);
 		intptr_t endPos = _pEditView->execute(SCI_GETSELECTIONEND);
-		endLine = _pEditView->execute(SCI_LINEFROMPOSITION, endPos);
+		endLine = endLineCorrect = _pEditView->execute(SCI_LINEFROMPOSITION, endPos);
 
 		if (startPos != _pEditView->execute(SCI_POSITIONFROMLINE, startLine))
 			startPos = _pEditView->execute(SCI_POSITIONFROMLINE, startLine);
 
-		if (endPos != _pEditView->execute(SCI_POSITIONFROMLINE, endLine) && endPos < _pEditView->execute(SCI_GETLINEENDPOSITION, endLine))
+		if (endPos == _pEditView->execute(SCI_POSITIONFROMLINE, endLine))
+			endLineCorrect = endLine - 1;
+		else if (endPos < _pEditView->execute(SCI_GETLINEENDPOSITION, endLine))
 			endPos = _pEditView->execute(SCI_GETLINEENDPOSITION, endLine);
-		
+
 		dataLength = endPos - startPos + 1;
 		_pEditView->execute(SCI_SETSEL, startPos, endPos);
 	}
@@ -1328,246 +1334,228 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
 		return;
 	}
 
-	char * source = new char[dataLength];
-	if (source == NULL)
-	{
-		restoreSelection();
-		return;
-	}
-
-	if (!isEntireDoc)
-		_pEditView->execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(source));
-	else
-		_pEditView->execute(SCI_GETTEXT, dataLength, reinterpret_cast<LPARAM>(source));
-
-	intptr_t count = 0;
-	intptr_t column = 0;
-	intptr_t newCurrentPos = 0;
-	intptr_t tabStop = tabWidth - 1;   // remember, counting from zero !
-	bool onlyLeading = false;
-
-	if (whichWay == tab2Space)
-	{
-		// count how many tabs are there
-		for (const char * ch = source; *ch; ++ch)
-		{
-			if (*ch == '\t')
-				++count;
-		}
-		if (count == 0)
-		{
-			restoreSelection();
-			delete [] source;
-			return;
-		}
-	}
-	// allocate tabwidth-1 chars extra per tab, just to be safe
-	size_t newLen = dataLength + count * (tabWidth - 1) + 1;
-	char * destination = new char[newLen];
-	if (destination == NULL)
-	{
-		restoreSelection();
-		delete [] source;
-		return;
-	}
-	char * dest = destination;
 	intptr_t changeDataCount = 0;
+	intptr_t newCurrentPos = 0;
 
-	switch (whichWay)
+	_pEditView->execute(SCI_BEGINUNDOACTION);
+
+	for (intptr_t idx = startLine; idx < endLineCorrect + 1; ++idx)
 	{
-		case tab2Space:
+		intptr_t startPos = _pEditView->execute(SCI_POSITIONFROMLINE, idx);
+		intptr_t endPos = _pEditView->execute(SCI_GETLINEENDPOSITION, idx);
+		dataLength = endPos - startPos + 1;
+
+		char * source = new char[dataLength];
+		if (source == NULL)
+			continue;
+
+		_pEditView->execute(SCI_SETSEL, startPos, endPos);
+		_pEditView->execute(SCI_GETSELTEXT, 0, reinterpret_cast<LPARAM>(source));
+
+		intptr_t count = 0;
+		intptr_t column = 0;
+		intptr_t tabStop = tabWidth - 1;   // remember, counting from zero !
+		bool onlyLeading = false;
+
+		if (whichWay == tab2Space)
 		{
-			// rip through each line of the file
-			for (int i = 0; source[i] != '\0'; ++i)
+			// count how many tabs are there
+			for (const char * ch = source; *ch; ++ch)
 			{
-				if (source[i] == '\t')
-				{
-					intptr_t insertTabs = tabWidth - (column % tabWidth);
-					for (int j = 0; j < insertTabs; ++j)
-					{
-						*dest++ = ' ';
-						changeDataCount += 1;
-						if (i < currentPos)
-							++newCurrentPos;
-					}
-					column += insertTabs;
-				}
-				else
-				{
-					*dest++ = source[i];
-					if (i < currentPos)
-						++newCurrentPos;
-					if ((source[i] == '\n') || (source[i] == '\r'))
-						column = 0;
-					else if ((source[i] & 0xC0) != 0x80)  // UTF_8 support: count only bytes that don't start with 10......
-						++column;
-				}
+				if (*ch == '\t')
+					++count;
 			}
-			*dest = '\0';
-			break;
-		}
-		case space2TabLeading:
-		{
-			onlyLeading = true;
-		}
-		case space2TabAll:
-		{
-			bool nextChar = false;
-			int counter = 0;
-			bool nonSpaceFound = false;
-			for (int i = 0; source[i] != '\0'; ++i)
+			if (count == 0)
 			{
-				if (nonSpaceFound == false)
+				delete [] source;
+				continue;
+			}
+		}
+		// allocate tabwidth-1 chars extra per tab, just to be safe
+		size_t newLen = dataLength + count * (tabWidth - 1) + 1;
+		char * destination = new char[newLen];
+		if (destination == NULL)
+		{
+			delete [] source;
+			continue;
+		}
+		char * dest = destination;
+		intptr_t changeDataLineCount = 0;
+
+		switch (whichWay)
+		{
+			case tab2Space:
+			{
+				// rip through each line of the file
+				for (int i = 0; source[i] != '\0'; ++i)
 				{
-					while (source[i + counter] == ' ')
+					if (source[i] == '\t')
 					{
-						if ((column + counter) == tabStop)
+						intptr_t insertTabs = tabWidth - (column % tabWidth);
+						for (int j = 0; j < insertTabs; ++j)
 						{
-							tabStop += tabWidth;
-							if (counter >= 1)        // counter is counted from 0, so counter >= max-1
-							{
-								*dest++ = '\t';
-								changeDataCount += 1;
-								i += counter;
-								column += counter + 1;
-								counter = 0;
-								nextChar = true;
-								if (i <= currentPos)
-									++newCurrentPos;
-								break;
-							}
-							else if (source[i+1] == ' ' || source[i+1] == '\t')  // if followed by space or TAB, convert even a single space to TAB
-							{
-								*dest++ = '\t';
-								changeDataCount += 1;
-								i++;
-								column += 1;
-								counter = 0;
-								if (i <= currentPos)
-									++newCurrentPos;
-							}
-							else       // single space, don't convert it to TAB
-							{
-								*dest++ = source[i];
-								column += 1;
-								counter = 0;
-								nextChar = true;
-								if (i <= currentPos)
-									++newCurrentPos;
-								break;
-							}
+							*dest++ = ' ';
+							changeDataCount++;
+							changeDataLineCount++;
+							if (idx == currentLine && i < currentPosInLine)
+								++newCurrentPos;
 						}
-						else
-							++counter;
+						column += insertTabs;
+					}
+					else
+					{
+						*dest++ = source[i];
+						if (idx == currentLine && i < currentPosInLine)
+							++newCurrentPos;
+						if ((source[i] == '\n') || (source[i] == '\r'))
+							column = 0;
+						else if ((source[i] & 0xC0) != 0x80)  // UTF_8 support: count only bytes that don't start with 10......
+							++column;
+					}
+				}
+				*dest = '\0';
+				break;
+			}
+			case space2TabLeading:
+			{
+				onlyLeading = true;
+			}
+			case space2TabAll:
+			{
+				bool nextChar = false;
+				int counter = 0;
+				bool nonSpaceFound = false;
+				for (int i = 0; source[i] != '\0'; ++i)
+				{
+					if (nonSpaceFound == false)
+					{
+						while (source[i + counter] == ' ')
+						{
+							if ((column + counter) == tabStop)
+							{
+								tabStop += tabWidth;
+								if (counter >= 1)        // counter is counted from 0, so counter >= max-1
+								{
+									*dest++ = '\t';
+									changeDataCount++;
+									changeDataLineCount++;
+									i += counter;
+									column += counter + 1;
+									counter = 0;
+									nextChar = true;
+									if (idx == currentLine && i <= currentPosInLine)
+										++newCurrentPos;
+									break;
+								}
+								else if (source[i + 1] == ' ' || source[i + 1] == '\t')  // if followed by space or TAB, convert even a single space to TAB
+								{
+									*dest++ = '\t';
+									changeDataCount++;
+									changeDataLineCount++;
+									i++;
+									column += 1;
+									counter = 0;
+									if (idx == currentLine && i <= currentPosInLine)
+										++newCurrentPos;
+								}
+								else       // single space, don't convert it to TAB
+								{
+									*dest++ = source[i];
+									column += 1;
+									counter = 0;
+									nextChar = true;
+									if (idx == currentLine && i <= currentPosInLine)
+										++newCurrentPos;
+									break;
+								}
+							}
+							else
+								++counter;
+						}
+
+						if (nextChar == true)
+						{
+							nextChar = false;
+							continue;
+						}
+
+						if (source[i] == ' ' && source[i + counter] == '\t') // spaces "absorbed" by a TAB on the right
+						{
+							*dest++ = '\t';
+							changeDataCount++;
+							changeDataLineCount++;
+							i += counter;
+							column = tabStop + 1;
+							tabStop += tabWidth;
+							counter = 0;
+							if (idx == currentLine && i <= currentPosInLine)
+								++newCurrentPos;
+							continue;
+						}
 					}
 
-					if (nextChar == true)
-					{
-						nextChar = false;
-						continue;
-					}
+					if (onlyLeading == true && nonSpaceFound == false)
+						nonSpaceFound = true;
 
-					if (source[i] == ' ' && source[i + counter] == '\t') // spaces "absorbed" by a TAB on the right
+					if (source[i] == '\n' || source[i] == '\r')
 					{
-						*dest++ = '\t';
-						changeDataCount += 1;
-						i += counter;
+						*dest++ = source[i];
+						column = 0;
+						tabStop = tabWidth - 1;
+						nonSpaceFound = false;
+					}
+					else if (source[i] == '\t')
+					{
+						*dest++ = source[i];
 						column = tabStop + 1;
 						tabStop += tabWidth;
 						counter = 0;
-						if (i <= currentPos)
-							++newCurrentPos;
-						continue;
 					}
-				}
-
-				if (onlyLeading == true && nonSpaceFound == false)
-					nonSpaceFound = true;
-
-				if (source[i] == '\n' || source[i] == '\r')
-				{
-					*dest++ = source[i];
-					column = 0;
-					tabStop = tabWidth - 1;
-					nonSpaceFound = false;
-				}
-				else if (source[i] == '\t')
-				{
-					*dest++ = source[i];
-					column = tabStop + 1;
-					tabStop += tabWidth;
-					counter = 0;
-				}
-				else
-				{
-					*dest++ = source[i];
-					counter = 0;
-					if ((source[i] & 0xC0) != 0x80)   // UTF_8 support: count only bytes that don't start with 10......
+					else
 					{
-						++column;
+						*dest++ = source[i];
+						counter = 0;
+						if ((source[i] & 0xC0) != 0x80)   // UTF_8 support: count only bytes that don't start with 10......
+						{
+							++column;
 
-						if (column > 0 && column % tabWidth == 0)
-							tabStop += tabWidth;
+							if (column > 0 && column % tabWidth == 0)
+								tabStop += tabWidth;
+						}
 					}
+
+					if (idx == currentLine && i < currentPosInLine)
+						++newCurrentPos;
 				}
-
-				if (i < currentPos)
-					++newCurrentPos;
+				*dest = '\0';
+				break;
 			}
-			*dest = '\0';
-			break;
-		}
-	}
-
-	if (changeDataCount)
-	{
-		vector<int> bookmarks;
-		vector<int> folding;
-
-		_pEditView->execute(SCI_BEGINUNDOACTION);
-
-		for (int i = static_cast<int>(startLine); i <= endLine; ++i)
-		{
-			if (bookmarkPresent(i))
-			{
-				bookmarks.push_back(i);
-				if (!isEntireDoc)
-					_pEditView->execute(SCI_MARKERDELETE, i, MARK_BOOKMARK);
-			}
-
-			if ((_pEditView->execute(SCI_GETFOLDLEVEL, i) & SC_FOLDLEVELHEADERFLAG))
-				if (_pEditView->execute(SCI_GETFOLDEXPANDED, i) == 0)
-					folding.push_back(i);
 		}
 
-		if (!isEntireDoc)
+		if (changeDataLineCount)
 		{
 			_pEditView->execute(SCI_TARGETFROMSELECTION);
 			_pEditView->execute(SCI_REPLACETARGET, static_cast<WPARAM>(-1), reinterpret_cast<LPARAM>(destination));
-			_pEditView->execute(SCI_SETSEL, _pEditView->execute(SCI_GETTARGETSTART), _pEditView->execute(SCI_GETTARGETEND));
 		}
+
+		// clean up
+		delete [] source;
+		delete [] destination;
+	
+	}
+
+	_pEditView->execute(SCI_ENDUNDOACTION);
+
+	if (changeDataCount)
+	{
+		if (!isEntireDoc)
+			_pEditView->execute(SCI_SETSEL, _pEditView->execute(SCI_POSITIONFROMLINE, startLine), endLineCorrect != endLine ? _pEditView->execute(SCI_POSITIONFROMLINE, endLine) : _pEditView->execute(SCI_GETLINEENDPOSITION, endLine));
 		else
-		{
-			_pEditView->execute(SCI_SETTEXT, 0, reinterpret_cast<LPARAM>(destination));
-			_pEditView->execute(SCI_GOTOPOS, newCurrentPos);
-		}
-
-		for (size_t i = 0; i < bookmarks.size(); ++i)
-			_pEditView->execute(SCI_MARKERADD, bookmarks[i], MARK_BOOKMARK);
-
-		for (size_t i = 0; i < folding.size(); ++i)
-			_pEditView->fold(folding[i], false);
-
-		_pEditView->execute(SCI_ENDUNDOACTION);
+			_pEditView->execute(SCI_GOTOPOS, _pEditView->execute(SCI_POSITIONFROMLINE, currentLine) + newCurrentPos);
 	}
 	else
-	{
 		restoreSelection();
-	}
 
-	// clean up
-	delete [] source;
-	delete [] destination;
 }
 
 void Notepad_plus::doTrim(trimOp whichPart)


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12720, https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12745.

Changes made related to the current state:
- add stream selection support. Partially selected lines are expanded to full lines without last EOL (same as `Trim`).
- block selection is not supported (just return).
- if nothing was change we restore original selection.
-  if nothing was change we don't replace original data (actually it was only for `Tab to Space`, now this applies to all commands). Replacing data with the same data unnecessarily changes the history.
- making some performance improvements by moving some things elsewhere (like obtaining bookmarks).

I didn't change code responsible for how Tab to Space conversion (and vice versa) works (add only one variable `changeDataCount` here). Changes were made only before this action and after this action.

Actually (before this PR), when we make a selection and execute commands, changes are made to the entire document, not just to the selection. In the case of a large file and a small selection, I don't know if the changes covered only the selection or the entire document. At first glance (if we don't see all the changed data), it seems that only for selection (but it's not true).

![image](https://user-images.githubusercontent.com/2730894/210134672-6b4b2df3-1caf-42da-9f88-f46b706f2951.png)

If selection has to be not supported at all then return should be done here (to not mislead us).

---
I have one additional question for the more experienced who can perform detailed debugging.

When we have some bookmark, make selection, copy data (`Ctrl+C`) and paste this data (`Ctrl+V`) we get this:

![image](https://user-images.githubusercontent.com/2730894/210135655-cefe321b-d4a6-4f30-9eb3-df1c94c1e7c2.png)
 
It seems Notepad (or Scintilla) incorrectly changing bookmark here. They should be deleted or keept, but we have some strange dislocation.

Now when we make undo we get this:

![image](https://user-images.githubusercontent.com/2730894/210135947-043d8cda-9380-49b8-b466-a9c07215283e.png)

but this is not the initial state. Bookomark was on line 2 (not line 3).

This not  happens when we select all + copy and paste + undo:

![image](https://user-images.githubusercontent.com/2730894/210136004-925dfeb7-61f7-4905-ba81-b15e4f0dc1dd.png)

This behavior also bothers me in this PR but I got around this for selection by deleting the bookmarks after remembering them. It's still not perfect because when we do undo such bookmark is restored. Well, but at the moment it must be like that because I do not know on whose side the problem is: Notepad++ or Scintilla?

Select => Tab to Space => Undo
![image](https://user-images.githubusercontent.com/2730894/210136397-1b5d63e2-b598-4299-b625-03cd37e6afe5.png)
