### PR TITLE
fix infinite loop in running macro to EOF

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1471,6 +1471,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				int indexMacro = _runMacroDlg.getMacro2Exec();
 				intptr_t deltaLastLine = 0;
 				intptr_t deltaCurrLine = 0;
+				bool cursorMovedUp = false;
 
 				Macro m = _macro;
 
@@ -1492,7 +1493,14 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					}
 					else // run until eof
 					{
-						bool cursorMovedUp = deltaCurrLine < 0;
+						if (counter > 2 && cursorMovedUp != (deltaCurrLine < 0) && deltaLastLine >= 0)
+						{
+							// the current line must be monotonically increasing or monotonically
+							// decreasing. Otherwise we don't know that the loop will end,
+							// unless the number of lines is decreasing with every iteration.
+							break;
+						}
+						cursorMovedUp = deltaCurrLine < 0;
 						deltaLastLine = _pEditView->execute(SCI_GETLINECOUNT) - 1 - lastLine;
 						deltaCurrLine = _pEditView->getCurrentLineNumber() - currLine;
 


### PR DESCRIPTION
Fix issue https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13342
To test fix, try making file
```
f
f
```
and recording macro of find/replace form searching for `f` *with wrap-around enabled*, then running until EOF.
To confirm that this PR does not cause the loop to always end after one iteration, try adding more lines of f's, and `run until end of file` a few times. You should find that it will run until after the first wrap-around, just as one would expect.

This does not break any existing behavior, including:
- macros where the cursor moves towards EOF but line num doesn't change (those already stopped after one iteration)
- macros where line(s) are deleted with every iteration (even if line number doesn't change, they run until file empty)
- macros where the line number increases with each iteration
- macros where the cursor advances up or down with each iteration but would eventually stop anyway (those end at the correct time)