### PR TITLE
Add session.xml.fail2Load for analyzing

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3596,6 +3596,10 @@ void NppParameters::writeSession(const Session & session, const TCHAR *fileName)
 				TEXT("The old session file will be restored."),
 				TEXT("Error of saving session file"),
 				MB_OK | MB_APPLMODAL | MB_ICONWARNING);
+
+			wstring sessionPathNameFail2Load = sessionPathName;
+			sessionPathNameFail2Load += L".fail2Load";
+			MoveFileEx(sessionPathName, sessionPathNameFail2Load.c_str(), MOVEFILE_REPLACE_EXISTING);
 			CopyFile(backupPathName, sessionPathName, FALSE);
 		}
 	}


### PR DESCRIPTION
When session.xml is written while Notepad++ exit, it'll be load for checking if it's an valid xml file. If not, then it will be replaced by the old session file (if any).

This commit renames session.xml to session.xml.fail2Load so in case of the situation user can provide session.xml.fail2Load to devs for analyzing.

ref: #13694