### PR TITLE
Add latest support version for Windows 95/98/ME/NT4

### DIFF
--- a/SUPPORTED_SYSTEM.md
+++ b/SUPPORTED_SYSTEM.md
@@ -7,11 +7,11 @@
 
 |           OS            | can be run (version can be run)  |      supported            |
 |-------------------------|----------------------------------|---------------------------|
-| **Windows 95**          | NO (unknown)                     |          NO               |
-| **Windows 98**          | NO (unknown)                     |          NO               |
-| **Windows ME**          | NO (unknown)                     |          NO               |
-| **Windows NT**          | NO (unknown)                     |          NO               |
-| **Windows 2000**        | NO (v6.6.9 & previous versions)  |          NO               |
+| **Windows 95**          | NO (v3.9 & previous versions)    |          NO               |
+| **Windows 98**          | NO (v6.0\*\* & previous versions) |         NO               |
+| **Windows ME**          | NO (v6.0\*\* & previous versions) |         NO               |
+| **Windows NT 4.0**      | NO (v4.7.3\*\* & previous versions) |       NO               |
+| **Windows 2000**        | NO (v6.6.9\*\* & previous versions) |       NO               |
 | **Windows XP**          | NO (v7.9.2 & previous versions)  |          NO               |
 | **Windows Server 2003** | NO (v7.9.2 & previous versions)  |          NO               |
 | **Windows Vista**       | NO\* (v8.4.6 & previous versions)|          NO               |
@@ -22,6 +22,8 @@
 | **Windows 10**          | YES                              |          YES              |
 | **Windows 11**          | YES                              |          YES              |
 
-\* The current version of Notepad++ built by GCC can be run under Vista & Server 2008 
+\* The current version of Notepad++ built by GCC can be run under Vista & Server 2008
+
+\*\* You need to disable unworking plugins.
 
 *Note that the list is meant for the last SP of each version*


### PR DESCRIPTION
With searching in Google and trying to run several official unmodified verions of Notepad++ in virtual machines. Notepad++ come with several plugins enabled, which may stop working before Notepad++ version. Please attention that, the installed version of Internet Explorer may affect other software, which I did not test. The following is what I get.


For Windows 95, refer to these links:

http://www.win3x.org/win3board/viewtopic.php?t=17221

https://notepad-plus-plus.narkive.com/6lktixGR/notepad-plus-help-notepad-v4-0-does-not-work-on-win95

I've confirmed that Notepad++ 3.9 runs on Windows 95 RTM/OSR 2.5, and Notepad++ 4.0.1 doesn't (4.0 not found, but I think there's only minor changes). So Notepad++ 3.9 is the latest version for Windows 95.


For Windows NT 4.0, nothing found when searching.

I've confirmed that Notepad++ 4.6 runs on Windows NT 4.0 SP6, and Notepad++ 4.7.1/4.7.2/4.7.3 runs with error of plugin, and Notepad++ 4.7.5 doesn't work. So Notpad++ 4.7.3 is the latest for Windows NT 4 with plugins disabled.


For Windows 98/ME, refer to these links:

http://web.archive.org/web/20110709191226/http://notepad-plus-plus.org/news/notepad-5.9.1-release-is-available.html

https://msfn.org/board/topic/105936-last-versions-of-software-for-windows-98se/page/68/#comment-1176861

I've confirmed that Notepad++ 5.9.6.2 (ANSI) runs Windows 98 SE/ME, and Notepad++ 5.9.8/6.0 (ANSI) runs with error of plugin, and Notepad++ 6.1 doesn't work because no ANSI version available. So Notepad++ 6.0 (ANSI) is the latest for Windows 98/ME with plugins disabled.


For Windows 2000, I've confirmed that Notepad++ 6.5 runs on Windows 2000 SP4, and Notepad++ 6.6/6.6.9 with default plugins runs with error, and Notepad++ 6.7 doesn't work. So Notepad++ 6.6.9 is the latest for Windows 2000 with plugins disabled.