### PR TITLE
Translate Command Argument Help dialog

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1530,6 +1530,45 @@ Do you want to save your changes before switching themes?"/> <!-- HowToReproduce
                 </FileMenu>
             </Menus>
         </ProjectManager>
+        <CmdLineArgsHelp>
+            <title name="Notepad++ Command Argument Help"/>
+            <intro name="Usage"/>
+            <arg-help-desc name="This help message"/>
+            <arg-multiInst-desc name="Launch another Notepad++ instance"/>
+            <arg-noPlugin-desc name="Launch Notepad++ without loading any plugin"/>
+            <arg-l-desc name="Open file or Ghost type with syntax highlighting of choice"/>
+            <arg-udl-value name="My UDL Name"/>
+            <arg-udl-desc name="Open file by applying User Defined Language"/>
+            <arg-L-desc name="Apply indicated localization, $STR_REPLACE_langCode$ is browser language code"/>
+            <arg-n-desc name="Scroll to indicated line on $STR_REPLACE_filePath$"/>
+            <arg-c-desc name="Scroll to indicated column on $STR_REPLACE_filePath$"/>
+            <arg-p-desc name="Scroll to indicated position on $STR_REPLACE_filePath$"/>
+            <arg-x-desc name="Move Notepad++ to indicated left side position on the screen"/>
+            <arg-y-desc name="Move Notepad++ to indicated top position on the screen"/>
+            <arg-monitor-desc name="Open file with file monitoring enabled"/>
+            <arg-nosession-desc name="Launch Notepad++ without previous session"/>
+            <arg-notabbar-desc name="Launch Notepad++ without tabbar"/>
+            <arg-ro-desc name="Make the $STR_REPLACE_filePath$ read only"/>
+            <arg-systemtray-desc name="Launch Notepad++ directly in system tray"/>
+            <arg-loadingTime-desc name="Display Notepad++ loading time"/>
+            <arg-alwaysOnTop-desc name="Make Notepad++ always on top"/>
+            <arg-openSession-desc name="Open a session. $STR_REPLACE_filePath$ must be a session file"/>
+            <arg-r-desc name="Open files recursively. This argument will be ignored if $STR_REPLACE_filePath$ contain no wildcard character"/>
+            <arg-qn-value name="Easter egg name"/>
+            <arg-qn-desc name="Ghost type easter egg via its name"/>
+            <arg-qt-value name="text to display"/>
+            <arg-qt-desc name="Ghost type the given text"/>
+            <arg-qf-value name="D:\my quote.txt"/>
+            <arg-qf-desc name="Ghost type a file content via the file path"/>
+            <arg-qSpeed-desc name="Ghost typing speed. Value from 1 to 3 for slow, fast and fastest"/>
+            <arg-quickPrint-desc name="Print the file given as $STR_REPLACE_filePath$ then quit Notepad++"/>
+            <arg-settingsDir-value name="D:\your settings dir"/>
+            <arg-settingsDir-desc name="Override the default settings dir"/>
+            <arg-openFoldersAsWorkspace-desc name="Open $STR_REPLACE_filePath$ of folder(s) as workspace"/>
+            <arg-titleAdd-value name="text to add"/>
+            <arg-titleAdd-desc name="Add the given text to Notepad++ title bar"/>
+            <arg-filePath-desc name="File or folder name to open (absolute or relative path name)"/>
+        </CmdLineArgsHelp>
         <MiscStrings>
             <!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders. -->
             <word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &quot;Match whole word only&quot; option checked."/> <!-- HowToReproduce: In "Delimiter" section of Preferences dialog, hover your mouse on the "?" button. -->

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1530,6 +1530,45 @@ Do you want to save your changes before switching themes?"/> <!-- HowToReproduce
                 </FileMenu>
             </Menus>
         </ProjectManager>
+        <CmdLineArgsHelp>
+            <title name="Notepad++ Command Argument Help"/>
+            <intro name="Usage"/>
+            <arg-help-desc name="This help message"/>
+            <arg-multiInst-desc name="Launch another Notepad++ instance"/>
+            <arg-noPlugin-desc name="Launch Notepad++ without loading any plugin"/>
+            <arg-l-desc name="Open file or Ghost type with syntax highlighting of choice"/>
+            <arg-udl-value name="My UDL Name"/>
+            <arg-udl-desc name="Open file by applying User Defined Language"/>
+            <arg-L-desc name="Apply indicated localization, $STR_REPLACE_langCode$ is browser language code"/>
+            <arg-n-desc name="Scroll to indicated line on $STR_REPLACE_filePath$"/>
+            <arg-c-desc name="Scroll to indicated column on $STR_REPLACE_filePath$"/>
+            <arg-p-desc name="Scroll to indicated position on $STR_REPLACE_filePath$"/>
+            <arg-x-desc name="Move Notepad++ to indicated left side position on the screen"/>
+            <arg-y-desc name="Move Notepad++ to indicated top position on the screen"/>
+            <arg-monitor-desc name="Open file with file monitoring enabled"/>
+            <arg-nosession-desc name="Launch Notepad++ without previous session"/>
+            <arg-notabbar-desc name="Launch Notepad++ without tabbar"/>
+            <arg-ro-desc name="Make the $STR_REPLACE_filePath$ read only"/>
+            <arg-systemtray-desc name="Launch Notepad++ directly in system tray"/>
+            <arg-loadingTime-desc name="Display Notepad++ loading time"/>
+            <arg-alwaysOnTop-desc name="Make Notepad++ always on top"/>
+            <arg-openSession-desc name="Open a session. $STR_REPLACE_filePath$ must be a session file"/>
+            <arg-r-desc name="Open files recursively. This argument will be ignored if $STR_REPLACE_filePath$ contain no wildcard character"/>
+            <arg-qn-value name="Easter egg name"/>
+            <arg-qn-desc name="Ghost type easter egg via its name"/>
+            <arg-qt-value name="text to display"/>
+            <arg-qt-desc name="Ghost type the given text"/>
+            <arg-qf-value name="D:\my quote.txt"/>
+            <arg-qf-desc name="Ghost type a file content via the file path"/>
+            <arg-qSpeed-desc name="Ghost typing speed. Value from 1 to 3 for slow, fast and fastest"/>
+            <arg-quickPrint-desc name="Print the file given as $STR_REPLACE_filePath$ then quit Notepad++"/>
+            <arg-settingsDir-value name="D:\your settings dir"/>
+            <arg-settingsDir-desc name="Override the default settings dir"/>
+            <arg-openFoldersAsWorkspace-desc name="Open $STR_REPLACE_filePath$ of folder(s) as workspace"/>
+            <arg-titleAdd-value name="text to add"/>
+            <arg-titleAdd-desc name="Add the given text to Notepad++ title bar"/>
+            <arg-filePath-desc name="File or folder name to open (absolute or relative path name)"/>
+        </CmdLineArgsHelp>
         <MiscStrings>
             <!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders. -->
             <word-chars-list-tip value="This allows you to include additional character into current word characters while double clicking for selection or searching with &quot;Match whole word only&quot; option checked."/> <!-- HowToReproduce: In "Delimiter" section of Preferences dialog, hover your mouse on the "?" button. -->

--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -18,42 +18,6 @@
 
 const int splitterSize = 8;
 
-const TCHAR COMMAND_ARG_HELP[] = TEXT("Usage :\r\
-\r\
-notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-udl=\"My UDL Name\"] [-LlangCode] [-nLineNumber] [-cColumnNumber] [-pPosition] [-xLeftPos] [-yTopPos] [-monitor] [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime] [-alwaysOnTop] [-openSession] [-r] [-qn=\"Easter egg name\" | -qt=\"a text to display.\" | -qf=\"D:\\my quote.txt\"] [-qSpeed1|2|3] [-quickPrint] [-settingsDir=\"d:\\your settings dir\\\"] [-openFoldersAsWorkspace]  [-titleAdd=\"additional title bar text\"][filePath]\r\
-\r\
---help : This help message\r\
--multiInst : Launch another Notepad++ instance\r\
--noPlugin : Launch Notepad++ without loading any plugin\r\
--l : Open file or Ghost type with syntax highlighting of choice\r\
--udl=\"My UDL Name\": Open file by applying User Defined Language\r\
--L : Apply indicated localization, langCode is browser language code\r\
--n : Scroll to indicated line on filePath\r\
--c : Scroll to indicated column on filePath\r\
--p : Scroll to indicated position on filePath\r\
--x : Move Notepad++ to indicated left side position on the screen\r\
--y : Move Notepad++ to indicated top position on the screen\r\
--monitor: Open file with file monitoring enabled\r\
--nosession : Launch Notepad++ without previous session\r\
--notabbar : Launch Notepad++ without tabbar\r\
--ro : Make the filePath read only\r\
--systemtray : Launch Notepad++ directly in system tray\r\
--loadingTime : Display Notepad++ loading time\r\
--alwaysOnTop : Make Notepad++ always on top\r\
--openSession : Open a session. filePath must be a session file\r\
--r : Open files recursively. This argument will be ignored\r\
-     if filePath contain no wildcard character\r\
--qn=\"Easter egg name\": Ghost type easter egg via its name\r\
--qt=\"text to display.\": Ghost type the given text\r\
--qf=\"D:\\my quote.txt\": Ghost type a file content via the file path\r\
--qSpeed : Ghost typing speed. Value from 1 to 3 for slow, fast and fastest\r\
--quickPrint : Print the file given as argument then quit Notepad++\r\
--settingsDir=\"d:\\your settings dir\\\": Override the default settings dir\r\
--openFoldersAsWorkspace: open filePath of folder(s) as workspace\r\
--titleAdd=\"string\": add string to Notepad++ title bar\r\
-filePath : file or folder name to open (absolute or relative path name)\r\
-");
-
 
 class Notepad_plus_Window : public Window
 {

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3337,8 +3337,12 @@ void Notepad_plus::command(int id)
 
 		case IDM_CMDLINEARGUMENTS:
 		{
-			// No translattable
-			::MessageBox(_pPublicInterface->getHSelf(), COMMAND_ARG_HELP, TEXT("Notepad++ Command Argument Help"), MB_OK | MB_APPLMODAL);
+			generic_string title, msg;
+			_nativeLangSpeaker.getCmdLineArgsStrings(title, msg);
+			int msgBoxType = MB_OK | MB_APPLMODAL;
+			if (_nativeLangSpeaker.isRTL())
+				msgBoxType |= MB_RTLREADING | MB_RIGHT;
+			::MessageBox(_pPublicInterface->getHSelf(), msg.c_str(), title.c_str(), msgBoxType);
 			break;
 		}
 

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -25,6 +25,92 @@ using namespace std;
 
 
 
+static const TCHAR COMMAND_ARG_HELP_TEMPLATE[] = TEXT("$STR_REPLACE_intro$ :\r\
+\r\
+notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-udl=\"$STR_REPLACE_udl_value$\"] [-LlangCode] [-nLineNumber] [-cColumnNumber] [-pPosition] [-xLeftPos] [-yTopPos] [-monitor] [-nosession] [-notabbar] [-ro] [-systemtray] [-loadingTime] [-alwaysOnTop] [-openSession] [-r] [-qn=\"$STR_REPLACE_qn_value$\" | -qt=\"$STR_REPLACE_qt_value$\" | -qf=\"$STR_REPLACE_qf_value$\"] [-qSpeed1|2|3] [-quickPrint] [-settingsDir=\"$STR_REPLACE_settingsDir_value$\"] [-openFoldersAsWorkspace] [-titleAdd=\"$STR_REPLACE_titleAdd_value$\"][filePath]\r\
+\r\
+--help : $STR_REPLACE_help_desc$\r\
+-multiInst : $STR_REPLACE_multiInst_desc$\r\
+-noPlugin : $STR_REPLACE_noPlugin_desc$\r\
+-l : $STR_REPLACE_l_desc$\r\
+-udl=\"$STR_REPLACE_udl_value$\": $STR_REPLACE_udl_desc$\r\
+-L : $STR_REPLACE_L_desc$\r\
+-n : $STR_REPLACE_n_desc$\r\
+-c : $STR_REPLACE_c_desc$\r\
+-p : $STR_REPLACE_p_desc$\r\
+-x : $STR_REPLACE_x_desc$\r\
+-y : $STR_REPLACE_y_desc$\r\
+-monitor : $STR_REPLACE_monitor_desc$\r\
+-nosession : $STR_REPLACE_nosession_desc$\r\
+-notabbar : $STR_REPLACE_notabbar_desc$\r\
+-ro : $STR_REPLACE_ro_desc$\r\
+-systemtray : $STR_REPLACE_systemtray_desc$\r\
+-loadingTime : $STR_REPLACE_loadingTime_desc$\r\
+-alwaysOnTop : $STR_REPLACE_alwaysOnTop_desc$\r\
+-openSession : $STR_REPLACE_openSession_desc$\r\
+-r : $STR_REPLACE_r_desc$\r\
+-qn=\"$STR_REPLACE_qn_value$\" : $STR_REPLACE_qn_desc$\r\
+-qt=\"$STR_REPLACE_qt_value$\" : $STR_REPLACE_qt_desc$\r\
+-qf=\"$STR_REPLACE_qf_value$\" : $STR_REPLACE_qf_desc$\r\
+-qSpeed : $STR_REPLACE_qSpeed_desc$\r\
+-quickPrint : $STR_REPLACE_quickPrint_desc$\r\
+-settingsDir=\"$STR_REPLACE_settingsDir_value$\" : $STR_REPLACE_settingsDir_desc$\r\
+-openFoldersAsWorkspace : $STR_REPLACE_openFoldersAsWorkspace_desc$\r\
+-titleAdd=\"$STR_REPLACE_titleAdd_value$\" : $STR_REPLACE_titleAdd_desc$\r\
+filePath : $STR_REPLACE_filePath_desc$\r\
+");
+
+static const char* COMMAND_ARG_HELP_DATA[][3] = {
+//==============================================
+//	{placeholder, defaultText, targetNode},
+//==============================================
+	{"$STR_REPLACE_intro$", "Usage", "intro"},
+
+	{"$STR_REPLACE_help_desc$", "This help message", "arg-help-desc"},
+	{"$STR_REPLACE_multiInst_desc$", "Launch another Notepad++ instance", "arg-multiInst-desc"},
+	{"$STR_REPLACE_noPlugin_desc$", "Launch Notepad++ without loading any plugin", "arg-noPlugin-desc"},
+	{"$STR_REPLACE_l_desc$", "Open file or Ghost type with syntax highlighting of choice", "arg-l-desc"},
+	{"$STR_REPLACE_udl_value$", "My UDL Name", "arg-udl-value"},
+	{"$STR_REPLACE_udl_desc$", "Open file by applying User Defined Language", "arg-udl-desc"},
+
+	{"$STR_REPLACE_L_desc$", "Apply indicated localization, $STR_REPLACE_langCode$ is browser language code", "arg-L-desc"},
+	{"$STR_REPLACE_n_desc$", "Scroll to indicated line on $STR_REPLACE_filePath$", "arg-n-desc"},
+	{"$STR_REPLACE_c_desc$", "Scroll to indicated column on $STR_REPLACE_filePath$", "arg-c-desc"},
+	{"$STR_REPLACE_p_desc$", "Scroll to indicated position on $STR_REPLACE_filePath$", "arg-p-desc"},
+	{"$STR_REPLACE_x_desc$", "Move Notepad++ to indicated left side position on the screen", "arg-x-desc"},
+	{"$STR_REPLACE_y_desc$", "Move Notepad++ to indicated top position on the screen", "arg-y-desc"},
+
+	{"$STR_REPLACE_monitor_desc$", "Open file with file monitoring enabled", "arg-monitor-desc"},
+	{"$STR_REPLACE_nosession_desc$", "Launch Notepad++ without previous session", "arg-nosession-desc"},
+	{"$STR_REPLACE_notabbar_desc$", "Launch Notepad++ without tabbar", "arg-notabbar-desc"},
+	{"$STR_REPLACE_ro_desc$", "Make the $STR_REPLACE_filePath$ read only", "arg-ro-desc"},
+	{"$STR_REPLACE_systemtray_desc$", "Launch Notepad++ directly in system tray", "arg-systemtray-desc"},
+	{"$STR_REPLACE_loadingTime_desc$", "Display Notepad++ loading time", "arg-loadingTime-desc"},
+
+	{"$STR_REPLACE_alwaysOnTop_desc$", "Make Notepad++ always on top", "arg-alwaysOnTop-desc"},
+	{"$STR_REPLACE_openSession_desc$", "Open a session. $STR_REPLACE_filePath$ must be a session file", "arg-openSession-desc"},
+	{"$STR_REPLACE_r_desc$", "Open files recursively. This argument will be ignored if $STR_REPLACE_filePath$ contain no wildcard character", "arg-r-desc"},
+
+	{"$STR_REPLACE_qn_value$", "Easter egg name", "arg-qn-value"},
+	{"$STR_REPLACE_qn_desc$", "Ghost type easter egg via its name", "arg-qn-desc"},
+	{"$STR_REPLACE_qt_value$", "text to display", "arg-qt-value"},
+	{"$STR_REPLACE_qt_desc$", "Ghost type the given text", "arg-qt-desc"},
+	{"$STR_REPLACE_qf_value$", "D:\\my quote.txt", "arg-qf-value"},
+	{"$STR_REPLACE_qf_desc$", "Ghost type a file content via the file path", "arg-qf-desc"},
+	{"$STR_REPLACE_qSpeed_desc$", "Ghost typing speed. Value from 1 to 3 for slow, fast and fastest", "arg-qSpeed-desc"},
+
+	{"$STR_REPLACE_quickPrint_desc$", "Print the file given as $STR_REPLACE_filePath$ then quit Notepad++", "arg-quickPrint-desc"},
+	{"$STR_REPLACE_settingsDir_value$", "D:\\your settings dir", "arg-settingsDir-value"},
+	{"$STR_REPLACE_settingsDir_desc$", "Override the default settings dir", "arg-settingsDir-desc"},
+	{"$STR_REPLACE_openFoldersAsWorkspace_desc$", "Open $STR_REPLACE_filePath$ of folder(s) as workspace", "arg-openFoldersAsWorkspace-desc"},
+	{"$STR_REPLACE_titleAdd_value$", "text to add", "arg-titleAdd-value"},
+	{"$STR_REPLACE_titleAdd_desc$", "Add the given text to Notepad++ title bar", "arg-titleAdd-desc"},
+	{"$STR_REPLACE_filePath_desc$", "File or folder name to open (absolute or relative path name)", "arg-filePath-desc"},
+
+	{"$STR_REPLACE_langCode$", "langCode", nullptr},
+	{"$STR_REPLACE_filePath$", "filePath", nullptr}
+};
+
 MenuPosition menuPos[] = {
 //==============================================
 //	{L0,  L1, L2, id},
@@ -1123,6 +1209,28 @@ bool NativeLangSpeaker::getDoSaveOrNotStrings(generic_string& title, generic_str
 		}
 	}
 	return false;
+}
+
+void NativeLangSpeaker::getCmdLineArgsStrings(generic_string& title, generic_string& msg)
+{
+	const char *rootNode = "CmdLineArgsHelp";
+	title = getAttrNameStr(TEXT("Notepad++ Command Argument Help"), rootNode, "title");
+
+	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+	generic_string msgTemp = COMMAND_ARG_HELP_TEMPLATE;
+	const int cells = sizeof(COMMAND_ARG_HELP_DATA[0]) / sizeof(char*);
+	const int rows = (sizeof(COMMAND_ARG_HELP_DATA) / sizeof(char*)) / cells;
+	for (int i = 0; i < rows; i++)
+	{
+		const generic_string placeholderStr = wmc.char2wchar(COMMAND_ARG_HELP_DATA[i][0], _nativeLangEncoding);
+		const generic_string defaultTextStr = wmc.char2wchar(COMMAND_ARG_HELP_DATA[i][1], _nativeLangEncoding);
+		const char* targetNode = COMMAND_ARG_HELP_DATA[i][2];
+		if (targetNode)
+			msgTemp = stringReplace(msgTemp, placeholderStr, getAttrNameStr(defaultTextStr.c_str(), rootNode, targetNode));
+		else
+			msgTemp = stringReplace(msgTemp, placeholderStr, defaultTextStr);
+	}
+	msg = msgTemp;
 }
 
 bool NativeLangSpeaker::changeDlgLang(HWND hDlg, const char *dlgTagName, char *title, size_t titleMaxSize)

--- a/PowerEditor/src/localization.h
+++ b/PowerEditor/src/localization.h
@@ -59,6 +59,7 @@ public:
 	void changePluginsAdminDlgLang(PluginsAdminDlg & pluginsAdminDlg);
 
 	bool getDoSaveOrNotStrings(generic_string& title, generic_string& msg);
+	void getCmdLineArgsStrings(generic_string& title, generic_string& msg);
 
     bool isRTL() const {
         return _isRTL;

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -484,9 +484,6 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 		cmdLineParams._udlName = udlName;
 	}
 
-	if (showHelp)
-		::MessageBox(NULL, COMMAND_ARG_HELP, TEXT("Notepad++ Command Argument Help"), MB_OK);
-
 	if (cmdLineParams._localizationPath != TEXT(""))
 	{
 		// setStartWithLocFileName() should be called before parameters are loaded
@@ -494,6 +491,18 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 	}
 
 	nppParameters.load();
+
+	if (showHelp)
+	{
+		NativeLangSpeaker nativeLangSpeaker;
+		nativeLangSpeaker.init(nppParameters.getNativeLangA());
+		generic_string title, msg;
+		nativeLangSpeaker.getCmdLineArgsStrings(title, msg);
+		int msgBoxType = MB_OK;
+		if (nativeLangSpeaker.isRTL())
+			msgBoxType |= MB_RTLREADING | MB_RIGHT;
+		::MessageBox(NULL, msg.c_str(), title.c_str(), msgBoxType);
+	}
 
 	NppGUI & nppGui = nppParameters.getNppGUI();
 


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13166.

This can be done in many ways. In this approach:
- descriptions can be changed
- example values can be changed
- works with a `-L` argument
- the general format cannot be changed (there is a fixed template)
- it's easier to add something new because we don't have to play with reading/combining data in function (just add the appropriate entries in template/data/xml).