### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.5.4

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
-			  May 7th (v8.5.3), May 24th (v8.5.4)
+			  May 7th (v8.5.3), June 9th (v8.5.4)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -1053,6 +1053,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 					<Item id="6411" name="Linguaghju predefinitu :"/>
 					<Item id="6419" name="Ducumentu novu"/>
 					<Item id="6420" name="Appiecà à i schedarii ANSI aperti"/>
+					<Item id="6432" name="Sempre apre un ducumentu novu di più à u lanciu"/>
 				</NewDoc>
 
 				<DefaultDir title="Cartulare predefinitu">

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-The comments are here for explanation, it's not necessary to translate them.
+Translation note:
+1. Please install XML Tools plugin for formatting your XML translation. Via menu "Plugins -> XML Tools-> Pretty Print" command.
+2. All the comments are for explanation, they are not for translation.
 -->
 <!--
-The latest update of Corsican translation file is available here:
+Additionnal information about Corsican localization:
+
+1. The latest update of Corsican translation file is available here:
 	https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/PowerEditor/installer/nativeLang/corsican.xml
 
-History of Corsican translation for Notepad++
+2. History of Corsican translation for Notepad++:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
-			  May 7th (v8.5.3)
+			  May 7th (v8.5.3), May 21st (v8.5.4)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -23,11 +27,11 @@ History of Corsican translation for Notepad++
 	- Updated in 2017 by Patriccollu di Santa Maria è Sichè: April 30th (v7.3.3), August 19th (v7.5)
 	- Created on September 14th, 2016 for version 6.9.2 by Patriccollu di Santa Maria è Sichè
 
-An additionnal information about Corsican translation for Notepad++ is available here:
+3. An additionnal information about Corsican translation for Notepad++ is available here:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.5.3">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.5.4">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -376,8 +380,8 @@ An additionnal information about Corsican translation for Notepad++ is available
 					<Item id="48018" name="&amp;Mudificà l’ozzioni di u listinu cuntestuale"/>
 					<Item id="48009" name="&amp;Definizione di l’accurtatoghji di tastera…"/>
 					<Item id="48011" name="&amp;Preferenze…"/>
-					<Item id="48014" name="Apre u cartulare di l’estensioni…"/>
-					<Item id="48015" name="Ghjestione di l’estensioni…"/>
+					<Item id="48014" name="Apre u cartulare di i moduli d’estensione…"/>
+					<Item id="48015" name="Ghjestione di i moduli d’estensione…"/>
 					<Item id="48501" name="Ingenerà…"/>
 					<Item id="48502" name="Ingenerà per certi schedarii…"/>
 					<Item id="48503" name="Ingenerà in u preme’papei per a selezzione"/>
@@ -564,16 +568,16 @@ An additionnal information about Corsican translation for Notepad++ is available
 				<Item id="2" name="C&amp;hjode"/>
 			</SHA256FromTextDlg>
 
-			<PluginsAdminDlg title="Ghjestione di l’estensioni" titleAvailable="Dispunibule" titleUpdates="Rinnovi" titleInstalled="Installate" titleIncompatible="Incumpatibile">
-				<ColumnPlugin name="Estensione"/>
+			<PluginsAdminDlg title="Ghjestione di i moduli d’estensione" titleAvailable="Dispunibule" titleUpdates="Rinnovi" titleInstalled="Installati" titleIncompatible="Incumpatibile">
+				<ColumnPlugin name="Moduli d’estensione"/>
 				<ColumnVersion name="Versione"/>
-				<Item id="5501" name="Circà :"/>
-				<Item id="5503" name="Installà"/>
-				<Item id="5504" name="Rinnovà"/>
-				<Item id="5505" name="Caccià"/>
-				<Item id="5508" name="Seguente"/>
-				<Item id="5509" name="Versione di u modulu di lista di l’estensioni : "/>
-				<Item id="5511" name="Dipositu di u modulu di lista di l’estensioni"/>
+				<Item id="5501" name="&amp;Circà :"/>
+				<Item id="5503" name="&amp;Installà"/>
+				<Item id="5504" name="&amp;Rinnovà"/>
+				<Item id="5505" name="C&amp;accià"/>
+				<Item id="5508" name="&amp;Seguente"/>
+				<Item id="5509" name="Versione di a lista di moduli :"/>
+				<Item id="5511" name="Dipositu di a lista di i moduli"/>
 				<Item id="2" name="Chjode"/>
 			</PluginsAdminDlg>
 
@@ -750,7 +754,7 @@ An additionnal information about Corsican translation for Notepad++ is available
 				<Item id="20003" name="Creà novu…"/>
 				<Item id="20004" name="Caccià"/>
 				<Item id="20005" name="Arregistrà cù n…"/>
-				<Item id="20007" name="Linguaghju : "/>
+				<Item id="20007" name="Linguaghju"/>
 				<Item id="20009" name="Est. :"/>
 				<Item id="20012" name="Rispettà MAIU/minu"/>
 				<Item id="20011" name="Trasparenza"/>
@@ -758,7 +762,7 @@ An additionnal information about Corsican translation for Notepad++ is available
 				<Item id="20016" name="Espurtà…"/>
 				<Item id="20017" name="Staccà"/>
 				<StylerDialog title="Dialogu di u stilu">
-					<Item id="25030" name="Ozzioni di grafia :"/>
+					<Item id="25030" name="Ozzioni di grafia"/>
 					<Item id="25006" name="Culore di primu pianu"/>
 					<Item id="25007" name="Culore di fondu"/>
 					<Item id="25031" name="Nome :"/>
@@ -766,7 +770,7 @@ An additionnal information about Corsican translation for Notepad++ is available
 					<Item id="25001" name="Grassu"/>
 					<Item id="25002" name="Italicu"/>
 					<Item id="25003" name="Sottulineatu"/>
-					<Item id="25029" name="Incastramentu :"/>
+					<Item id="25029" name="Incastramentu"/>
 					<Item id="25008" name="Delimitatore 1"/>
 					<Item id="25009" name="Delimitatore 2"/>
 					<Item id="25010" name="Delimitatore 3"/>
@@ -796,20 +800,20 @@ An additionnal information about Corsican translation for Notepad++ is available
 				<Folder title="Stilu di piegatura è predefinizione">
 					<Item id="21101" name="Stilu predefinitu"/>
 					<Item id="21102" name="Stilu"/>
-					<Item id="21105" name="Documentazione :"/>
+					<Item id="21105" name="Documentazione"/>
 					<Item id="21104" name="Situ timpurariu di documentazione :"/>
 					<Item id="21106" name="Piegatura &amp;cumpatta (piegà linee viote dinù)"/>
-					<Item id="21220" name="Stilu 1 di piegatura di codice :"/>
+					<Item id="21220" name="Stilu 1 di piegatura di codice"/>
 					<Item id="21224" name="Apertura :"/>
 					<Item id="21225" name="Mezu :"/>
 					<Item id="21226" name="Chjusura :"/>
 					<Item id="21227" name="Stilu"/>
-					<Item id="21320" name="Stilu 2 di piegatura di codice (separadori richiesti) :"/>
+					<Item id="21320" name="Stilu 2 di piegatura di codice (separadori richiesti)"/>
 					<Item id="21324" name="Apertura :"/>
 					<Item id="21325" name="Mezu :"/>
 					<Item id="21326" name="Chjusura :"/>
 					<Item id="21327" name="Stilu"/>
-					<Item id="21420" name="Stilu di piegatura di cummentu :"/>
+					<Item id="21420" name="Stilu di piegatura di cummentu"/>
 					<Item id="21424" name="Apertura :"/>
 					<Item id="21425" name="Mezu :"/>
 					<Item id="21426" name="Chjusura :"/>
@@ -1034,7 +1038,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 					<Item id="6212" name="Senza distrazzione"/>
 				</MarginsBorderEdge>
 
-				<NewDoc title="Novu ducumentu">
+				<NewDoc title="Ducumentu novu">
 					<Item id="6401" name="Furmatu (fine di linea)"/>
 					<Item id="6402" name="Windows (CR LF)"/>
 					<Item id="6403" name="Unix (LF)"/>
@@ -1046,7 +1050,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 					<Item id="6409" name="UTF-16 Big Endian cù BOM"/>
 					<Item id="6410" name="UTF-16 Little Endian cù BOM"/>
 					<Item id="6411" name="Linguaghju predefinitu :"/>
-					<Item id="6419" name="Novu ducumentu"/>
+					<Item id="6419" name="Ducumentu novu"/>
 					<Item id="6420" name="Appiecà à i schedarii ANSI aperti"/>
 				</NewDoc>
 
@@ -1302,7 +1306,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 			<ColumnEditor title="Mudificazione in modu culonna">
 				<Item id="2023" name="&amp;Testu à framette"/>
 				<Item id="2033" name="&amp;Numeru à framette"/>
-				<Item id="2030" name="Numeru di &amp;principiu :"/>
+				<Item id="2030" name="Numeru &amp;iniziale :"/>
 				<Item id="2031" name="&amp;Cresce da :"/>
 				<Item id="2038" name="D&amp;avanti :"/>
 				<ComboBox id="2039">
@@ -1323,7 +1327,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 				<Item id="1" name="Circalle tutte"/>
 				<Item id="2" name="Chjode"/>
 				<Item id="1711" name="&amp;Cosa à circà :"/>
-				<Item id="1713" name="Circà solu in e linee truvate"/>
+				<Item id="1713" name="Circà solu in e linee &amp;truvate"/>
 				<Item id="1714" name="&amp;Parolla sana deve currisponde"/>
 				<Item id="1715" name="Rispettà &amp;Maiuscule è minuscule"/>
 				<Item id="1716" name="Modu di ricerca"/>
@@ -1436,7 +1440,7 @@ Ci vole à caccià a so radica da u pannellu nanzu d’aghjunghje u cartulare «
 			<ProjectPanelSaveError title="$STR_REPLACE$" message="Un sbagliu hè accadutu à a scrittura di u schedariu di u spaziu di travagliu.
 U vostru spaziu di travagliu ùn hè micca statu arregistratu."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 			<ProjectPanelOpenDoSaveDirtyWsOrNot title="Apre u spaziu di travagliu" message="U spaziu di travagliu attuale hè statu mudificatu. Vulete arregistrà u prughjettu attuale ?"/>
-			<ProjectPanelNewDoSaveDirtyWsOrNot title="Novu spaziu di travagliu" message="U spaziu di travagliu attuale hè statu mudificatu. Vulete arregistrà u prughjettu attuale ?"/>
+			<ProjectPanelNewDoSaveDirtyWsOrNot title="Spaziu novu di travagliu" message="U spaziu di travagliu attuale hè statu mudificatu. Vulete arregistrà u prughjettu attuale ?"/>
 			<ProjectPanelOpenFailed title="Apre u spaziu di travagliu" message="U spaziu di travagliu ùn pò micca esse apertu.
 Pare chì u schedariu à apre ùn hè micca un schedariu di prughjettu accettevule."/>
 			<ProjectPanelRemoveFolderFromProject title="Caccià u cartulare da u prughjettu" message="Tutti i sottu-elementi seranu cacciati.
@@ -1540,7 +1544,7 @@ Rinuminendu « shortcuts.xml.v8.5.2.backup » in « shortcuts.xml », e vost
 					<Item id="1" name="Mudificà"/>
 				</Entries>
 				<WorkspaceMenu>
-					<Item id="3122" name="Novu spaziu di travagliu"/>
+					<Item id="3122" name="Spaziu novu di travagliu"/>
 					<Item id="3123" name="Apre u spaziu di travagliu"/>
 					<Item id="3124" name="Ricaricà u spaziu di travagliu"/>
 					<Item id="3125" name="Arregistrà"/>
@@ -1652,9 +1656,9 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
 			<finder-wrap-long-lines value="Ritornu autumaticu à a linea per e linee longhe"/>
 			<common-ok value="Vai"/>
 			<common-cancel value="Abbandunà"/>
-			<common-name value="Nome : "/>
+			<common-name value="Nome"/>
 			<tabrename-title value="Rinuminà l’unghjetta attuale"/>
-			<tabrename-newname value="Novu nome : "/>
+			<tabrename-newname value="Nome novu"/>
 			<splitter-rotate-left value="Girà à manca"/>
 			<splitter-rotate-right value="Girà à diritta"/>
 			<userdefined-title-new value="Creà un novu linguaghju…"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -1148,7 +1148,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 
 				<RecentFilesHistory title="Schedarii recenti">
 					<Item id="6304" name="Cronolugia di i schedarii recenti"/>
-                    <Item id="6306" name="Numeru massimu d’elementi :"/>
+					<Item id="6306" name="Numeru massimu d’elementi :"/>
 					<Item id="6305" name="Ùn verificà micca à u lanciu"/>
 					<Item id="6429" name="Affissera"/>
 					<Item id="6424" name="In sottulistinu"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
-			  May 7th (v8.5.3), May 21st (v8.5.4)
+			  May 7th (v8.5.3), May 22nd (v8.5.4)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -720,8 +720,8 @@ Additionnal information about Corsican localization:
 					<Item id="44105" name="Passà à u pannellu di prughjettu 2"/>
 					<Item id="44106" name="Passà à u pannellu di prughjettu 3"/>
 					<Item id="44107" name="Passà à u cartulare cum’è spaziu di travagliu"/>
-					<Item id="44108" name="Passà à a lista di e funzioni"/>
 					<Item id="44109" name="Passà à a lista di i ducumenti"/>
+					<Item id="44108" name="Passà à a lista di e funzioni"/>
 					<Item id="44110" name="Caccià u culore da l’unghjetta"/>
 					<Item id="44111" name="Appiecà u culore 1 à l’unghjetta"/>
 					<Item id="44112" name="Appiecà u culore 2 à l’unghjetta"/>
@@ -936,21 +936,22 @@ Additionnal information about Corsican localization:
 					<Item id="6108" name="Bluccà (senza sguillà é depone)"/>
 					<Item id="6109" name="Abbughjà l’unghjette inattive"/>
 					<Item id="6110" name="Barra culurita nant’à l’unghjetta attiva"/>
-
-					<Item id="6111" name="Affissà a barra di statu"/>
 					<Item id="6112" name="Buttonu di chjusura per ogni unghjetta"/>
 					<Item id="6113" name="Doppiu-cliccu per chjode u ducumentu"/>
 					<Item id="6118" name="Piattà"/>
 					<Item id="6119" name="Multi-linea"/>
 					<Item id="6120" name="Verticale"/>
 					<Item id="6121" name="Esce quandu l’ultima unghjetta si chjode"/>
+					<Item id="6128" name="Icone alternative"/>
+					
+					<Item id="6133" name="Barra di statu"/>
+					<Item id="6134" name="Piattà"/>
 
 					<Item id="6131" name="Listinu"/>
 					<Item id="6122" name="Piattà a barra di listinu (impiegà Alt o F10 per attivà o disattivà)"/>
 					<Item id="6132" name="Piattà l’accurtatoghji diritti ＋ ▼ ✕ da a barra di listinu (Richiede di rilancià Notepad++)"/>
-					<Item id="6123" name="Lingua"/>
 
-					<Item id="6128" name="Icone alternative"/>
+					<Item id="6123" name="Lingua"/>
 				</Global>
 				<Scintillas title="Mudificazione">
 					<Item id="6216" name="Preferenze di cursore"/>
@@ -1147,6 +1148,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 
 				<RecentFilesHistory title="Schedarii recenti">
 					<Item id="6304" name="Cronolugia di i schedarii recenti"/>
+                    <Item id="6306" name="Numeru massimu d’elementi :"/>
 					<Item id="6305" name="Ùn verificà micca à u lanciu"/>
 					<Item id="6429" name="Affissera"/>
 					<Item id="6424" name="In sottulistinu"/>
@@ -1202,7 +1204,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 					<Item id="6155" name="* A mudificazione di sta preferenza richiede di rilancià Notepad++"/>
 					<Item id="6171" name="Persunalizazione d’inserzione di a data è l’ora"/>
 					<Item id="6175" name="Invertisce l’ordine predefinitu di a data è l’ora (furmatu cortu è longu)"/>
-					<Item id="6172" name="persunalizatu :"/>
+					<Item id="6172" name="Furmatu persunalizatu :"/>
 					<Item id="6181" name="Statu di u pannellu è [-nosession] *"/>
 					<Item id="6182" name="Arricurdassi di u statu di u pannellu (pannellu hè apertu) in d’altre istanze (modu multi-finestra) o quandu s’impiega u parametru di linea di cumanda [-nosession]"/>
 					<Item id="6183" name="Cronolugia di u preme’papei"/>
@@ -1385,14 +1387,17 @@ Ci vole à attivà l’ozzione « À u depone d’un cartulare, apre tutti i sc
 			<SortingError title="Sbagliu di classificazione" message="Impussibule di fà una classificazione numerica per via di a linea $INT_REPLACE$."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 			<ColumnModeTip title="Minichichja di modu culonna" message="
 Ci hè 3 manere di passà à u modu di selezzione da a culonna :
+
 1. (Tastera è topu)  Mantene u tastu Alt quandu si trascineghja cù un cliccu mancu
+
 2. (Tastera solu)  Mantene i tasti Alt+Maius quandu s’impiegheghja e fleccie
+
 3. (Tastera o topu)
       Piazzà a barra d’inserzione à u locu di principiu sceltu per
 	   a pusizione di u bloccu di culonna, eppò lancià a cumanda
        « Principiu è fine di a selezzione in modu di culonna » ;
       Dispiazzà a barra d’inserzione à u locu di fine sceltu per
-	   a pusizione di u bloccu di culonna, eppò lancià a cumanda
+	   a pusizione di u bloccu di culonna, eppò lancià torna a cumanda
        « Principiu è fine di a selezzione in modu di culonna »"/>
 			<BufferInvalidWarning title="Arregistramentu fiascatu" message="Ùn si pò micca arregistrà : U stampone hè inaccetevule."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 			<DoCloseOrNot title="Cunservà u schedariu inesistente" message="U schedariu « $STR_REPLACE$ » ùn esiste più.

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
-			  May 7th (v8.5.3), May 22nd (v8.5.4)
+			  May 7th (v8.5.3), May 24th (v8.5.4)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -1353,7 +1353,7 @@ Sciglite « Sempre sì » s’è ùn vulete più risponde à sta dumanda.
 Pudete attivà torna st’ozzione in u dialogu di e preferenze."/>
 				<Item id="6" name="&amp;Sì"/>
 				<Item id="7" name="&amp;Nò"/>
-				<Item id="4" name="Sempre sì"/>
+				<Item id="4" name="S&amp;empre sì"/>
 			</DoSaveAll><!-- HowToReproduce: Check the 'Enable Save All confirm dialog' checkbox in Preference->MISC, now click 'Save all' -->
 		</Dialog>
 		<MessageBox>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/052626ca99bc5ec0f81d380491f147b292f6d145 User Define dlgs
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/3c15ff5783de1d2d9e0f73be8209b557d7aa6fe2 [xml] Make all the localization files pretty printed
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/4e0f50416de10093bf9ebd60309919d967469278 GUI Enhancement: Plugins Admin dialog
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/af8b339296737256de19b4be73f6b9a7a8b161bc GUI enhancement: Find in Finder dialog
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/41af936855940ac1014100824470266630a0ba53 GUI Enhancement: Column Editor

Updated on May 22<sup>nd</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/a1d7db8049ce89bd537d4ca769af8d7f10feee45 GUI Enhancement: General & Editing sections in Preferences dialog

Updated on May 24<sup>th</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/1806b8994b2bcad849765661880138934d712a21 GUIEnhancement: About, Debug, Save dialogs

Updated on June 9<sup>th</sup> for this commit:
  * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/61503a2dcd6b208e266d57efff4575c0195d8adf Add "open new blank document in addition on startup" ability

I also updated a couple of strings regarding Plugin List.

Cheers,
Patriccollu.