### PR TITLE
Fix ignored writeStr return value in TiXmlDocument::SaveFile

### DIFF
--- a/PowerEditor/src/TinyXml/tinyxml.cpp
+++ b/PowerEditor/src/TinyXml/tinyxml.cpp
@@ -784,8 +784,7 @@ bool TiXmlDocument::SaveFile( const TCHAR * filename ) const
 		std::unique_ptr<std::string> outputStr = std::make_unique<std::string>();
 		Print(*outputStr, 0);
 		if (!outputStr->empty())
-			file.writeStr(*outputStr);
-		return true;
+			return file.writeStr(*outputStr);
 	}
 
 	return false;


### PR DESCRIPTION
@donho 

When I analyzed the file saving way for the #13514 I have found a common problem in the N++ code but forgot to report it.

The [TiXmlDocument::SaveFile](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/28594daef3440b1e791cb03c9f7c507a74c54813/PowerEditor/src/TinyXml/tinyxml.cpp#L788) could return incorrectly `true` even when the underlying [writeStr func](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/28594daef3440b1e791cb03c9f7c507a74c54813/PowerEditor/src/TinyXml/tinyxml.cpp#LL787C4-L787C4) failed. This can have unexpected results, e.g. in your commit https://github.com/donho/notepad-plus-plus/commit/45148fef5bd518f3ff071f35862ceeb12eb356a3 where you are testing the `sessionSaveOK`.

I am sorry, but currentIy I cannot test this simple patch myself, I am using the Github web interface only.