### PR TITLE
Fix exclude functions in comment zones

### DIFF
--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -735,7 +735,7 @@ void FunctionMixParser::parse(std::vector<foundInfo> & foundInfos, size_t begin,
 	{
 		for (size_t i = 0, len = nonScannedZones.size(); i < len; ++i)
 		{
-			_funcUnitPaser->funcParse(foundInfos, nonScannedZones[i].first, nonScannedZones[i].second, ppEditView, classStructName);
+			_funcUnitPaser->funcParse(foundInfos, nonScannedZones[i].first, nonScannedZones[i].second, ppEditView, classStructName, &commentZones);
 		}
 	}
 }


### PR DESCRIPTION
Fix #12759

Functions can be found in comment zones when using `FunctionMixParser::parse()`. Passing `commentZones` to `funcParse()` can invalidate functions found in comment zones.