### PR TITLE
Add translation of 'Edit with Notepad++'

### DIFF
--- a/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
+++ b/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
@@ -32,7 +32,7 @@ Edit_with_Notepad++=Mit Notepad++ öffnen
 Edit_with_Notepad++=Editar con Notepad++
 
 [italian.xml]
-Edit_with_Notepad++=Apri con Notepad++
+Edit_with_Notepad++=Modifica con Notepad++
 
 [portuguese.xml]
 Edit_with_Notepad++=Editar com o Notepad++

--- a/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
+++ b/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
@@ -26,7 +26,7 @@ Edit_with_Notepad++=Edit with Notepad++
 Edit_with_Notepad++=Notepad++ で編集
 
 [german.xml]
-Edit_with_Notepad++=Mit Notepad++ öffnen
+Edit_with_Notepad++=Mit Notepad++ bearbeiten
 
 [spanish.xml]
 Edit_with_Notepad++=Editar con Notepad++

--- a/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
+++ b/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
@@ -74,7 +74,7 @@ Edit_with_Notepad++=Edit with Notepad++
 Edit_with_Notepad++=Edit with Notepad++
 
 [hindi.xml]
-Edit_with_Notepad++=Edit with Notepad++
+Edit_with_Notepad++=Notepad++ में एडिट करें
 
 [nynorsk.xml]
 Edit_with_Notepad++=Edit with Notepad++

--- a/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
+++ b/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
@@ -170,7 +170,7 @@ Edit_with_Notepad++=Edit with Notepad++
 Edit_with_Notepad++=Edit with Notepad++
 
 [vietnamese.xml]
-Edit_with_Notepad++=Edit with Notepad++
+Edit_with_Notepad++=Sửa bằng Notepad++
 
 [welsh.xml]
 Edit_with_Notepad++=Edit with Notepad++


### PR DESCRIPTION
Explorer context menu item under Windows 11 can be translated thanks to https://github.com/notepad-plus-plus/notepad-plus-plus/commit/a0031159cd15e2798996f53c05d98b10ec69ead0

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13201

People can also add translation in the comment below - I will add them into this PR.