### PR TITLE
Fix search results output alignment for large file searches

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1387,7 +1387,7 @@ int nbDigitsFromNbLines(size_t nbLines)
 	else // rare case
 	{
 		nbDigits = 7;
-		nbLines /= 1000000;
+		nbLines /= 10000000;
 
 		while (nbLines)
 		{


### PR DESCRIPTION
Fix #13481