### PR TITLE
Change workspace "save as" behavior

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -699,7 +699,7 @@ public:
 		if (SUCCEEDED(hr) && _defExt && _defExt[0] != '\0')
 			hr = _dialog->SetDefaultExtension(_defExt);
 
-		if (SUCCEEDED(hr) && _initialFileName)
+		if (SUCCEEDED(hr) && !_initialFileName.empty())
 		{
 			generic_string newFileName = _initialFileName;
 			if (_fileTypeIndex >= 0 && _fileTypeIndex < static_cast<int>(_filterSpec.size()))
@@ -897,7 +897,7 @@ public:
 	generic_string _initialFolder;
 	generic_string _fallbackFolder;
 	const TCHAR* _checkboxLabel = nullptr;
-	const TCHAR* _initialFileName = nullptr;
+	generic_string _initialFileName;
 	bool _isCheckboxActive = true;
 	std::vector<Filter> _filterSpec;
 	int _fileTypeIndex = -1;	// preferred file type index
@@ -926,6 +926,45 @@ CustomFileDialog::CustomFileDialog(HWND hwnd) : _impl{ std::make_unique<Impl>() 
 }
 
 CustomFileDialog::~CustomFileDialog() = default;
+
+void CustomFileDialog::initCustomFileDialog(const generic_string& filePath, const generic_string& extDescription)
+{
+	NppParameters& nppParams = NppParameters::getInstance();
+
+	if(!filePath.empty())
+	{
+		generic_string fileExt;
+		generic_string rootDirectory;
+		generic_string fileName;
+
+		size_t delimPosition = filePath.find_last_of('\\');
+		if(delimPosition != std::string::npos)
+		{
+			rootDirectory = filePath.substr(0, delimPosition);
+			fileName = filePath.substr(delimPosition + 1);
+		}
+		else
+		{
+			rootDirectory = nppParams.getWorkingDir();
+			fileName = filePath;
+		}
+
+		setFolder(rootDirectory.c_str());
+		setDefFileName(fileName.c_str());
+
+		delimPosition = filePath.find_last_of('.');
+		if(delimPosition != std::string::npos)
+		{
+			fileExt = filePath.substr(delimPosition);
+			if(!fileExt.empty())
+			{
+				setExtFilter(extDescription.c_str(), fileExt.c_str());
+				setDefExt(fileExt.c_str());
+				setExtIndex(0);
+			}
+		}
+	}
+}
 
 void CustomFileDialog::setTitle(const TCHAR* title)
 {

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.h
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.h
@@ -50,6 +50,7 @@ public:
 	bool getCheckboxState() const;
 	bool isReadOnly() const;
 
+	void initCustomFileDialog(const generic_string& Path, const generic_string& extDescription);
 private:
 	class Impl;
 	std::unique_ptr<Impl> _impl;

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -1187,10 +1187,10 @@ void ProjectPanel::popupMenuCmd(int cmdID)
 bool ProjectPanel::saveWorkSpaceAs(bool saveCopyAs)
 {
 	CustomFileDialog fDlg(_hSelf);
-	setFileExtFilter(fDlg);
-	fDlg.setExtIndex(0);		// 0 index for "custom extention" type if any else for "All types *.*"
+	fDlg.initCustomFileDialog(getWorkSpaceFilePath(), _TEXT("Notepad++ Workspace File"));
 
 	const generic_string fn = fDlg.doSaveDlg();
+
 	if (fn.empty())
 		return false;
 


### PR DESCRIPTION
Fix #13086 
Change workspace "save as" behavior to include setting the custom file dialog current directory, file name and extension using currently loaded workspace.