### PR TITLE
Fix Project Workspace "Save a Copy As" confusion issue

### DIFF
--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -384,7 +384,7 @@ bool ProjectPanel::saveWorkSpace()
 	} 
 }
 
-bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName)
+bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName, bool updateName)
 {
 	//write <NotepadPlus>: use the default file name if new file name is not given
 	const TCHAR * fn2write = projectFileName?projectFileName:_workSpaceFilePath.c_str();
@@ -429,7 +429,10 @@ bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName)
 		return false;
 	}
 	TCHAR * fileName = PathFindFileName(fn2write);
-	_treeView.renameItem(tvRoot, fileName);
+	if (updateName) 
+	{
+		_treeView.renameItem(tvRoot, fileName);
+	}
 	return true;
 }
 
@@ -1194,7 +1197,7 @@ bool ProjectPanel::saveWorkSpaceAs(bool saveCopyAs)
 	if (fn.empty())
 		return false;
 
-	if (!writeWorkSpace(fn.c_str()))
+	if (!writeWorkSpace(fn.c_str(), !saveCopyAs))
 		return false;
 
 	if (!saveCopyAs)

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -384,7 +384,7 @@ bool ProjectPanel::saveWorkSpace()
 	} 
 }
 
-bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName, bool updateName)
+bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName, bool doUpdateGUI)
 {
 	//write <NotepadPlus>: use the default file name if new file name is not given
 	const TCHAR * fn2write = projectFileName?projectFileName:_workSpaceFilePath.c_str();
@@ -429,7 +429,7 @@ bool ProjectPanel::writeWorkSpace(const TCHAR *projectFileName, bool updateName)
 		return false;
 	}
 	TCHAR * fileName = PathFindFileName(fn2write);
-	if (updateName) 
+	if (doUpdateGUI)
 	{
 		_treeView.renameItem(tvRoot, fileName);
 	}

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
@@ -125,7 +125,7 @@ protected:
 	void recursiveAddFilesFrom(const TCHAR *folderPath, HTREEITEM hTreeItem);
 	HTREEITEM addFolder(HTREEITEM hTreeItem, const TCHAR *folderName);
 
-	bool writeWorkSpace(const TCHAR *projectFileName = NULL);
+	bool writeWorkSpace(const TCHAR *projectFileName = NULL, bool updateName = true);
 	generic_string getRelativePath(const generic_string & fn, const TCHAR *workSpaceFileName);
 	void buildProjectXml(TiXmlNode *root, HTREEITEM hItem, const TCHAR* fn2write);
 	NodeType getNodeType(HTREEITEM hItem);

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.h
@@ -125,7 +125,7 @@ protected:
 	void recursiveAddFilesFrom(const TCHAR *folderPath, HTREEITEM hTreeItem);
 	HTREEITEM addFolder(HTREEITEM hTreeItem, const TCHAR *folderName);
 
-	bool writeWorkSpace(const TCHAR *projectFileName = NULL, bool updateName = true);
+	bool writeWorkSpace(const TCHAR *projectFileName = NULL, bool doUpdateGUI = true);
 	generic_string getRelativePath(const generic_string & fn, const TCHAR *workSpaceFileName);
 	void buildProjectXml(TiXmlNode *root, HTREEITEM hItem, const TCHAR* fn2write);
 	NodeType getNodeType(HTREEITEM hItem);


### PR DESCRIPTION
Project name is no longer updated in the tree when "save copy as" is used.

Fix #13135