### PR TITLE
Improvement for issue #13178.  Shift click to quickly close a tab.

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -170,7 +170,7 @@ public:
 	void fileOpen();
 	void fileNew();
     bool fileReload();
-	bool fileClose(BufferID id = BUFFER_INVALID, int curView = -1);	//use curView to override view to close from
+	bool fileClose(BufferID id = BUFFER_INVALID, int curView = -1, bool promptIfDirty = true);	//use curView to override view to close from
 	bool fileCloseAll(bool doDeleteBackup, bool isSnapshotMode = false);
 	bool fileCloseAllButCurrent();
 	bool fileCloseAllGiven(const std::vector<int>& krvecBufferIndexes);

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -975,7 +975,7 @@ int Notepad_plus::setFileOpenSaveDlgFilters(CustomFileDialog & fDlg, bool showAl
 }
 
 
-bool Notepad_plus::fileClose(BufferID id, int curView)
+bool Notepad_plus::fileClose(BufferID id, int curView, bool promptIfDirty)
 {
 	BufferID bufferID = id;
 	if (id == BUFFER_INVALID)
@@ -991,7 +991,7 @@ bool Notepad_plus::fileClose(BufferID id, int curView)
 	{
 		// Do nothing
 	}
-	else if (buf->isDirty())
+	else if (buf->isDirty() && promptIfDirty)
 	{
 		res = doSaveOrNot(fileNamePath);
 		if (res == IDYES)

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -313,6 +313,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			return TRUE;
 		}
 
+		case TCN_TABDELETE_NO_PROMPT:
 		case TCN_TABDELETE:
 		{
 			int index = tabNotification->_tabOrigin;
@@ -324,7 +325,8 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				activateBuffer(bufferToClose, iView);
 			}
 
-			if (fileClose(bufferToClose, iView))
+			const bool promptIfDirty = (notification->nmhdr.code != TCN_TABDELETE_NO_PROMPT);
+			if (fileClose(bufferToClose, iView, promptIfDirty))
 				checkDocState();
 
 			break;

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -792,7 +792,14 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			{
 				if ((_whichCloseClickDown == currentTabOn) && _closeButtonZone.isHit(xPos, yPos, _currentHoverTabRect, _isVertical))
 				{
-					notify(TCN_TABDELETE, currentTabOn);
+					if ((::GetKeyState(VK_SHIFT) & 0x80000000) == 0)
+					{
+						notify(TCN_TABDELETE, currentTabOn);
+					} 
+					else
+					{
+						notify(TCN_TABDELETE_NO_PROMPT, currentTabOn);
+					}
 					_whichCloseClickDown = -1;
 
 					// Get the next tab at same position

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -35,6 +35,7 @@
 #define TCN_MOUSEHOVERING (TCN_FIRST - 13)
 #define TCN_MOUSELEAVING (TCN_FIRST - 14)
 #define TCN_MOUSEHOVERSWITCHING (TCN_FIRST - 15)
+#define TCN_TABDELETE_NO_PROMPT (TCN_FIRST - 16)  //Same as TCN_TABDELETE but don't show message box if dirty
 
 #define WM_TABSETSTYLE	(WM_APP + 0x024)
 


### PR DESCRIPTION
Implementing the proposed feature for issue #13178:  Hold Shift while clicking close to close a tab without a dialog to ask if you want to save a modified file.

I can add documentation if this PR is approved.
