### PR TITLE
Add JSON5 support

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -32,7 +32,8 @@ enum LangType {L_TEXT, L_PHP , L_C, L_CPP, L_CS, L_OBJC, L_JAVA, L_RC,\
 			   L_ASN1, L_AVS, L_BLITZBASIC, L_PUREBASIC, L_FREEBASIC, \
 			   L_CSOUND, L_ERLANG, L_ESCRIPT, L_FORTH, L_LATEX, \
 			   L_MMIXAL, L_NIM, L_NNCRONTAB, L_OSCRIPT, L_REBOL, \
-			   L_REGISTRY, L_RUST, L_SPICE, L_TXT2TAGS, L_VISUALPROLOG, L_TYPESCRIPT,\
+			   L_REGISTRY, L_RUST, L_SPICE, L_TXT2TAGS, L_VISUALPROLOG,\
+			   L_TYPESCRIPT, L_JSON5,\
 			   // Don't use L_JS, use L_JAVASCRIPT instead
 			   // The end of enumated language type, so it should be always at the end
 			   L_EXTERNAL};

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3280,7 +3280,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 
 	if (type == L_C || type == L_CPP || type == L_JAVA || type == L_CS || type == L_OBJC ||
 		type == L_PHP || type == L_JS || type == L_JAVASCRIPT || type == L_JSP || type == L_CSS || type == L_PERL || 
-		type == L_RUST || type == L_POWERSHELL || type == L_JSON || autoIndentMode == ExternalLexerAutoIndentMode::C_Like)
+		type == L_RUST || type == L_POWERSHELL || type == L_JSON || type == L_JSON5 || autoIndentMode == ExternalLexerAutoIndentMode::C_Like)
 	{
 		if (((eolMode == SC_EOL_CRLF || eolMode == SC_EOL_LF) && ch == '\n') ||
 			(eolMode == SC_EOL_CR && ch == '\r'))
@@ -3323,7 +3323,7 @@ void Notepad_plus::maintainIndentation(TCHAR ch)
 				_pEditView->setLineIndent(curLine, indentAmountPrevLine);
 			}
 			// These languages do no support single line control structures without braces.
-			else if (type == L_PERL || type == L_RUST || type == L_POWERSHELL || type == L_JSON)
+			else if (type == L_PERL || type == L_RUST || type == L_POWERSHELL || type == L_JSON || type == L_JSON5)
 			{
 				_pEditView->setLineIndent(curLine, indentAmountPrevLine);
 			}
@@ -3502,6 +3502,8 @@ LangType Notepad_plus::menuID2LangType(int cmdID)
 			return L_JAVASCRIPT;
 		case IDM_LANG_JSON:
 			return L_JSON;
+		case IDM_LANG_JSON5:
+			return L_JSON5;
         case IDM_LANG_PHP :
             return L_PHP;
         case IDM_LANG_ASP :

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -933,6 +933,7 @@ BEGIN
         MENUITEM "Java",                    IDM_LANG_JAVA
         MENUITEM "JavaScript",              IDM_LANG_JS
         MENUITEM "JSON",                    IDM_LANG_JSON
+        MENUITEM "JSON5",                   IDM_LANG_JSON5
         MENUITEM "JSP",                     IDM_LANG_JSP
         MENUITEM "KIXtart",                 IDM_LANG_KIX
         MENUITEM "LISP",                    IDM_LANG_LISP
@@ -1052,6 +1053,7 @@ BEGIN
         MENUITEM "Java",                  IDM_LANG_JAVA
         MENUITEM "JavaScript",            IDM_LANG_JS
         MENUITEM "JSON",                  IDM_LANG_JSON
+        MENUITEM "JSON5",                 IDM_LANG_JSON5
         MENUITEM "JSP",                   IDM_LANG_JSP
     END
     MENUITEM "KIXtart",                   IDM_LANG_KIX

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3390,6 +3390,7 @@ void Notepad_plus::command(int id)
         case IDM_LANG_XML :
         case IDM_LANG_JS :
 		case IDM_LANG_JSON :
+		case IDM_LANG_JSON5 :
         case IDM_LANG_PHP :
         case IDM_LANG_ASP :
         case IDM_LANG_CSS :

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -7432,6 +7432,8 @@ int NppParameters::langTypeToCommandID(LangType lt) const
 			id = IDM_LANG_JS; break;
 		case L_JSON:
 			id = IDM_LANG_JSON; break;
+		case L_JSON5:
+			id = IDM_LANG_JSON5; break;
 		case L_PHP :
 			id = IDM_LANG_PHP; break;
 		case L_ASP :

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -152,6 +152,7 @@ LanguageNameInfo ScintillaEditView::_langNameInfoArray[L_EXTERNAL + 1] = {
 	{TEXT("txt2tags"),		TEXT("txt2tags"),			TEXT("txt2tags file"),									L_TXT2TAGS,		"txt2tags"},
 	{TEXT("visualprolog"),	TEXT("Visual Prolog"),		TEXT("Visual Prolog file"),								L_VISUALPROLOG,	"visualprolog"},
 	{TEXT("typescript"),	TEXT("TypeScript"),			TEXT("TypeScript file"),								L_TYPESCRIPT,	"cpp"},
+	{TEXT("json5"),			TEXT("json5"),				TEXT("JSON5 file"),										L_JSON5,		"json"},
 	{TEXT("ext"),			TEXT("External"),			TEXT("External"),										L_EXTERNAL,		"null"}
 };
 
@@ -690,9 +691,10 @@ void ScintillaEditView::setEmbeddedJSLexer()
 	execute(SCI_STYLESETEOLFILLED, SCE_HJ_COMMENTDOC, true);
 }
 
-void ScintillaEditView::setJsonLexer()
+void ScintillaEditView::setJsonLexer(bool isJson5)
 {
-	setLexerFromLangID(L_JSON);
+	LangType j = isJson5 ? L_JSON5 : L_JSON;
+	setLexerFromLangID(j);
 
 	const TCHAR *pKwArray[10] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
@@ -712,14 +714,14 @@ void ScintillaEditView::setJsonLexer()
 		keywordList2 = wstring2string(kwlW, CP_ACP);
 	}
 
-	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList, L_JSON, LANG_INDEX_INSTR)));
-	execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList2, L_JSON, LANG_INDEX_INSTR2)));
+	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList, j, LANG_INDEX_INSTR)));
+	execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(getCompleteKeywordList(keywordList2, j, LANG_INDEX_INSTR2)));
 
 	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold"), reinterpret_cast<LPARAM>("1"));
 	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.compact"), reinterpret_cast<LPARAM>("0"));
 
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.comment"), reinterpret_cast<LPARAM>("1"));
-	execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.preprocessor"), reinterpret_cast<LPARAM>("1"));
+	if (j == L_JSON5)
+		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("lexer.json.allow.comments"), reinterpret_cast<LPARAM>("1"));
 }
 
 void ScintillaEditView::setEmbeddedPhpLexer()
@@ -1530,6 +1532,8 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 
 		case L_JSON:
 			setJsonLexer(); break;
+		case L_JSON5:
+			setJsonLexer(true); break;
 
 		case L_CSS :
 			setCssLexer(); break;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -657,7 +657,7 @@ protected:
 	void setEmbeddedJSLexer();
     void setEmbeddedPhpLexer();
     void setEmbeddedAspLexer();
-	void setJsonLexer();
+	void setJsonLexer(bool isJson5 = false);
 	void setTypeScriptLexer();
 
 	//Simple lexers

--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -205,6 +205,7 @@
             <Keywords name="instre1">false null true</Keywords>
             <Keywords name="instre2">@id @context @type @value @language @container @list @set @reverse @index @base @vocab @graph</Keywords>
         </Language>
+        <Language name="json5" ext="json5 jsonc" commentLine="//" commentStart="/*" commentEnd="*/"/>
         <Language name="jsp" ext="jsp" commentLine="//" commentStart="/*" commentEnd="*/"/>
         <Language name="kix" ext="kix" commentLine=";" commentStart="" commentEnd="">
             <Keywords name="instre1">? and beep big break call cd cls color cookie1 copy debug del dim display do until exit flushkb for each next function endfunction get gets global go gosub goto if else endif md or password play quit rd redim return run select case endselect set setl setm settime shell sleep small use while loop</Keywords>

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -534,6 +534,7 @@
     #define    IDM_LANG_TXT2TAGS           (IDM_LANG + 82)
     #define    IDM_LANG_VISUALPROLOG       (IDM_LANG + 83)
     #define    IDM_LANG_TYPESCRIPT         (IDM_LANG + 84)
+    #define    IDM_LANG_JSON5              (IDM_LANG + 85)
 
     #define    IDM_LANG_EXTERNAL           (IDM_LANG + 165)
     #define    IDM_LANG_EXTERNAL_LIMIT     (IDM_LANG + 179)


### PR DESCRIPTION
Currently, it's only JSONC (with js comment supported). It will be enhanced in the future.

Usage: set your file to JSON5 via language menu, or change file extension to `.json5` or `.jsonc`.
Note that the keywords and stylers are shared with JSON.

Fix #11676, fix #11713