### PR TITLE
Add edit_with_notepad translation for BA/HR/RS languages

### DIFF
--- a/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
+++ b/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
@@ -122,7 +122,7 @@ Edit_with_Notepad++=Edit dengan Notepad++
 Edit_with_Notepad++=Edit with Notepad++
 
 [croatian.xml]
-Edit_with_Notepad++=Edit with Notepad++
+Edit_with_Notepad++=Uredi s Notepad++
 
 [basque.xml]
 Edit_with_Notepad++=Edit with Notepad++
@@ -131,7 +131,7 @@ Edit_with_Notepad++=Edit with Notepad++
 Edit_with_Notepad++=Edit with Notepad++
 
 [serbian.xml]
-Edit_with_Notepad++=Edit with Notepad++
+Edit_with_Notepad++=Uredi s Notepad++
 
 [malay.xml]
 Edit_with_Notepad++=Edit with Notepad++
@@ -152,7 +152,7 @@ Edit_with_Notepad++=Edit with Notepad++
 Edit_with_Notepad++=Edit with Notepad++
 
 [bosnian.xml]
-Edit_with_Notepad++=Edit with Notepad++
+Edit_with_Notepad++=Uredi s Notepad++
 
 [mongolian.xml]
 Edit_with_Notepad++=Edit with Notepad++


### PR DESCRIPTION
This adds translation for Bosnian, Croatian and Serbian language.