### PR TITLE
Add ini files to exclusions for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ before_build:
         $allowMaster = $true
         if ($allowMaster -or $env:APPVEYOR_PULL_REQUEST_NUMBER) {
             $folders_onejob = "PowerEditor/(Test|(installer/(filesForTesting|functionList)))/"
-            $files_nowork = "md|txt|log"
+            $files_nowork = "md|txt|log|ini"
             $files_modified = @(git diff --name-only HEAD~1)
             $files_notmached = @($files_modified | Where-Object {$_ -notmatch "\.(xml|$files_nowork)$|$folders_onejob"})
             if (($files_modified.length -gt 0 -and $files_notmached.length -eq 0) -or $env:APPVEYOR_REPO_COMMIT_MESSAGE -match "\[force (xml|nowork)\]") {


### PR DESCRIPTION
Changing this file [explorerContextMenuEntryLocal.ini](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini) unnecessary run full build. INI files can be treated the same as `md`, `txt` or `log`.

But if for some reason all of them cannot be omitted, only this one can be added to the exceptions.