### PR TITLE
Add ability to select multiple files to close without saving in Document list

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -246,6 +246,24 @@ void Notepad_plus::command(int id)
 			}
 			break;
 
+		case IDM_DOCLIST_FILESCLOSENOSAVE:
+		case IDM_DOCLIST_FILESCLOSEOTHERSNOSAVE:
+			if (_pDocumentListPanel)
+			{
+				vector<SwitcherFileInfo> files = _pDocumentListPanel->getSelectedFiles(id == IDM_DOCLIST_FILESCLOSEOTHERSNOSAVE);
+				for (size_t i = 0, len = files.size(); i < len; ++i)
+				{
+					bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
+					doClose(files[i]._bufID, files[i]._iView, isSnapshotMode);
+				}
+				if (id == IDM_DOCLIST_FILESCLOSEOTHERS)
+				{
+					// Get current buffer and its view
+					_pDocumentListPanel->activateItem(_pEditView->getCurrentBufferID(), currentView());
+				}
+			}
+			break;
+
 		case IDM_DOCLIST_COPYNAMES:
 		case IDM_DOCLIST_COPYPATHS:
 			if (_pDocumentListPanel)

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -982,18 +982,15 @@ bool Notepad_plus::fileClose(BufferID id, int curView)
 		bufferID = _pEditView->getCurrentBufferID();
 	Buffer * buf = MainFileManager.getBufferByID(bufferID);
 
-	int res;
-
-	//process the fileNamePath into LRF
-	const TCHAR *fileNamePath = buf->getFullPathName();
-
 	if (buf->isUntitled() && buf->docLength() == 0)
 	{
 		// Do nothing
 	}
 	else if (buf->isDirty())
 	{
-		res = doSaveOrNot(fileNamePath);
+		const TCHAR* fileNamePath = buf->getFullPathName();
+		int res = doSaveOrNot(fileNamePath);
+
 		if (res == IDYES)
 		{
 			if (!fileSave(id)) // the cancel button of savedialog is pressed, aborts closing

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -494,8 +494,10 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					if (!_fileSwitcherMultiFilePopupMenu.isCreated())
 					{
 						vector<MenuItemUnit> itemUnitArray;
-						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSE, TEXT("Close Selected files")));
-						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSEOTHERS, TEXT("Close Other files")));
+						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSE, TEXT("Close Selected Files")));
+						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSENOSAVE, TEXT("Close Selected Files Without Saving")));
+						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSEOTHERS, TEXT("Close Other Files")));
+						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_FILESCLOSEOTHERSNOSAVE, TEXT("Close Other Files Without Saving")));
 						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_COPYNAMES, TEXT("Copy Selected Names")));
 						itemUnitArray.push_back(MenuItemUnit(IDM_DOCLIST_COPYPATHS, TEXT("Copy Selected Pathnames")));
 

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -256,6 +256,8 @@
     #define    IDM_DOCLIST_FILESCLOSEOTHERS       (IDM_MISC + 2)
     #define    IDM_DOCLIST_COPYNAMES              (IDM_MISC + 3)
     #define    IDM_DOCLIST_COPYPATHS              (IDM_MISC + 4)
+    #define    IDM_DOCLIST_FILESCLOSENOSAVE       (IDM_MISC + 5)
+    #define    IDM_DOCLIST_FILESCLOSEOTHERSNOSAVE (IDM_MISC + 6)
 
 
 #define IDM_VIEW    (IDM + 4000)                


### PR DESCRIPTION
The 2 commands "Close Selected Files Without Saving" & "Close Other Files Without Saving" (via context menu) get user's confirmation only once then close all selected (or unselected) files without saving files.

Fix #13178