### PR TITLE
Fix saving wrong macro/run menu UTF8 folder name after commands modification

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3420,7 +3420,23 @@ void NppParameters::insertMacro(TiXmlNode *macrosRoot, const MacroShortcut & mac
 	macroRoot->ToElement()->SetAttribute(TEXT("Shift"), key._isShift?TEXT("yes"):TEXT("no"));
 	macroRoot->ToElement()->SetAttribute(TEXT("Key"), key._key);
 	if (!folderName.empty())
-		macroRoot->ToElement()->SetAttribute(TEXT("FolderName"), folderName);
+	{
+		// W -> A -> W
+		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+		const char* folderNameA = wmc.wchar2char(folderName.c_str(), SC_CP_UTF8);
+
+		size_t len = strlen(folderNameA);
+		wchar_t* folderNameW = new wchar_t[len+1];
+
+		for (size_t i = 0; i < len; ++i)
+		{
+			folderNameW[i] = folderNameA[i];
+		}
+		folderNameW[len] = '\0';
+
+		macroRoot->ToElement()->SetAttribute(TEXT("FolderName"), folderNameW);
+		delete[] folderNameW;
+	}
 
 	for (size_t i = 0, len = macro._macro.size(); i < len ; ++i)
 	{
@@ -3446,7 +3462,23 @@ void NppParameters::insertUserCmd(TiXmlNode *userCmdRoot, const UserCommand & us
 	cmdRoot->ToElement()->SetAttribute(TEXT("Key"), key._key);
 	cmdRoot->InsertEndChild(TiXmlText(userCmd._cmd.c_str()));
 	if (!folderName.empty())
-		cmdRoot->ToElement()->SetAttribute(TEXT("FolderName"), folderName);
+	{
+		// W -> A -> W
+		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
+		const char* folderNameA = wmc.wchar2char(folderName.c_str(), SC_CP_UTF8);
+
+		size_t len = strlen(folderNameA);
+		wchar_t* folderNameW = new wchar_t[len + 1];
+
+		for (size_t i = 0; i < len; ++i)
+		{
+			folderNameW[i] = folderNameA[i];
+		}
+		folderNameW[len] = '\0';
+
+		cmdRoot->ToElement()->SetAttribute(TEXT("FolderName"), folderNameW);
+		delete[] folderNameW;
+	}
 }
 
 


### PR DESCRIPTION

The macro/run commands menu folder (submenu entry) can be UTF8 characters. After modification of macro/run shortcut commands, the macro/run menu UTF8 folder names can be saved correctly by this commit, but in Unicode character number form instead of human readible characters.

Fix #12670