### PR TITLE
Add -Wextra flag for GCC builds

### DIFF
--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -53,13 +53,13 @@ SUBMAKEFLAGS := -O --no-print-directory
 ifeq "$(filter-out 0,$(DEBUG))" ""
 BUILD_TYPE := release
 BUILD_SUFFIX :=
-CXXFLAGS += -Os -Wconversion
+CXXFLAGS += -O3 -Wconversion
 CPP_DEFINE += NDEBUG
 LDFLAGS += -s
 else
 BUILD_TYPE := debug
 BUILD_SUFFIX := -debug
-CXXFLAGS += -Og -g -Wall -Wpedantic -Wconversion
+CXXFLAGS += -Og -g -Wpedantic -Wall -Wextra -Wno-cast-function-type -Wconversion
 CPP_DEFINE += DEBUG
 endif
 

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -37,9 +37,11 @@
 #define WINAPI_LAMBDA
 #endif
 
-#ifdef _MSC_VER
-#pragma comment(lib, "uxtheme.lib")
-#endif
+// already added in project files
+// keep for plugin authors
+//#ifdef _MSC_VER
+//#pragma comment(lib, "uxtheme.lib")
+//#endif
 
 constexpr COLORREF HEXRGB(DWORD rrggbb) {
 	// from 0xRRGGBB like natural #RRGGBB
@@ -3052,7 +3054,7 @@ namespace NppDarkMode
 	using IndividualTabColours = std::array<HLSColour, 5>;
 
 	static constexpr IndividualTabColours individualTabHuesFor_Dark  { { HLSColour{37, 60, 60}, HLSColour{70, 60, 60}, HLSColour{144, 70, 60}, HLSColour{255, 60, 60}, HLSColour{195, 60, 60} } };
-	static const IndividualTabColours individualTabHues              { { HLSColour{37, 210, 150}, HLSColour{70, 210, 150}, HLSColour{144, 210, 150}, HLSColour{255, 210, 150}, HLSColour{195, 210, 150}}};
+	static constexpr IndividualTabColours individualTabHues          { { HLSColour{37, 210, 150}, HLSColour{70, 210, 150}, HLSColour{144, 210, 150}, HLSColour{255, 210, 150}, HLSColour{195, 210, 150}}};
 
 
 	COLORREF getIndividualTabColour(int colourIndex, bool themeDependant, bool saturated)

--- a/PowerEditor/src/ScintillaComponent/DocTabView.h
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.h
@@ -30,7 +30,7 @@ public :
 	DocTabView():TabBarPlus(), _pView(NULL) {};
 	virtual ~DocTabView(){};
 	
-	virtual void destroy() {
+	virtual void destroy() override {
 		TabBarPlus::destroy();
 	};
 
@@ -84,7 +84,7 @@ public :
 		return _hideTabBarStatus;
 	};
 
-	virtual void reSizeTo(RECT & rc);
+	virtual void reSizeTo(RECT & rc) override;
 
 	const ScintillaEditView* getScintillaEditView() const {
 		return _pView;

--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.cpp
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.cpp
@@ -966,12 +966,12 @@ void TiXmlAttributeA::SetDoubleValue( double _value )
 	SetValue (buf);
 }
 
-const int TiXmlAttributeA::IntValue() const
+int TiXmlAttributeA::IntValue() const
 {
 	return atoi (value.c_str ());
 }
 
-const double  TiXmlAttributeA::DoubleValue() const
+double TiXmlAttributeA::DoubleValue() const
 {
 	return atof (value.c_str ());
 }

--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.h
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.h
@@ -583,10 +583,10 @@ public:
 		prev = next = 0;
 	}
 
-	const char*		Name()  const		{ return name.c_str (); }		///< Return the name of this attribute.
-	const char*		Value() const		{ return value.c_str (); }		///< Return the value of this attribute.
-	const int       IntValue() const;									///< Return the value of this attribute, converted to an integer.
-	const double	DoubleValue() const;								///< Return the value of this attribute, converted to a double.
+	const char*     Name()  const		{ return name.c_str (); }		///< Return the name of this attribute.
+	const char*     Value() const		{ return value.c_str (); }		///< Return the value of this attribute.
+	int             IntValue() const;									///< Return the value of this attribute, converted to an integer.
+	double          DoubleValue() const;								///< Return the value of this attribute, converted to a double.
 
 	/** QueryIntValue examines the value string. It is an alternative to the
 		IntValue() method with richer error checking.
@@ -1052,7 +1052,7 @@ public:
 	/** Generally, you probably want the error string ( ErrorDesc() ). But if you
 		prefer the ErrorId, this function will fetch it.
 	*/
-	const int ErrorId()	const				{ return errorId; }
+	int ErrorId()	const					{ return errorId; }
 
 	/** Returns the location (if known) of the error. The first column is column 1, 
 		and the first row is row 1. A value of 0 means the row and column wasn't applicable

--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -928,12 +928,12 @@ void TiXmlAttribute::SetDoubleValue( double _value )
 	SetValue (buf);
 }
 
-const int TiXmlAttribute::IntValue() const
+int TiXmlAttribute::IntValue() const
 {
 	return _wtoi (value.c_str ());
 }
 
-const double  TiXmlAttribute::DoubleValue() const
+double  TiXmlAttribute::DoubleValue() const
 {
 	return _wtof(value.c_str ());
 }

--- a/PowerEditor/src/TinyXml/tinyxml.h
+++ b/PowerEditor/src/TinyXml/tinyxml.h
@@ -585,10 +585,10 @@ public:
 		prev = next = 0;
 	}
 
-	const TCHAR*		Name()  const		{ return name.c_str (); }		///< Return the name of this attribute.
-	const TCHAR*		Value() const		{ return value.c_str (); }		///< Return the value of this attribute.
-	const int       IntValue() const;									///< Return the value of this attribute, converted to an integer.
-	const double	DoubleValue() const;								///< Return the value of this attribute, converted to a double.
+	const TCHAR*        Name()  const		{ return name.c_str (); }		///< Return the name of this attribute.
+	const TCHAR*        Value() const		{ return value.c_str (); }		///< Return the value of this attribute.
+	int                 IntValue() const;									///< Return the value of this attribute, converted to an integer.
+	double              DoubleValue() const;								///< Return the value of this attribute, converted to a double.
 
 	/** QueryIntValue examines the value generic_string. It is an alternative to the
 		IntValue() method with richer error checking.
@@ -1051,7 +1051,7 @@ public:
 	/** Generally, you probably want the error generic_string ( ErrorDesc() ). But if you
 		prefer the ErrorId, this function will fetch it.
 	*/
-	const int ErrorId()	const				{ return errorId; }
+	int ErrorId()	const					{ return errorId; }
 
 	/** Returns the location (if known) of the error. The first column is column 1, 
 		and the first row is row 1. A value of 0 means the row and column wasn't applicable

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -168,7 +168,11 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			_debugInfoStr += buildTime;
 			_debugInfoStr += TEXT("\r\n");
 
-#if defined(__GNUC__)
+#if defined(__clang__)
+			_debugInfoStr += TEXT("Built with : Clang ");
+			_debugInfoStr += wmc.char2wchar(__clang_version__, CP_ACP);
+			_debugInfoStr += TEXT("\r\n");
+#elif defined(__GNUC__)
 			_debugInfoStr += TEXT("Built with : GCC ");
 			_debugInfoStr += wmc.char2wchar(__VERSION__, CP_ACP);
 			_debugInfoStr += TEXT("\r\n");

--- a/PowerEditor/src/WinControls/StatusBar/StatusBar.h
+++ b/PowerEditor/src/WinControls/StatusBar/StatusBar.h
@@ -38,7 +38,7 @@ public:
 	virtual void destroy() override;
     virtual void reSizeTo(const RECT& rc);
 
-	int getHeight() const;
+	int getHeight() const override;
 
     bool setText(const TCHAR* str, int whichPart);
 	bool setOwnerDrawText(const TCHAR* str);

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -107,7 +107,7 @@ public:
 		this->_canModifyName = sc._canModifyName;
 		return *this;
 	}
-	friend inline const bool operator==(const Shortcut & a, const Shortcut & b) {
+	friend inline bool operator==(const Shortcut & a, const Shortcut & b) {
 		return ((lstrcmp(a.getMenuName(), b.getMenuName()) == 0) && 
 			(a._keyCombo._isCtrl == b._keyCombo._isCtrl) && 
 			(a._keyCombo._isAlt == b._keyCombo._isAlt) && 
@@ -116,7 +116,7 @@ public:
 			);
 	};
 
-	friend inline const bool operator!=(const Shortcut & a, const Shortcut & b) {
+	friend inline bool operator!=(const Shortcut & a, const Shortcut & b) {
 		return !(a == b);
 	};
 
@@ -233,7 +233,7 @@ public:
     };
 
 	//only compares the internal KeyCombos, nothing else
-	friend inline const bool operator==(const ScintillaKeyMap & a, const ScintillaKeyMap & b) {
+	friend inline bool operator==(const ScintillaKeyMap & a, const ScintillaKeyMap & b) {
 		bool equal = a._size == b._size;
 		if (!equal)
 			return false;
@@ -250,7 +250,7 @@ public:
 		return equal;
 	};
 
-	friend inline const bool operator!=(const ScintillaKeyMap & a, const ScintillaKeyMap & b) {
+	friend inline bool operator!=(const ScintillaKeyMap & a, const ScintillaKeyMap & b) {
 		return !(a == b);
 	};
 

--- a/PowerEditor/visual.net/notepadPlus.Cpp.props
+++ b/PowerEditor/visual.net/notepadPlus.Cpp.props
@@ -35,6 +35,12 @@
       <AdditionalManifestFiles>..\src\dpiAware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(PlatformToolset)'=='ClangCL'">
+    <ClCompile>
+      <TreatWarningAsError>false</TreatWarningAsError>
+      <AdditionalOptions>-Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-reserved-id-macro -Wno-pragma-pack -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-overloaded-virtual %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <Optimization>Disabled</Optimization>

--- a/PowerEditor/visual.net/notepadPlus.Cpp.props
+++ b/PowerEditor/visual.net/notepadPlus.Cpp.props
@@ -9,6 +9,11 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(PlatformToolset)'=='ClangCL'">
+    <!-- Clang build has issue with embedding manifest, manifest will be added after build in PostBuildEvent-->
+    <GenerateManifest>false</GenerateManifest>
+    <EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
   <ItemDefinitionGroup Label="Globals">
     <ClCompile>
       <AdditionalIncludeDirectories>..\src\WinControls\AboutDlg;..\..\scintilla\include;..\..\lexilla\include;..\include;..\src\WinControls;..\src\WinControls\ImageListSet;..\src\WinControls\OpenSaveFileDialog;..\src\WinControls\SplitterContainer;..\src\WinControls\StaticDialog;..\src\WinControls\TabBar;..\src\WinControls\ToolBar;..\src\MISC\Process;..\src\ScintillaComponent;..\src\MISC;..\src\MISC\SysMsg;..\src\WinControls\StatusBar;..\src;..\src\WinControls\StaticDialog\RunDlg;..\src\tinyxml;..\src\WinControls\ColourPicker;..\src\Win32Explr;..\src\MISC\RegExt;..\src\WinControls\TrayIcon;..\src\WinControls\shortcut;..\src\WinControls\Grid;..\src\WinControls\ContextMenu;..\src\MISC\PluginsManager;..\src\WinControls\Preference;..\src\WinControls\WindowsDlg;..\src\WinControls\TaskList;..\src\WinControls\DockingWnd;..\src\WinControls\TreeView;..\src\WinControls\ToolTip;..\src\MISC\Exception;..\src\MISC\Common;..\src\tinyxml\tinyXmlA;..\src\WinControls\AnsiCharPanel;..\src\WinControls\ClipboardHistory;..\src\WinControls\FindCharsInRange;..\src\WinControls\VerticalFileSwitcher;..\src\WinControls\ProjectPanel;..\src\WinControls\DocumentMap;..\src\WinControls\FunctionList;..\src\uchardet;..\src\WinControls\FileBrowser;..\src\WinControls\ReadDirectoryChanges;..\src\MISC\md5;..\src\WinControls\PluginsAdmin;..\src\json;..\src\MISC\sha2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -77,6 +82,34 @@
       <ProgramDatabaseFile>$(OutDir)npp.pdb</ProgramDatabaseFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
+    <PostBuildEvent>
+      <Command>
+copy "..\src\langs.model.xml" "$(OutDir)langs.model.xml"
+copy "..\src\stylers.model.xml" "$(OutDir)stylers.model.xml"
+copy "..\src\shortcuts.xml" "$(OutDir)shortcuts.xml"
+copy "..\src\contextMenu.xml" "$(OutDir)contextMenu.xml"
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(PlatformToolset)|$(Configuration)'=='ClangCL|Release'">
+    <PostBuildEvent>
+      <Command>
+copy "..\src\langs.model.xml" "$(OutDir)langs.model.xml"
+copy "..\src\stylers.model.xml" "$(OutDir)stylers.model.xml"
+copy "..\src\shortcuts.xml" "$(OutDir)shortcuts.xml"
+copy "..\src\contextMenu.xml" "$(OutDir)contextMenu.xml"
+"mt.exe" -nologo -manifest "..\src\notepad++.exe.manifest" -outputresource:"$(OutDir)notepad++.exe"
+"mt.exe" -updateresource:"$(OutDir)notepad++.exe";#1 -manifest "..\src\dpiAware.manifest"
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(PlatformToolset)|$(Configuration)'=='ClangCL|Debug'">
+    <PostBuildEvent>
+      <Command>
+"mt.exe" -nologo -manifest "..\src\notepad++.exe.manifest" -outputresource:"$(OutDir)notepad++.exe"
+"mt.exe" -updateresource:"$(OutDir)notepad++.exe";#1 -manifest "..\src\dpiAware.manifest"
+      </Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -100,34 +100,10 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <PostBuildEvent>
-      <Command>
-copy ..\src\langs.model.xml ..\bin\langs.model.xml
-copy ..\src\stylers.model.xml ..\bin\stylers.model.xml
-copy ..\src\shortcuts.xml ..\bin\shortcuts.xml
-copy ..\src\contextMenu.xml ..\bin\contextMenu.xml
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PostBuildEvent>
-      <Command>
-copy ..\src\langs.model.xml ..\bin64\langs.model.xml
-copy ..\src\stylers.model.xml ..\bin64\stylers.model.xml
-copy ..\src\shortcuts.xml ..\bin64\shortcuts.xml
-copy ..\src\contextMenu.xml ..\bin64\contextMenu.xml
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <PostBuildEvent>
-      <Command>
-copy ..\src\langs.model.xml ..\binarm64\langs.model.xml
-copy ..\src\stylers.model.xml ..\binarm64\stylers.model.xml
-copy ..\src\shortcuts.xml ..\binarm64\shortcuts.xml
-copy ..\src\contextMenu.xml ..\binarm64\contextMenu.xml
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\DarkMode\DarkMode.cpp" />


### PR DESCRIPTION
fix ignored-qualifiers warnings
fix inconsistent-missing-override warnings
use -O3 flag for GCC builds to keep inline with scintilla and lexilla 
add clang default settings in props
add clang detection in debug info

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13099

