### PR TITLE
Translate tray icon context menu

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -424,6 +424,14 @@ The comments are here for explanation, it's not necessary to translate them.
                 <Item CMDID="44115" name="Apply Color 5"/>
                 <Item CMDID="44110" name="Remove Color"/>
             </TabBar>
+            <TrayIcon>
+                <Item id="43101" name="Activate"/>
+                <Item id="43102" name="New"/>
+                <Item id="43103" name="New and Paste"/>
+                <Item id="43104" name="Open..."/>
+                <Item id="43013" name="Find in Files..."/>
+                <Item id="43105" name="Close Tray Icon"/>
+            </TrayIcon>
         </Menu>
 
         <Dialog>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -385,8 +385,6 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="11009" name="Size Larger to Smaller"/>
                 </Commands>
             </Main>
-            <Splitter>
-            </Splitter>
             <TabBar>
                 <Item CMDID="41003" name="Close"/>
                 <Item CMDID="0" name="Close Multiple Tabs"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -424,6 +424,14 @@ The comments are here for explanation, it's not necessary to translate them.
                 <Item CMDID="44115" name="Apply Color 5"/>
                 <Item CMDID="44110" name="Remove Color"/>
             </TabBar>
+            <TrayIcon>
+                <Item id="43101" name="Activate"/>
+                <Item id="43102" name="New"/>
+                <Item id="43103" name="New and Paste"/>
+                <Item id="43104" name="Open..."/>
+                <Item id="43013" name="Find in Files..."/>
+                <Item id="43105" name="Close Tray Icon"/>
+            </TrayIcon>
         </Menu>
 
         <Dialog>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -385,8 +385,6 @@ The comments are here for explanation, it's not necessary to translate them.
                     <Item id="11009" name="Size Larger to Smaller"/>
                 </Commands>
             </Main>
-            <Splitter>
-            </Splitter>
             <TabBar>
                 <Item CMDID="41003" name="Close"/>
                 <Item CMDID="0" name="Close Multiple Tabs"/>

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2597,6 +2597,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					HMENU hTrayIconMenu;  // shortcut menu
 					hmenu = ::LoadMenu(_pPublicInterface->getHinst(), MAKEINTRESOURCE(IDR_SYSTRAYPOPUP_MENU));
 					hTrayIconMenu = ::GetSubMenu(hmenu, 0);
+					_nativeLangSpeaker.changeLangTryIconContexMenu(hTrayIconMenu);
 					SetForegroundWindow(hwnd);
 					TrackPopupMenu(hTrayIconMenu, TPM_LEFTALIGN, p.x, p.y, 0, hwnd, NULL);
 					PostMessage(hwnd, WM_NULL, 0, 0);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2597,7 +2597,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					HMENU hTrayIconMenu;  // shortcut menu
 					hmenu = ::LoadMenu(_pPublicInterface->getHinst(), MAKEINTRESOURCE(IDR_SYSTRAYPOPUP_MENU));
 					hTrayIconMenu = ::GetSubMenu(hmenu, 0);
-					_nativeLangSpeaker.changeLangTryIconContexMenu(hTrayIconMenu);
+					_nativeLangSpeaker.changeLangTrayIconContexMenu(hTrayIconMenu);
 					SetForegroundWindow(hwnd);
 					TrackPopupMenu(hTrayIconMenu, TPM_LEFTALIGN, p.x, p.y, 0, hwnd, NULL);
 					PostMessage(hwnd, WM_NULL, 0, 0);

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -489,7 +489,7 @@ void NativeLangSpeaker::changeLangTabDropContextMenu(HMENU hCM)
 	}
 }
 
-void NativeLangSpeaker::changeLangTryIconContexMenu(HMENU hCM)
+void NativeLangSpeaker::changeLangTrayIconContexMenu(HMENU hCM)
 {
 	if (!_nativeLangA) return;
 

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -489,6 +489,33 @@ void NativeLangSpeaker::changeLangTabDropContextMenu(HMENU hCM)
 	}
 }
 
+void NativeLangSpeaker::changeLangTryIconContexMenu(HMENU hCM)
+{
+	if (!_nativeLangA) return;
+
+	TiXmlNodeA *tryIconMenu = _nativeLangA->FirstChild("Menu");
+	if (!tryIconMenu) return;
+
+	tryIconMenu = tryIconMenu->FirstChild("TrayIcon");
+	if (!tryIconMenu) return;
+
+	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+
+	for (TiXmlNodeA *childNode = tryIconMenu->FirstChildElement("Item");
+		childNode ;
+		childNode = childNode->NextSibling("Item") )
+	{
+		TiXmlElementA *element = childNode->ToElement();
+		int id;
+		const char *sentinel = element->Attribute("id", &id);
+		const char *name = element->Attribute("name");
+		if (sentinel && (name && name[0]))
+		{
+			const wchar_t *nameW = wmc.char2wchar(name, _nativeLangEncoding);
+			::ModifyMenu(hCM, id, MF_BYCOMMAND, id, nameW);
+		}
+	}
+}
 
 void NativeLangSpeaker::changeConfigLang(HWND hDlg)
 {

--- a/PowerEditor/src/localization.h
+++ b/PowerEditor/src/localization.h
@@ -38,13 +38,14 @@ public:
 
 class NativeLangSpeaker {
 public:
-    NativeLangSpeaker():_nativeLangA(NULL), _nativeLangEncoding(CP_ACP), _isRTL(false), _fileName(NULL){};
-    void init(TiXmlDocumentA *nativeLangDocRootA, bool loadIfEnglish = false);
+	NativeLangSpeaker():_nativeLangA(NULL), _nativeLangEncoding(CP_ACP), _isRTL(false), _fileName(NULL){};
+	void init(TiXmlDocumentA *nativeLangDocRootA, bool loadIfEnglish = false);
 	void changeConfigLang(HWND hDlg);
 	void changeLangTabContextMenu(HMENU hCM);
 	TiXmlNodeA * searchDlgNode(TiXmlNodeA *node, const char *dlgTagName);
 	bool changeDlgLang(HWND hDlg, const char *dlgTagName, char *title = NULL, size_t titleMaxSize = 0);
 	void changeLangTabDropContextMenu(HMENU hCM);
+	void changeLangTryIconContexMenu(HMENU hCM);
 	generic_string getSubMenuEntryName(const char *nodeName) const;
 	generic_string getNativeLangMenuString(int itemID) const;
 	generic_string getShortcutNameString(int itemID) const;
@@ -52,29 +53,29 @@ public:
 	void changeMenuLang(HMENU menuHandle);
 	void changeShortcutLang();
 	void changeStyleCtrlsLang(HWND hDlg, int *idArray, const char **translatedText);
-    void changeUserDefineLang(UserDefineDialog *userDefineDlg);
+	void changeUserDefineLang(UserDefineDialog *userDefineDlg);
 	void changeUserDefineLangPopupDlg(HWND hDlg);
-    void changeFindReplaceDlgLang(FindReplaceDlg & findReplaceDlg);
-    void changePrefereceDlgLang(PreferenceDlg & preference);
+	void changeFindReplaceDlgLang(FindReplaceDlg & findReplaceDlg);
+	void changePrefereceDlgLang(PreferenceDlg & preference);
 	void changePluginsAdminDlgLang(PluginsAdminDlg & pluginsAdminDlg);
 
 	bool getDoSaveOrNotStrings(generic_string& title, generic_string& msg);
 
-    bool isRTL() const {
-        return _isRTL;
-    };
+	bool isRTL() const {
+		return _isRTL;
+	};
 
-    const char * getFileName() const {
-        return _fileName;
-    };
+	const char * getFileName() const {
+		return _fileName;
+	};
 
-    const TiXmlNodeA * getNativeLangA() {
-        return _nativeLangA;
-    };
+	const TiXmlNodeA * getNativeLangA() {
+		return _nativeLangA;
+	};
 
-    int getLangEncoding() const {
-        return _nativeLangEncoding;
-    };
+	int getLangEncoding() const {
+		return _nativeLangEncoding;
+	};
 	bool getMsgBoxLang(const char *msgBoxTagName, generic_string & title, generic_string & message);
 	generic_string getShortcutMapperLangStr(const char *nodeName, const TCHAR *defaultStr) const;
 	generic_string getProjectPanelLangMenuStr(const char * nodeName, int cmdID, const TCHAR *defaultStr) const;
@@ -87,8 +88,8 @@ public:
 private:
 	TiXmlNodeA *_nativeLangA;
 	int _nativeLangEncoding;
-    bool _isRTL;
-    const char *_fileName;
+	bool _isRTL;
+	const char *_fileName;
 };
 
 

--- a/PowerEditor/src/localization.h
+++ b/PowerEditor/src/localization.h
@@ -45,7 +45,7 @@ public:
 	TiXmlNodeA * searchDlgNode(TiXmlNodeA *node, const char *dlgTagName);
 	bool changeDlgLang(HWND hDlg, const char *dlgTagName, char *title = NULL, size_t titleMaxSize = 0);
 	void changeLangTabDropContextMenu(HMENU hCM);
-	void changeLangTryIconContexMenu(HMENU hCM);
+	void changeLangTrayIconContexMenu(HMENU hCM);
 	generic_string getSubMenuEntryName(const char *nodeName) const;
 	generic_string getNativeLangMenuString(int itemID) const;
 	generic_string getShortcutNameString(int itemID) const;


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11628.

@donho 
This node is necessary here?
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/235b51af67de112c86b5e0a522b586d8dc826832/PowerEditor/installer/nativeLang/english.xml#L388-L389