### PR TITLE
Correct parameter error in specific call to doOpen

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1991,7 +1991,7 @@ void Notepad_plus::fileOpen()
 	size_t sz = fns.size();
 	for (size_t i = 0 ; i < sz ; ++i)
 	{
-		BufferID test = doOpen(fns.at(i).c_str(), fDlg.isReadOnly());
+		BufferID test = doOpen(fns.at(i).c_str(), false, fDlg.isReadOnly());
 		if (test != BUFFER_INVALID)
 			lastOpened = test;
 	}


### PR DESCRIPTION
Fix #13150 

I could not generate a user-level bug from this, but the call to `doOpen` is clearly wrong, when looking at its signature:

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/9627494043d3ace4d4b5ab04b85fbdd0bd5a87a5/PowerEditor/src/Notepad_plus.h#L164