### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.5.0

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 6th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 7th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
 		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
@@ -1131,7 +1131,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                 <RecentFilesHistory title="Schedarii recenti">
                     <Item id="6304" name="Cronolugia di i schedarii recenti"/>
                     <Item id="6306" name="Numeru massimu d’elementi :"/>
-                    <Item id="6305" name="Ùn verificà micca à l’avviu"/>
+                    <Item id="6305" name="Ùn verificà micca à u lanciu"/>
                     <Item id="6429" name="Affissera"/>
                     <Item id="6424" name="In sottulistinu"/>
                     <Item id="6425" name="Nome di schedariu solu"/>
@@ -1145,7 +1145,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                     <Item id="6819" name="Salvaguardia ogni :"/>
                     <Item id="6821" name="seconde"/>
                     <Item id="6822" name="Chjassu :"/>
-                    <Item id="6309" name="Arricurdassi di a sessione currente per u prossimu avviu"/>
+                    <Item id="6309" name="Arricurdassi di a sessione currente per u prossimu lanciu"/>
                     <Item id="6801" name="Salvaguardia à l’arregistramentu"/>
                     <Item id="6315" name="Alcuna"/>
                     <Item id="6316" name="Salvaguardia simplice"/>
@@ -1442,6 +1442,7 @@ Cuntinuà ?"/>
             <NeedToRestartToLoadPlugins title="Notepad++ richiede d’esse rilanciatu" message="Ci vole à rilancià Notepad++ per caricà l’estensioni chì sò state installate."/> <!-- HowToReproduce: Import a plugin via menu "Settings->Import->Import Plugin(s)...". -->
             <ChangeHistoryEnabledWarning title="Notepad++ richiede d’esse rilanciatu" message="Ci vole à rilancià Notepad++ per permette l’affissera di a cronolugia di i cambiamenti."/> <!-- HowToReproduce: uncheck "Display Change History" via Preferences dialog "Marges/Border/Edge. -->
             <WindowsSessionExit title="Notepad++ - Fine di a sessione Windows" message="A sessione Windows stà per piantassi ma ci hè qualchì datu chì ùn hè micca arregistratu. Vulete esce di Notepad++ subitu ?"/>
+            <LanguageMenuCompactWarning title="Cumpattà l’affissera di u listinu" message="St’ozzione serà cambiata à u prossimu lanciu."/> <!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Cronolugia di u preme’papei"/>
@@ -1696,7 +1697,7 @@ U+200B : spaziu di larghezza nulla
 U+FEFF : spaziu nonspezzevule di larghezza nulla
 Per ottene a lista sana, fighjate u Manuale di l’utilizatore.
 Impiegà u buttone « ? » à diritta per apre u manuale di l’utilizatore nant’à u situ web." />
-            <npcCustomColor-tip value="Accede à u Cunfiguratore di stilu per persunalizà u culore predefinitu di i spazii bianchi selezziunati è di i caratteri nonstampevule (« Culore persunalizatu di i caratteri nonstampevule »)." />
+            <npcCustomColor-tip value="Accede à u Cunfiguratore di stilu per persunalizà u culore predefinitu di i spazii bianchi selezziunati è di i caratteri nonstampevule (&quot;Non-printing characters custom color&quot;)." /> <!-- Don't translate "(&quot;Non-printing characters custom color&quot;)" -->
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 12th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 13th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
 		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
@@ -1647,6 +1647,8 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <summary-nbsel1 value=" caratteri selezziunati ("/>
             <summary-nbsel2 value=" ottetti) in "/>
             <summary-nbrange value=" selezzioni"/>
+            <progress-cancel-button value="Abbandunà"/>
+            <progress-cancel-info value="Abbandonu di l’operazione, aspittate per piacè..."/>
             <find-in-files-progress-title value="Prugressione di a ricerca in i schedarii…"/>
             <replace-in-files-confirm-title value="Cunfirmazione"/>
             <replace-in-files-confirm-directory value="Vulete rimpiazzà tutte l’occurrenze in :"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 7th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 12th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
 		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
@@ -1168,6 +1168,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                     <Item id="6811" name="Da u"/>
                     <Item id="6813" name="u caratteru"/>
                     <Item id="6814" name="Valori accettati : 1 - 9"/>
+                    <Item id="6872" name="Accurtà a lista d’empiimentu autumaticu"/>
                     <Item id="6815" name="Sugerisce i parametri di funzione à l’entrata"/>
                     <Item id="6851" name="Inserzione autumatica"/>
                     <Item id="6857" name=" Chjusura html/xml"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -241,7 +241,7 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="43019" name="Cupià e linee indettate"/>
                     <Item id="43020" name="Incullà (per rimpiazzà) e linee indettate"/>
                     <Item id="43021" name="Caccià e linee indettate"/>
-                    <Item id="43051" name="Caccià e linee senza marca"/>
+                    <Item id="43051" name="Caccià e linee senza indetta"/>
                     <Item id="43050" name="Invertisce l’indette"/>
                     <Item id="43052" name="Circà caratteri in &amp;una stesa…"/>
                     <Item id="43053" name="Tuttu selezziunà trà e parentesi chì currisp&amp;ondenu"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -640,6 +640,9 @@ The comments are here for explanation, it's not necessary to translate them.
                 <SettingCategory name="Preferenze"/>
                 <ToolCategory name="Attrezzi"/>
                 <ExecuteCategory name="Eseguisce"/>
+                <ModifyContextMenu name="Mudificà"/>
+                <DeleteContextMenu name="Squassà"/>
+                <ClearContextMenu name="Viutà"/>
                 <MainCommandNames>
                     <Item id="41019" name="Apre cù l’espluratore u cartulare cuntenendu u schedariu"/>
                     <Item id="41020" name="Apre cù l’invitu di cumanda u cartulare cuntenendu u schedariu"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,6 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
+		- Updated on February 6th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
 		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
@@ -41,7 +42,7 @@ The comments are here for explanation, it's not necessary to translate them.
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 -->
 <NotepadPlus>
-    <Native-Langue name="Corsu" filename="corsican.xml" version="8.4.9">
+    <Native-Langue name="Corsu" filename="corsican.xml" version="8.5.0">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -150,6 +151,7 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="42006" name="&amp;Squassà"/>
                     <Item id="42007" name="T&amp;uttu selezziunà"/>
                     <Item id="42020" name="Principiu è &amp;fine di a selezzione"/>
+                    <Item id="42089" name="Principiu è fine di a selezzione in modu di culonna"/>
                     <Item id="42084" name="A data è l’ora (corta)"/>
                     <Item id="42085" name="A data è l’ora (longa)"/>
                     <Item id="42086" name="A data è l’ora (furmatu persunalizatu)"/>
@@ -302,7 +304,7 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="44022" name="Ritornu autumaticu à a linea"/>
                     <Item id="44023" name="&amp;Ingrandà u testu (Ctrl+rutulella insù)"/>
                     <Item id="44024" name="&amp;Diminuì u testu (Ctrl+rutulella inghjò)"/>
-                    <Item id="44025" name="Affissà i spazii bianchi è e tabulazioni"/>
+                    <Item id="44025" name="Affissà i spazii è e tabulazioni"/>
                     <Item id="44026" name="Affissà i simbuli di fine di linea"/>
                     <Item id="44029" name="Spiegà tutti i livelli"/>
                     <Item id="44030" name="Ripiegà u livellu attuale"/>
@@ -332,6 +334,7 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="44113" name="Appiecà u culore 3"/>
                     <Item id="44114" name="Appiecà u culore 4"/>
                     <Item id="44115" name="Appiecà u culore 5"/>
+                    <Item id="44130" name="Affissà i caratteri nonstampevule"/>
                     <Item id="44032" name="Attivà o disattivà u modu di screnu sanu"/>
                     <Item id="44033" name="Risturà l’ingrandamentu predefinitu"/>
                     <Item id="44034" name="Sempre in primu pianu"/>
@@ -959,6 +962,10 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="6248" name="Predefinitu"/>
                     <Item id="6249" name="Testu in chjaru"/>
                     <Item id="6250" name="Culore persunalizatu"/>
+                    <Item id="6252" name="Caratteri nonstampevule"/>
+                    <Item id="6254" name="Abbreviamentu"/>
+                    <Item id="6255" name="Puntu di codice"/>
+                    <Item id="6256" name="Culore persunalizatu"/>
                 </Scintillas>
 
                 <DarkMode title="Modu scuru">
@@ -1354,7 +1361,17 @@ E vostre preferenze di nivulu anu da esse abbandunate. Ci vole à rimette un val
             <DroppingFolderAsProjectModeWarning title="Azzione inaccetevule" message="Pudete depone solu schedarii o cartulari ma micca tremindui, perchè site in u modu di dipositu Cartulare cum’è spaziu di travagliu.
 Ci vole à attivà l’ozzione « À u depone d’un cartulare, apre tutti i schedarii invece d’impiegallu cum’è spaziu di travagliu » in a sezzione « Cartulare predefinitu » di e Preferenze per fà què."/>
             <SortingError title="Sbagliu di classificazione" message="Impussibule di fà una classificazione numerica per via di a linea $INT_REPLACE$."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
-            <ColumnModeTip title="Minichichja di modu culonna" message="Ci vole à impiegà « ALT+selez. cù topu » o « Alt+Maiusc+fleccia » per passà à u modu culonna."/>
+            <ColumnModeTip title="Minichichja di modu culonna" message="
+Ci hè 3 manere di passà à u modu di selezzione da a culonna :
+1. (Tastera è topu)  Mantene u tastu Alt quandu si trascineghja cù un cliccu mancu
+2. (Tastera solu)  Mantene i tasti Alt+Maius quandu s’impiegheghja e fleccie
+3. (Tastera o topu)
+      Piazzà a barra d’inserzione à u locu di principiu sceltu per
+	   a pusizione di u bloccu di culonna, eppò lancià a cumanda
+       « Principiu è fine di a selezzione in modu di culonna » ;
+      Dispiazzà a barra d’inserzione à u locu di fine sceltu per
+	   a pusizione di u bloccu di culonna, eppò lancià a cumanda
+       « Principiu è fine di a selezzione in modu di culonna »"/>
             <BufferInvalidWarning title="Arregistramentu fiascatu" message="Ùn pò micca arregistrà : U stampone hè inaccetevule."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
             <DoCloseOrNot title="Cunservà u schedariu inesistente" message="U schedariu « $STR_REPLACE$ » ùn esiste più.
 Cunservà stu schedariu in l’editore ?"/>
@@ -1661,6 +1678,25 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
 NOTA :
 1. Per funziunà bè, a mudificazione di quelle ozzioni richiede d’apre torna i schedarii tamanti chì sò dighjà aperti.
 2. S’è l’ozzione « Disattivà di manera glubale u ritornu autumaticu à a linea » hè attiva è chì un schedariu tamantu hè apertu, tandu u ritornu autumaticu à a linea serà disattivatu per tutti i schedarii. Pudete attivallu torna via l’ozzione di listinu Affissera > Ritornu autumaticu à a linea." />
+            <npcNote-tip value="Riprisentanza di i spazii bianchi « nonASCII » selezziunati è di i caratteri (di cuntrollu) nonstampevule.
+NOTA :
+Certi caratteri ponu avè dighjà una riprisentanza è dunque esse videvule. A predefinizione per u separadore di linea è quellu di paragrafu hè di riprisentallu da un abbreviamentu.
+Impiegà a riprisentanza disattiverà l’effetti nant’à i caratteri in u testu.
+Per ottene a lista sana di i spazii bianchi selezziunati è di i caratteri nonstampevule, fighjate u Manuale di l’utilizatore.
+Impiegà stu buttone per apre u manuale di l’utilizatore nant’à u situ web." />
+            <npcAbbreviation-tip value="Abbreviamentu : nome
+NBSP : spaziu nonspezzevule
+ZWSP : spaziu di larghezza nulla
+ZWNBSP : spaziu nonspezzevule di larghezza nulla
+Per ottene a lista sana, fighjate u Manuale di l’utilizatore.
+Impiegà u buttone « ? » à diritta per apre u manuale di l’utilizatore nant’à u situ web." />
+            <npcCodepoint-tip value="Puntu di codice : nome
+U+00A0 : spaziu nonspezzevule
+U+200B : spaziu di larghezza nulla
+U+FEFF : spaziu nonspezzevule di larghezza nulla
+Per ottene a lista sana, fighjate u Manuale di l’utilizatore.
+Impiegà u buttone « ? » à diritta per apre u manuale di l’utilizatore nant’à u situ web." />
+            <npcCustomColor-tip value="Accede à u Cunfiguratore di stilu per persunalizà u culore predefinitu di i spazii bianchi selezziunati è di i caratteri nonstampevule (« Culore persunalizatu di i caratteri nonstampevule »)." />
         </MiscStrings>
     </Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 13th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 14th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
 		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
@@ -629,6 +629,17 @@ The comments are here for explanation, it's not necessary to translate them.
                 <ScintillaCommandsTab name="Cumande Scintilla"/>
                 <ConflictInfoOk name="Nisunu cunflittu d’accurtatoghju per st’elementu."/>
                 <ConflictInfoEditing name="Nisunu cunflittu . . ."/>
+                <WindowCategory name="Finestra"/>
+                <FileCategory name="Schedariu"/>
+                <EditCategory name="Mudificazione"/>
+                <SearchCategory name="Ricerca"/>
+                <ViewCategory name="Affissera"/>
+                <FormatCategory name="Cudificazione"/>
+                <LangCategory name="Linguaghju"/>
+                <AboutCategory name="Apprupositu"/>
+                <SettingCategory name="Preferenze"/>
+                <ToolCategory name="Attrezzi"/>
+                <ExecuteCategory name="Eseguisce"/>
                 <MainCommandNames>
                     <Item id="41019" name="Apre cù l’espluratore u cartulare cuntenendu u schedariu"/>
                     <Item id="41020" name="Apre cù l’invitu di cumanda u cartulare cuntenendu u schedariu"/>
@@ -1444,6 +1455,8 @@ Cuntinuà ?"/>
             <ChangeHistoryEnabledWarning title="Notepad++ richiede d’esse rilanciatu" message="Ci vole à rilancià Notepad++ per permette l’affissera di a cronolugia di i cambiamenti."/> <!-- HowToReproduce: uncheck "Display Change History" via Preferences dialog "Marges/Border/Edge. -->
             <WindowsSessionExit title="Notepad++ - Fine di a sessione Windows" message="A sessione Windows stà per piantassi ma ci hè qualchì datu chì ùn hè micca arregistratu. Vulete esce di Notepad++ subitu ?"/>
             <LanguageMenuCompactWarning title="Cumpattà l’affissera di u listinu" message="St’ozzione serà cambiata à u prossimu lanciu."/> <!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
+            <SwitchUnsavedThemeWarning title="$STR_REPLACE$" message="I cambiamenti micca arregistrati stanu per esse squassati !
+Vulete arregistrà i vostri cambiamenti nanzu di cambià di tema ?"/> <!-- HowToReproduce: In the Style Configurator dialog change some theme and switch to other theme without saving. -->
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Cronolugia di u preme’papei"/>
@@ -1453,6 +1466,7 @@ Cuntinuà ?"/>
             <ColumnName name="Nome"/>
             <ColumnExt name="Est."/>
             <ColumnPath name="Chjassu"/>
+            <ListGroups name="Gruppà da vista"/>
         </DocList>
         <WindowsDlg>
             <ColumnName name="Nome"/>
@@ -1648,7 +1662,7 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <summary-nbsel2 value=" ottetti) in "/>
             <summary-nbrange value=" selezzioni"/>
             <progress-cancel-button value="Abbandunà"/>
-            <progress-cancel-info value="Abbandonu di l’operazione, aspittate per piacè..."/>
+            <progress-cancel-info value="Abbandonu di l’operazione, aspittate per piacè…"/>
             <find-in-files-progress-title value="Prugressione di a ricerca in i schedarii…"/>
             <replace-in-files-confirm-title value="Cunfirmazione"/>
             <replace-in-files-confirm-directory value="Vulete rimpiazzà tutte l’occurrenze in :"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 21st, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 24th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
 		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
@@ -1348,7 +1348,8 @@ Pudete attivà torna st’ozzione in u dialogu di e preferenze."/>
                 <Item id="4" name="Sempre sì"/>
             </DoSaveAll> <!-- HowToReproduce: Check the 'Enable Save All confirm dialog' checkbox in Preference->MISC, now click 'Save all' -->
         </Dialog>
-        <MessageBox> <!-- $INT_REPLACE$ is a place holder, don't translate it -->
+        <MessageBox>
+            <!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders. -->
             <ContextMenuXmlEditWarning title="Mudificazione di u listinu cuntestuale" message="A mudificazione di contextMenu.xml vi permette di cambià l’ozzioni di u listinu cuntestuale di Notepad++.
 Ci vole à rilancià Notepad++ per piglià in contu e mudificazioni di contextMenu.xml."/>
             <SaveCurrentModifWarning title="Arregistrà a mudificazione currente" message="Ci vuleria à arregistrà e mudificazioni currente.
@@ -1372,7 +1373,7 @@ Da veru, vulete apreli ?"/> <!-- HowToReproduce: Check "Open all files of folde
 lettura sola, o in un cartulare chì richiede diritti d’accessu di scrittura.
 E vostre preferenze di nivulu anu da esse abbandunate. Ci vole à rimette un valore accetevule via u dialogu di Preferenze."/>
             <FilePathNotFoundWarning title="Apertura di schedariu" message="U schedariu chì voi pruvate d’apre ùn esiste micca."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
-            <SessionFileInvalidError title="Ùn pò micca caricà una sessione" message="U schedariu di sessione hè sia alteratu, sia micca accettevule."/> <!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
+            <SessionFileInvalidError title="Ùn si pò micca caricà una sessione" message="U schedariu di sessione hè sia alteratu, sia inaccettevule."/> <!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
             <DroppingFolderAsProjectModeWarning title="Azzione inaccetevule" message="Pudete depone solu schedarii o cartulari ma micca tremindui, perchè site in u modu di dipositu Cartulare cum’è spaziu di travagliu.
 Ci vole à attivà l’ozzione « À u depone d’un cartulare, apre tutti i schedarii invece d’impiegallu cum’è spaziu di travagliu » in a sezzione « Cartulare predefinitu » di e Preferenze per fà què."/>
             <SortingError title="Sbagliu di classificazione" message="Impussibule di fà una classificazione numerica per via di a linea $INT_REPLACE$."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
@@ -1387,7 +1388,7 @@ Ci hè 3 manere di passà à u modu di selezzione da a culonna :
       Dispiazzà a barra d’inserzione à u locu di fine sceltu per
 	   a pusizione di u bloccu di culonna, eppò lancià a cumanda
        « Principiu è fine di a selezzione in modu di culonna »"/>
-            <BufferInvalidWarning title="Arregistramentu fiascatu" message="Ùn pò micca arregistrà : U stampone hè inaccetevule."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+            <BufferInvalidWarning title="Arregistramentu fiascatu" message="Ùn si pò micca arregistrà : U stampone hè inaccetevule."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
             <DoCloseOrNot title="Cunservà u schedariu inesistente" message="U schedariu « $STR_REPLACE$ » ùn esiste più.
 Cunservà stu schedariu in l’editore ?"/>
             <DoDeleteOrNot title="Squassà u schedariu" message="U schedariu « $STR_REPLACE$ »
@@ -1415,8 +1416,10 @@ Vulete andà nant’à a pagina di Notepad++ per scaricà l’ultima versione ?
             <WantToOpenHugeFile title="Avertimentu d’apertura di schedariu maiò" message="L’apertura d’un schedariu più maiò chè 2 Go pò piglià parechji minuti.
 Vulete aprelu ?"/>
             <CreateNewFileOrNot title="Creà un novu schedariu" message="« $STR_REPLACE$ » ùn esiste. Creallu ?"/>
-            <CreateNewFileError title="Creà un novu schedariu" message="Ùn pò micca creà u schedariu « $STR_REPLACE$ »."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
-            <OpenFileError title="SBAGLIU" message="Ùn pò micca apre u schedariu « $STR_REPLACE$ »."/>
+            <CreateNewFileError title="Creà un novu schedariu" message="Ùn si pò micca creà u schedariu « $STR_REPLACE$ »."/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+            <OpenFileError title="SBAGLIU" message="Ùn si pò micca apre u schedariu « $STR_REPLACE$ »."/>
+            <OpenFileNoFolderError title="Ùn si pò micca apre u schedariu" message="« $STR_REPLACE1$ » ùn pò micca esse apertu :
+U cartulare « $STR_REPLACE2$ » ùn esiste micca."/>
             <FileBackupFailed title="Fiascu di salvaguardia di schedariu" message="A versione precedente di u schedariu ùn pò micca esse arregistrata in u cartulare di salvaguardia : « $STR_REPLACE$ ».
 
 Vulete arregistrà u schedariu attuale quantunque ?"/> <!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
@@ -1437,7 +1440,7 @@ Pare chì u schedariu à apre ùn hè micca un schedariu di prughjettu accettevu
             <ProjectPanelRemoveFolderFromProject title="Caccià u cartulare da u prughjettu" message="Tutti i sottu-elementi seranu cacciati.
 Da veru, vulete caccià stu cartulare da u prughjettu ?"/>
             <ProjectPanelRemoveFileFromProject title="Caccià u schedariu da u prughjettu" message="Da veru, vulete caccià stu schedariu da u prughjettu ?"/>
-            <ProjectPanelReloadError title="Ricaricà u spaziu di travagliu" message="Ùn pò micca truvà u schedariu à ricaricà."/>
+            <ProjectPanelReloadError title="Ricaricà u spaziu di travagliu" message="Ùn si pò micca truvà u schedariu à ricaricà."/>
             <ProjectPanelReloadDirty title="Ricaricà u spaziu di travagliu" message="U spaziu di travagliu attuale hè statu mudificatu. Un ricaricamentu scarterà tutte e mudificazioni.
 Vulete cuntinuà ?"/>
             <UDLNewNameError title="Sbagliu UDL" message="Stu nome hè impiegatu da un altru linguaghju,
@@ -1565,7 +1568,7 @@ Vulete arregistrà i vostri cambiamenti nanzu di cambià di tema ?"/> <!-- HowT
             </Menus>
         </ProjectManager>
         <MiscStrings>
-            <!-- $INT_REPLACE$  and $STR_REPLACE$ are a place holders, don't translate these place holders -->
+            <!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders. -->
             <word-chars-list-tip value="Què permette d’include caratteri addiziunali in i caratteri di parolle currente quandu ci hè un doppiu cliccu per selezziunà o una ricerca cù l’ozzione « Parolla sana deve currisponde » selezziunata."/> <!-- HowToReproduce: In "Delimiter" section of Preferences dialog, hover your mouse on the "?" button. -->
 
             <!-- Don't translate "(&quot;EOL custom color&quot;)" -->
@@ -1647,7 +1650,6 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <splitter-rotate-right value="Girà à diritta"/>
             <recent-file-history-maxfile value="Numeru : "/>
             <recent-file-history-customlength value="Longhezza : "/>
-            <language-tabsize value="Dimens. tabul. : "/>
             <userdefined-title-new value="Creà un novu linguaghju…"/>
             <userdefined-title-save value="Arregistrà u nome di u linguaghju attuale cum’è…"/>
             <userdefined-title-rename value="Rinuminà u linguaghju attuale"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,7 +4,7 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on February 14th, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
+		- Updated on February 21st, 2023 for version 8.5.0 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
 		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
 		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
@@ -759,6 +759,7 @@ The comments are here for explanation, it's not necessary to translate them.
                 <Item id="20011" name="Trasparenza"/>
                 <Item id="20015" name="Impurtà…"/>
                 <Item id="20016" name="Espurtà…"/>
+                <Item id="20017" name="Staccà"/>
                 <StylerDialog title="Dialogu di u stilu">
                     <Item id="25030" name="Ozzioni di grafia :"/>
                     <Item id="25006" name="Culore di primu pianu"/>
@@ -1181,7 +1182,6 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                     <Item id="6824" name="Ignurà i numeri"/>
                     <Item id="6811" name="Da u"/>
                     <Item id="6813" name="u caratteru"/>
-                    <Item id="6814" name="Valori accettati : 1 - 9"/>
                     <Item id="6872" name="Accurtà a lista d’empiimentu autumaticu"/>
                     <Item id="6815" name="Sugerisce i parametri di funzione à l’entrata"/>
                     <Item id="6851" name="Inserzione autumatica"/>
@@ -1651,7 +1651,6 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <userdefined-title-new value="Creà un novu linguaghju…"/>
             <userdefined-title-save value="Arregistrà u nome di u linguaghju attuale cum’è…"/>
             <userdefined-title-rename value="Rinuminà u linguaghju attuale"/>
-            <autocomplete-nb-char value="N° carat. : "/>
             <edit-verticaledge-nb-col value="N° di culonne :"/>
             <summary value="Statistiche"/>
             <summary-filepath value="Chjassu d’accessu : "/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/07924528c4407f0d99f8ac01862e2d21dcc69899 Add Begin/End Select in Column Mode command
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/aaab190763b720e2eed6495d8508b970d09ad39c Add show non-printable characters command

Updated on February 7<sup>th</sup> for these commits:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/dc99ce103550a3441f474b44c0a4075af3ed41ba Make Non-Print Characters show by default
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/43d9f0d665248e252642e3f8cd4c2a8b9b1370e5 Translate 'Compact Language Menu' popup dialog

Updated on February 12<sup>th</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/9eab1f566d59c08e9f30d6faa2e4d6f56f05edc0 Add option to make auto-completion list brief

Updated on February 13<sup>th</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/3f13957f69738670a39fd589fe3cd85de1b307f8 Make two items in progress dialog translatable

Updated on February 14<sup>th</sup> for these commits:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f7fcab4c219b7187ce9d6ca300c96f06f8f2e877 Make categories in the Shortcut Mapper dialog translatable
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/0c704fd66b12170c17ccd97c6b5f3d72e40e241c Make theme warning message translatable (switching unsaved theme to another
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/37963ea21ad7876903c669e2190e6f2b2dde7e39 Apply tab colors to document list items
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f403b1226471370ab203bc66a313fc976e626cd2 Make Context menu in Shortcut Mapper (Modify, Delete, Clear) translatable

Updated on February 21<sup>st</sup> for these commits:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/9627494043d3ace4d4b5ab04b85fbdd0bd5a87a5 Fix translation issue for Dock/Undock label in User-Defined dialog
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/caff51c78817dedbe0e5b74a55b93adfef78eccc GUI enhancement: replace auto-complete link mini dlg with slider
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/3f3aed43edcc26d21ff32eed3eea102a62977865 Rename commanfd "Remove Unmarked Lines" to "Remove Non-Bookmarked Lines"

Updated on February 24<sup>th</sup> for these commits:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/a68963503774919790d0d226010141093e79538e Make "Cannot open file" message translatable
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/8b3f072a38657b521b14403d64d42d7d7db2a5cf GUI enhancement: use edit field instead of tab size link + mini dlg
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/99e7c5a84cc994b795b7b5e7acfa4943b9b03ed4 Set english.xml version right

Cheers,
Patriccollu.