### PR TITLE
Set dpiAwareness to PerMonitorV2 through manifest file

### DIFF
--- a/PowerEditor/src/dpiAware.manifest
+++ b/PowerEditor/src/dpiAware.manifest
@@ -1,9 +1,9 @@
-<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:windowsSettings
-         xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>


### PR DESCRIPTION
Proposal to fix #6284 (and several other DPI-related issues).
DPI Awareness level set on manifest file as PerMonitorV2.
For Windows < 10 (more generally, Windows where dpiAwareness is not available), dpiAware directive will be used, as per Microsoft documentation https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process
Tested on Windows 11 with dual monitor: main with scale 125%, second with scale 100%
