### PR TITLE
[xml] Change "Replace by" wording in Tab Settings

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1040,7 +1040,7 @@ You can define several column markers by using white space to separate the diffe
                     <Item id="6507" name="Make language menu compact"/>
                     <Item id="6508" name="Language Menu"/>
                     <Item id="6301" name="Tab Settings"/>
-                    <Item id="6302" name="Replace by space"/>
+                    <Item id="6302" name="Tab key inserts space(s)"/>
                     <Item id="6303" name="Tab size: "/>
                     <Item id="6510" name="Use default value"/>
                     <Item id="6335" name="Treat backslash as escape character for SQL"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1040,7 +1040,7 @@ You can define several column markers by using white space to separate the diffe
                     <Item id="6507" name="Make language menu compact"/>
                     <Item id="6508" name="Language Menu"/>
                     <Item id="6301" name="Tab Settings"/>
-                    <Item id="6302" name="Replace by space"/>
+                    <Item id="6302" name="Tab key inserts space(s)"/>
                     <Item id="6303" name="Tab size: "/>
                     <Item id="6510" name="Use default value"/>
                     <Item id="6335" name="Treat backslash as escape character for SQL"/>


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13186.

Actual text:
![image](https://user-images.githubusercontent.com/2730894/223156352-332b652b-f437-482b-961f-9dc68dcfd80a.png)

New variant from this PR:
![image](https://user-images.githubusercontent.com/2730894/223155391-da662d64-357d-4f40-96bd-0722f47070af.png)

Other proposed text:
![image](https://user-images.githubusercontent.com/2730894/223155550-5cdfeafc-87cd-4bae-b255-55d7d7ec6852.png)

There is some room for a more informative description.