### PR TITLE
Fix clang warnings

### DIFF
--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -250,6 +250,8 @@ const char* xpmboxDark[] = {
 
 using namespace std;
 
+constexpr size_t tagMaxLen = 256;
+
 static bool isInList(const generic_string& word, const vector<generic_string> & wordArray)
 {
 	for (size_t i = 0, len = wordArray.size(); i < len; ++i)

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.h
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.h
@@ -20,8 +20,6 @@
 #include "FunctionCallTip.h"
 #include "tinyxml.h"
 
-const size_t tagMaxLen = 256;
-
 class ScintillaEditView;
 
 struct MatchedCharInserted {

--- a/PowerEditor/src/ScintillaComponent/Printer.h
+++ b/PowerEditor/src/ScintillaComponent/Printer.h
@@ -47,7 +47,6 @@ private :
 	ScintillaEditView *_pSEView = nullptr;
 	size_t _startPos = 0;
 	size_t _endPos = 0;
-	size_t _nbPageTotal =0;
 	bool _isRTL = false;
 };
 

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -508,7 +508,7 @@ void FileBrowser::notified(LPNMHDR notification)
 			wcscpy_s(lpttt->szText, _expandAllFolders.c_str());
 		}
 	}
-	else if ((notification->hwndFrom == _treeView.getHSelf()))
+	else if (notification->hwndFrom == _treeView.getHSelf())
 	{
 		TCHAR textBuffer[MAX_PATH] = { '\0' };
 		TVITEM tvItem;

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.h
@@ -131,7 +131,6 @@ private:
 	FunctionParsersManager _funcParserMgr;
 	std::vector< std::pair<int, int> > _skipZones;
 	std::vector<TreeParams> _treeParams;
-	HIMAGELIST _hTreeViewImaLst = nullptr;
 
 	generic_string parseSubLevel(size_t begin, size_t end, std::vector< generic_string > dataToSearch, intptr_t& foundPos);
 	size_t getBodyClosePos(size_t begin, const TCHAR *bodyOpenSymbol, const TCHAR *bodyCloseSymbol);

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -592,7 +592,7 @@ void ProjectPanel::notified(LPNMHDR notification)
 		::SendMessage(_hParent, WM_COMMAND, IDM_VIEW_PROJECT_PANEL_1 + _panelID, 0);
 		SetWindowLongPtr (getHSelf(), DWLP_MSGRESULT, _isClosed ? 0 : 1);
 	}
-	else if ((notification->hwndFrom == _treeView.getHSelf()))
+	else if (notification->hwndFrom == _treeView.getHSelf())
 	{
 		TCHAR textBuffer[MAX_PATH] = { '\0' };
 		TVITEM tvItem{};

--- a/boostregex/BoostRegExSearch.cxx
+++ b/boostregex/BoostRegExSearch.cxx
@@ -53,12 +53,12 @@ using namespace boost;
 class BoostRegexSearch : public RegexSearchBase
 {
 public:
-	BoostRegexSearch() : _substituted(NULL) {}
+	BoostRegexSearch() {}
 	
 	virtual ~BoostRegexSearch()
 	{
 		delete[] _substituted;
-		_substituted = NULL;
+		_substituted = nullptr;
 	}
 	
 	virtual Sci::Position FindText(Document* doc, Sci::Position minPos, Sci::Position maxPos, const char *regex,
@@ -243,10 +243,10 @@ private:
 	EncodingDependent<char,    AnsiDocumentIterator> _ansi;
 	EncodingDependent<wchar_t, UTF8DocumentIterator> _utf8;
 	
-	char *_substituted;
+	char *_substituted = nullptr;
 	
 	Match _lastMatch;
-	int _lastDirection;
+	int _lastDirection = 0;
 };
 
 namespace Scintilla::Internal

--- a/lexilla/lexers/LexObjC.cxx
+++ b/lexilla/lexers/LexObjC.cxx
@@ -30,7 +30,6 @@
 using namespace Lexilla;
 
 constexpr auto KEYWORD_BOXHEADER = 1;
-constexpr auto KEYWORD_FOLDCONTRACTED = 2;
 
 static bool IsOKBeforeRE(const int ch) {
 	return (ch == '(') || (ch == '=') || (ch == ',');
@@ -57,18 +56,6 @@ static inline bool IsADoxygenChar(const int ch) {
 	        ch == '\\' || ch == '&' || ch == '<' ||
 	        ch == '>' || ch == '#' || ch == '{' ||
 	        ch == '}' || ch == '[' || ch == ']');
-}
-
-static inline bool IsStateComment(const int state) {
-	return ((state == SCE_C_COMMENT) ||
-	        (state == SCE_C_COMMENTLINE) ||
-	        (state == SCE_C_COMMENTDOC) ||
-	        (state == SCE_C_COMMENTDOCKEYWORD) ||
-	        (state == SCE_C_COMMENTDOCKEYWORDERROR));
-}
-
-static inline bool IsStateString(const int state) {
-	return ((state == SCE_C_STRING) || (state == SCE_C_VERBATIM));
 }
 
 static void ColouriseObjCDoc(size_t startPos, int length, int initStyle, WordList *keywordlists[],


### PR DESCRIPTION
- reduced visibility of tagMaxLen to AutoCompletion.cpp
- fixed missing init of BoostRegexSearch::_lastDirection, adapted also _substituted
- removed unused vars Printer::_nbPageTotal, FunctionListPanel::_hTreeViewImaLst
- fileBrowser.cpp(511,35): warning : equality comparison with extraneous parentheses [-Wparentheses-equality]
- ProjectPanel.cpp(595,35): warning : equality comparison with extraneous parentheses [-Wparentheses-equality]
- removed unused methods IsStateComment(), IsStateString() from LexObjC.cxx
- removed unused var KEYWORD_FOLDCONTRACTED from LexObjC.cxx