### PR TITLE
fix infinite loop in wrapped find/replace macros

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1496,35 +1496,35 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					{
 						if ( counter >= times )
 							break;
+						continue;
 					}
-					else // run until eof
+					// else run until eof
+					
+					// the line number must monotonically increase or decrease
+					// if direction ever changes, bail out to avoid infinite loop
+					if ((counter > 1) && ((deltaCurrLine < 0) != cursorMovedUp))
+						break;
+					cursorMovedUp = deltaCurrLine < 0;
+					deltaLastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1 - lastLine;
+					deltaCurrLine = _pEditView->getCurrentLineNumber() - currLine;
+
+					if (( deltaCurrLine == 0 )	// line no. not changed?
+						&& (deltaLastLine >= 0))  // and no lines removed?
+						break; // exit
+
+					// Update the line count, but only if the number of lines remaining is shrinking.
+					// Otherwise, the macro playback may never end.
+					if (deltaLastLine < deltaCurrLine)
+						lastLine += deltaLastLine;
+
+					// save current line
+					currLine += deltaCurrLine;
+
+					// eof?
+					if ((currLine > lastLine) || (currLine < 0)
+						|| ((deltaCurrLine == 0) && (currLine == 0) && ((deltaLastLine >= 0) || cursorMovedUp)))
 					{
-						// the line number must monotonically increase or decrease
-						// if direction ever changes, bail out to avoid infinite loop
-						if ((counter > 1) && ((deltaCurrLine < 0) != cursorMovedUp))
-							break;
-						cursorMovedUp = deltaCurrLine < 0;
-						deltaLastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1 - lastLine;
-						deltaCurrLine = _pEditView->getCurrentLineNumber() - currLine;
-
-						if (( deltaCurrLine == 0 )	// line no. not changed?
-							&& (deltaLastLine >= 0))  // and no lines removed?
-							break; // exit
-
-						// Update the line count, but only if the number of lines remaining is shrinking.
-						// Otherwise, the macro playback may never end.
-						if (deltaLastLine < deltaCurrLine)
-							lastLine += deltaLastLine;
-
-						// save current line
-						currLine += deltaCurrLine;
-
-						// eof?
-						if ((currLine > lastLine) || (currLine < 0)
-							|| ((deltaCurrLine == 0) && (currLine == 0) && ((deltaLastLine >= 0) || cursorMovedUp)))
-						{
-							break;
-						}
+						break;
 					}
 				}
 				_pEditView->execute(SCI_ENDUNDOACTION);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1477,6 +1477,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				int indexMacro = _runMacroDlg.getMacro2Exec();
 				intptr_t deltaLastLine = 0;
 				intptr_t deltaCurrLine = 0;
+				bool cursorMovedUp = false;
 
 				Macro m = _macro;
 
@@ -1498,7 +1499,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					}
 					else // run until eof
 					{
-						bool cursorMovedUp = deltaCurrLine < 0;
+						// the line number must monotonically increase or decrease
+						// if direction ever changes, bail out to avoid infinite loop
+						if ((counter > 1) && ((deltaCurrLine < 0) != cursorMovedUp))
+							break;
+						cursorMovedUp = deltaCurrLine < 0;
 						deltaLastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1 - lastLine;
 						deltaCurrLine = _pEditView->getCurrentLineNumber() - currLine;
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1508,8 +1508,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					deltaLastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1 - lastLine;
 					deltaCurrLine = _pEditView->getCurrentLineNumber() - currLine;
 
-					if (( deltaCurrLine == 0 )	// line no. not changed?
-						&& (deltaLastLine >= 0))  // and no lines removed?
+					bool currLineUnchanged = deltaCurrLine == 0;
+					bool noLinesRemoved = deltaLastLine >= 0;
+					if (currLineUnchanged && noLinesRemoved)
 						break; // exit
 
 					// Update the line count, but only if the number of lines remaining is shrinking.
@@ -1521,8 +1522,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					currLine += deltaCurrLine;
 
 					// eof?
-					if ((currLine > lastLine) || (currLine < 0)
-						|| ((deltaCurrLine == 0) && (currLine == 0) && ((deltaLastLine >= 0) || cursorMovedUp)))
+					if ((currLine > lastLine)
+						|| (currLine < 0)
+						|| (currLineUnchanged
+							&& (currLine == 0)
+							&& (noLinesRemoved || cursorMovedUp)))
 					{
 						break;
 					}


### PR DESCRIPTION
This would address #13342.
Tested on Win32 and x64 builds.

In the past, the macro runner didn't check if the direction the cursor was moving changed. By adding a check to make sure that the cursor didn't switch from moving down to moving up from one macro run to the next, we avoid infinite loops.

The easiest way to test that this works is to do the following:
1. create a file containing the text
```
f
f
```
2. Start recording a macro.
3. Ctrl+F for `f`. Make sure that `Wrap around` is turned *on*!
4. Stop recording the macro.
5. Go to `Run a macro multiple times` and `run until end of file`. In previous versions of Notepad++, this will cause an infinite loop. In this version, it should stop at some point, though not necessarily the last line in the file.