### PR TITLE
Fix Issue 13350 by reverting minimumRequiredVersion to previous value…

### DIFF
--- a/PowerEditor/visual.net/notepadPlus.Cpp.props
+++ b/PowerEditor/visual.net/notepadPlus.Cpp.props
@@ -134,7 +134,7 @@ copy "..\src\contextMenu.xml" "$(OutDir)contextMenu.xml"
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
-      <MinimumRequiredVersion>6.00</MinimumRequiredVersion>
+      <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">


### PR DESCRIPTION
… for 32b environment.

This will fix issue #13350 so anyone that uses C# DLL can continue enjoying Notepad++.

The value set here was the one existing in previous version of Notepad++ prior to the 10/01/2023.