### PR TITLE
Backup session file in case of its corruption

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -47,7 +47,15 @@ Win32_IO_File::Win32_IO_File(const wchar_t *fname)
 			pathAppend(nppIssueLog, issueFn);
 
 			std::string msg = _path;
-			msg += " is opened.";
+			if (_hFile != INVALID_HANDLE_VALUE)
+			{
+				msg += " is opened.";
+			}
+			else
+			{
+				msg += " failed to open, CreateFileW ErrorCode: ";
+				msg += std::to_string(::GetLastError());
+			}
 			writeLog(nppIssueLog.c_str(), msg.c_str());
 		}
 	}


### PR DESCRIPTION
It could be, in certain unknown circumstances, the session file (session.xml) is saved with the incorrect characters (for example NUL characters) which leads session file corrupted. This commit makes a backup of session file before rewritting it, then check the session file after it having been writting - if written session file is corrupted, the backup session file will be restored, otherwise the backup file will be removed.

Ref: 
1. https://github.com/notepad-plus-plus/notepad-plus-plus/issues/6133#issuecomment-1121781830
2. https://github.com/notepad-plus-plus/notepad-plus-plus/issues/6133#issuecomment-1544703701

Fix #13514