### PR TITLE
Korean IME append extension issue 

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -709,8 +709,8 @@ private:
 	UINT _currentType = 0;  // File type currenly selected in dialog.
 	UINT _lastSelectedType = 0;  // Last selected non-wildcard file type.
 	UINT _wildcardType = 0;  // Wildcard *.* file type index (usually 1).
-	LANGID _keyboardLayoutLanguage;
-	bool _isHangul; // Korean IME specific flag
+	LANGID _keyboardLayoutLanguage = LANG_NEUTRAL;
+	bool _isHangul = false; // Korean IME specific flag
 };
 std::unordered_map<HWND, FileDialogEventHandler*> FileDialogEventHandler::s_handleMap;
 

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -529,10 +529,10 @@ private:
 	{
 		auto hwnd = GetFocus();
 		auto himc = ImmGetContext(hwnd);
-		auto isImeActivated = ImmGetOpenStatus(himc); // return true when CJK IME is in local language input mode
+		auto isLocalInputMode = ImmGetOpenStatus(himc); // return true when CJK IME is in local language input mode
 		ImmReleaseContext(hwnd, himc);
 
-		return (lang == LANG_KOREAN) && isImeActivated;
+		return (lang == LANG_KOREAN) && isLocalInputMode;
 	};
 
 	// Transforms a forward-slash path to a canonical Windows path.

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -252,7 +252,8 @@ public:
 	{
 		_lastUsedFolder = getDialogFolder(dlg);
 
-		// block this function when hangul status for finish letter composition
+		// Ignore OnFileOk() as OnPreFileOk() is not called when in Hangul mode.
+		// check KbdProcHook() for details.
 		if (_isHangul)
 			return S_FALSE;
 
@@ -499,7 +500,6 @@ private:
 		generic_string fileName = getDialogFileName(_dialog);
 		expandEnv(fileName);
 		bool nameChanged = transformPath(fileName);
-
 		// Update the controls.
 		if (!::PathIsDirectory(getAbsPath(fileName).c_str()))
 		{
@@ -654,7 +654,7 @@ private:
 
 					if (it->second->_isHangul)
 					{
-						// hangul mode to alphabet mode
+						// If IME is in Hangul mode, ignore VK_RETURN to complete the composition and change to alphabetical input mode to proceed to onPreFileOk() on the next VK_RETURN.
 						auto himc = ImmGetContext(hwnd);
 						ImmSetConversionStatus(himc, IME_CMODE_ALPHANUMERIC, IME_SMODE_NONE);
 						ImmReleaseContext(hwnd, himc);
@@ -701,7 +701,7 @@ private:
 	UINT _lastSelectedType = 0;  // Last selected non-wildcard file type.
 	UINT _wildcardType = 0;  // Wildcard *.* file type index (usually 1).
 	LANGID _keyboardLayoutLanguage;
-	bool _isHangul; // Korean IME specific
+	bool _isHangul; // Korean IME specific flag
 };
 std::unordered_map<HWND, FileDialogEventHandler*> FileDialogEventHandler::s_handleMap;
 


### PR DESCRIPTION
Related issues
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11582
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12225
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12366

Currently, there is a bug in notepad++'s add extension feature only for Korean input after it was changed to hooking-based in the commit below.
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/b5a5baf13bb3f0b041f49698afb74af2b7059f6a#diff-eeb5624a35a43795da4eb970149a9ce7d22858b678a242affd2357520ea3e9f2R607

### Bug
1. Attempting to save via Enter appends the last character to the extension.
2. Candidate mode is similar, with more varied issues depending on IME.

### Cause
1. the hooking function is executed before the Hangul composition is completed and the last character is added after the extension.
2. Same for Candidate mode.

### Workaround
It is almost impossible to fix issue 2 while maintaining the current Enter hooking
Exiting Candidate Mode can be done by pressing Enter, ESC, number key, or clicking on a candidate character, but there is too much code to cover all of these cases.
In addition, the Windows input framework is fragmented into IMM and TSF, and various IMEs have different implementations, so it is almost impossible to determine the state of Candidate or Hangul composition through IME hooking.
I have seen differences in the events fired by different Windows versions and different IME programs for the same IME behavior.
This PR solves problem 1 and partially solves problem 2 by not saving with Enter when in Hangul mode.

### Changes
When in Candidate/Hangul mode, the user completes the combination with the first Enter, encounters the text with the extension, and must press Enter again to save.
In this case, the same user experience can be achieved by sending one more Enter keystroke in the code section, but I think it's not intuitively understandable for non-Korean developers and I'm not sure this won't cause other problems, so I excluded it.

Now
![ezgif com-gif-maker(3)](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/18587161/eb223e1d-865c-4978-9f8c-e3b40c6d709a)

Now candidate
![notepp_now_candidate](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/18587161/ae0a440d-f474-458f-a387-b7e7751493d4)

Now candidate, Windows' lastest version of Korean IME
![notepp_now_candidate2](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/18587161/55c2470d-498f-4d76-bcb3-28eba765d39c)

This PR
![ezgif com-gif-maker(2)](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/18587161/70ac818f-8c6e-4b70-a60d-48c424b4115f)
If the user enters Enter in Korean IME mode, the user must enter Enter once more to complete the save.

This PR candidate
![ezgif com-gif-maker(1)](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/18587161/7689f051-058c-454c-92cc-f21a602ab37e)
