### PR TITLE
Check translation sent in installer Windows 11 and Update explorerContextMenuEntryLocal.ini

### DIFF
--- a/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
+++ b/PowerEditor/installer/nativeLang/explorerContextMenuEntryLocal.ini
@@ -38,7 +38,7 @@ Edit_with_Notepad++=Modifica con Notepad++
 Edit_with_Notepad++=Editar com o Notepad++
 
 [brazilian_portuguese.xml]
-Edit_with_Notepad++=Editar com Notepad++
+Edit_with_Notepad++=Editar com o Notepad++
 
 [dutch.xml]
 Edit_with_Notepad++=Edit with Notepad++


### PR DESCRIPTION
Although I use Portuguese from Brazil, I received the Portuguese from Portugal translation, so I added the "O" so that the two translations are the same, but it would be good to check why I didn't receive the Brazilian one!

![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/11423362/5268fde0-ac59-4566-be11-1f3a57f2c311)
