### PR TITLE
Add message NPPM_DARKMODESUBCLASSANDTHEME

### DIFF
--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -45,7 +45,7 @@ CPP_DEFINE := UNICODE _UNICODE OEMRESOURCE NOMINMAX _WIN32_WINNT=_WIN32_WINNT_VI
 LD := $(CXX)
 LDFLAGS := -municode -mwindows
 LD_PATH :=
-LD_LINK := comctl32 crypt32 dbghelp ole32 sensapi shlwapi uuid uxtheme version wininet wintrust
+LD_LINK := comctl32 crypt32 dbghelp ole32 sensapi shlwapi uuid uxtheme version wininet wintrust dwmapi
 LD_LINK += $(patsubst lib%.a,%,$(SCINTILLA_TARGET)) $(patsubst lib%.a,%,$(LEXILLA_TARGET)) imm32 msimg32 ole32 oleaut32
 SUBMAKEFLAGS := -O --no-print-directory
 

--- a/PowerEditor/src/CMakeLists.txt
+++ b/PowerEditor/src/CMakeLists.txt
@@ -380,7 +380,7 @@ SET(rcFiles
 
 IF (WIN32)
 	SET(option WIN32)
-	SET(win32_LIBRARIES comctl32 shlwapi dbghelp version crypt32 wintrust sensapi wininet imm32 msimg32 uxtheme)
+	SET(win32_LIBRARIES comctl32 shlwapi dbghelp version crypt32 wintrust sensapi wininet imm32 msimg32 uxtheme dwmapi)
 	set(CMAKE_CXX_STANDARD 20)
 if ( MSVC )
 	#do not use for mingw builds

--- a/PowerEditor/src/DarkMode/DarkMode.cpp
+++ b/PowerEditor/src/DarkMode/DarkMode.cpp
@@ -266,19 +266,14 @@ bool IsWindows10() // or later OS version
 	return (g_buildNumber >= 17763);
 }
 
-bool IsWindows10(DWORD build)
-{
-	return (IsWindows10() && g_buildNumber >= build);
-}
-
 bool IsWindows11() // or later OS version
 {
 	return (g_buildNumber >= 22000);
 }
 
-bool IsWindows11(DWORD build)
+const DWORD GetWindowsBuildNumber()
 {
-	return (IsWindows11() && g_buildNumber >= build);
+	return g_buildNumber;
 }
 
 void InitDarkMode()

--- a/PowerEditor/src/DarkMode/DarkMode.cpp
+++ b/PowerEditor/src/DarkMode/DarkMode.cpp
@@ -266,9 +266,19 @@ bool IsWindows10() // or later OS version
 	return (g_buildNumber >= 17763);
 }
 
+bool IsWindows10(DWORD build)
+{
+	return (IsWindows10() && g_buildNumber >= build);
+}
+
 bool IsWindows11() // or later OS version
 {
 	return (g_buildNumber >= 22000);
+}
+
+bool IsWindows11(DWORD build)
+{
+	return (IsWindows11() && g_buildNumber >= build);
 }
 
 void InitDarkMode()

--- a/PowerEditor/src/DarkMode/DarkMode.h
+++ b/PowerEditor/src/DarkMode/DarkMode.h
@@ -16,4 +16,6 @@ void EnableDarkScrollBarForWindowAndChildren(HWND hwnd);
 void InitDarkMode();
 void SetDarkMode(bool useDarkMode, bool fixDarkScrollbar);
 bool IsWindows10();
+bool IsWindows10(DWORD build);
 bool IsWindows11();
+bool IsWindows11(DWORD build);

--- a/PowerEditor/src/DarkMode/DarkMode.h
+++ b/PowerEditor/src/DarkMode/DarkMode.h
@@ -16,6 +16,5 @@ void EnableDarkScrollBarForWindowAndChildren(HWND hwnd);
 void InitDarkMode();
 void SetDarkMode(bool useDarkMode, bool fixDarkScrollbar);
 bool IsWindows10();
-bool IsWindows10(DWORD build);
 bool IsWindows11();
-bool IsWindows11(DWORD build);
+const DWORD GetWindowsBuildNumber();

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -558,65 +558,23 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//
 	// Might not work properly in C# plugins.
 	//
-	// Returns succesful combinations from dmfRequiredMask.
+	// Returns succesful combinations of flags.
 	//
 
 	namespace NppDarkMode
 	{
-		// Used on parent of edit, listbox, static text, treeview, listview and toolbar controls.
-		// Should be used only one time on parent control after its creation
-		// even when starting in light mode.
-		// e.g. in WM_INITDIALOG, in WM_CREATE or after CreateWindow.
-		constexpr ULONG dmfSubclassParent =     0x00000001UL;
-		// Should be used only one time on main control/window after initializations of all its children controls
-		// even when starting in light mode.
-		// Will also use dmfSetThemeChildren flag.
-		// e.g. in WM_INITDIALOG, in WM_CREATE or after CreateWindow.
-		constexpr ULONG dmfSubclassChildren =   0x00000002UL;
-		// Will apply theme on buttons with style:
-		// BS_PUSHLIKE, BS_PUSHBUTTON, BS_DEFPUSHBUTTON, BS_SPLITBUTTON or BS_DEFSPLITBUTTON.
-		// Will apply theme for scrollbars on edit, listbox and rich edit controls.
-		// Will apply theme for tooltips on listview, treeview and toolbar buttons.
-		// Should be handled after controls initializations and in NPPN_DARKMODECHANGED.
-		// Requires at least Windows 10 to work properly.
-		constexpr ULONG dmfSetThemeChildren =   0x00000004UL;
-		// Set dark title bar.
-		// Should be handled after controls initializations and in NPPN_DARKMODECHANGED.
-		// Requires at least Windows 10 and WS_CAPTION style to work properly.
-		constexpr ULONG dmfSetTitleBar =        0x00000008UL;
-		// Will apply dark explorer theme.
-		// Used mainly for scrollbars and tooltips not handled with dmfSetThemeChildren.
-		// Might also change style for other elements.
-		// Should be handled after controls initializations and in NPPN_DARKMODECHANGED.
-		// Requires at least Windows 10 to work properly.
-		constexpr ULONG dmfSetThemeDirectly =   0x00000010UL;
-
 		// Standard flags for main parent after its children are initialized.
-		// Check individual flags for more information.
-		// 0x000000BUL
-		constexpr ULONG dmfAfterInitParent = dmfSubclassParent | dmfSubclassChildren | dmfSetTitleBar;
+		constexpr ULONG dmfInit =               0x0000000BUL;
+
 		// Standard flags for main parent usually used in NPPN_DARKMODECHANGED.
-		// Check individual flags for more information.
-		// 0x000000CUL
-		constexpr ULONG dmfHandleChangeParent = dmfSetThemeChildren | dmfSetTitleBar;
-
-		// At least one of these flags should be used.
-		// currently same as dmfAllMask
-		// used internally
-		// 0x0000001FUL
-		//constexpr ULONG dmfRequiredMask = dmfSubclassParent | dmfSubclassChildren | dmfSetThemeChildren | dmfSetTitleBar | dmfSetThemeDirectly;
-
-		// every flags
-		// currently not used
-		// 0x0000001FUL
-		//constexpr ULONG dmfAllMask = dmfSubclassParent | dmfSubclassChildren | dmfSetThemeChildren | dmfSetTitleBar | dmfSetThemeDirectly;
+		constexpr ULONG dmfHandleChange =       0x0000000CUL;
 	};
 
 	// Examples:
 	//
 	// - after controls initializations in WM_INITDIALOG, in WM_CREATE or after CreateWindow:
 	//
-	//auto success = static_cast<ULONG>(::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfAfterInitParent), reinterpret_cast<LPARAM>(mainHwnd)));
+	//auto success = static_cast<ULONG>(::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfInit), reinterpret_cast<LPARAM>(mainHwnd)));
 	//
 	// - handling dark mode change:
 	//
@@ -626,8 +584,8 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//	{
 	//		case NPPN_DARKMODECHANGED:
 	//		{
-	//			::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(dmfHandleChangeParent), reinterpret_cast<LPARAM>(mainHwnd));
-	//			::SetWindowPos(mainHwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED); // to redraw titlebar
+	//			::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(dmfHandleChange), reinterpret_cast<LPARAM>(mainHwnd));
+	//			::SetWindowPos(mainHwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED); // to redraw titlebar and window
 	//			break;
 	//		}
 	//	}

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -574,7 +574,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 		// e.g. in WM_INITDIALOG, in WM_CREATE or after CreateWindow.
 		constexpr ULONG dmfSubclassChildren =   0x00000002UL;
 		// Will apply theme on buttons with style:
-		// BS_PUSHLIKE, BS_PUSHBUTTON, BS_DEFPUSHBUTTON, BS_SPLITBUTTON and BS_DEFSPLITBUTTON.
+		// BS_PUSHLIKE, BS_PUSHBUTTON, BS_DEFPUSHBUTTON, BS_SPLITBUTTON or BS_DEFSPLITBUTTON.
 		// Will apply theme for scrollbars on edit, listbox and rich edit controls.
 		// Will apply theme for tooltips on listview, treeview and toolbar buttons.
 		// Should be handled after controls initializations and in NPPN_DARKMODECHANGED.
@@ -592,11 +592,11 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 		constexpr ULONG dmfSetThemeDirectly =   0x00000010UL;
 
 		// Standard flags for main parent after its children are initialized.
-		// e.g. in WM_INITDIALOG, in WM_CREATE or after CreateWindow.
-		// Should be used only one time on main control/window after initializations of all its children controls.
+		// Check individual flags for more information.
 		// 0x000000BUL
 		constexpr ULONG dmfAfterInitParent = dmfSubclassParent | dmfSubclassChildren | dmfSetTitleBar;
 		// Standard flags for main parent usually used in NPPN_DARKMODECHANGED.
+		// Check individual flags for more information.
 		// 0x000000CUL
 		constexpr ULONG dmfHandleChangeParent = dmfSetThemeChildren | dmfSetTitleBar;
 

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -562,7 +562,8 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//
 	// Might not work properly in C# plugins.
 	//
-	// Returns FALSE if parent subclass was not successful, hwnd == nullptr or dmFlags were invalid, otherwise TRUE.
+	// Returns FALSE if parent subclass was not successful, hwnd == nullptr or none of dmfSetParent and dmfSetChildren flags were set,
+	// otherwise TRUE.
 	//
 
 	namespace NppDarkMode

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -549,6 +549,50 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// void* NPPM_GETBOOKMARKID(0, 0)
 	// Returns the bookmark ID
 
+	#define NPPM_DARKMODESUBCLASSANDTHEME (NPPMSG + 112)
+	// bool NPPM_DARKMODESUBCLASSANDTHEME(UINT dmFlags, HWND hwnd)
+	// Subclass hwnd to add support for generic dark mode.
+	// When applying first time on main hwnd use "dmFlags = NppDarkMode::dmfAll".
+	// In case edit, listbox, static text, treeview, listview and toolbar controls don't have parent as main hwnd,
+	// call NPPM_DARKMODESUBCLASSANDTHEME on their parent and use "dmFlags = NppDarkMode::dmfSetParent".
+	// When handling dark mode change with NPPN_DARKMODECHANGED, use "dmFlags = NppDarkMode::dmfSetChildren".
+	// 
+	// Docking panels don't need to call NPPM_DARKMODESUBCLASSANDTHEME for main hwnd.
+	// Subclassing is applied automatically unless DWS_USEOWNDARKMODE flag is used.
+	//
+	// Might not work properly in C# plugins.
+	//
+	// Returns FALSE if parent subclass was not successful, hwnd == nullptr or dmFlags were invalid, otherwise TRUE.
+	//
+
+	namespace NppDarkMode
+	{
+		constexpr UINT dmfSetParent = 0x01;
+		constexpr UINT dmfSetChildren = 0x02; // without dmfSubclassChildren will only theme
+		constexpr UINT dmfSubclassChildren = 0x04; // should be used only on main hwnd when applying subclass first time
+		constexpr UINT dmfAll = dmfSetParent | dmfSetChildren | dmfSubclassChildren; // 0x07
+	};
+
+	// Examples:
+	//
+	// - first time:
+	//
+	//auto success = static_cast<bool>(::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfAll), reinterpret_cast<LPARAM>(mainHwnd)));
+	//
+	// - handling dark mode change:
+	//
+	//extern "C" __declspec(dllexport) void beNotified(SCNotification * notifyCode)
+	//{
+	//	switch (notifyCode->nmhdr.code)
+	//	{
+	//		case NPPN_DARKMODECHANGED:
+	//		{
+	//			::SendMessage(nppData._nppHandle, NPPM_DARKMODESUBCLASSANDTHEME, static_cast<WPARAM>(NppDarkMode::dmfSetChildren), reinterpret_cast<LPARAM>(mainHwnd));
+	//			::SetWindowPos(mainHwnd, nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+	//			break;
+	//		}
+	//	}
+	//}
 
 
 	// For RUNCOMMAND_USER

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3110,6 +3110,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return static_cast<LRESULT>(false);
 		}
 
+		case NPPM_DARKMODESUBCLASSANDTHEME:
+		{
+			return static_cast<LRESULT>(NppDarkMode::autoSubclassAndThemePlugin(reinterpret_cast<HWND>(lParam), static_cast<UINT>(wParam)));
+		}
+
 		case NPPM_DOCLISTDISABLEPATHCOLUMN:
 		case NPPM_DOCLISTDISABLEEXTCOLUMN:
 		{

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3112,7 +3112,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_DARKMODESUBCLASSANDTHEME:
 		{
-			return static_cast<LRESULT>(NppDarkMode::autoSubclassAndThemePlugin(reinterpret_cast<HWND>(lParam), static_cast<UINT>(wParam)));
+			return static_cast<LRESULT>(NppDarkMode::autoSubclassAndThemePlugin(reinterpret_cast<HWND>(lParam), static_cast<ULONG>(wParam)));
 		}
 
 		case NPPM_DOCLISTDISABLEPATHCOLUMN:

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -548,19 +548,14 @@ namespace NppDarkMode
 		return IsWindows10();
 	}
 
-	bool isWindows10(DWORD build)
-	{
-		return IsWindows10(build);
-	}
-
 	bool isWindows11()
 	{
 		return IsWindows11();
 	}
 
-	bool isWindows11(DWORD build)
+	const DWORD getWindowsBuildNumber()
 	{
-		return IsWindows10(build);
+		return GetWindowsBuildNumber();
 	}
 
 	COLORREF invertLightness(COLORREF c)
@@ -2865,7 +2860,8 @@ namespace NppDarkMode
 
 	void setDarkTitleBar(HWND hwnd)
 	{
-		if (NppDarkMode::isWindows10(19041U))
+		constexpr DWORD win10Build2004 = 19041;
+		if (NppDarkMode::getWindowsBuildNumber() >= win10Build2004)
 		{
 			BOOL value = NppDarkMode::isEnabled() ? TRUE : FALSE;
 			::DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -20,6 +20,7 @@
 #include "DarkMode/DarkMode.h"
 #include "DarkMode/UAHMenuBar.h"
 
+#include <dwmapi.h>
 #include <uxtheme.h>
 #include <vssym32.h>
 
@@ -33,6 +34,9 @@
 #ifdef __GNUC__
 #include <cmath>
 #define WINAPI_LAMBDA WINAPI
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
 #else
 #define WINAPI_LAMBDA
 #endif
@@ -40,6 +44,7 @@
 // already added in project files
 // keep for plugin authors
 //#ifdef _MSC_VER
+//#pragma comment(lib, "dwmapi.lib")
 //#pragma comment(lib, "uxtheme.lib")
 //#endif
 
@@ -543,9 +548,19 @@ namespace NppDarkMode
 		return IsWindows10();
 	}
 
+	bool isWindows10(DWORD build)
+	{
+		return IsWindows10(build);
+	}
+
 	bool isWindows11()
 	{
 		return IsWindows11();
+	}
+
+	bool isWindows11(DWORD build)
+	{
+		return IsWindows10(build);
 	}
 
 	COLORREF invertLightness(COLORREF c)
@@ -2827,8 +2842,16 @@ namespace NppDarkMode
 
 	void setDarkTitleBar(HWND hwnd)
 	{
-		NppDarkMode::allowDarkModeForWindow(hwnd, NppDarkMode::isEnabled());
-		NppDarkMode::setTitleBarThemeColor(hwnd);
+		if (NppDarkMode::isWindows10(19041U))
+		{
+			BOOL value = NppDarkMode::isEnabled() ? TRUE : FALSE;
+			::DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
+		}
+		else
+		{
+			NppDarkMode::allowDarkModeForWindow(hwnd, NppDarkMode::isEnabled());
+			NppDarkMode::setTitleBarThemeColor(hwnd);
+		}
 	}
 
 	void setDarkExplorerTheme(HWND hwnd)

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -2566,17 +2566,40 @@ namespace NppDarkMode
 
 	ULONG autoSubclassAndThemePlugin(HWND hwnd, ULONG dmFlags)
 	{
-		// defined in Notepad_plus_msgs.h
-		//constexpr ULONG dmfSubclassParent =     0x00000001UL;
-		//constexpr ULONG dmfSubclassChildren =   0x00000002UL;
-		//constexpr ULONG dmfSetThemeChildren =   0x00000004UL;
-		//constexpr ULONG dmfSetTitleBar =        0x00000008UL;
-		//constexpr ULONG dmfSetThemeDirectly =   0x00000010UL;
-		//constexpr ULONG dmfAfterInitParent =    dmfSubclassParent | dmfSubclassChildren | dmfSetTitleBar; // 0x000000BUL
-		//constexpr ULONG dmfHandleChangeParent = dmfSetThemeChildren | dmfSetTitleBar;                     // 0x000000CUL
+		// Used on parent of edit, listbox, static text, treeview, listview and toolbar controls.
+		// Should be used only one time on parent control after its creation
+		// even when starting in light mode.
+		// e.g. in WM_INITDIALOG, in WM_CREATE or after CreateWindow.
+		constexpr ULONG dmfSubclassParent =     0x00000001UL;
+		// Should be used only one time on main control/window after initializations of all its children controls
+		// even when starting in light mode.
+		// Will also use dmfSetThemeChildren flag.
+		// e.g. in WM_INITDIALOG, in WM_CREATE or after CreateWindow.
+		constexpr ULONG dmfSubclassChildren =   0x00000002UL;
+		// Will apply theme on buttons with style:
+		// BS_PUSHLIKE, BS_PUSHBUTTON, BS_DEFPUSHBUTTON, BS_SPLITBUTTON or BS_DEFSPLITBUTTON.
+		// Will apply theme for scrollbars on edit, listbox and rich edit controls.
+		// Will apply theme for tooltips on listview, treeview and toolbar buttons.
+		// Should be handled after controls initializations and in NPPN_DARKMODECHANGED.
+		// Requires at least Windows 10 to work properly.
+		constexpr ULONG dmfSetThemeChildren =   0x00000004UL;
+		// Set dark title bar.
+		// Should be handled after controls initializations and in NPPN_DARKMODECHANGED.
+		// Requires at least Windows 10 and WS_CAPTION style to work properly.
+		constexpr ULONG dmfSetTitleBar =        0x00000008UL;
+		// Will apply dark explorer theme.
+		// Used mainly for scrollbars and tooltips not handled with dmfSetThemeChildren.
+		// Might also change style for other elements.
+		// Should be handled after controls initializations and in NPPN_DARKMODECHANGED.
+		// Requires at least Windows 10 to work properly.
+		constexpr ULONG dmfSetThemeDirectly =   0x00000010UL;
 
-		constexpr ULONG dmfRequiredMask = dmfSubclassParent | dmfSubclassChildren | dmfSetThemeChildren | dmfSetTitleBar | dmfSetThemeDirectly;
-		//constexpr ULONG dmfAllMask = dmfSubclassParent | dmfSubclassChildren | dmfSetThemeChildren | dmfSetTitleBar | dmfSetThemeDirectly;
+		// defined in Notepad_plus_msgs.h
+		//constexpr ULONG dmfInit =             dmfSubclassParent | dmfSubclassChildren | dmfSetTitleBar; // 0x000000BUL
+		//constexpr ULONG dmfHandleChange =     dmfSetThemeChildren | dmfSetTitleBar;                     // 0x000000CUL
+
+		constexpr ULONG dmfRequiredMask =       dmfSubclassParent | dmfSubclassChildren | dmfSetThemeChildren | dmfSetTitleBar | dmfSetThemeDirectly;
+		//constexpr ULONG dmfAllMask =          dmfSubclassParent | dmfSubclassChildren | dmfSetThemeChildren | dmfSetTitleBar | dmfSetThemeDirectly;
 		
 		if (hwnd == nullptr || (dmFlags & dmfRequiredMask) == 0)
 		{

--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -2557,7 +2557,7 @@ namespace NppDarkMode
 		//constexpr int dmfSubclassChildren = 0x04;
 		//constexpr int dmfAll = dmfSetParent | dmfSetChildren | dmfSubclassChildren; // 0x07
 
-		if (hwnd == nullptr || (dmFlags & dmfAll) == 0)
+		if (hwnd == nullptr || (dmFlags & (dmfSetParent | dmfSetChildren)) == 0)
 		{
 			return false;
 		}

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -216,6 +216,7 @@ namespace NppDarkMode
 	LRESULT darkTreeViewNotifyCustomDraw(LPARAM lParam);
 
 	void autoSubclassAndThemePluginDockWindow(HWND hwnd);
+	bool autoSubclassAndThemePlugin(HWND hwnd, UINT dmFlags);
 	void autoSubclassAndThemeWindowNotify(HWND hwnd);
 
 	bool subclassTabUpDownControl(HWND hwnd);

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -118,7 +118,9 @@ namespace NppDarkMode
 	void setAdvancedOptions();
 
 	bool isWindows10();
+	bool isWindows10(DWORD build);
 	bool isWindows11();
+	bool isWindows11(DWORD build);
 
 	COLORREF invertLightness(COLORREF c);
 	COLORREF invertLightnessSofter(COLORREF c);

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -216,7 +216,7 @@ namespace NppDarkMode
 	LRESULT darkTreeViewNotifyCustomDraw(LPARAM lParam);
 
 	void autoSubclassAndThemePluginDockWindow(HWND hwnd);
-	bool autoSubclassAndThemePlugin(HWND hwnd, UINT dmFlags);
+	ULONG autoSubclassAndThemePlugin(HWND hwnd, ULONG dmFlags);
 	void autoSubclassAndThemeWindowNotify(HWND hwnd);
 
 	bool subclassTabUpDownControl(HWND hwnd);

--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -118,9 +118,8 @@ namespace NppDarkMode
 	void setAdvancedOptions();
 
 	bool isWindows10();
-	bool isWindows10(DWORD build);
 	bool isWindows11();
-	bool isWindows11(DWORD build);
+	const DWORD getWindowsBuildNumber();
 
 	COLORREF invertLightness(COLORREF c);
 	COLORREF invertLightnessSofter(COLORREF c);

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
@@ -20,7 +20,7 @@
 
 intptr_t CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 {
-	switch (message) 
+	switch (message)
 	{
 		case WM_INITDIALOG :
 		{
@@ -135,6 +135,7 @@ intptr_t CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM)
 					break;
 				}
 			}
+			return FALSE;
 		}
 
 		default :

--- a/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionListPanel.cpp
@@ -294,7 +294,7 @@ bool FunctionListPanel::serialize(const generic_string & outputFilename)
 
 			for (auto & i : j[nodesLabel])
 			{
-				if (nodeName == i[nameLabel])
+				if (nodeName == std::string{ i[nameLabel] })
 				{
 					i[leavesLabel].push_back(leafName.c_str());
 					isFound = true;

--- a/PowerEditor/visual.net/notepadPlus.Cpp.props
+++ b/PowerEditor/visual.net/notepadPlus.Cpp.props
@@ -42,7 +42,7 @@
       <AnalyzeExternalRuleset>NativeRecommendedRules.ruleset</AnalyzeExternalRuleset>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Dbghelp.lib;Version.lib;Crypt32.lib;wintrust.lib;Sensapi.lib;wininet.lib;imm32.lib;msimg32.lib;uxtheme.lib;libscintilla.lib;liblexilla.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;Dbghelp.lib;Version.lib;Crypt32.lib;wintrust.lib;Sensapi.lib;wininet.lib;imm32.lib;msimg32.lib;uxtheme.lib;dwmapi.lib;libscintilla.lib;liblexilla.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>


### PR DESCRIPTION
to allow plugin authors to use generic dark mode

Needs some testing and feedback from plugin authors.
Unfortunately not for C# plugins.

fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13574
related https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13572