### PR TITLE
Untested cleanup jobs for context menus

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -290,6 +290,20 @@ ${MementoSection} "Context Menu Entry" explorerContextMenu
 			File /oname=$INSTDIR\NppModernShell.dll "..\bin64\NppModernShell.dll"
 		!endif
 		Exec 'rundll32.exe"$INSTDIR\NppModernShell.dll,RegisterSparsePackage"'
+
+		; Make sure old NppShell dll's are unregistered and removed
+		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
+		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
+		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
+		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
+		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
+		Exec 'regsvr32 /u /s "$INSTDIR\NppShell_06.dll"'
+		Delete "$INSTDIR\NppShell_01.dll"
+		Delete "$INSTDIR\NppShell_02.dll"
+		Delete "$INSTDIR\NppShell_03.dll"
+		Delete "$INSTDIR\NppShell_04.dll"
+		Delete "$INSTDIR\NppShell_05.dll"
+		Delete "$INSTDIR\NppShell_06.dll"
 		
 	${Else} ; the old "Edit with Notepad++" menu entry still works under Windows 10 and previous OS
 	

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -70,6 +70,7 @@ Section un.explorerContextMenu
 	Delete "$INSTDIR\NppShell_05.dll"
 	Delete "$INSTDIR\NppShell_06.dll"
 	
+	Exec 'rundll32.exe"$INSTDIR\NppModernShell.dll,UnregisterSparsePackage"'
 	
  	ReadRegStr $muiVerbStrUn HKLM "SOFTWARE\Classes\*\shell\pintohome" MUIVerb
 	${UnStrStr} $nppSubStrUn $muiVerbStrUn "Notepad++"


### PR DESCRIPTION
This PR makes sure the NppShell dlls are unregistered and removed when upgrading on Windows 11, since the new dll is used instead.
This also unregisters the modern shell context menu when uninstalling.

This is untested, since I cannot create the installer.