### PR TITLE
Translate context menu in Shortcut Mapper dialog

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -603,6 +603,9 @@ The comments are here for explanation, it's not necessary to translate them.
                 <SettingCategory name="Setting"/>
                 <ToolCategory name="Tool"/>
                 <ExecuteCategory name="Execute"/>
+                <ModifyContextMenu name="Modify"/>
+                <DeleteContextMenu name="Delete"/>
+                <ClearContextMenu name="Clear"/>
                 <MainCommandNames>
                     <Item id="41019" name="Open containing folder in Explorer"/>
                     <Item id="41020" name="Open containing folder in Command Prompt"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -547,6 +547,9 @@
                 <SettingCategory name="Setting"/>
                 <ToolCategory name="Tool"/>
                 <ExecuteCategory name="Execute"/>
+                <ModifyContextMenu name="Modify"/>
+                <DeleteContextMenu name="Delete"/>
+                <ClearContextMenu name="Clear"/>
                 <MainCommandNames>
                     <Item id="41019" name="Open containing folder in Explorer"/>
                     <Item id="41020" name="Open containing folder in Command Prompt"/>

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -287,7 +287,6 @@ void ShortcutMapper::fillOutBabyGrid()
 	{
 		case STATE_MENU:
 		{
-			NativeLangSpeaker* nativeLangSpeaker = NppParameters::getInstance().getNativeLangSpeaker();
 			vector<CommandShortcut> & cshortcuts = nppParam.getUserShortcuts();
 			cs_index = 1;
 			for (size_t i = 0; i < nbItems; ++i)
@@ -1095,9 +1094,13 @@ intptr_t CALLBACK ShortcutMapper::run_dlgProc(UINT message, WPARAM wParam, LPARA
 							if (!_rightClickMenu.isCreated())
 							{
 								vector<MenuItemUnit> itemUnitArray;
-								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_MODIFY, TEXT("Modify")));
-								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_DELETE, TEXT("Delete")));
-								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_CLEAR, TEXT("Clear")));
+								NativeLangSpeaker* nativeLangSpeaker = NppParameters::getInstance().getNativeLangSpeaker();
+								generic_string modifyStr = nativeLangSpeaker->getShortcutMapperLangStr("ModifyContextMenu", TEXT("Modify"));
+								generic_string deleteStr = nativeLangSpeaker->getShortcutMapperLangStr("DeleteContextMenu", TEXT("Delete"));
+								generic_string clearStr = nativeLangSpeaker->getShortcutMapperLangStr("ClearContextMenu", TEXT("Clear"));
+								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_MODIFY, modifyStr.c_str()));
+								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_DELETE, deleteStr.c_str()));
+								itemUnitArray.push_back(MenuItemUnit(IDM_BABYGRID_CLEAR, clearStr.c_str()));
 								_rightClickMenu.create(_hSelf, itemUnitArray);
 							}
 


### PR DESCRIPTION
Make Context menu in Shortcut Mapper (Modify, Delete, Clear) translatable.
(One of issues in https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8972)