### PR TITLE
Fix UDL deletion issue

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1349,9 +1349,11 @@ private:
 struct UdlXmlFileState final {
 	TiXmlDocument* _udlXmlDoc = nullptr;
 	bool _isDirty = false;
+	bool _isInDefaultSharedContainer = false; // contained in "userDefineLang.xml" file
 	std::pair<unsigned char, unsigned char> _indexRange;
 
-	UdlXmlFileState(TiXmlDocument* doc, bool isDirty, std::pair<unsigned char, unsigned char> range) : _udlXmlDoc(doc), _isDirty(isDirty), _indexRange(range) {};
+	UdlXmlFileState(TiXmlDocument* doc, bool isDirty, bool isInDefaultSharedContainer, std::pair<unsigned char, unsigned char> range)
+		: _udlXmlDoc(doc), _isDirty(isDirty), _isInDefaultSharedContainer(isInDefaultSharedContainer), _indexRange(range) {};
 };
 
 const int NB_LANG = 100;


### PR DESCRIPTION
While there are the UDL in the userDefineLangs folder (new system) and a (or some) UDL in "userDefineLang.xml" (old system). The complete UDL deletion in "userDefineLang.xml" not remove "userDefineLang.xml" file. This PR fixes the problem.

Fix #8101