### PR TITLE
Add the UTF8 character ability for Run & Macro menu

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -597,23 +597,23 @@ void PluginsManager::addInMenuFromPMIndex(int i)
 
 		int cmdID = ID_PLUGINS_CMD + static_cast<int32_t>(_pluginsCommands.size() - 1);
 		_pluginInfos[i]->_funcItems[j]._cmdID = cmdID;
-		generic_string itemName = _pluginInfos[i]->_funcItems[j]._itemName;
+		string itemName = wstring2string(_pluginInfos[i]->_funcItems[j]._itemName, CP_UTF8);
 
 		if (_pluginInfos[i]->_funcItems[j]._pShKey)
 		{
 			ShortcutKey & sKey = *(_pluginInfos[i]->_funcItems[j]._pShKey);
-            PluginCmdShortcut pcs(Shortcut(itemName.c_str(), sKey._isCtrl, sKey._isAlt, sKey._isShift, sKey._key), cmdID, _pluginInfos[i]->_moduleName.c_str(), j);
+            PluginCmdShortcut pcs(Shortcut(itemName.c_str(), sKey._isCtrl, sKey._isAlt, sKey._isShift, sKey._key), cmdID, wstring2string(_pluginInfos[i]->_moduleName, CP_UTF8).c_str(), j);
 			pluginCmdSCList.push_back(pcs);
-			itemName += TEXT("\t");
+			itemName += "\t";
 			itemName += pcs.toString();
 		}
 		else
 		{	//no ShortcutKey is provided, add an disabled shortcut (so it can still be mapped, Paramaters class can still index any changes and the toolbar wont funk out
             Shortcut sc(itemName.c_str(), false, false, false, 0x00);
-            PluginCmdShortcut pcs(sc, cmdID, _pluginInfos[i]->_moduleName.c_str(), j);	//VK_NULL and everything disabled, the menu name is left alone
+            PluginCmdShortcut pcs(sc, cmdID, wstring2string(_pluginInfos[i]->_moduleName, CP_UTF8).c_str(), j);	//VK_NULL and everything disabled, the menu name is left alone
 			pluginCmdSCList.push_back(pcs);
 		}
-		::InsertMenu(_pluginInfos[i]->_pluginMenu, j, MF_BYPOSITION, cmdID, itemName.c_str());
+		::InsertMenu(_pluginInfos[i]->_pluginMenu, j, MF_BYPOSITION, cmdID, string2wstring(itemName, CP_UTF8).c_str());
 
 		if (_pluginInfos[i]->_funcItems[j]._init2Check)
 			::CheckMenuItem(_hPluginsMenu, cmdID, MF_BYCOMMAND | MF_CHECKED);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5346,8 +5346,8 @@ bool Notepad_plus::addCurrentMacro()
 			::InsertMenu(hMacroMenu, posBase + nbTopLevelItem + 2, MF_BYCOMMAND, IDM_SETTING_SHORTCUT_MAPPER_MACRO, nativeLangShortcutMapperMacro.c_str());
         }
 		theMacros.push_back(ms);
-		macroMenu.push_back(MenuItemUnit(cmdID, ms.getName()));
-		::InsertMenu(hMacroMenu, static_cast<UINT>(posBase + nbTopLevelItem), MF_BYPOSITION, cmdID, ms.toMenuItemString().c_str());
+		macroMenu.push_back(MenuItemUnit(cmdID, string2wstring(ms.getName(), CP_UTF8)));
+		::InsertMenu(hMacroMenu, static_cast<UINT>(posBase + nbTopLevelItem), MF_BYPOSITION, cmdID, string2wstring(ms.toMenuItemString(), CP_UTF8).c_str());
 		_accelerator.updateShortcuts();
 		nppParams.setShortcutDirty();
 		return true;
@@ -8515,7 +8515,7 @@ void Notepad_plus::updateCommandShortcuts()
 				shortcutName = menuName;
 		}
 
-		csc.setName(menuName.c_str(), shortcutName.c_str());
+		csc.setName(wstring2string(menuName, CP_UTF8).c_str(), wstring2string(shortcutName, CP_UTF8).c_str());
 	}
 }
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1455,7 +1455,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_FRSAVE_STR:
 		{
-			_macro.push_back(recordedMacroStep(static_cast<int32_t>(wParam), 0, 0, reinterpret_cast<const TCHAR *>(lParam), recordedMacroStep::mtSavedSnR));
+			_macro.push_back(recordedMacroStep(static_cast<int32_t>(wParam), 0, 0, reinterpret_cast<const char *>(lParam), recordedMacroStep::mtSavedSnR));
 			break;
 		}
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -48,7 +48,7 @@ void Notepad_plus::macroPlayback(Macro macro)
 		if (step->isScintillaMacro())
 			step->PlayBack(_pPublicInterface, _pEditView);
 		else
-			_findReplaceDlg.execSavedCommand(step->_message, step->_lParameter, step->_sParameter);
+			_findReplaceDlg.execSavedCommand(step->_message, step->_lParameter, string2wstring(step->_sParameter, CP_UTF8));
 	}
 
 	_pEditView->execute(SCI_ENDUNDOACTION);
@@ -3964,7 +3964,7 @@ void Notepad_plus::command(int id)
 				vector<UserCommand> & theUserCommands = (NppParameters::getInstance()).getUserCommandList();
 				UserCommand ucmd = theUserCommands[i];
 
-				Command cmd(ucmd.getCmd());
+				Command cmd(string2wstring(ucmd.getCmd(), CP_UTF8));
 				cmd.run(_pPublicInterface->getHSelf());
 			}
 			else if ((id >= ID_PLUGINS_CMD) && (id < ID_PLUGINS_CMD_LIMIT))

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -1025,8 +1025,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				recordedMacroStep(
 					notification->message,
 					notification->wParam,
-					notification->lParam,
-					static_cast<int32_t>(_pEditView->execute(SCI_GETCODEPAGE))
+					notification->lParam
 				)
 			);
 			break;

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1471,12 +1471,12 @@ bool NppParameters::load()
 		::CopyFile(srcShortcutsPath.c_str(), _shortcutsPath.c_str(), TRUE);
 	}
 
-	_pXmlShortcutDoc = new TiXmlDocumentA();
-	loadOkay = _pXmlShortcutDoc->LoadUnicodeFilePath(_shortcutsPath.c_str());
+	_pXmlShortcutDocA = new TiXmlDocumentA();
+	loadOkay = _pXmlShortcutDocA->LoadUnicodeFilePath(_shortcutsPath.c_str());
 	if (!loadOkay)
 	{
-		delete _pXmlShortcutDoc;
-		_pXmlShortcutDoc = nullptr;
+		delete _pXmlShortcutDocA;
+		_pXmlShortcutDocA = nullptr;
 		isAllLaoded = false;
 	}
 	else
@@ -1613,10 +1613,9 @@ void NppParameters::destroyInstance()
 
 	delete _pXmlNativeLangDocA;
 	delete _pXmlToolIconsDoc;
-	delete _pXmlShortcutDoc;
+	delete _pXmlShortcutDocA;
 	delete _pXmlContextMenuDocA;
 	delete _pXmlTabContextMenuDocA;
-	delete _pXmlBlacklistDoc;
 	delete 	getInstancePointer();
 }
 
@@ -1903,10 +1902,10 @@ std::pair<unsigned char, unsigned char> NppParameters::addUserDefineLangsFromXml
 
 bool NppParameters::getShortcutsFromXmlTree()
 {
-	if (!_pXmlShortcutDoc)
+	if (!_pXmlShortcutDocA)
 		return false;
 
-	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
+	TiXmlNodeA *root = _pXmlShortcutDocA->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1917,10 +1916,10 @@ bool NppParameters::getShortcutsFromXmlTree()
 
 bool NppParameters::getMacrosFromXmlTree()
 {
-	if (!_pXmlShortcutDoc)
+	if (!_pXmlShortcutDocA)
 		return false;
 
-	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
+	TiXmlNodeA *root = _pXmlShortcutDocA->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1931,10 +1930,10 @@ bool NppParameters::getMacrosFromXmlTree()
 
 bool NppParameters::getUserCmdsFromXmlTree()
 {
-	if (!_pXmlShortcutDoc)
+	if (!_pXmlShortcutDocA)
 		return false;
 
-	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
+	TiXmlNodeA *root = _pXmlShortcutDocA->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1945,10 +1944,10 @@ bool NppParameters::getUserCmdsFromXmlTree()
 
 bool NppParameters::getPluginCmdsFromXmlTree()
 {
-	if (!_pXmlShortcutDoc)
+	if (!_pXmlShortcutDocA)
 		return false;
 
-	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
+	TiXmlNodeA *root = _pXmlShortcutDocA->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1959,10 +1958,10 @@ bool NppParameters::getPluginCmdsFromXmlTree()
 
 bool NppParameters::getScintKeysFromXmlTree()
 {
-	if (!_pXmlShortcutDoc)
+	if (!_pXmlShortcutDocA)
 		return false;
 
-	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
+	TiXmlNodeA *root = _pXmlShortcutDocA->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -3188,9 +3187,9 @@ bool NppParameters::writeSettingsFilesOnCloudForThe1stTime(const generic_string 
 	// shortcuts.xml
 	generic_string cloudShortcutsPath = cloudSettingsPath;
 	pathAppend(cloudShortcutsPath, TEXT("shortcuts.xml"));
-	if (!::PathFileExists(cloudShortcutsPath.c_str()) && _pXmlShortcutDoc)
+	if (!::PathFileExists(cloudShortcutsPath.c_str()) && _pXmlShortcutDocA)
 	{
-		isOK = _pXmlShortcutDoc->SaveUnicodeFilePath(cloudShortcutsPath.c_str());
+		isOK = _pXmlShortcutDocA->SaveUnicodeFilePath(cloudShortcutsPath.c_str());
 		if (!isOK)
 			return false;
 	}
@@ -3532,18 +3531,18 @@ void NppParameters::writeShortcuts()
 {
 	if (!_isAnyShortcutModified) return;
 
-	if (!_pXmlShortcutDoc)
+	if (!_pXmlShortcutDocA)
 	{
 		//do the treatment
-		_pXmlShortcutDoc = new TiXmlDocumentA();
+		_pXmlShortcutDocA = new TiXmlDocumentA();
 		TiXmlDeclarationA* decl = new TiXmlDeclarationA("1.0", "UTF-8", "");
-		_pXmlShortcutDoc->LinkEndChild(decl);
+		_pXmlShortcutDocA->LinkEndChild(decl);
 	}
 
-	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
+	TiXmlNodeA *root = _pXmlShortcutDocA->FirstChild("NotepadPlus");
 	if (!root)
 	{
-		root = _pXmlShortcutDoc->InsertEndChild(TiXmlElementA("NotepadPlus"));
+		root = _pXmlShortcutDocA->InsertEndChild(TiXmlElementA("NotepadPlus"));
 	}
 
 	TiXmlNodeA *cmdRoot = root->FirstChild("InternalCommands");
@@ -3599,7 +3598,7 @@ void NppParameters::writeShortcuts()
 	{
 		insertScintKey(scitillaKeyRoot, _scintillaKeyCommands[_scintillaModifiedKeyIndices[i]]);
 	}
-	_pXmlShortcutDoc->SaveUnicodeFilePath(_shortcutsPath.c_str());
+	_pXmlShortcutDocA->SaveUnicodeFilePath(_shortcutsPath.c_str());
 }
 
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1471,8 +1471,8 @@ bool NppParameters::load()
 		::CopyFile(srcShortcutsPath.c_str(), _shortcutsPath.c_str(), TRUE);
 	}
 
-	_pXmlShortcutDoc = new TiXmlDocument(_shortcutsPath);
-	loadOkay = _pXmlShortcutDoc->LoadFile();
+	_pXmlShortcutDoc = new TiXmlDocumentA();
+	loadOkay = _pXmlShortcutDoc->LoadUnicodeFilePath(_shortcutsPath.c_str());
 	if (!loadOkay)
 	{
 		delete _pXmlShortcutDoc;
@@ -1906,7 +1906,7 @@ bool NppParameters::getShortcutsFromXmlTree()
 	if (!_pXmlShortcutDoc)
 		return false;
 
-	TiXmlNode *root = _pXmlShortcutDoc->FirstChild(TEXT("NotepadPlus"));
+	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1920,7 +1920,7 @@ bool NppParameters::getMacrosFromXmlTree()
 	if (!_pXmlShortcutDoc)
 		return false;
 
-	TiXmlNode *root = _pXmlShortcutDoc->FirstChild(TEXT("NotepadPlus"));
+	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1934,7 +1934,7 @@ bool NppParameters::getUserCmdsFromXmlTree()
 	if (!_pXmlShortcutDoc)
 		return false;
 
-	TiXmlNode *root = _pXmlShortcutDoc->FirstChild(TEXT("NotepadPlus"));
+	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1948,7 +1948,7 @@ bool NppParameters::getPluginCmdsFromXmlTree()
 	if (!_pXmlShortcutDoc)
 		return false;
 
-	TiXmlNode *root = _pXmlShortcutDoc->FirstChild(TEXT("NotepadPlus"));
+	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
@@ -1962,24 +1962,12 @@ bool NppParameters::getScintKeysFromXmlTree()
 	if (!_pXmlShortcutDoc)
 		return false;
 
-	TiXmlNode *root = _pXmlShortcutDoc->FirstChild(TEXT("NotepadPlus"));
+	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
 	if (!root)
 		return false;
 
 	feedScintKeys(root);
 	return true;
-}
-
-bool NppParameters::getBlackListFromXmlTree()
-{
-	if (!_pXmlBlacklistDoc)
-		return false;
-
-	TiXmlNode *root = _pXmlBlacklistDoc->FirstChild(TEXT("NotepadPlus"));
-	if (!root)
-		return false;
-
-	return feedBlacklist(root);
 }
 
 void NppParameters::initMenuKeys()
@@ -1989,7 +1977,7 @@ void NppParameters::initMenuKeys()
 	for (int i = 0; i < nbCommands; ++i)
 	{
 		wkd = winKeyDefs[i];
-		Shortcut sc((wkd.specialName ? wkd.specialName : TEXT("")), wkd.isCtrl, wkd.isAlt, wkd.isShift, static_cast<unsigned char>(wkd.vKey));
+		Shortcut sc((wkd.specialName ? wstring2string(wkd.specialName, CP_UTF8).c_str() : ""), wkd.isCtrl, wkd.isAlt, wkd.isShift, static_cast<unsigned char>(wkd.vKey));
 		_shortcuts.push_back( CommandShortcut(sc, wkd.functionId) );
 	}
 }
@@ -2016,7 +2004,7 @@ void NppParameters::initScintillaKeys()
 		}
 		else
 		{
-			Shortcut s = Shortcut(skd.name, skd.isCtrl, skd.isAlt, skd.isShift, static_cast<unsigned char>(skd.vKey));
+			Shortcut s = Shortcut(wstring2string(skd.name, CP_UTF8).c_str(), skd.isCtrl, skd.isAlt, skd.isShift, static_cast<unsigned char>(skd.vKey));
 			ScintillaKeyMap sm = ScintillaKeyMap(s, skd.functionId, skd.redirFunctionId);
 			_scintillaKeyCommands.push_back(sm);
 			++prevIndex;
@@ -2712,17 +2700,17 @@ void NppParameters::feedFindHistoryParameters(TiXmlNode *node)
 		_findHistory._isPurge = (lstrcmp(TEXT("yes"), boolStr) == 0);
 }
 
-void NppParameters::feedShortcut(TiXmlNode *node)
+void NppParameters::feedShortcut(TiXmlNodeA *node)
 {
-	TiXmlNode *shortcutsRoot = node->FirstChildElement(TEXT("InternalCommands"));
+	TiXmlNodeA *shortcutsRoot = node->FirstChildElement("InternalCommands");
 	if (!shortcutsRoot) return;
 
-	for (TiXmlNode *childNode = shortcutsRoot->FirstChildElement(TEXT("Shortcut"));
+	for (TiXmlNodeA *childNode = shortcutsRoot->FirstChildElement("Shortcut");
 		childNode ;
-		childNode = childNode->NextSibling(TEXT("Shortcut")) )
+		childNode = childNode->NextSibling("Shortcut"))
 	{
 		int id;
-		const TCHAR *idStr = (childNode->ToElement())->Attribute(TEXT("id"), &id);
+		const char* idStr = (childNode->ToElement())->Attribute("id", &id);
 		if (idStr)
 		{
 			//find the commandid that matches this Shortcut sc and alter it, push back its index in the modified list, if not present
@@ -2739,73 +2727,52 @@ void NppParameters::feedShortcut(TiXmlNode *node)
 	}
 }
 
-void NppParameters::feedMacros(TiXmlNode *node)
+void NppParameters::feedMacros(TiXmlNodeA *node)
 {
-	TiXmlNode *macrosRoot = node->FirstChildElement(TEXT("Macros"));
+	TiXmlNodeA *macrosRoot = node->FirstChildElement("Macros");
 	if (!macrosRoot) return;
 
-	for (TiXmlNode *childNode = macrosRoot->FirstChildElement(TEXT("Macro"));
+	for (TiXmlNodeA *childNode = macrosRoot->FirstChildElement("Macro");
 		childNode ;
-		childNode = childNode->NextSibling(TEXT("Macro")) )
+		childNode = childNode->NextSibling("Macro"))
 	{
 		Shortcut sc;
-		generic_string fdnm;
+		string fdnm;
 		if (getShortcuts(childNode, sc, &fdnm))
 		{
 			Macro macro;
 			getActions(childNode, macro);
 			int cmdID = ID_MACRO + static_cast<int32_t>(_macros.size());
 			_macros.push_back(MacroShortcut(sc, macro, cmdID));
-
-			// User could add folder name in his/her native language,
-			// so let's make non-western languages displayable here.
-			if (!fdnm.empty())
-			{
-				// The function WideCharToMultiByte with CP_ACP doesn't work.
-				// So we use our way to convert to char from wchar_t:
-				size_t len = fdnm.size();
-				const wchar_t* fdnmW = fdnm.c_str();
-				char* fdnmA = new char[len+1];
-				for (size_t i = 0; i < len; ++i)
-				{
-					fdnmA[i] = (char)fdnmW[i];
-				}
-				fdnmA[len] = '\0';
-
-				WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-				fdnm = wmc.char2wchar(fdnmA, SC_CP_UTF8);
-
-				delete[] fdnmA;
-			}
-			_macroMenuItems.push_back(MenuItemUnit(cmdID, sc.getName(), fdnm));
+			_macroMenuItems.push_back(MenuItemUnit(cmdID, string2wstring(sc.getName(), CP_UTF8), string2wstring(fdnm, CP_UTF8)));
 		}
 	}
 }
 
 
-void NppParameters::getActions(TiXmlNode *node, Macro & macro)
+void NppParameters::getActions(TiXmlNodeA *node, Macro & macro)
 {
-	for (TiXmlNode *childNode = node->FirstChildElement(TEXT("Action"));
+	for (TiXmlNodeA *childNode = node->FirstChildElement("Action");
 		childNode ;
-		childNode = childNode->NextSibling(TEXT("Action")) )
+		childNode = childNode->NextSibling("Action") )
 	{
 		int type;
-		const TCHAR *typeStr = (childNode->ToElement())->Attribute(TEXT("type"), &type);
+		const char *typeStr = (childNode->ToElement())->Attribute("type", &type);
 		if ((!typeStr) || (type > 3))
 			continue;
 
 		int msg = 0;
-		(childNode->ToElement())->Attribute(TEXT("message"), &msg);
+		(childNode->ToElement())->Attribute("message", &msg);
 
 		int wParam = 0;
-		(childNode->ToElement())->Attribute(TEXT("wParam"), &wParam);
+		(childNode->ToElement())->Attribute("wParam", &wParam);
 
 		int lParam = 0;
-		(childNode->ToElement())->Attribute(TEXT("lParam"), &lParam);
+		(childNode->ToElement())->Attribute("lParam", &lParam);
 
-		const TCHAR *sParam = (childNode->ToElement())->Attribute(TEXT("sParam"));
+		const char *sParam = (childNode->ToElement())->Attribute("sParam");
 		if (!sParam)
-			sParam = TEXT("");
+			sParam = "";
 		recordedMacroStep step(msg, wParam, lParam, sParam, type);
 		if (step.isValid())
 			macro.push_back(step);
@@ -2813,71 +2780,49 @@ void NppParameters::getActions(TiXmlNode *node, Macro & macro)
 	}
 }
 
-void NppParameters::feedUserCmds(TiXmlNode *node)
+void NppParameters::feedUserCmds(TiXmlNodeA *node)
 {
-	TiXmlNode *userCmdsRoot = node->FirstChildElement(TEXT("UserDefinedCommands"));
+	TiXmlNodeA *userCmdsRoot = node->FirstChildElement("UserDefinedCommands");
 	if (!userCmdsRoot) return;
 
-	for (TiXmlNode *childNode = userCmdsRoot->FirstChildElement(TEXT("Command"));
+	for (TiXmlNodeA *childNode = userCmdsRoot->FirstChildElement("Command");
 		childNode ;
-		childNode = childNode->NextSibling(TEXT("Command")) )
+		childNode = childNode->NextSibling("Command") )
 	{
 		Shortcut sc;
-		generic_string fdnm;
+		string fdnm;
 		if (getShortcuts(childNode, sc, &fdnm))
 		{
-			TiXmlNode *aNode = childNode->FirstChild();
+			TiXmlNodeA *aNode = childNode->FirstChild();
 			if (aNode)
 			{
-				const TCHAR *cmdStr = aNode->Value();
+				const char* cmdStr = aNode->Value();
 				if (cmdStr)
 				{
 					int cmdID = ID_USER_CMD + static_cast<int32_t>(_userCommands.size());
 					_userCommands.push_back(UserCommand(sc, cmdStr, cmdID));
-
-					// User could add folder name in his/her native language,
-					// so let's make non-western languages displayable here.
-					if (!fdnm.empty())
-					{
-						// The function WideCharToMultiByte with CP_ACP doesn't work.
-						// So we use our way to convert to char from wchar_t:
-						size_t len = fdnm.size();
-						const wchar_t* fdnmW = fdnm.c_str();
-						char* fdnmA = new char[len + 1];
-						for (size_t i = 0; i < len; ++i)
-						{
-							fdnmA[i] = (char)fdnmW[i];
-						}
-						fdnmA[len] = '\0';
-
-						WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-						fdnm = wmc.char2wchar(fdnmA, SC_CP_UTF8);
-
-						delete[] fdnmA;
-					}
-
-					_runMenuItems.push_back(MenuItemUnit(cmdID, sc.getName(), fdnm));
+					_runMenuItems.push_back(MenuItemUnit(cmdID, string2wstring(sc.getName(), CP_UTF8), string2wstring(fdnm, CP_UTF8)));
 				}
 			}
 		}
 	}
 }
 
-void NppParameters::feedPluginCustomizedCmds(TiXmlNode *node)
+void NppParameters::feedPluginCustomizedCmds(TiXmlNodeA *node)
 {
-	TiXmlNode *pluginCustomizedCmdsRoot = node->FirstChildElement(TEXT("PluginCommands"));
+	TiXmlNodeA *pluginCustomizedCmdsRoot = node->FirstChildElement("PluginCommands");
 	if (!pluginCustomizedCmdsRoot) return;
 
-	for (TiXmlNode *childNode = pluginCustomizedCmdsRoot->FirstChildElement(TEXT("PluginCommand"));
+	for (TiXmlNodeA *childNode = pluginCustomizedCmdsRoot->FirstChildElement("PluginCommand");
 		childNode ;
-		childNode = childNode->NextSibling(TEXT("PluginCommand")) )
+		childNode = childNode->NextSibling("PluginCommand") )
 	{
-		const TCHAR *moduleName = (childNode->ToElement())->Attribute(TEXT("moduleName"));
+		const char *moduleName = (childNode->ToElement())->Attribute("moduleName");
 		if (!moduleName)
 			continue;
 
 		int internalID = -1;
-		const TCHAR *internalIDStr = (childNode->ToElement())->Attribute(TEXT("internalID"), &internalID);
+		const char *internalIDStr = (childNode->ToElement())->Attribute("internalID", &internalID);
 
 		if (!internalIDStr)
 			continue;
@@ -2887,7 +2832,7 @@ void NppParameters::feedPluginCustomizedCmds(TiXmlNode *node)
 		for (size_t i = 0; i < len; ++i)
 		{
 			PluginCmdShortcut & pscOrig = _pluginCommands[i];
-			if (!wcsnicmp(pscOrig.getModuleName(), moduleName, lstrlen(moduleName)) && pscOrig.getInternalID() == internalID)
+			if (!strnicmp(pscOrig.getModuleName(), moduleName, strlen(moduleName)) && pscOrig.getInternalID() == internalID)
 			{
 				//Found matching command
 				getShortcuts(childNode, _pluginCommands[i]);
@@ -2898,22 +2843,22 @@ void NppParameters::feedPluginCustomizedCmds(TiXmlNode *node)
 	}
 }
 
-void NppParameters::feedScintKeys(TiXmlNode *node)
+void NppParameters::feedScintKeys(TiXmlNodeA *node)
 {
-	TiXmlNode *scintKeysRoot = node->FirstChildElement(TEXT("ScintillaKeys"));
+	TiXmlNodeA *scintKeysRoot = node->FirstChildElement("ScintillaKeys");
 	if (!scintKeysRoot) return;
 
-	for (TiXmlNode *childNode = scintKeysRoot->FirstChildElement(TEXT("ScintKey"));
+	for (TiXmlNodeA *childNode = scintKeysRoot->FirstChildElement("ScintKey");
 		childNode ;
-		childNode = childNode->NextSibling(TEXT("ScintKey")) )
+		childNode = childNode->NextSibling("ScintKey") )
 	{
 		int scintKey;
-		const TCHAR *keyStr = (childNode->ToElement())->Attribute(TEXT("ScintID"), &scintKey);
+		const char *keyStr = (childNode->ToElement())->Attribute("ScintID", &scintKey);
 		if (!keyStr)
 			continue;
 
 		int menuID;
-		keyStr = (childNode->ToElement())->Attribute(TEXT("menuCmdID"), &menuID);
+		keyStr = (childNode->ToElement())->Attribute("menuCmdID", &menuID);
 		if (!keyStr)
 			continue;
 
@@ -2930,27 +2875,27 @@ void NppParameters::feedScintKeys(TiXmlNode *node)
 				_scintillaKeyCommands[i].setKeyComboByIndex(0, _scintillaKeyCommands[i].getKeyCombo());
 				addScintillaModifiedIndex(i);
 				KeyCombo kc;
-				for (TiXmlNode *nextNode = childNode->FirstChildElement(TEXT("NextKey"));
+				for (TiXmlNodeA *nextNode = childNode->FirstChildElement("NextKey");
 					nextNode ;
-					nextNode = nextNode->NextSibling(TEXT("NextKey")))
+					nextNode = nextNode->NextSibling("NextKey"))
 				{
-					const TCHAR *str = (nextNode->ToElement())->Attribute(TEXT("Ctrl"));
+					const char *str = (nextNode->ToElement())->Attribute("Ctrl");
 					if (!str)
 						continue;
-					kc._isCtrl = (lstrcmp(TEXT("yes"), str) == 0);
+					kc._isCtrl = (strcmp("yes", str) == 0);
 
-					str = (nextNode->ToElement())->Attribute(TEXT("Alt"));
+					str = (nextNode->ToElement())->Attribute("Alt");
 					if (!str)
 						continue;
-					kc._isAlt = (lstrcmp(TEXT("yes"), str) == 0);
+					kc._isAlt = (strcmp("yes", str) == 0);
 
-					str = (nextNode->ToElement())->Attribute(TEXT("Shift"));
+					str = (nextNode->ToElement())->Attribute("Shift");
 					if (!str)
 						continue;
-					kc._isShift = (lstrcmp(TEXT("yes"), str) == 0);
+					kc._isShift = (strcmp("yes", str) == 0);
 
 					int key;
-					str = (nextNode->ToElement())->Attribute(TEXT("Key"), &key);
+					str = (nextNode->ToElement())->Attribute("Key", &key);
 					if (!str)
 						continue;
 					kc._key = static_cast<unsigned char>(key);
@@ -2962,56 +2907,38 @@ void NppParameters::feedScintKeys(TiXmlNode *node)
 	}
 }
 
-bool NppParameters::feedBlacklist(TiXmlNode *node)
-{
-	TiXmlNode *blackListRoot = node->FirstChildElement(TEXT("PluginBlackList"));
-	if (!blackListRoot) return false;
-
-	for (TiXmlNode *childNode = blackListRoot->FirstChildElement(TEXT("Plugin"));
-		childNode ;
-		childNode = childNode->NextSibling(TEXT("Plugin")) )
-	{
-		const TCHAR *name = (childNode->ToElement())->Attribute(TEXT("name"));
-		if (name)
-		{
-			_blacklist.push_back(name);
-		}
-	}
-	return true;
-}
-
-bool NppParameters::getShortcuts(TiXmlNode *node, Shortcut & sc, generic_string* folderName)
+bool NppParameters::getShortcuts(TiXmlNodeA *node, Shortcut & sc, string* folderName)
 {
 	if (!node) return false;
 
-	const TCHAR *name = (node->ToElement())->Attribute(TEXT("name"));
+	const char* name = (node->ToElement())->Attribute("name");
 	if (!name)
-		name = TEXT("");
+		name = "";
 
 	bool isCtrl = false;
-	const TCHAR *isCtrlStr = (node->ToElement())->Attribute(TEXT("Ctrl"));
+	const char* isCtrlStr = (node->ToElement())->Attribute("Ctrl");
 	if (isCtrlStr)
-		isCtrl = (lstrcmp(TEXT("yes"), isCtrlStr) == 0);
+		isCtrl = (strcmp("yes", isCtrlStr) == 0);
 
 	bool isAlt = false;
-	const TCHAR *isAltStr = (node->ToElement())->Attribute(TEXT("Alt"));
+	const char* isAltStr = (node->ToElement())->Attribute("Alt");
 	if (isAltStr)
-		isAlt = (lstrcmp(TEXT("yes"), isAltStr) == 0);
+		isAlt = (strcmp("yes", isAltStr) == 0);
 
 	bool isShift = false;
-	const TCHAR *isShiftStr = (node->ToElement())->Attribute(TEXT("Shift"));
+	const char* isShiftStr = (node->ToElement())->Attribute("Shift");
 	if (isShiftStr)
-		isShift = (lstrcmp(TEXT("yes"), isShiftStr) == 0);
+		isShift = (strcmp("yes", isShiftStr) == 0);
 
 	int key;
-	const TCHAR *keyStr = (node->ToElement())->Attribute(TEXT("Key"), &key);
+	const char* keyStr = (node->ToElement())->Attribute("Key", &key);
 	if (!keyStr)
 		return false;
 
 	if (folderName)
 	{
-		const TCHAR* fn = (node->ToElement())->Attribute(TEXT("FolderName"));
-		*folderName = fn ? fn : L"";
+		const char* fn = (node->ToElement())->Attribute("FolderName");
+		*folderName = fn ? fn : "";
 	}
 
 	sc = Shortcut(name, isCtrl, isAlt, isShift, static_cast<unsigned char>(key));
@@ -3263,7 +3190,7 @@ bool NppParameters::writeSettingsFilesOnCloudForThe1stTime(const generic_string 
 	pathAppend(cloudShortcutsPath, TEXT("shortcuts.xml"));
 	if (!::PathFileExists(cloudShortcutsPath.c_str()) && _pXmlShortcutDoc)
 	{
-		isOK = _pXmlShortcutDoc->SaveFile(cloudShortcutsPath.c_str());
+		isOK = _pXmlShortcutDoc->SaveUnicodeFilePath(cloudShortcutsPath.c_str());
 		if (!isOK)
 			return false;
 	}
@@ -3398,115 +3325,87 @@ void NppParameters::writeNeed2SaveUDL()
 }
 
 
-void NppParameters::insertCmd(TiXmlNode *shortcutsRoot, const CommandShortcut & cmd)
+void NppParameters::insertCmd(TiXmlNodeA *shortcutsRoot, const CommandShortcut & cmd)
 {
 	const KeyCombo & key = cmd.getKeyCombo();
-	TiXmlNode *sc = shortcutsRoot->InsertEndChild(TiXmlElement(TEXT("Shortcut")));
-	sc->ToElement()->SetAttribute(TEXT("id"), cmd.getID());
-	sc->ToElement()->SetAttribute(TEXT("Ctrl"), key._isCtrl?TEXT("yes"):TEXT("no"));
-	sc->ToElement()->SetAttribute(TEXT("Alt"), key._isAlt?TEXT("yes"):TEXT("no"));
-	sc->ToElement()->SetAttribute(TEXT("Shift"), key._isShift?TEXT("yes"):TEXT("no"));
-	sc->ToElement()->SetAttribute(TEXT("Key"), key._key);
+	TiXmlNodeA *sc = shortcutsRoot->InsertEndChild(TiXmlElementA("Shortcut"));
+	sc->ToElement()->SetAttribute("id", cmd.getID());
+	sc->ToElement()->SetAttribute("Ctrl", key._isCtrl?"yes":"no");
+	sc->ToElement()->SetAttribute("Alt", key._isAlt?"yes":"no");
+	sc->ToElement()->SetAttribute("Shift", key._isShift?"yes":"no");
+	sc->ToElement()->SetAttribute("Key", key._key);
 }
 
 
-void NppParameters::insertMacro(TiXmlNode *macrosRoot, const MacroShortcut & macro, const generic_string& folderName)
+void NppParameters::insertMacro(TiXmlNodeA *macrosRoot, const MacroShortcut & macro, const string& folderName)
 {
 	const KeyCombo & key = macro.getKeyCombo();
-	TiXmlNode *macroRoot = macrosRoot->InsertEndChild(TiXmlElement(TEXT("Macro")));
-	macroRoot->ToElement()->SetAttribute(TEXT("name"), macro.getMenuName());
-	macroRoot->ToElement()->SetAttribute(TEXT("Ctrl"), key._isCtrl?TEXT("yes"):TEXT("no"));
-	macroRoot->ToElement()->SetAttribute(TEXT("Alt"), key._isAlt?TEXT("yes"):TEXT("no"));
-	macroRoot->ToElement()->SetAttribute(TEXT("Shift"), key._isShift?TEXT("yes"):TEXT("no"));
-	macroRoot->ToElement()->SetAttribute(TEXT("Key"), key._key);
+	TiXmlNodeA *macroRoot = macrosRoot->InsertEndChild(TiXmlElementA("Macro"));
+	macroRoot->ToElement()->SetAttribute("name", macro.getMenuName());
+	macroRoot->ToElement()->SetAttribute("Ctrl", key._isCtrl?"yes":"no");
+	macroRoot->ToElement()->SetAttribute("Alt", key._isAlt?"yes":"no");
+	macroRoot->ToElement()->SetAttribute("Shift", key._isShift?"yes":"no");
+	macroRoot->ToElement()->SetAttribute("Key", key._key);
 	if (!folderName.empty())
 	{
-		// W -> A -> W
-		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-		const char* folderNameA = wmc.wchar2char(folderName.c_str(), SC_CP_UTF8);
-
-		size_t len = strlen(folderNameA);
-		wchar_t* folderNameW = new wchar_t[len+1];
-
-		for (size_t i = 0; i < len; ++i)
-		{
-			folderNameW[i] = folderNameA[i];
-		}
-		folderNameW[len] = '\0';
-
-		macroRoot->ToElement()->SetAttribute(TEXT("FolderName"), folderNameW);
-		delete[] folderNameW;
+		macroRoot->ToElement()->SetAttribute("FolderName", folderName);
 	}
 
 	for (size_t i = 0, len = macro._macro.size(); i < len ; ++i)
 	{
-		TiXmlNode *actionNode = macroRoot->InsertEndChild(TiXmlElement(TEXT("Action")));
+		TiXmlNodeA *actionNode = macroRoot->InsertEndChild(TiXmlElementA("Action"));
 		const recordedMacroStep & action = macro._macro[i];
-		actionNode->ToElement()->SetAttribute(TEXT("type"), action._macroType);
-		actionNode->ToElement()->SetAttribute(TEXT("message"), action._message);
-		actionNode->ToElement()->SetAttribute(TEXT("wParam"), static_cast<int>(action._wParameter));
-		actionNode->ToElement()->SetAttribute(TEXT("lParam"), static_cast<int>(action._lParameter));
-		actionNode->ToElement()->SetAttribute(TEXT("sParam"), action._sParameter.c_str());
+		actionNode->ToElement()->SetAttribute("type", action._macroType);
+		actionNode->ToElement()->SetAttribute("message", action._message);
+		actionNode->ToElement()->SetAttribute("wParam", static_cast<int>(action._wParameter));
+		actionNode->ToElement()->SetAttribute("lParam", static_cast<int>(action._lParameter));
+		actionNode->ToElement()->SetAttribute("sParam", action._sParameter.c_str());
 	}
 }
 
 
-void NppParameters::insertUserCmd(TiXmlNode *userCmdRoot, const UserCommand & userCmd, const generic_string& folderName)
+void NppParameters::insertUserCmd(TiXmlNodeA *userCmdRoot, const UserCommand & userCmd, const string& folderName)
 {
 	const KeyCombo & key = userCmd.getKeyCombo();
-	TiXmlNode *cmdRoot = userCmdRoot->InsertEndChild(TiXmlElement(TEXT("Command")));
-	cmdRoot->ToElement()->SetAttribute(TEXT("name"), userCmd.getMenuName());
-	cmdRoot->ToElement()->SetAttribute(TEXT("Ctrl"), key._isCtrl?TEXT("yes"):TEXT("no"));
-	cmdRoot->ToElement()->SetAttribute(TEXT("Alt"), key._isAlt?TEXT("yes"):TEXT("no"));
-	cmdRoot->ToElement()->SetAttribute(TEXT("Shift"), key._isShift?TEXT("yes"):TEXT("no"));
-	cmdRoot->ToElement()->SetAttribute(TEXT("Key"), key._key);
-	cmdRoot->InsertEndChild(TiXmlText(userCmd._cmd.c_str()));
+	TiXmlNodeA *cmdRoot = userCmdRoot->InsertEndChild(TiXmlElementA("Command"));
+	cmdRoot->ToElement()->SetAttribute("name", userCmd.getMenuName());
+	cmdRoot->ToElement()->SetAttribute("Ctrl", key._isCtrl?"yes":"no");
+	cmdRoot->ToElement()->SetAttribute("Alt", key._isAlt?"yes":"no");
+	cmdRoot->ToElement()->SetAttribute("Shift", key._isShift?"yes":"no");
+	cmdRoot->ToElement()->SetAttribute("Key", key._key);
+	cmdRoot->InsertEndChild(TiXmlTextA(userCmd._cmd.c_str()));
 	if (!folderName.empty())
 	{
-		// W -> A -> W
-		WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-		const char* folderNameA = wmc.wchar2char(folderName.c_str(), SC_CP_UTF8);
-
-		size_t len = strlen(folderNameA);
-		wchar_t* folderNameW = new wchar_t[len + 1];
-
-		for (size_t i = 0; i < len; ++i)
-		{
-			folderNameW[i] = folderNameA[i];
-		}
-		folderNameW[len] = '\0';
-
-		cmdRoot->ToElement()->SetAttribute(TEXT("FolderName"), folderNameW);
-		delete[] folderNameW;
+		cmdRoot->ToElement()->SetAttribute("FolderName", folderName);
 	}
 }
 
 
-void NppParameters::insertPluginCmd(TiXmlNode *pluginCmdRoot, const PluginCmdShortcut & pluginCmd)
+void NppParameters::insertPluginCmd(TiXmlNodeA *pluginCmdRoot, const PluginCmdShortcut & pluginCmd)
 {
 	const KeyCombo & key = pluginCmd.getKeyCombo();
-	TiXmlNode *pluginCmdNode = pluginCmdRoot->InsertEndChild(TiXmlElement(TEXT("PluginCommand")));
-	pluginCmdNode->ToElement()->SetAttribute(TEXT("moduleName"), pluginCmd.getModuleName());
-	pluginCmdNode->ToElement()->SetAttribute(TEXT("internalID"), pluginCmd.getInternalID());
-	pluginCmdNode->ToElement()->SetAttribute(TEXT("Ctrl"), key._isCtrl?TEXT("yes"):TEXT("no"));
-	pluginCmdNode->ToElement()->SetAttribute(TEXT("Alt"), key._isAlt?TEXT("yes"):TEXT("no"));
-	pluginCmdNode->ToElement()->SetAttribute(TEXT("Shift"), key._isShift?TEXT("yes"):TEXT("no"));
-	pluginCmdNode->ToElement()->SetAttribute(TEXT("Key"), key._key);
+	TiXmlNodeA *pluginCmdNode = pluginCmdRoot->InsertEndChild(TiXmlElementA("PluginCommand"));
+	pluginCmdNode->ToElement()->SetAttribute("moduleName", pluginCmd.getModuleName());
+	pluginCmdNode->ToElement()->SetAttribute("internalID", pluginCmd.getInternalID());
+	pluginCmdNode->ToElement()->SetAttribute("Ctrl", key._isCtrl?"yes":"no");
+	pluginCmdNode->ToElement()->SetAttribute("Alt", key._isAlt?"yes":"no");
+	pluginCmdNode->ToElement()->SetAttribute("Shift", key._isShift?"yes":"no");
+	pluginCmdNode->ToElement()->SetAttribute("Key", key._key);
 }
 
 
-void NppParameters::insertScintKey(TiXmlNode *scintKeyRoot, const ScintillaKeyMap & scintKeyMap)
+void NppParameters::insertScintKey(TiXmlNodeA *scintKeyRoot, const ScintillaKeyMap & scintKeyMap)
 {
-	TiXmlNode *keyRoot = scintKeyRoot->InsertEndChild(TiXmlElement(TEXT("ScintKey")));
-	keyRoot->ToElement()->SetAttribute(TEXT("ScintID"), scintKeyMap.getScintillaKeyID());
-	keyRoot->ToElement()->SetAttribute(TEXT("menuCmdID"), scintKeyMap.getMenuCmdID());
+	TiXmlNodeA *keyRoot = scintKeyRoot->InsertEndChild(TiXmlElementA("ScintKey"));
+	keyRoot->ToElement()->SetAttribute("ScintID", scintKeyMap.getScintillaKeyID());
+	keyRoot->ToElement()->SetAttribute("menuCmdID", scintKeyMap.getMenuCmdID());
 
 	//Add main shortcut
 	KeyCombo key = scintKeyMap.getKeyComboByIndex(0);
-	keyRoot->ToElement()->SetAttribute(TEXT("Ctrl"), key._isCtrl?TEXT("yes"):TEXT("no"));
-	keyRoot->ToElement()->SetAttribute(TEXT("Alt"), key._isAlt?TEXT("yes"):TEXT("no"));
-	keyRoot->ToElement()->SetAttribute(TEXT("Shift"), key._isShift?TEXT("yes"):TEXT("no"));
-	keyRoot->ToElement()->SetAttribute(TEXT("Key"), key._key);
+	keyRoot->ToElement()->SetAttribute("Ctrl", key._isCtrl?"yes":"no");
+	keyRoot->ToElement()->SetAttribute("Alt", key._isAlt?"yes":"no");
+	keyRoot->ToElement()->SetAttribute("Shift", key._isShift?"yes":"no");
+	keyRoot->ToElement()->SetAttribute("Key", key._key);
 
 	//Add additional shortcuts
 	size_t size = scintKeyMap.getSize();
@@ -3514,12 +3413,12 @@ void NppParameters::insertScintKey(TiXmlNode *scintKeyRoot, const ScintillaKeyMa
 	{
 		for (size_t i = 1; i < size; ++i)
 		{
-			TiXmlNode *keyNext = keyRoot->InsertEndChild(TiXmlElement(TEXT("NextKey")));
+			TiXmlNodeA *keyNext = keyRoot->InsertEndChild(TiXmlElementA("NextKey"));
 			key = scintKeyMap.getKeyComboByIndex(i);
-			keyNext->ToElement()->SetAttribute(TEXT("Ctrl"), key._isCtrl?TEXT("yes"):TEXT("no"));
-			keyNext->ToElement()->SetAttribute(TEXT("Alt"), key._isAlt?TEXT("yes"):TEXT("no"));
-			keyNext->ToElement()->SetAttribute(TEXT("Shift"), key._isShift?TEXT("yes"):TEXT("no"));
-			keyNext->ToElement()->SetAttribute(TEXT("Key"), key._key);
+			keyNext->ToElement()->SetAttribute("Ctrl", key._isCtrl?"yes":"no");
+			keyNext->ToElement()->SetAttribute("Alt", key._isAlt?"yes":"no");
+			keyNext->ToElement()->SetAttribute("Shift", key._isShift?"yes":"no");
+			keyNext->ToElement()->SetAttribute("Key", key._key);
 		}
 	}
 }
@@ -3636,22 +3535,22 @@ void NppParameters::writeShortcuts()
 	if (!_pXmlShortcutDoc)
 	{
 		//do the treatment
-		_pXmlShortcutDoc = new TiXmlDocument(_shortcutsPath);
-		TiXmlDeclaration* decl = new TiXmlDeclaration(TEXT("1.0"), TEXT("UTF-8"), TEXT(""));
+		_pXmlShortcutDoc = new TiXmlDocumentA();
+		TiXmlDeclarationA* decl = new TiXmlDeclarationA("1.0", "UTF-8", "");
 		_pXmlShortcutDoc->LinkEndChild(decl);
 	}
 
-	TiXmlNode *root = _pXmlShortcutDoc->FirstChild(TEXT("NotepadPlus"));
+	TiXmlNodeA *root = _pXmlShortcutDoc->FirstChild("NotepadPlus");
 	if (!root)
 	{
-		root = _pXmlShortcutDoc->InsertEndChild(TiXmlElement(TEXT("NotepadPlus")));
+		root = _pXmlShortcutDoc->InsertEndChild(TiXmlElementA("NotepadPlus"));
 	}
 
-	TiXmlNode *cmdRoot = root->FirstChild(TEXT("InternalCommands"));
+	TiXmlNodeA *cmdRoot = root->FirstChild("InternalCommands");
 	if (cmdRoot)
 		root->RemoveChild(cmdRoot);
 
-	cmdRoot = root->InsertEndChild(TiXmlElement(TEXT("InternalCommands")));
+	cmdRoot = root->InsertEndChild(TiXmlElementA("InternalCommands"));
 	for (size_t i = 0, len = _customizedShortcuts.size(); i < len ; ++i)
 	{
 		size_t index = _customizedShortcuts[i];
@@ -3659,48 +3558,48 @@ void NppParameters::writeShortcuts()
 		insertCmd(cmdRoot, csc);
 	}
 
-	TiXmlNode *macrosRoot = root->FirstChild(TEXT("Macros"));
+	TiXmlNodeA *macrosRoot = root->FirstChild("Macros");
 	if (macrosRoot)
 		root->RemoveChild(macrosRoot);
 
-	macrosRoot = root->InsertEndChild(TiXmlElement(TEXT("Macros")));
+	macrosRoot = root->InsertEndChild(TiXmlElementA("Macros"));
 
 	for (size_t i = 0, len = _macros.size(); i < len ; ++i)
 	{
-		insertMacro(macrosRoot, _macros[i], _macroMenuItems.getItemFromIndex(i)._parentFolderName);
+		insertMacro(macrosRoot, _macros[i], wstring2string(_macroMenuItems.getItemFromIndex(i)._parentFolderName, CP_UTF8));
 	}
 
-	TiXmlNode *userCmdRoot = root->FirstChild(TEXT("UserDefinedCommands"));
+	TiXmlNodeA *userCmdRoot = root->FirstChild("UserDefinedCommands");
 	if (userCmdRoot)
 		root->RemoveChild(userCmdRoot);
 
-	userCmdRoot = root->InsertEndChild(TiXmlElement(TEXT("UserDefinedCommands")));
+	userCmdRoot = root->InsertEndChild(TiXmlElementA("UserDefinedCommands"));
 
 	for (size_t i = 0, len = _userCommands.size(); i < len ; ++i)
 	{
-		insertUserCmd(userCmdRoot, _userCommands[i], _runMenuItems.getItemFromIndex(i)._parentFolderName);
+		insertUserCmd(userCmdRoot, _userCommands[i], wstring2string(_runMenuItems.getItemFromIndex(i)._parentFolderName, CP_UTF8));
 	}
 
-	TiXmlNode *pluginCmdRoot = root->FirstChild(TEXT("PluginCommands"));
+	TiXmlNodeA *pluginCmdRoot = root->FirstChild("PluginCommands");
 	if (pluginCmdRoot)
 		root->RemoveChild(pluginCmdRoot);
 
-	pluginCmdRoot = root->InsertEndChild(TiXmlElement(TEXT("PluginCommands")));
+	pluginCmdRoot = root->InsertEndChild(TiXmlElementA("PluginCommands"));
 	for (size_t i = 0, len = _pluginCustomizedCmds.size(); i < len ; ++i)
 	{
 		insertPluginCmd(pluginCmdRoot, _pluginCommands[_pluginCustomizedCmds[i]]);
 	}
 
-	TiXmlNode *scitillaKeyRoot = root->FirstChild(TEXT("ScintillaKeys"));
+	TiXmlNodeA *scitillaKeyRoot = root->FirstChild("ScintillaKeys");
 	if (scitillaKeyRoot)
 		root->RemoveChild(scitillaKeyRoot);
 
-	scitillaKeyRoot = root->InsertEndChild(TiXmlElement(TEXT("ScintillaKeys")));
+	scitillaKeyRoot = root->InsertEndChild(TiXmlElementA("ScintillaKeys"));
 	for (size_t i = 0, len = _scintillaModifiedKeyIndices.size(); i < len ; ++i)
 	{
 		insertScintKey(scitillaKeyRoot, _scintillaKeyCommands[_scintillaModifiedKeyIndices[i]]);
 	}
-	_pXmlShortcutDoc->SaveFile();
+	_pXmlShortcutDoc->SaveUnicodeFilePath(_shortcutsPath.c_str());
 }
 
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1814,7 +1814,7 @@ private:
 	TiXmlDocument *_pXmlUserLangDoc = nullptr; // userDefineLang.xml
 	std::vector<UdlXmlFileState> _pXmlUserLangsDoc; // userDefineLang customized XMLs
 	TiXmlDocument *_pXmlToolIconsDoc = nullptr; // toolbarIcons.xml
-	TiXmlDocument *_pXmlShortcutDoc = nullptr; // shortcuts.xml
+	TiXmlDocumentA *_pXmlShortcutDoc = nullptr; // shortcuts.xml
 	TiXmlDocument *_pXmlBlacklistDoc = nullptr; // not implemented
 
 	TiXmlDocumentA *_pXmlNativeLangDocA = nullptr; // nativeLang.xml
@@ -1976,7 +1976,6 @@ private:
 	bool getPluginCmdsFromXmlTree();
 	bool getScintKeysFromXmlTree();
 	bool getSessionFromXmlTree(TiXmlDocument *pSessionDoc, Session& session);
-	bool getBlackListFromXmlTree();
 
 	void feedGUIParameters(TiXmlNode *node);
 	void feedKeyWordsParameters(TiXmlNode *node);
@@ -1993,23 +1992,22 @@ private:
 	void feedUserStyles(TiXmlNode *node);
 	void feedUserKeywordList(TiXmlNode *node);
 	void feedUserSettings(TiXmlNode *node);
-	void feedShortcut(TiXmlNode *node);
-	void feedMacros(TiXmlNode *node);
-	void feedUserCmds(TiXmlNode *node);
-	void feedPluginCustomizedCmds(TiXmlNode *node);
-	void feedScintKeys(TiXmlNode *node);
-	bool feedBlacklist(TiXmlNode *node);
+	void feedShortcut(TiXmlNodeA *node);
+	void feedMacros(TiXmlNodeA *node);
+	void feedUserCmds(TiXmlNodeA *node);
+	void feedPluginCustomizedCmds(TiXmlNodeA *node);
+	void feedScintKeys(TiXmlNodeA *node);
 
-	void getActions(TiXmlNode *node, Macro & macro);
-	bool getShortcuts(TiXmlNode *node, Shortcut & sc, generic_string* folderName = nullptr);
+	void getActions(TiXmlNodeA *node, Macro & macro);
+	bool getShortcuts(TiXmlNodeA *node, Shortcut & sc, std::string* folderName = nullptr);
 
 	void writeStyle2Element(const Style & style2Write, Style & style2Sync, TiXmlElement *element);
 	void insertUserLang2Tree(TiXmlNode *node, UserLangContainer *userLang);
-	void insertCmd(TiXmlNode *cmdRoot, const CommandShortcut & cmd);
-	void insertMacro(TiXmlNode *macrosRoot, const MacroShortcut & macro, const generic_string& folderName);
-	void insertUserCmd(TiXmlNode *userCmdRoot, const UserCommand & userCmd, const generic_string& folderName);
-	void insertScintKey(TiXmlNode *scintKeyRoot, const ScintillaKeyMap & scintKeyMap);
-	void insertPluginCmd(TiXmlNode *pluginCmdRoot, const PluginCmdShortcut & pluginCmd);
+	void insertCmd(TiXmlNodeA *cmdRoot, const CommandShortcut & cmd);
+	void insertMacro(TiXmlNodeA *macrosRoot, const MacroShortcut & macro, const std::string& folderName);
+	void insertUserCmd(TiXmlNodeA *userCmdRoot, const UserCommand & userCmd, const std::string& folderName);
+	void insertScintKey(TiXmlNodeA *scintKeyRoot, const ScintillaKeyMap & scintKeyMap);
+	void insertPluginCmd(TiXmlNodeA *pluginCmdRoot, const PluginCmdShortcut & pluginCmd);
 	TiXmlElement * insertGUIConfigBoolNode(TiXmlNode *r2w, const TCHAR *name, bool bVal);
 	void insertDockingParamNode(TiXmlNode *GUIRoot);
 	void writeExcludedLangList(TiXmlElement *element);

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1814,8 +1814,8 @@ private:
 	TiXmlDocument *_pXmlUserLangDoc = nullptr; // userDefineLang.xml
 	std::vector<UdlXmlFileState> _pXmlUserLangsDoc; // userDefineLang customized XMLs
 	TiXmlDocument *_pXmlToolIconsDoc = nullptr; // toolbarIcons.xml
-	TiXmlDocumentA *_pXmlShortcutDoc = nullptr; // shortcuts.xml
-	TiXmlDocument *_pXmlBlacklistDoc = nullptr; // not implemented
+
+	TiXmlDocumentA *_pXmlShortcutDocA = nullptr; // shortcuts.xml
 
 	TiXmlDocumentA *_pXmlNativeLangDocA = nullptr; // nativeLang.xml
 	TiXmlDocumentA *_pXmlContextMenuDocA = nullptr; // contextMenu.xml

--- a/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.cpp
+++ b/PowerEditor/src/TinyXml/tinyXmlA/tinyxmlA.cpp
@@ -87,6 +87,8 @@ void TiXmlBaseA::PutString( const TIXMLA_STRING& str, TIXMLA_STRING* outString )
 			outString->append( entity[4].str, entity[4].strLength );
 			++i;
 		}
+		// Remove the following code for that attribute value can be human readable if it contains Unicode characters
+		/*
 		else if ( c < 32 || c > 126 )
 		{
 			// Easy pass at non-alpha/numeric/symbol
@@ -96,6 +98,7 @@ void TiXmlBaseA::PutString( const TIXMLA_STRING& str, TIXMLA_STRING* outString )
 			outString->append( buf, strlen( buf ) );
 			++i;
 		}
+		*/
 		else
 		{
 			char realc = static_cast<char>(c);

--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -84,6 +84,8 @@ void TiXmlBase::PutString( const TIXML_STRING& str, TIXML_STRING* outString )
 			outString->append( entity[4].str, entity[4].strLength );
 			++i;
 		}
+		// Remove the following code for that attribute value can be human readable if it contains Unicode characters
+		/*
 		else if ( c < 32 || c > 126 )
 		{
 			// Easy pass at non-alpha/numeric/symbol
@@ -93,6 +95,7 @@ void TiXmlBase::PutString( const TIXML_STRING& str, TIXML_STRING* outString )
 			outString->append( buf, lstrlen( buf ) );
 			++i;
 		}
+		*/
 		else
 		{
 			TCHAR realc = static_cast<TCHAR>(c);

--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -84,8 +84,6 @@ void TiXmlBase::PutString( const TIXML_STRING& str, TIXML_STRING* outString )
 			outString->append( entity[4].str, entity[4].strLength );
 			++i;
 		}
-		// Remove the following code for that attribute value can be human readable if it contains Unicode characters
-		/*
 		else if ( c < 32 || c > 126 )
 		{
 			// Easy pass at non-alpha/numeric/symbol
@@ -95,7 +93,6 @@ void TiXmlBase::PutString( const TIXML_STRING& str, TIXML_STRING* outString )
 			outString->append( buf, lstrlen( buf ) );
 			++i;
 		}
-		*/
 		else
 		{
 			TCHAR realc = static_cast<TCHAR>(c);

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -197,8 +197,8 @@ bool ShortcutMapper::isFilterValid(Shortcut sc)
 	if (_shortcutFilter.empty())
 		return true;
 
-	generic_string shortcut_name = stringToLower(generic_string(sc.getName()));
-	generic_string shortcut_value = stringToLower(sc.toString());
+	wstring shortcut_name = stringToLower(string2wstring(sc.getName(), CP_UTF8));
+	wstring shortcut_value = stringToLower(string2wstring(sc.toString(), CP_UTF8));
 
 	// test the filter on the shortcut name and value
 	return (shortcut_name.find(_shortcutFilter) != std::string::npos) || 
@@ -210,7 +210,7 @@ bool ShortcutMapper::isFilterValid(PluginCmdShortcut sc)
 	// Do like a classic search on shortcut name, then search on the plugin name.
 	Shortcut shortcut = sc;
 	bool match = false;
-	generic_string module_name = stringToLower(generic_string(sc.getModuleName()));
+	wstring module_name = stringToLower(string2wstring(sc.getModuleName(), CP_UTF8));
 	if (isFilterValid(shortcut)){
 		return true;
 	}
@@ -296,9 +296,9 @@ void ShortcutMapper::fillOutBabyGrid()
 					if (findKeyConflicts(nullptr, cshortcuts[i].getKeyCombo(), i))
 						isMarker = _babygrid.setMarker(true);
 
-					_babygrid.setText(cs_index, 1, cshortcuts[i].getName());
+					_babygrid.setText(cs_index, 1, string2wstring(cshortcuts[i].getName(), CP_UTF8).c_str());
 					if (cshortcuts[i].isEnabled()) //avoid empty strings for better performance
-						_babygrid.setText(cs_index, 2, cshortcuts[i].toString().c_str());
+						_babygrid.setText(cs_index, 2, string2wstring(cshortcuts[i].toString(), CP_UTF8).c_str());
 
 					const TCHAR* category = cshortcuts[i].getCategory();
 					generic_string categoryStr = nativeLangSpeaker->getShortcutMapperLangStr((std::string(wstring2string(category, CP_UTF8)) + "Category").c_str(), category);
@@ -328,9 +328,9 @@ void ShortcutMapper::fillOutBabyGrid()
 					if (findKeyConflicts(nullptr, cshortcuts[i].getKeyCombo(), i))
 						isMarker = _babygrid.setMarker(true);
 
-					_babygrid.setText(cs_index, 1, cshortcuts[i].getName());
+					_babygrid.setText(cs_index, 1, string2wstring(cshortcuts[i].getName(), CP_UTF8).c_str());
 					if (cshortcuts[i].isEnabled()) //avoid empty strings for better performance
-						_babygrid.setText(cs_index, 2, cshortcuts[i].toString().c_str());
+						_babygrid.setText(cs_index, 2, string2wstring(cshortcuts[i].toString(), CP_UTF8).c_str());
 	
 					if (isMarker)
 						isMarker = _babygrid.setMarker(false);
@@ -357,9 +357,9 @@ void ShortcutMapper::fillOutBabyGrid()
 					if (findKeyConflicts(nullptr, cshortcuts[i].getKeyCombo(), i))
 						isMarker = _babygrid.setMarker(true);
 
-					_babygrid.setText(cs_index, 1, cshortcuts[i].getName());
+					_babygrid.setText(cs_index, 1, string2wstring(cshortcuts[i].getName(), CP_UTF8).c_str());
 					if (cshortcuts[i].isEnabled()) //avoid empty strings for better performance
-						_babygrid.setText(cs_index, 2, cshortcuts[i].toString().c_str());
+						_babygrid.setText(cs_index, 2, string2wstring(cshortcuts[i].toString(), CP_UTF8).c_str());
 	
 					if (isMarker)
 						isMarker = _babygrid.setMarker(false);
@@ -387,10 +387,10 @@ void ShortcutMapper::fillOutBabyGrid()
 					if (findKeyConflicts(nullptr, cshortcuts[i].getKeyCombo(), i))
 						isMarker = _babygrid.setMarker(true);
 
-					_babygrid.setText(cs_index, 1, cshortcuts[i].getName());
+					_babygrid.setText(cs_index, 1, string2wstring(cshortcuts[i].getName(), CP_UTF8).c_str());
 					if (cshortcuts[i].isEnabled()) //avoid empty strings for better performance
-						_babygrid.setText(cs_index, 2, cshortcuts[i].toString().c_str());
-					_babygrid.setText(cs_index, 3, cshortcuts[i].getModuleName());
+						_babygrid.setText(cs_index, 2, string2wstring(cshortcuts[i].toString(), CP_UTF8).c_str());
+					_babygrid.setText(cs_index, 3, string2wstring(cshortcuts[i].getModuleName(), CP_UTF8).c_str());
 	
 					if (isMarker)
 						isMarker = _babygrid.setMarker(false);
@@ -427,9 +427,9 @@ void ShortcutMapper::fillOutBabyGrid()
 						}
 					}
 
-					_babygrid.setText(cs_index, 1, cshortcuts[i].getName());
+					_babygrid.setText(cs_index, 1, string2wstring(cshortcuts[i].getName(), CP_UTF8).c_str());
 					if (cshortcuts[i].isEnabled()) //avoid empty strings for better performance
-						_babygrid.setText(cs_index, 2, cshortcuts[i].toString().c_str());
+						_babygrid.setText(cs_index, 2, string2wstring(cshortcuts[i].toString(), CP_UTF8).c_str());
 	
 					if (isMarker)
 						isMarker = _babygrid.setMarker(false);
@@ -1285,9 +1285,9 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 							*keyConflictLocation += TEXT("  |  ");
 							*keyConflictLocation += std::to_wstring(itemIndex + 1);
 							*keyConflictLocation += TEXT("   ");
-							*keyConflictLocation += vShortcuts[itemIndex].getName();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].getName(), CP_UTF8);
 							*keyConflictLocation += TEXT("  ( ");
-							*keyConflictLocation += vShortcuts[itemIndex].toString();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].toString(), CP_UTF8);
 							*keyConflictLocation += TEXT(" )");
 						}
 					}
@@ -1319,9 +1319,9 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 							*keyConflictLocation += TEXT("  |  ");
 							*keyConflictLocation += std::to_wstring(itemIndex + 1);
 							*keyConflictLocation += TEXT("   ");
-							*keyConflictLocation += vShortcuts[itemIndex].getName();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].getName(), CP_UTF8);
 							*keyConflictLocation += TEXT("  ( ");
-							*keyConflictLocation += vShortcuts[itemIndex].toString();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].toString(), CP_UTF8);
 							*keyConflictLocation += TEXT(" )");
 						}
 					}
@@ -1353,9 +1353,9 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 							*keyConflictLocation += TEXT("  |  ");
 							*keyConflictLocation += std::to_wstring(itemIndex + 1);
 							*keyConflictLocation += TEXT("   ");
-							*keyConflictLocation += vShortcuts[itemIndex].getName();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].getName(), CP_UTF8);
 							*keyConflictLocation += TEXT("  ( ");
-							*keyConflictLocation += vShortcuts[itemIndex].toString();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].toString(), CP_UTF8);
 							*keyConflictLocation += TEXT(" )");
 						}
 					}
@@ -1387,9 +1387,9 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 							*keyConflictLocation += TEXT("  |  ");
 							*keyConflictLocation += std::to_wstring(itemIndex + 1);
 							*keyConflictLocation += TEXT("   ");
-							*keyConflictLocation += vShortcuts[itemIndex].getName();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].getName(), CP_UTF8);;
 							*keyConflictLocation += TEXT("  ( ");
-							*keyConflictLocation += vShortcuts[itemIndex].toString();
+							*keyConflictLocation += string2wstring(vShortcuts[itemIndex].toString(), CP_UTF8);
 							*keyConflictLocation += TEXT(" )");
 						}
 					}
@@ -1427,9 +1427,9 @@ bool ShortcutMapper::findKeyConflicts(__inout_opt generic_string * const keyConf
 									*keyConflictLocation += TEXT("*   ");
 								else
 									*keyConflictLocation += TEXT("   ");
-								*keyConflictLocation += vShortcuts[itemIndex].getName();
+								*keyConflictLocation += string2wstring(vShortcuts[itemIndex].getName(), CP_UTF8);
 								*keyConflictLocation += TEXT("  ( ");
-								*keyConflictLocation += vShortcuts[itemIndex].toString(sciIndex);
+								*keyConflictLocation += string2wstring(vShortcuts[itemIndex].toString(sciIndex), CP_UTF8);
 								*keyConflictLocation += TEXT(" )");
 							}
 						}

--- a/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
+++ b/PowerEditor/src/WinControls/StaticDialog/RunDlg/RunDlg.cpp
@@ -338,7 +338,7 @@ intptr_t CALLBACK RunDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
 
 					TCHAR cmd[MAX_PATH];
 					::GetDlgItemText(_hSelf, IDC_COMBO_RUN_PATH, cmd, MAX_PATH);
-					UserCommand uc(Shortcut(), cmd, cmdID);
+					UserCommand uc(Shortcut(), wstring2string(cmd, CP_UTF8).c_str(), cmdID);
 					uc.init(_hInst, _hSelf);
 
 					if (uc.doDialog() != -1)
@@ -351,8 +351,8 @@ intptr_t CALLBACK RunDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam
 							::InsertMenu(hRunMenu, posBase - 1, MF_BYPOSITION, static_cast<unsigned int>(-1), 0);
 						
 						theUserCmds.push_back(uc);
-						runMenu.push_back(MenuItemUnit(cmdID, uc.getName()));
-						::InsertMenu(hRunMenu, posBase + nbTopLevelItem, MF_BYPOSITION, cmdID, uc.toMenuItemString().c_str());
+						runMenu.push_back(MenuItemUnit(cmdID, string2wstring(uc.getName(), CP_UTF8)));
+						::InsertMenu(hRunMenu, posBase + nbTopLevelItem, MF_BYPOSITION, cmdID, string2wstring(uc.toMenuItemString(), CP_UTF8).c_str());
 
 						NppParameters& nppParams = NppParameters::getInstance();
                         if (nbTopLevelItem == 0)

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -387,7 +387,7 @@ intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPar
 			int iFound = -1;
 			for (size_t i = 0 ; i < nbKeys ; ++i)
 			{
-				::SendDlgItemMessage(_hSelf, IDC_KEY_COMBO, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(namedKeyArray[i].name));
+				::SendDlgItemMessage(_hSelf, IDC_KEY_COMBO, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(string2wstring(namedKeyArray[i].name, CP_UTF8).c_str()));
 
 				if (_keyCombo._key == namedKeyArray[i].id)
 					iFound = static_cast<int32_t>(i);
@@ -1054,7 +1054,7 @@ intptr_t CALLBACK ScintillaKeyMap::run_dlgProc(UINT Message, WPARAM wParam, LPAR
 
 			for (size_t i = 0 ; i < nbKeys ; ++i)
 			{
-				::SendDlgItemMessage(_hSelf, IDC_KEY_COMBO, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(namedKeyArray[i].name));
+				::SendDlgItemMessage(_hSelf, IDC_KEY_COMBO, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(string2wstring(namedKeyArray[i].name, CP_UTF8).c_str()));
 			}
 
 			for (size_t i = 0; i < _size; ++i)

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -485,7 +485,7 @@ intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPar
 
 					if (_canModifyName)
 					{
-						TCHAR editName[nameLenMax];
+						TCHAR editName[nameLenMax]{};
 						::SendDlgItemMessage(_hSelf, IDC_NAME_EDIT, WM_GETTEXT, nameLenMax, reinterpret_cast<LPARAM>(editName));
 						setName(wstring2string(editName, CP_UTF8).c_str());
 					}

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -28,137 +28,137 @@
 using namespace std;
 
 struct KeyIDNAME {
-	const TCHAR * name = nullptr;
+	const char * name = nullptr;
 	UCHAR id = 0;
 };
 
 KeyIDNAME namedKeyArray[] = {
-{TEXT("None"), VK_NULL},
+{"None", VK_NULL},
 
-{TEXT("Backspace"), VK_BACK},
-{TEXT("Tab"), VK_TAB},
-{TEXT("Enter"), VK_RETURN},
-{TEXT("Esc"), VK_ESCAPE},
-{TEXT("Spacebar"), VK_SPACE},
+{"Backspace", VK_BACK},
+{"Tab", VK_TAB},
+{"Enter", VK_RETURN},
+{"Esc", VK_ESCAPE},
+{"Spacebar", VK_SPACE},
 
-{TEXT("Page up"), VK_PRIOR},
-{TEXT("Page down"), VK_NEXT},
-{TEXT("End"), VK_END},
-{TEXT("Home"), VK_HOME},
-{TEXT("Left"), VK_LEFT},
-{TEXT("Up"), VK_UP},
-{TEXT("Right"), VK_RIGHT},
-{TEXT("Down"), VK_DOWN},
+{"Page up", VK_PRIOR},
+{"Page down", VK_NEXT},
+{"End", VK_END},
+{"Home", VK_HOME},
+{"Left", VK_LEFT},
+{"Up", VK_UP},
+{"Right", VK_RIGHT},
+{"Down", VK_DOWN},
 
-{TEXT("INS"), VK_INSERT},
-{TEXT("DEL"), VK_DELETE},
+{"INS", VK_INSERT},
+{"DEL", VK_DELETE},
 
-{TEXT("0"), VK_0},
-{TEXT("1"), VK_1},
-{TEXT("2"), VK_2},
-{TEXT("3"), VK_3},
-{TEXT("4"), VK_4},
-{TEXT("5"), VK_5},
-{TEXT("6"), VK_6},
-{TEXT("7"), VK_7},
-{TEXT("8"), VK_8},
-{TEXT("9"), VK_9},
-{TEXT("A"), VK_A},
-{TEXT("B"), VK_B},
-{TEXT("C"), VK_C},
-{TEXT("D"), VK_D},
-{TEXT("E"), VK_E},
-{TEXT("F"), VK_F},
-{TEXT("G"), VK_G},
-{TEXT("H"), VK_H},
-{TEXT("I"), VK_I},
-{TEXT("J"), VK_J},
-{TEXT("K"), VK_K},
-{TEXT("L"), VK_L},
-{TEXT("M"), VK_M},
-{TEXT("N"), VK_N},
-{TEXT("O"), VK_O},
-{TEXT("P"), VK_P},
-{TEXT("Q"), VK_Q},
-{TEXT("R"), VK_R},
-{TEXT("S"), VK_S},
-{TEXT("T"), VK_T},
-{TEXT("U"), VK_U},
-{TEXT("V"), VK_V},
-{TEXT("W"), VK_W},
-{TEXT("X"), VK_X},
-{TEXT("Y"), VK_Y},
-{TEXT("Z"), VK_Z},
+{"0", VK_0},
+{"1", VK_1},
+{"2", VK_2},
+{"3", VK_3},
+{"4", VK_4},
+{"5", VK_5},
+{"6", VK_6},
+{"7", VK_7},
+{"8", VK_8},
+{"9", VK_9},
+{"A", VK_A},
+{"B", VK_B},
+{"C", VK_C},
+{"D", VK_D},
+{"E", VK_E},
+{"F", VK_F},
+{"G", VK_G},
+{"H", VK_H},
+{"I", VK_I},
+{"J", VK_J},
+{"K", VK_K},
+{"L", VK_L},
+{"M", VK_M},
+{"N", VK_N},
+{"O", VK_O},
+{"P", VK_P},
+{"Q", VK_Q},
+{"R", VK_R},
+{"S", VK_S},
+{"T", VK_T},
+{"U", VK_U},
+{"V", VK_V},
+{"W", VK_W},
+{"X", VK_X},
+{"Y", VK_Y},
+{"Z", VK_Z},
 
-{TEXT("Numpad 0"), VK_NUMPAD0},
-{TEXT("Numpad 1"), VK_NUMPAD1},
-{TEXT("Numpad 2"), VK_NUMPAD2},
-{TEXT("Numpad 3"), VK_NUMPAD3},
-{TEXT("Numpad 4"), VK_NUMPAD4},
-{TEXT("Numpad 5"), VK_NUMPAD5},
-{TEXT("Numpad 6"), VK_NUMPAD6},
-{TEXT("Numpad 7"), VK_NUMPAD7},
-{TEXT("Numpad 8"), VK_NUMPAD8},
-{TEXT("Numpad 9"), VK_NUMPAD9},
-{TEXT("Num *"), VK_MULTIPLY},
-{TEXT("Num +"), VK_ADD},
-//{TEXT("Num Enter"), VK_SEPARATOR},	//this one doesnt seem to work
-{TEXT("Num -"), VK_SUBTRACT},
-{TEXT("Num ."), VK_DECIMAL},
-{TEXT("Num /"), VK_DIVIDE},
-{TEXT("F1"), VK_F1},
-{TEXT("F2"), VK_F2},
-{TEXT("F3"), VK_F3},
-{TEXT("F4"), VK_F4},
-{TEXT("F5"), VK_F5},
-{TEXT("F6"), VK_F6},
-{TEXT("F7"), VK_F7},
-{TEXT("F8"), VK_F8},
-{TEXT("F9"), VK_F9},
-{TEXT("F10"), VK_F10},
-{TEXT("F11"), VK_F11},
-{TEXT("F12"), VK_F12},
+{"Numpad 0", VK_NUMPAD0},
+{"Numpad 1", VK_NUMPAD1},
+{"Numpad 2", VK_NUMPAD2},
+{"Numpad 3", VK_NUMPAD3},
+{"Numpad 4", VK_NUMPAD4},
+{"Numpad 5", VK_NUMPAD5},
+{"Numpad 6", VK_NUMPAD6},
+{"Numpad 7", VK_NUMPAD7},
+{"Numpad 8", VK_NUMPAD8},
+{"Numpad 9", VK_NUMPAD9},
+{"Num *", VK_MULTIPLY},
+{"Num +", VK_ADD},
+// {"Num Enter"), VK_SEPARATOR},	//this one doesnt seem to work
+{"Num -", VK_SUBTRACT},
+{"Num .", VK_DECIMAL},
+{"Num /", VK_DIVIDE},
+{"F1", VK_F1},
+{"F2", VK_F2},
+{"F3", VK_F3},
+{"F4", VK_F4},
+{"F5", VK_F5},
+{"F6", VK_F6},
+{"F7", VK_F7},
+{"F8", VK_F8},
+{"F9", VK_F9},
+{"F10", VK_F10},
+{"F11", VK_F11},
+{"F12", VK_F12},
 
-{TEXT("~"), VK_OEM_3},
-{TEXT("-"), VK_OEM_MINUS},
-{TEXT("="), VK_OEM_PLUS},
-{TEXT("["), VK_OEM_4},
-{TEXT("]"), VK_OEM_6},
-{TEXT(";"), VK_OEM_1},
-{TEXT("'"), VK_OEM_7},
-{TEXT("\\"), VK_OEM_5},
-{TEXT(","), VK_OEM_COMMA},
-{TEXT("."), VK_OEM_PERIOD},
-{TEXT("/"), VK_OEM_2},
+{"~", VK_OEM_3},
+{"-", VK_OEM_MINUS},
+{"=", VK_OEM_PLUS},
+{"[", VK_OEM_4},
+{"]", VK_OEM_6},
+{";", VK_OEM_1},
+{"'", VK_OEM_7},
+{"\\", VK_OEM_5},
+{",", VK_OEM_COMMA},
+{".", VK_OEM_PERIOD},
+{"/", VK_OEM_2},
 
-{TEXT("<>"), VK_OEM_102},
+{"<>", VK_OEM_102},
 };
 
 #define nbKeys sizeof(namedKeyArray)/sizeof(KeyIDNAME)
 
-generic_string Shortcut::toString() const
+string Shortcut::toString() const
 {
-	generic_string sc = TEXT("");
+	string sc;
 	if (!isEnabled())
 		return sc;
 
 	if (_keyCombo._isCtrl)
-		sc += TEXT("Ctrl+");
+		sc += "Ctrl+";
 	if (_keyCombo._isAlt)
-		sc += TEXT("Alt+");
+		sc += "Alt+";
 	if (_keyCombo._isShift)
-		sc += TEXT("Shift+");
+		sc += "Shift+";
 
-	generic_string keyString;
+	string keyString;
 	getKeyStrFromVal(_keyCombo._key, keyString);
 	sc += keyString;
 	return sc;
 }
 
-void Shortcut::setName(const TCHAR * menuName, const TCHAR * shortcutName)
+void Shortcut::setName(const char* menuName, const char* shortcutName)
 {
-	lstrcpyn(_menuName, menuName, nameLenMax);
-	TCHAR const * name = shortcutName ? shortcutName : menuName;
+	lstrcpynA(_menuName, menuName, nameLenMax);
+	char const * name = shortcutName ? shortcutName : menuName;
 	size_t i = 0, j = 0;
 	while (name[j] != 0 && i < (nameLenMax - 1))
 	{
@@ -181,34 +181,34 @@ void Shortcut::setName(const TCHAR * menuName, const TCHAR * shortcutName)
 	_name[i] = 0;
 }
 
-generic_string ScintillaKeyMap::toString() const
+string ScintillaKeyMap::toString() const
 {
-	generic_string sc = TEXT("");
+	string sc;
 	size_t nbCombos = getSize();
 	for (size_t combo = 0; combo < nbCombos; ++combo)
 	{
 		sc += toString(combo);
 		if (combo < nbCombos - 1)
-			sc += TEXT(" or ");
+			sc += " or ";
 	}
 	return sc;
 }
 
-generic_string ScintillaKeyMap::toString(size_t index) const
+string ScintillaKeyMap::toString(size_t index) const
 {
-	generic_string sc = TEXT("");
+	string sc = "";
 	if (!isEnabled())
 		return sc;
 
 	KeyCombo kc = _keyCombos[index];
 	if (kc._isCtrl)
-		sc += TEXT("Ctrl+");
+		sc += "Ctrl+";
 	if (kc._isAlt)
-		sc += TEXT("Alt+");
+		sc += "Alt+";
 	if (kc._isShift)
-		sc += TEXT("Shift+");
+		sc += "Shift+";
 
-	generic_string keyString;
+	string keyString;
 	getKeyStrFromVal(kc._key, keyString);
 	sc += keyString;
 	return sc;
@@ -268,9 +268,9 @@ size_t ScintillaKeyMap::getSize() const
 	return _size;
 }
 
-void getKeyStrFromVal(UCHAR keyVal, generic_string & str)
+void getKeyStrFromVal(UCHAR keyVal, string & str)
 {
-	str = TEXT("");
+	str = "";
 	bool found = false;
 	size_t i;
 	for (i = 0; i < nbKeys; ++i)
@@ -284,22 +284,22 @@ void getKeyStrFromVal(UCHAR keyVal, generic_string & str)
 	if (found)
 		str = namedKeyArray[i].name;
 	else 
-		str = TEXT("Unlisted");
+		str = "Unlisted";
 }
 
-void getNameStrFromCmd(DWORD cmd, generic_string & str)
+void getNameStrFromCmd(DWORD cmd, wstring & str)
 {
 	if ((cmd >= ID_MACRO) && (cmd < ID_MACRO_LIMIT))
 	{
 		vector<MacroShortcut> & theMacros = (NppParameters::getInstance()).getMacroList();
 		int i = cmd - ID_MACRO;
-		str = theMacros[i].getName();
+		str = string2wstring(theMacros[i].getName(), CP_UTF8);
 	}
 	else if ((cmd >= ID_USER_CMD) && (cmd < ID_USER_CMD_LIMIT))
 	{
 		vector<UserCommand> & userCommands = (NppParameters::getInstance()).getUserCommandList();
 		int i = cmd - ID_USER_CMD;
-		str = userCommands[i].getName();
+		str = string2wstring(userCommands[i].getName(), CP_UTF8);
 	}
 	else if ((cmd >= ID_PLUGINS_CMD) && (cmd < ID_PLUGINS_CMD_LIMIT))
 	{
@@ -313,7 +313,7 @@ void getNameStrFromCmd(DWORD cmd, generic_string & str)
 				break;
 			}
 		}
-		str = pluginCmds[i].getName();
+		str = string2wstring(pluginCmds[i].getName(), CP_UTF8);
 	}
 	else
 	{
@@ -375,7 +375,7 @@ intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPar
 		{
 			NppDarkMode::autoSubclassAndThemeChildControls(_hSelf);
 
-			::SetDlgItemText(_hSelf, IDC_NAME_EDIT, _canModifyName ? getMenuName() : getName());	//display the menu name, with ampersands, for macros
+			::SetDlgItemText(_hSelf, IDC_NAME_EDIT, _canModifyName ? string2wstring(getMenuName(), CP_UTF8).c_str() : string2wstring(getName(), CP_UTF8).c_str());	//display the menu name, with ampersands, for macros
 			if (!_canModifyName)
 				::SendDlgItemMessage(_hSelf, IDC_NAME_EDIT, EM_SETREADONLY, TRUE, 0);
 			auto textlen = ::SendDlgItemMessage(_hSelf, IDC_NAME_EDIT, WM_GETTEXTLENGTH, 0, 0);
@@ -487,7 +487,7 @@ intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPar
 					{
 						TCHAR editName[nameLenMax];
 						::SendDlgItemMessage(_hSelf, IDC_NAME_EDIT, WM_GETTEXT, nameLenMax, reinterpret_cast<LPARAM>(editName));
-						setName(editName);
+						setName(wstring2string(editName, CP_UTF8).c_str());
 					}
 					::EndDialog(_hSelf, 0);
 					updateConflictState(true);
@@ -683,10 +683,10 @@ void Accelerator::updateMenuItemByCommand(const CommandShortcut& csc)
 	// Ensure that the menu item state is also maintained
 	UINT cmdFlags = GetMenuState(_hAccelMenu, cmdID, MF_BYCOMMAND );
 	cmdFlags = MF_BYCOMMAND | ((cmdFlags&MF_CHECKED) ? MF_CHECKED : MF_UNCHECKED) | ((cmdFlags&MF_DISABLED) ? MF_DISABLED : MF_ENABLED);
-	::ModifyMenu(_hAccelMenu, cmdID, cmdFlags, cmdID, csc.toMenuItemString().c_str());
+	::ModifyMenu(_hAccelMenu, cmdID, cmdFlags, cmdID, string2wstring(csc.toMenuItemString(), CP_UTF8).c_str());
 }
 
-recordedMacroStep::recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam, int codepage)
+recordedMacroStep::recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam)
 	: _message(iMessage), _wParameter(wParam), _lParameter(lParam), _macroType(mtUseLParameter)
 { 
 	if (_lParameter)
@@ -715,9 +715,7 @@ recordedMacroStep::recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam,
 			case IDD_FINDINFILES_FILTERS_COMBO:
 			{
 				char *ch = reinterpret_cast<char *>(_lParameter);
-				TCHAR tch[2];
-				::MultiByteToWideChar(codepage, 0, ch, -1, tch, 2);
-				_sParameter = *tch;
+				_sParameter = *ch;
 				_macroType = mtUseSParameter;
 				_lParameter = 0;
 			}
@@ -881,11 +879,14 @@ void recordedMacroStep::PlayBack(Window* pNotepad, ScintillaEditView *pEditView)
 
 		if (_macroType == mtUseSParameter) 
 		{
+			/*
 			int byteBufferLength = ::WideCharToMultiByte(static_cast<UINT>(pEditView->execute(SCI_GETCODEPAGE)), 0, _sParameter.c_str(), -1, NULL, 0, NULL, NULL);
 			auto byteBuffer = std::make_unique< char[] >(byteBufferLength);
 			::WideCharToMultiByte(static_cast<UINT>(pEditView->execute(SCI_GETCODEPAGE)), 0, _sParameter.c_str(), -1, byteBuffer.get(), byteBufferLength, NULL, NULL);
 			auto lParam = reinterpret_cast<LPARAM>(byteBuffer.get());
 			pEditView->execute(_message, _wParameter, lParam);
+			*/
+			pEditView->execute(_message, _wParameter, (LPARAM)_sParameter.c_str());
 		}
 		else
 		{
@@ -974,8 +975,7 @@ void ScintillaAccelerator::updateMenuItemByID(const ScintillaKeyMap& skm, int id
 	if (skm.isEnabled())
 	{
 		menuItem += TEXT("\t");
-		//menuItem += TEXT("Sc:");	//sc: scintilla shortcut
-		menuItem += skm.toString();
+		menuItem += string2wstring(skm.toString(), CP_UTF8);
 	}
 	::ModifyMenu(_hAccelMenu, id, MF_BYCOMMAND, id, menuItem.c_str());
 	::DrawMenuBar(_hMenuParent);
@@ -1049,7 +1049,7 @@ intptr_t CALLBACK ScintillaKeyMap::run_dlgProc(UINT Message, WPARAM wParam, LPAR
 		{
 			NppDarkMode::autoSubclassAndThemeChildControls(_hSelf);
 
-			::SetDlgItemText(_hSelf, IDC_NAME_EDIT, _name);
+			::SetDlgItemText(_hSelf, IDC_NAME_EDIT, string2wstring(_name, CP_UTF8).c_str());
 			_keyCombo = _keyCombos[0];
 
 			for (size_t i = 0 ; i < nbKeys ; ++i)
@@ -1228,7 +1228,7 @@ intptr_t CALLBACK ScintillaKeyMap::run_dlgProc(UINT Message, WPARAM wParam, LPAR
 
 CommandShortcut::CommandShortcut(const Shortcut& sc, long id) :	Shortcut(sc), _id(id)
 {
-	_shortcutName = sc.getName();
+	_shortcutName = string2wstring(sc.getName(), CP_UTF8);
 	if ( _id >= IDM_WINDOW_SORT_FN_ASC and _id <= IDM_WINDOW_SORT_FS_DSC)
 		_category = TEXT("Window");
 	else if ( _id < IDM_EDIT)

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -27,8 +27,8 @@ const size_t nameLenMax = 64;
 
 class NppParameters;
 
-void getKeyStrFromVal(UCHAR keyVal, generic_string & str);
-void getNameStrFromCmd(DWORD cmd, generic_string & str);
+void getKeyStrFromVal(UCHAR keyVal, std::string & str);
+void getNameStrFromCmd(DWORD cmd, std::wstring & str);
 static size_t keyTranslate(size_t keyIn) {
 	switch (keyIn) {
 		case VK_DOWN:		return SCK_DOWN;
@@ -64,22 +64,22 @@ struct KeyCombo {
 	UCHAR _key = 0;
 };
 
-class Shortcut  : public StaticDialog {
+class Shortcut : public StaticDialog {
 public:
 	Shortcut(): _canModifyName(false) {
-		setName(TEXT(""));
+		setName("");
 		_keyCombo._isCtrl = false;
 		_keyCombo._isAlt = false;
 		_keyCombo._isShift = false;
 		_keyCombo._key = 0;
 	};
 
-	Shortcut(const TCHAR *name, bool isCtrl, bool isAlt, bool isShift, UCHAR key) : _canModifyName(false) {
+	Shortcut(const char* name, bool isCtrl, bool isAlt, bool isShift, UCHAR key) : _canModifyName(false) {
 		_name[0] = '\0';
 		if (name) {
 			setName(name);
 		} else {
-			setName(TEXT(""));
+			setName("");
 		}
 		_keyCombo._isCtrl = isCtrl;
 		_keyCombo._isAlt = isAlt;
@@ -108,7 +108,7 @@ public:
 		return *this;
 	}
 	friend inline bool operator==(const Shortcut & a, const Shortcut & b) {
-		return ((lstrcmp(a.getMenuName(), b.getMenuName()) == 0) && 
+		return ((strcmp(a.getMenuName(), b.getMenuName()) == 0) && 
 			(a._keyCombo._isCtrl == b._keyCombo._isCtrl) && 
 			(a._keyCombo._isAlt == b._keyCombo._isAlt) && 
 			(a._keyCombo._isShift == b._keyCombo._isShift) && 
@@ -140,12 +140,12 @@ public:
 		return (_keyCombo._key != 0);
 	};
 
-	virtual generic_string toString() const;					//the hotkey part
-	generic_string toMenuItemString() const {					//generic_string suitable for menu
-		generic_string str = _menuName;
+	virtual std::string toString() const;					//the hotkey part
+	std::string toMenuItemString() const {					//generic_string suitable for menu
+		std::string str = _menuName;
 		if (isEnabled())
 		{
-			str += TEXT("\t");
+			str += "\t";
 			str += toString();
 		}
 		return str;
@@ -154,15 +154,15 @@ public:
 		return _keyCombo;
 	};
 
-	const TCHAR * getName() const {
+	const char* getName() const {
 		return _name;
 	};
 
-	const TCHAR * getMenuName() const {
+	const char* getMenuName() const {
 		return _menuName;
 	}
 
-	void setName(const TCHAR * menuName, const TCHAR * shortcutName = NULL);
+	void setName(const char* menuName, const char* shortcutName = NULL);
 
 	void clear(){
 		_keyCombo._isCtrl = false;
@@ -176,8 +176,8 @@ protected :
 	KeyCombo _keyCombo;
 	virtual intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam);
 	bool _canModifyName = false;
-	TCHAR _name[nameLenMax] = {'\0'};		//normal name is plain text (for display purposes)
-	TCHAR _menuName[nameLenMax] = { '\0' };	//menu name has ampersands for quick keys
+	char _name[nameLenMax] = {'\0'};		//normal name is plain text (for display purposes)
+	char _menuName[nameLenMax] = { '\0' };	//menu name has ampersands for quick keys
 	void updateConflictState(const bool endSession = false) const;
 };
 		 
@@ -224,8 +224,8 @@ public:
 	bool isEnabled() const;
 	size_t getSize() const;
 
-	generic_string toString() const;
-	generic_string toString(size_t index) const;
+	std::string toString() const;
+	std::string toString(size_t index) const;
 
 	intptr_t doDialog()
 	{
@@ -277,15 +277,15 @@ struct recordedMacroStep {
 	int _message = 0;
 	uptr_t _wParameter = 0;
 	uptr_t _lParameter = 0;
-	generic_string _sParameter;
+	std::string _sParameter;
 	MacroTypeIndex _macroType = mtMenuCommand;
 	
-	recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam, int codepage);
+	recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam);
 	explicit recordedMacroStep(int iCommandID): _wParameter(iCommandID) {};
 
-	recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam, const TCHAR *sParam, int type)
+	recordedMacroStep(int iMessage, uptr_t wParam, uptr_t lParam, const char *sParam, int type)
 		: _message(iMessage), _wParameter(wParam), _lParameter(lParam), _macroType(MacroTypeIndex(type)){
-			_sParameter = (sParam)?generic_string(sParam):TEXT("");	
+			_sParameter = (sParam) ? std::string(sParam) : "";	
 	};
 
 	bool isValid() const {
@@ -312,16 +312,16 @@ private:
 class UserCommand : public CommandShortcut {
 friend class NppParameters;
 public:
-	UserCommand(const Shortcut& sc, const TCHAR *cmd, int id) : CommandShortcut(sc, id), _cmd(cmd) {_canModifyName = true;};
-	const TCHAR* getCmd() const {return _cmd.c_str();};
+	UserCommand(const Shortcut& sc, const char *cmd, int id) : CommandShortcut(sc, id), _cmd(cmd) {_canModifyName = true;};
+	const char* getCmd() const {return _cmd.c_str();};
 private:
-	generic_string _cmd;
+	std::string _cmd;
 };
 
 class PluginCmdShortcut : public CommandShortcut {
 //friend class NppParameters;
 public:
-	PluginCmdShortcut(const Shortcut& sc, int id, const TCHAR *moduleName, unsigned short internalID) :\
+	PluginCmdShortcut(const Shortcut& sc, int id, const char*moduleName, unsigned short internalID) :\
 		CommandShortcut(sc, id), _id(id), _moduleName(moduleName), _internalID(internalID) {};
 	bool isValid() const {
 		if (!Shortcut::isValid())
@@ -330,13 +330,13 @@ public:
 			return false;
 		return true;
 	}
-	const TCHAR * getModuleName() const {return _moduleName.c_str();};
+	const char* getModuleName() const {return _moduleName.c_str();};
 	int getInternalID() const {return _internalID;};
 	unsigned long getID() const {return _id;};
 
 private :
 	unsigned long _id;
-	generic_string _moduleName;
+	std::string _moduleName;
 	int _internalID;
 };
 

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -1043,9 +1043,7 @@ void NativeLangSpeaker::changeShortcutLang()
 				CommandShortcut & csc = mainshortcuts[index];
 				if (csc.getID() == (unsigned long)id) 
 				{
-					WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-					const wchar_t * nameW = wmc.char2wchar(name, _nativeLangEncoding);
-					csc.setName(nameW);
+					csc.setName(name);
 				}
 			}
 		}
@@ -1073,10 +1071,7 @@ void NativeLangSpeaker::changeShortcutLang()
 			{
 				const char *name = element->Attribute("name");
 				ScintillaKeyMap & skm = scinshortcuts[index];
-
-				WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
-				const wchar_t * nameW = wmc.char2wchar(name, _nativeLangEncoding);
-				skm.setName(nameW);
+				skm.setName(name);
 			}
 		}
 	}


### PR DESCRIPTION
Add the UTF8 character ability for Run & Macro menu by using GUI or by editing shortcut.xml.
Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13221#issuecomment-1457325172

Fix #13488 