### PR TITLE
Fix missing items in word autocomplete

### DIFF
--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -458,7 +458,10 @@ void AutoCompletion::getWordArray(vector<generic_string> & wordArray, TCHAR *beg
 
 	size_t docLength = _pEditView->execute(SCI_GETLENGTH);
 
-	int flags = SCFIND_WORDSTART | SCFIND_MATCHCASE | SCFIND_REGEXP | SCFIND_POSIX;
+	int flags = SCFIND_WORDSTART | SCFIND_REGEXP | SCFIND_POSIX;
+
+	if (!_ignoreCase || (!_funcCompletionActive && _curLang == L_TEXT))
+		flags |= SCFIND_MATCHCASE;
 
 	_pEditView->execute(SCI_SETSEARCHFLAGS, flags);
 	intptr_t posFind = _pEditView->searchInTarget(expr.c_str(), expr.length(), 0, docLength);


### PR DESCRIPTION
Fix #13060

Word autocomplete change from case sensitive search to variable search based on `_ignoreCase` unless language type is text. This allows text documents to retain case sensitive search to respect typed case as the issue only affects case insensitive Data/Programming languages. If *normal.xml* exist in the autocomplete folder then xml defaults apply for text so would be case insensitive by default unless overridden by the xml setting `<Environment ignoreCase="no" />`.

If **full** variable search based on `_ignoreCase` is considered more suitable by including text, then a change is possible.