### PR TITLE
Fix "Edit with Notepad++" context menu needs restarting OS issue

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -267,7 +267,7 @@ ${MementoSection} "Context Menu Entry" explorerContextMenu
 
 	SetOverwrite try
 	SetOutPath "$INSTDIR\contextMenu\"
-
+/*
 	; Make sure old NppShell dll's are unregistered and removed
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
@@ -281,7 +281,7 @@ ${MementoSection} "Context Menu Entry" explorerContextMenu
 	Delete "$INSTDIR\NppShell_04.dll"
 	Delete "$INSTDIR\NppShell_05.dll"
 	Delete "$INSTDIR\NppShell_06.dll"
-	
+*/
 	
 	!ifdef ARCH64
 		File /oname=$INSTDIR\contextMenu\NppShell.msix "..\bin64\NppShell.msix"

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -262,11 +262,6 @@ FunctionEnd
 
 !include "nsisInclude\themes.nsh"
 
-!include "StrFunc.nsh"
-${Using:StrFunc} StrStr
-
-Var muiVerbStr
-Var nppSubStr
 
 ${MementoSection} "Context Menu Entry" explorerContextMenu
 

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -267,21 +267,6 @@ ${MementoSection} "Context Menu Entry" explorerContextMenu
 
 	SetOverwrite try
 	SetOutPath "$INSTDIR\contextMenu\"
-/*
-	; Make sure old NppShell dll's are unregistered and removed
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
-	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_06.dll"'
-	Delete "$INSTDIR\NppShell_01.dll"
-	Delete "$INSTDIR\NppShell_02.dll"
-	Delete "$INSTDIR\NppShell_03.dll"
-	Delete "$INSTDIR\NppShell_04.dll"
-	Delete "$INSTDIR\NppShell_05.dll"
-	Delete "$INSTDIR\NppShell_06.dll"
-*/
 	
 	!ifdef ARCH64
 		File /oname=$INSTDIR\contextMenu\NppShell.msix "..\bin64\NppShell.msix"

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -271,27 +271,7 @@ Var nppSubStr
 ${MementoSection} "Context Menu Entry" explorerContextMenu
 
 	SetOverwrite try
-	SetOutPath "$INSTDIR\contextmenu\"
-
-	!ifdef ARCH64
-		File /oname=$INSTDIR\contextmenu\NppShell.msix "..\bin64\NppShell.msix"
-		File /oname=$INSTDIR\contextmenu\NppShell.dll "..\bin64\NppShell.x64.dll"
-	!else ifdef ARCHARM64
-		File /oname=$INSTDIR\contextmenu\NppShell.msix "..\binarm64\NppShell.msix"
-		File /oname=$INSTDIR\contextmenu\NppShell.dll "..\binarm64\NppShell.arm64.dll"
-	!else
-		; We need to test which arch we are running on, since 32bit exe can be run on both 32bit and 64bit Windows.
-		${If} ${RunningX64}
-			; We are running on 64bit Windows, so we need the msix as well, since it might be Windows 11.
-			File /oname=$INSTDIR\contextmenu\NppShell.msix "..\bin64\NppShell.msix"
-			File /oname=$INSTDIR\contextmenu\NppShell.dll "..\bin64\NppShell.x64.dll"
-		${Else}
-			; We are running on 32bit Windows, so no need for the msix file, since there is no way this could even be upgraded to Windows 11.
-			File /oname=$INSTDIR\contextmenu\NppShell.dll "..\bin\NppShell.x86.dll"
-		${EndIf}    
-
-	!endif
-	Exec 'regsvr32 /s "$INSTDIR\contextmenu\NppShell.dll"'
+	SetOutPath "$INSTDIR\contextMenu\"
 
 	; Make sure old NppShell dll's are unregistered and removed
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
@@ -306,6 +286,28 @@ ${MementoSection} "Context Menu Entry" explorerContextMenu
 	Delete "$INSTDIR\NppShell_04.dll"
 	Delete "$INSTDIR\NppShell_05.dll"
 	Delete "$INSTDIR\NppShell_06.dll"
+	
+	
+	!ifdef ARCH64
+		File /oname=$INSTDIR\contextMenu\NppShell.msix "..\bin64\NppShell.msix"
+		File /oname=$INSTDIR\contextMenu\NppShell.dll "..\bin64\NppShell.x64.dll"
+	!else ifdef ARCHARM64
+		File /oname=$INSTDIR\contextMenu\NppShell.msix "..\binarm64\NppShell.msix"
+		File /oname=$INSTDIR\contextMenu\NppShell.dll "..\binarm64\NppShell.arm64.dll"
+	!else
+		; We need to test which arch we are running on, since 32bit exe can be run on both 32bit and 64bit Windows.
+		${If} ${RunningX64}
+			; We are running on 64bit Windows, so we need the msix as well, since it might be Windows 11.
+			File /oname=$INSTDIR\contextMenu\NppShell.msix "..\bin64\NppShell.msix"
+			File /oname=$INSTDIR\contextMenu\NppShell.dll "..\bin64\NppShell.x64.dll"
+		${Else}
+			; We are running on 32bit Windows, so no need for the msix file, since there is no way this could even be upgraded to Windows 11.
+			File /oname=$INSTDIR\contextMenu\NppShell.dll "..\bin\NppShell.x86.dll"
+		${EndIf}    
+
+	!endif
+	
+	Exec 'regsvr32 /s "$INSTDIR\contextMenu\NppShell.dll"'
 
 ${MementoSectionEnd}
 

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -54,12 +54,6 @@ Function un.onUninstSuccess
 FunctionEnd
 
 
-!include "StrFunc.nsh"
-${Using:StrFunc} UnStrStr
-
-Var muiVerbStrUn
-Var nppSubStrUn
-
 Section un.explorerContextMenu
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
 	Exec 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'

--- a/PowerEditor/src/notepad++.exe.manifest
+++ b/PowerEditor/src/notepad++.exe.manifest
@@ -7,11 +7,6 @@
     name="Notepad++"
     type="win32"
 />
-<msix xmlns="urn:schemas-microsoft-com:msix.v1"
-    publisher="CN=Notepad++"
-    packageName="NotepadPlusPlus"
-    applicationId="NotepadPlusPlus"
-/>
 <description>Notepad++</description>
 <dependency>
     <dependentAssembly>


### PR DESCRIPTION
Fix context menu disappears issue while update.

It works with https://github.com/notepad-plus-plus/nppShell/pull/14 to fix
https://github.com/notepad-plus-plus/nppShell/issues/13

It fixes also the added dependency of the service "Application Information".

Fix #13446, fix #13457