### PR TITLE
Remember each individual show characters setting after toggling "Show All Characters" OFF

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2398,8 +2398,6 @@ void Notepad_plus::command(int id)
 		case IDM_VIEW_ALL_CHARACTERS:
 		{
 			const bool isChecked = !(::GetMenuState(_mainMenuHandle, id, MF_BYCOMMAND) == MF_CHECKED);
-			checkMenuItem(id, isChecked);
-			_toolBar.setCheck(id, isChecked);
 			
 			auto& svp1 = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
 			// when checking box, show all char types
@@ -2408,11 +2406,13 @@ void Notepad_plus::command(int id)
 			bool eolShow = isChecked || svp1._previousEolShow;
 			bool npcShow = isChecked || svp1._previousNpcShow;
 			bool ccUniEolShow = isChecked || svp1._previousCcUniEolShow;
+			bool allChecked = whiteSpaceShow && eolShow && npcShow && ccUniEolShow;
 			checkMenuItem(IDM_VIEW_TAB_SPACE, whiteSpaceShow);
 			checkMenuItem(IDM_VIEW_EOL, eolShow);
 			checkMenuItem(IDM_VIEW_NPC, npcShow);
 			checkMenuItem(IDM_VIEW_NPC_CCUNIEOL, ccUniEolShow);
-
+			checkMenuItem(id, allChecked);
+			_toolBar.setCheck(id, allChecked);
 
 			svp1._whiteSpaceShow = whiteSpaceShow;
 			svp1._eolShow = eolShow;

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2321,6 +2321,7 @@ void Notepad_plus::command(int id)
 
 			auto& svp1 = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
 			svp1._whiteSpaceShow = isChecked;
+			svp1.updatePreviousSettings();
 
 			const bool allChecked = svp1._whiteSpaceShow && svp1._eolShow && svp1._npcShow && svp1._ccUniEolShow;
 
@@ -2340,6 +2341,7 @@ void Notepad_plus::command(int id)
 
 			auto& svp1 = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
 			svp1._eolShow = isChecked;
+			svp1.updatePreviousSettings();
 
 			const bool allChecked = svp1._whiteSpaceShow && svp1._eolShow && svp1._npcShow && svp1._ccUniEolShow;
 
@@ -2356,6 +2358,7 @@ void Notepad_plus::command(int id)
 
 			auto& svp1 = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
 			svp1._npcShow = isChecked;
+			svp1.updatePreviousSettings();
 
 			// setNpcAndCcUniEOL() in showNpc() uses svp1._npcShow
 			_mainEditView.showNpc(isChecked);
@@ -2378,6 +2381,7 @@ void Notepad_plus::command(int id)
 
 			auto& svp1 = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
 			svp1._ccUniEolShow = isChecked;
+			svp1.updatePreviousSettings();
 
 			// setNpcAndCcUniEOL() in showCcUniEol() uses svp1._ccUniEolShow
 			_mainEditView.showCcUniEol(isChecked);
@@ -2395,21 +2399,28 @@ void Notepad_plus::command(int id)
 		{
 			const bool isChecked = !(::GetMenuState(_mainMenuHandle, id, MF_BYCOMMAND) == MF_CHECKED);
 			checkMenuItem(id, isChecked);
-			checkMenuItem(IDM_VIEW_TAB_SPACE, isChecked);
-			checkMenuItem(IDM_VIEW_EOL, isChecked);
-			checkMenuItem(IDM_VIEW_NPC, isChecked);
-			checkMenuItem(IDM_VIEW_NPC_CCUNIEOL, isChecked);
 			_toolBar.setCheck(id, isChecked);
-
+			
 			auto& svp1 = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
+			// when checking box, show all char types
+			// when unchecking box, show whatever char types were showed before the box was checked
+			bool whiteSpaceShow = isChecked || svp1._previousWhiteSpaceShow;
+			bool eolShow = isChecked || svp1._previousEolShow;
+			bool npcShow = isChecked || svp1._previousNpcShow;
+			bool ccUniEolShow = isChecked || svp1._previousCcUniEolShow;
+			checkMenuItem(IDM_VIEW_TAB_SPACE, whiteSpaceShow);
+			checkMenuItem(IDM_VIEW_EOL, eolShow);
+			checkMenuItem(IDM_VIEW_NPC, npcShow);
+			checkMenuItem(IDM_VIEW_NPC_CCUNIEOL, ccUniEolShow);
 
-			svp1._whiteSpaceShow = isChecked;
-			svp1._eolShow = isChecked;
-			svp1._npcShow = isChecked;
-			svp1._ccUniEolShow = isChecked;
 
-			_mainEditView.showInvisibleChars(isChecked);
-			_subEditView.showInvisibleChars(isChecked);
+			svp1._whiteSpaceShow = whiteSpaceShow;
+			svp1._eolShow = eolShow;
+			svp1._npcShow = npcShow;
+			svp1._ccUniEolShow = ccUniEolShow;
+
+			_mainEditView.showInvisibleChars(npcShow, ccUniEolShow, whiteSpaceShow, eolShow);
+			_subEditView.showInvisibleChars(npcShow, ccUniEolShow, whiteSpaceShow, eolShow);
 
 			_findReplaceDlg.updateFinderScintillaForNpc();
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -947,15 +947,19 @@ struct ScintillaViewParams
 	intptr_t _zoom = 0;
 	intptr_t _zoom2 = 0;
 	bool _whiteSpaceShow = false;
+	bool _previousWhiteSpaceShow = false;
 	bool _eolShow = false;
+	bool _previousEolShow = false;
 	enum crlfMode {plainText = 0, roundedRectangleText = 1, plainTextCustomColor = 2, roundedRectangleTextCustomColor = 3};
 	crlfMode _eolMode = roundedRectangleText;
 	bool _npcShow = false;
+	bool _previousNpcShow = false;
 	enum npcMode { identity = 0, abbreviation = 1, codepoint = 2 };
 	npcMode _npcMode = abbreviation;
 	bool _npcCustomColor = false;
 	bool _npcIncludeCcUniEol = false;
 	bool _ccUniEolShow = true;
+	bool _previousCcUniEolShow = true;
 
 	int _borderWidth = 2;
 	bool _virtualSpace = false;
@@ -980,6 +984,13 @@ struct ScintillaViewParams
 			paddingLen = editViewWidth / defaultDiviser;
 		return paddingLen;
 	};
+
+	void updatePreviousSettings() {
+		_previousCcUniEolShow = _ccUniEolShow;
+		_previousEolShow = _eolShow;
+		_previousNpcShow = _npcShow;
+		_previousWhiteSpaceShow = _whiteSpaceShow;
+	}
 };
 
 const int NB_LIST = 20;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -526,11 +526,11 @@ public:
 		return svp._ccUniEolShow;
 	};
 
-	void showInvisibleChars(bool willBeShowed = true) {
-		showNpc(willBeShowed);
-		showCcUniEol(willBeShowed);
-		showWSAndTab(willBeShowed);
-		showEOL(willBeShowed);
+	void showInvisibleChars(bool npc, bool ccUniEol, bool whiteSpace, bool eol) {
+		showNpc(npc);
+		showCcUniEol(ccUniEol);
+		showWSAndTab(whiteSpace);
+		showEOL(eol);
 	};
 
 	//bool isShownInvisibleChars() {


### PR DESCRIPTION
Would address #13734

When the user selects "Show all characters", their previous character showing settings (e.g., show nonprinting and control chars but not EOL or whitespace) will be saved so that when they toggle "Show all characters" OFF it reverts to their previous settings.

TO TEST:
1. Add this text to a document (UTF-8 bytes are `[0xc2, 0xa0, 0x20, 0x9, 0x5, 0xd, 0xa]`):
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/46202915/60633fd6-acbf-4bd0-9f4a-eb0192a1841d)
2. Turn on "Show all characters"
3. Turn off "Show non-printing characters" so that the `NBSP` is no longer visible.
4. Turn on "Show all characters"
5. Turn off "Show all characters" again.
RESULT: You should now be able to see all characters except the `NBSP` at the beginning.