### PR TITLE
Add -Wconversion flag to makefile

### DIFF
--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -53,13 +53,13 @@ SUBMAKEFLAGS := -O --no-print-directory
 ifeq "$(filter-out 0,$(DEBUG))" ""
 BUILD_TYPE := release
 BUILD_SUFFIX :=
-CXXFLAGS += -Os
+CXXFLAGS += -Os -Wconversion
 CPP_DEFINE += NDEBUG
 LDFLAGS += -s
 else
 BUILD_TYPE := debug
 BUILD_SUFFIX := -debug
-CXXFLAGS += -Og -g -Wall -Wpedantic
+CXXFLAGS += -Og -g -Wall -Wpedantic -Wconversion
 CPP_DEFINE += DEBUG
 endif
 


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12740.

Few times I push PR (compiling in GCC without any problems) but it breaks on MSC so I waste of time. This is because MSC show warnings related to conversion problem and additionally treats them as an error. At the moment GCC ignores such thing so I added a proper flag that will support it.

*Anything that causes an error in MSC should be treated by GCC at least as a warning.

I din't change that warnings should be treated as errors. because I don't want GCC to be more restrictive than MSC and block the build (show warnings should be enough).

This change cause that for GCC and actual code we will see new warnings in log, but they can be corrected later.