### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.5.2

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -4,46 +4,26 @@ The comments are here for explanation, it's not necessary to translate them.
 -->
 <!--
     History of Corsican translation for Notepad++
-		- Updated on March 12th, 2023 for version 8.5.1 by Patriccollu di Santa Maria è Sichè
-		- Updated on February 24th, 2023 for version 8.5 by Patriccollu di Santa Maria è Sichè
-		- Updated on December 31st, 2022 for version 8.4.9 by Patriccollu di Santa Maria è Sichè
-		- Updated on December 1st, 2022 for version 8.4.8 by Patriccollu di Santa Maria è Sichè
-		- Updated on October 22nd, 2022 for version 8.4.7 by Patriccollu di Santa Maria è Sichè
-		- Updated on September 21st, 2022 for version 8.4.6 by Patriccollu di Santa Maria è Sichè
-		- Updated on August 24th, 2022 for version 8.4.5 by Patriccollu di Santa Maria è Sichè
-		- Updated on June 27th, 2022 for version 8.4.3 by Patriccollu di Santa Maria è Sichè
-		- Updated on May 25th, 2022 for version 8.4.2 by Patriccollu di Santa Maria è Sichè
-		- Updated on April 27th, 2022 for version 8.4.1 by Patriccollu di Santa Maria è Sichè
-		- Updated on April 7nd, 2022 for version 8.3.4 by Patriccollu di Santa Maria è Sichè
-		- Updated on February 21st, 2022 for version 8.3.2 by Patriccollu di Santa Maria è Sichè
-		- Updated on February 8th, 2022 for version 8.3.1 by Patriccollu di Santa Maria è Sichè
-		- Updated on January 11th, 2022 for version 8.2.1 by Patriccollu di Santa Maria è Sichè
-		- Updated on December 4th, 2021 for version 8.1.9.3 by Patriccollu di Santa Maria è Sichè
-		- Updated on September 13th, 2021 for version 8.1.5 by Patriccollu di Santa Maria è Sichè
-		- Updated on August 20th, 2021 for version 8.1.4 by Patriccollu di Santa Maria è Sichè
-		- Updated on July 31st, 2021 for version 8.1.3 by Patriccollu di Santa Maria è Sichè
-		- Updated on June 14th, 2021 for version 8.0.0 by Patriccollu di Santa Maria è Sichè
-		- Updated on May 20th, 2021 for version 7.9.6 by Patriccollu di Santa Maria è Sichè
-		- Updated on May 12th, 2021 for version 7.9.6 by Patriccollu di Santa Maria è Sichè
-		- Updated on January 27th, 2021 for version 7.9.3 by Patriccollu di Santa Maria è Sichè
-		- Updated on November 4th, 2020 for version 7.9.2 by Patriccollu di Santa Maria è Sichè
-		- Updated on September 16th, 2020 for version 7.9.1 by Patriccollu di Santa Maria è Sichè
-		- Updated on June 28th, 2020 for version 7.8.9 by Patriccollu di Santa Maria è Sichè
-		- Updated on April 19th, 2020 for version 7.8.7 by Patriccollu di Santa Maria è Sichè
-		- Updated on December 5th, 2019 for version 7.8.3 by Patriccollu di Santa Maria è Sichè
-		- Updated on November 2nd, 2019 for version 7.8.1 by Patriccollu di Santa Maria è Sichè
-		- Updated on July 7th, 2019 for version 7.7.2 by Patriccollu di Santa Maria è Sichè
-		- Updated on March 29th, 2019 for version 7.6.5 by Patriccollu di Santa Maria è Sichè
+
+		- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2)
+		- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
+		          Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
+		          Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
+		- Updated in 2021 by Patriccollu di Santa Maria è Sichè: Jan. 27th (v7.9.3), May 12th (v7.9.6), May 20th (v7.9.6),
+		          June 14th (v8.0.0), July 31st (v8.1.3), Aug. 20th (v8.1.4), Sep. 13th (v8.1.5), Dec. 4th (v8.1.9.3)
+		- Updated in 2020 by Patriccollu di Santa Maria è Sichè: Apr. 19th (v7.8.7), June 28th (v7.8.9), Sep. 16th (v7.9.1),
+		          Nov, 4th (v7.9.2)
+		- Updated in 2019 by Patriccollu di Santa Maria è Sichè: Mar. 29th (v7.6.5), July 7th (v7.7.2), Nov. 2nd (v7.8.1),
+		          Dec. 5th (v7.8.3)
 		- Updated on March 11th, 2018 for version 7.5.5 by Patriccollu di Santa Maria è Sichè
-		- Updated on August 19th, 2017 for version 7.5 by Patriccollu di Santa Maria è Sichè
-		- Updated on April 30th, 2017 for version 7.3.3 by Patriccollu di Santa Maria è Sichè
+		- Updated in 2017 by Patriccollu di Santa Maria è Sichè: April 30th (v7.3.3), August 19th (v7.5)
 		- Created on September 14th, 2016 for version 6.9.2 by Patriccollu di Santa Maria è Sichè
 
-    The latest update is still available here:
+    The latest update of Corsican translation file is available here:
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 -->
 <NotepadPlus>
-    <Native-Langue name="Corsu" filename="corsican.xml" version="8.5.1">
+    <Native-Langue name="Corsu" filename="corsican.xml" version="8.5.2">
         <Menu>
             <Main>
                 <!-- Main Menu Entries -->
@@ -1318,7 +1298,12 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
                 <Item id="2033" name="&amp;Numeru à framette"/>
                 <Item id="2030" name="Numeru di &amp;principiu :"/>
                 <Item id="2031" name="&amp;Cresce da :"/>
-                <Item id="2035" name="&amp;Zeru davanti"/>
+                <Item id="2038" name="D&amp;avanti :"/>
+                <ComboBox id="2039">
+                    <Element name="Nunda"/>
+                    <Element name="Zeri"/>
+                    <Element name="Spazii"/>
+                </ComboBox>
                 <Item id="2036" name="&amp;Ripete :"/>
                 <Item id="2032" name="Furmatu"/>
                 <Item id="2024" name="&amp;Decimale"/>
@@ -1499,8 +1484,9 @@ Vulete arregistrà i vostri cambiamenti nanzu di cambià di tema ?"/> <!-- HowT
             <ColumnVal name="Valore"/>
             <ColumnHex name="Esadecimale"/>
             <ColumnChar name="Caratteru"/>
-            <ColumnHtmlNumber name="Numeru HTML"/>
-            <ColumnHtmlName name="Codice HTML"/>
+            <ColumnHtmlName name="Nome HTML"/>
+            <ColumnHtmlNumber name="Decimale HTML"/>
+            <ColumnHtmlHexNb name="Esadecimale HTML"/>
         </AsciiInsertion>
         <DocumentMap>
             <PanelTitle name="Cartugrafia di u ducumentu"/>
@@ -1673,6 +1659,7 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
             <summary-nbsel1 value=" caratteri selezziunati ("/>
             <summary-nbsel2 value=" ottetti) in "/>
             <summary-nbrange value=" selezzioni"/>
+            <progress-hits-title value="Occurrenze :"/>
             <progress-cancel-button value="Abbandunà"/>
             <progress-cancel-info value="Abbandonu di l’operazione, aspittate per piacè…"/>
             <find-in-files-progress-title value="Prugressione di a ricerca in i schedarii…"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/7f54a4b959c51323db635f76a4c037cb8f432c0e Add ability to do leading spaces with ColumnEditor
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/9b67c93ef9e70f114ce56fee3bbd9ffb6e784742 Add more items and HTML Hexadecilmal column to ASCII panel
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/508b3fabd657d32488eb9105d0cdc90055f55d2b Add hits in-progress increased number to Search Progress dialog

I also reduced the size of comment - regarding History of Corsican translation - at the beginning of file.

Cheers,
Patriccollu.