### PR TITLE
Fix compiling on g++ 13 (#13821)

### DIFF
--- a/PowerEditor/src/MISC/sha1/calc_sha1.cpp
+++ b/PowerEditor/src/MISC/sha1/calc_sha1.cpp
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <cstdint>
 #include "sha1.h"
 #include "calc_sha1.h"
 

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChanges.h
@@ -40,6 +40,7 @@
 #endif
 
 #include <windows.h>
+#include <string>
 #include <vector>
 #include <list>
 

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
@@ -26,6 +26,8 @@
 //	http://qualapps.blogspot.com/2010/05/understanding-readdirectorychangesw.html
 //	See ReadMe.txt for overview information.
 
+#include <string>
+
 class CReadDirectoryChanges;
 
 namespace ReadDirectoryChangesPrivate


### PR DESCRIPTION
Fixes the missing imports of _cstdint_ for _uint8_t_ in _MISC/sha1/calc_sha1.cpp_ and _string_ for _std::wstring_ in  _WinControls/ReadDirectoryChanges/ReadDirectoryChanges{,Private}.h_. See issue #13821 for more details.