### PR TITLE
Backup old version of shortcuts.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1444,6 +1444,12 @@ Continue?"/>
             <LanguageMenuCompactWarning title="Compact Language Menu" message="This option will be changed on the next launch."/> <!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
             <SwitchUnsavedThemeWarning title="$STR_REPLACE$" message="Unsaved changes are about to be discarded!
 Do you want to save your changes before switching themes?"/> <!-- HowToReproduce: In the Style Configurator dialog change some theme and switch to other theme without saving. -->
+            <MacroAndRunCmdlWarning title="Macro and Run Commands Compatibility" message="Your Macro and Run commands saved in Notepad++ v.8.5.2 (or older) may not be compatible with the current version of Notepad++.
+Please test those commands and, if needed, re-edit them.
+
+Alternatively, you can downgrade to Notepad++ v8.5.2 and restore your previous data.
+Notepad++ will backup your old &quot;shortcuts.xml&quot; and save it as &quot;shortcuts.xml.v8.5.2.backup&quot;.
+Renaming &quot;shortcuts.xml.v8.5.2.backup&quot; -&gt; &quot;shortcuts.xml&quot;, your commands should be restored and work properly.&quot;/> <!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Clipboard History"/>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1449,7 +1449,7 @@ Please test those commands and, if needed, re-edit them.
 
 Alternatively, you can downgrade to Notepad++ v8.5.2 and restore your previous data.
 Notepad++ will backup your old &quot;shortcuts.xml&quot; and save it as &quot;shortcuts.xml.v8.5.2.backup&quot;.
-Renaming &quot;shortcuts.xml.v8.5.2.backup&quot; -&gt; &quot;shortcuts.xml&quot;, your commands should be restored and work properly.&quot;/> <!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
+Renaming &quot;shortcuts.xml.v8.5.2.backup&quot; -&gt; &quot;shortcuts.xml&quot;, your commands should be restored and work properly."/> <!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
         </MessageBox>
         <ClipboardHistory>
             <PanelTitle name="Clipboard History"/>

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3543,16 +3543,17 @@ void NppParameters::writeShortcuts()
 		wchar_t v852ShortcutsHasBeenBackup[MAX_PATH]{};
 		::wcscpy_s(v852ShortcutsHasBeenBackup, _shortcutsPath.c_str());
 		::PathRemoveFileSpec(v852ShortcutsHasBeenBackup);
-		::PathAppend(v852ShortcutsHasBeenBackup, L"v852ShortcutsHasBeenBackup.xml");
+		::PathAppend(v852ShortcutsHasBeenBackup, L"v852ShortcutsCompatibilityWarning.xml");
 
 		if (!::PathFileExists(v852ShortcutsHasBeenBackup))
 		{
-			// Creat v852ShortcutshasBeenBackup.xml for the future use
+			// Creat empty file v852ShortcutsCompatibilityWarning.xml for not giving warning, neither doing backup, in future use.
 			HANDLE hFile = ::CreateFile(v852ShortcutsHasBeenBackup, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 			::FlushFileBuffers(hFile);
 			::CloseHandle(hFile);
 
-			// backup shortcuts file
+			// backup shortcuts file "shortcuts.xml" to "shortcuts.xml.v8.5.2.backup"
+			// if the backup file already exists, it will not be overwritten.
 			wstring v852ShortcutsBackupPath = _shortcutsPath;
 			v852ShortcutsBackupPath += L".v8.5.2.backup";
 			::CopyFile(_shortcutsPath.c_str(), v852ShortcutsBackupPath.c_str(), TRUE);
@@ -3560,10 +3561,10 @@ void NppParameters::writeShortcuts()
 			// Warn User about the current shortcut will be changed and it has been backup. If users' the shortcuts.xml has been corrupted
 			// due to recoded macro under v8.5.2 (or previous versions) being modified by v8.5.3 (or later versions),
 			// user can always go back to Notepad++ v8.5.2 and use the backup of shortcuts.xml 
-			_pNativeLangSpeaker->messageBox("MacroEventualWarning",
+			_pNativeLangSpeaker->messageBox("MacroAndRunCmdlWarning",
 				nullptr,
-				TEXT("Your macro recorded under v8.5.2 or previous versions could be corrupted by this version of Notepad++.\nIf it happens, please delete damaged macro then record it again under the current version of Notepad++; or you can always go back to Notepad++ v8.5.2 then restore \"shortcuts.xml.v8.5.2.backup\" to \"shortcuts.xml\"."),
-				TEXT("Macro eventual incompatible warning"),
+				TEXT("Your Macro and Run commands saved in Notepad++ v.8.5.2 (or older) may not be compatible with the current version of Notepad++.\nPlease test those commands and, if needed, re-edit them.\n\nAlternatively, you can downgrade to Notepad++ v8.5.2 and restore your previous data.\nNotepad++ will backup your old \"shortcuts.xml\" and save it as \"shortcuts.xml.v8.5.2.backup\".\nRenaming \"shortcuts.xml.v8.5.2.backup\" -> \"shortcuts.xml\", your commands should be restored and work properly."),
+				TEXT("Macro and Run Commands Compatibility"),
 				MB_OK | MB_APPLMODAL | MB_ICONWARNING);
 		}
 	}

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3538,6 +3538,14 @@ void NppParameters::writeShortcuts()
 		TiXmlDeclarationA* decl = new TiXmlDeclarationA("1.0", "UTF-8", "");
 		_pXmlShortcutDocA->LinkEndChild(decl);
 	}
+	else
+	{
+		wstring v852ShortcutsBackupPath = _shortcutsPath;
+		v852ShortcutsBackupPath += L".v8.5.2.backup";
+
+		// backup shortcuts file
+		::CopyFile(_shortcutsPath.c_str(), v852ShortcutsBackupPath.c_str(), TRUE);
+	}
 
 	TiXmlNodeA *root = _pXmlShortcutDocA->FirstChild("NotepadPlus");
 	if (!root)

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3562,7 +3562,7 @@ void NppParameters::writeShortcuts()
 			// user can always go back to Notepad++ v8.5.2 and use the backup of shortcuts.xml 
 			_pNativeLangSpeaker->messageBox("MacroEventualWarning",
 				nullptr,
-				TEXT("Your macro recoded under v8.5.2 or previous versions could be corrupted by this version of Notepad++.\nIf it happens, please delete damaged macro then record it again under the current version of Notepad++; or you can always go back to Notepad++ v8.5.2 then restore \"shortcuts.xml.v8.5.2.backup\" to \"shortcuts.xml\"."),
+				TEXT("Your macro recorded under v8.5.2 or previous versions could be corrupted by this version of Notepad++.\nIf it happens, please delete damaged macro then record it again under the current version of Notepad++; or you can always go back to Notepad++ v8.5.2 then restore \"shortcuts.xml.v8.5.2.backup\" to \"shortcuts.xml\"."),
 				TEXT("Macro eventual incompatible warning"),
 				MB_OK | MB_APPLMODAL | MB_ICONWARNING);
 		}


### PR DESCRIPTION
An enhancement (fff5f9b - it will be in v8.5.3) makes Macro & Run menu completely localizable. However, it will bring a regression and critical bug for all macro recorded by v8.5.2 and previous versions. In order to remedy this issue, shortcuts.xml will be copied to shortcuts.xml.v8.5.2.backup before being written. So user can recover backup file if they want to back to v8.5.2 or previous version with the old data.

Fix #13589