### PR TITLE
Volatile Find uses least-strict option settings

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1372,15 +1372,26 @@ void Notepad_plus::command(int id)
 		case IDM_SEARCH_VOLATILE_FINDNEXT :
 		case IDM_SEARCH_VOLATILE_FINDPREV :
 		{
-			TCHAR text2Find[MAX_PATH] = { '\0' };
-			_pEditView->getGenericSelectedText(text2Find, MAX_PATH);
+			bool isFirstTime = !_findReplaceDlg.isCreated();
+			if (isFirstTime)
+			{
+				_findReplaceDlg.doDialog(FIND_DLG, _nativeLangSpeaker.isRTL(), false);
+			}
 
-			FindOption op;
-			op._isWholeWord = false;
-			op._whichDirection = (id == IDM_SEARCH_VOLATILE_FINDNEXT?DIR_DOWN:DIR_UP);
+			const int strSize = FINDREPLACE_MAXLENGTH;
+			TCHAR str[strSize] = { '\0' };
+			_pEditView->getGenericSelectedText(str, strSize);
+			if (isFirstTime)
+			{
+				_nativeLangSpeaker.changeFindReplaceDlgLang(_findReplaceDlg);
+			}
+
+			FindOption op = _findReplaceDlg.getCurrentOptions();
+			op._searchType = FindNormal;
+			op._whichDirection = (id == IDM_SEARCH_VOLATILE_FINDNEXT ? DIR_DOWN : DIR_UP);
 
 			FindStatus status = FSNoMessage;
-			_findReplaceDlg.processFindNext(text2Find, &op, &status);
+			_findReplaceDlg.processFindNext(str, &op, &status);
 			if (status == FSEndReached)
 			{
 				generic_string msg = _nativeLangSpeaker.getLocalizedStrFromID("find-status-end-reached", TEXT("Find: Found the 1st occurrence from the top. The end of the document has been reached."));

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1372,21 +1372,14 @@ void Notepad_plus::command(int id)
 		case IDM_SEARCH_VOLATILE_FINDNEXT :
 		case IDM_SEARCH_VOLATILE_FINDPREV :
 		{
-			bool isFirstTime = !_findReplaceDlg.isCreated();
-			if (isFirstTime)
-			{
-				_findReplaceDlg.doDialog(FIND_DLG, _nativeLangSpeaker.isRTL(), false);
-			}
-
 			const int strSize = FINDREPLACE_MAXLENGTH;
 			TCHAR str[strSize] = { '\0' };
 			_pEditView->getGenericSelectedText(str, strSize);
-			if (isFirstTime)
-			{
-				_nativeLangSpeaker.changeFindReplaceDlgLang(_findReplaceDlg);
-			}
 
-			FindOption op = _findReplaceDlg.getCurrentOptions();
+			FindOption op;
+			op._isMatchCase = false;
+			op._isWholeWord = false;
+			op._isWrapAround = true;
 			op._searchType = FindNormal;
 			op._whichDirection = (id == IDM_SEARCH_VOLATILE_FINDNEXT ? DIR_DOWN : DIR_UP);
 


### PR DESCRIPTION
Fix #13145 

-----------------------------------

Code unified with `IDM_SEARCH_SETANDFINDNEXT` block as much as reasonable (that block is currently fully working).  

-----------------------------------

To get a true picture of what this PR proposes, do this compare, with, e.g. ComparePlus plugin:

Left side of compare:
```
case IDM_SEARCH_SETANDFINDNEXT :
case IDM_SEARCH_SETANDFINDPREV :
{
...
}
```

Right side of compare (using the proposed new section from this PR):
```
case IDM_SEARCH_VOLATILE_FINDNEXT :
case IDM_SEARCH_VOLATILE_FINDPREV :
{
...
}
```

The difference should be that the "volatile" code (right-hand side) does NOT set the _Find what_ box data.

-----------------------------------

Perhaps it makes sense to do this with the code instead?:

```
case IDM_SEARCH_SETANDFINDNEXT :
case IDM_SEARCH_SETANDFINDPREV :
case IDM_SEARCH_VOLATILE_FINDNEXT :
case IDM_SEARCH_VOLATILE_FINDPREV :
{
...
}
```
