### PR TITLE
Fix C language parser for function list hanging issue

### DIFF
--- a/PowerEditor/installer/functionList/c.xml
+++ b/PowerEditor/installer/functionList/c.xml
@@ -36,7 +36,7 @@
 							)
 							\b
 							\s*
-						)*
+						)
 						(?'DECLARATOR'
 							(?'POINTER'
 								\*


### PR DESCRIPTION
#13663
The fix will make sure there is at least one return type / identifier in front of the function name identifier.
while (isValue(value)) { ... }
isValue(value) would be added to the function list

#12497
It will also stop hanging on long lists of identifiers.