### PR TITLE
Fix translation for Dock/Undock label in User-Defined dialog

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -722,6 +722,7 @@ The comments are here for explanation, it's not necessary to translate them.
                 <Item id="20011" name="Transparency"/>
                 <Item id="20015" name="Import..."/>
                 <Item id="20016" name="Export..."/>
+                <Item id="20017" name="Undock"/>
                 <StylerDialog title="Styler Dialog">
                     <Item id="25030" name="Font options:"/>
                     <Item id="25006" name="Foreground color"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -650,6 +650,7 @@
                 <Item id="20011" name="Transparency"/>
                 <Item id="20015" name="Import..."/>
                 <Item id="20016" name="Export..."/>
+                <Item id="20017" name="Undock"/>
                 <StylerDialog title="Styler Dialog">
                     <Item id="25030" name="Font options:"/>
                     <Item id="25006" name="Foreground colour"/>

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -933,9 +933,22 @@ void UserDefineDialog::changeStyle()
         if (targetNode)
             targetNode = targetNode->FirstChildElement("UserDefine");
     }
-    generic_string dockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Dock"), targetNode, std::to_string(IDC_DOCK_BUTTON).c_str());
-    generic_string undockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Undock"), targetNode, std::to_string(IDC_UNDOCK_BUTTON).c_str());
-    ::SetDlgItemText(_hSelf, IDC_DOCK_BUTTON, (_status == DOCK) ? undockStr.c_str() : dockStr.c_str());
+    generic_string dockButtonLabel;
+    generic_string defauleLabel;
+    string idStr;
+    if (_status == DOCK)
+    {
+        defauleLabel = TEXT("Undock");
+        idStr = std::to_string(IDC_UNDOCK_BUTTON);
+    }
+    else
+    {
+        defauleLabel = TEXT("Dock");
+        idStr = std::to_string(IDC_DOCK_BUTTON);
+    }
+
+    dockButtonLabel= pNativeSpeaker->getAttrNameByIdStr(defauleLabel.c_str(), targetNode, idStr.c_str());
+    ::SetDlgItemText(_hSelf, IDC_DOCK_BUTTON, dockButtonLabel.c_str());
 
     auto style = ::GetWindowLongPtr(_hSelf, GWL_STYLE);
     if (!style)

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -927,7 +927,7 @@ void UserDefineDialog::changeStyle()
     _status = !_status;
     NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
     TiXmlNodeA *targetNode = nullptr;
-    pNativeSpeaker->getNativeLangA() && (targetNode = (pNativeSpeaker->getNativeLangA())->FirstChildElement("Dialog")) && (targetNode = targetNode->FirstChildElement("UserDefine"));
+    pNativeSpeaker->getNativeLangA() && ((targetNode = (pNativeSpeaker->getNativeLangA()))->FirstChildElement("Dialog")) && ((targetNode = targetNode->FirstChildElement("UserDefine")));
     generic_string dockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Dock"), targetNode, std::to_string(IDC_DOCK_BUTTON).c_str());
     generic_string undockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Undock"), targetNode, std::to_string(IDC_UNDOCK_BUTTON).c_str());
     ::SetDlgItemText(_hSelf, IDC_DOCK_BUTTON, (_status == DOCK) ? undockStr.c_str() : dockStr.c_str());

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -925,9 +925,14 @@ void UserDefineDialog::reloadLangCombo()
 void UserDefineDialog::changeStyle()
 {
     _status = !_status;
-    ::SetDlgItemText(_hSelf, IDC_DOCK_BUTTON, (_status == DOCK)?TEXT("Undock"):TEXT("Dock"));
+    NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
+    TiXmlNodeA *targetNode = nullptr;
+    pNativeSpeaker->getNativeLangA() && (targetNode = (pNativeSpeaker->getNativeLangA())->FirstChildElement("Dialog")) && (targetNode = targetNode->FirstChildElement("UserDefine"));
+    generic_string dockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Dock"), targetNode, std::to_string(IDC_DOCK_BUTTON).c_str());
+    generic_string undockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Undock"), targetNode, std::to_string(IDC_UNDOCK_BUTTON).c_str());
+    ::SetDlgItemText(_hSelf, IDC_DOCK_BUTTON, (_status == DOCK) ? undockStr.c_str() : dockStr.c_str());
 
-	auto style = ::GetWindowLongPtr(_hSelf, GWL_STYLE);
+    auto style = ::GetWindowLongPtr(_hSelf, GWL_STYLE);
     if (!style)
         ::MessageBox(NULL, TEXT("GetWindowLongPtr failed in UserDefineDialog::changeStyle()"), TEXT(""), MB_OK);
 

--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -927,7 +927,12 @@ void UserDefineDialog::changeStyle()
     _status = !_status;
     NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
     TiXmlNodeA *targetNode = nullptr;
-    pNativeSpeaker->getNativeLangA() && ((targetNode = (pNativeSpeaker->getNativeLangA()))->FirstChildElement("Dialog")) && ((targetNode = targetNode->FirstChildElement("UserDefine")));
+    if (pNativeSpeaker->getNativeLangA())
+    {
+        targetNode = (pNativeSpeaker->getNativeLangA())->FirstChildElement("Dialog");
+        if (targetNode)
+            targetNode = targetNode->FirstChildElement("UserDefine");
+    }
     generic_string dockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Dock"), targetNode, std::to_string(IDC_DOCK_BUTTON).c_str());
     generic_string undockStr = pNativeSpeaker->getAttrNameByIdStr(TEXT("Undock"), targetNode, std::to_string(IDC_UNDOCK_BUTTON).c_str());
     ::SetDlgItemText(_hSelf, IDC_DOCK_BUTTON, (_status == DOCK) ? undockStr.c_str() : dockStr.c_str());

--- a/PowerEditor/src/ScintillaComponent/UserDefineResource.h
+++ b/PowerEditor/src/ScintillaComponent/UserDefineResource.h
@@ -35,6 +35,7 @@
     #define    IDC_AUTOCOMPLET_STATIC                       (IDD_GLOBAL_USERDEFINE_DLG + 14)
     #define    IDC_IMPORT_BUTTON                            (IDD_GLOBAL_USERDEFINE_DLG + 15)
     #define    IDC_EXPORT_BUTTON                            (IDD_GLOBAL_USERDEFINE_DLG + 16)
+    #define    IDC_UNDOCK_BUTTON                            (IDD_GLOBAL_USERDEFINE_DLG + 17)
 
 #define    IDD_FOLDER_STYLE_DLG   21000 // IDD_GLOBAL_USERDEFINE_DLG + 1000
      #define    IDC_DEFAULT                                 (IDD_FOLDER_STYLE_DLG + 100)

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -1331,6 +1331,29 @@ generic_string NativeLangSpeaker::getAttrNameStr(const TCHAR *defaultStr, const 
 	return defaultStr;
 }
 
+	generic_string NativeLangSpeaker::getAttrNameByIdStr(const TCHAR *defaultStr, TiXmlNodeA *targetNode, const char *nodeL1Value, const char *nodeL1Name, const char *nodeL2Name) const
+{
+	if (!targetNode) return defaultStr;
+
+	for (TiXmlNodeA *childNode = targetNode->FirstChildElement("Item");
+		childNode;
+		childNode = childNode->NextSibling("Item"))
+	{
+		TiXmlElementA *element = childNode->ToElement();
+		const char *id = element->Attribute(nodeL1Name);
+		if (id && id[0] && !strcmp(id, nodeL1Value))
+		{
+			const char *name = element->Attribute(nodeL2Name);
+			if (name && name[0])
+			{
+				WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+				return wmc.char2wchar(name, _nativeLangEncoding);
+			}
+		}
+	}
+	return defaultStr;
+}
+
 int NativeLangSpeaker::messageBox(const char *msgBoxTagName, HWND hWnd, const TCHAR *defaultMessage, const TCHAR *defaultTitle, int msgBoxType, int intInfo, const TCHAR *strInfo)
 {
 	if ((NppParameters::getInstance()).isEndSessionCritical())

--- a/PowerEditor/src/localization.h
+++ b/PowerEditor/src/localization.h
@@ -80,6 +80,7 @@ public:
 	generic_string getProjectPanelLangMenuStr(const char * nodeName, int cmdID, const TCHAR *defaultStr) const;
 	generic_string getFileBrowserLangMenuStr(int cmdID, const TCHAR *defaultStr) const;
 	generic_string getAttrNameStr(const TCHAR *defaultStr, const char *nodeL1Name, const char *nodeL2Name, const char *nodeL3Name = "name") const;
+	generic_string getAttrNameByIdStr(const TCHAR *defaultStr, TiXmlNodeA *targetNode, const char *nodeL1Value, const char *nodeL1Name = "id", const char *nodeL2Name = "name") const;
 	generic_string getLocalizedStrFromID(const char *strID, const generic_string& defaultString) const;
 
 	int messageBox(const char *msgBoxTagName, HWND hWnd, const TCHAR *message, const TCHAR *title, int msgBoxType, int intInfo = 0, const TCHAR *strInfo = NULL);


### PR DESCRIPTION
Fix [8020](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/8020).

@donho 
I create additional function `getAttrNameByIdStr`. It's universal, we pass the `targetNode` for searching `<Item>` elements  (so before passing we can choose any one, regardless of the level of nesting). It retrieves the value of the `"name"` attribute based on the name and the value of the `"id"` attribute. Attribute names `"id"` and `"name"` can be changed (these are default).
I noticed that sometimes we have already translated value(s) in some node(s) and it doesn't make sense to add more nodes with the same value (especially when we are in the same parent). Unfortunately, there was no universal method defined to achieve this, so I added it.

