### PR TITLE
Fix Change History wrong display after "Reload from Disk" command

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -8656,3 +8656,16 @@ HBITMAP Notepad_plus::generateSolidColourMenuItemIcon(COLORREF colour)
 
 	return hNewBitmap;
 }
+
+
+void Notepad_plus::clearChangesHistory()
+{
+	Sci_Position pos = (Sci_Position)::SendMessage(_pEditView->getHSelf(), SCI_GETCURRENTPOS, 0, 0);
+	int chFlags = (int)::SendMessage(_pEditView->getHSelf(), SCI_GETCHANGEHISTORY, 0, 0);
+
+	SendMessage(_pEditView->getHSelf(), SCI_EMPTYUNDOBUFFER, 0, 0);
+	SendMessage(_pEditView->getHSelf(), SCI_SETCHANGEHISTORY, SC_CHANGE_HISTORY_DISABLED, 0);
+
+	SendMessage(_pEditView->getHSelf(), SCI_SETCHANGEHISTORY, chFlags, 0);
+	SendMessage(_pEditView->getHSelf(), SCI_GOTOPOS, pos, 0);
+}

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -644,4 +644,6 @@ private:
 	void updateCommandShortcuts();
 
 	HBITMAP generateSolidColourMenuItemIcon(COLORREF colour);
+
+	void clearChangesHistory();
 };

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -588,6 +588,10 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	// Once reload is complete, activate buffer which will take care of
 	// many settings such as update status bar, clickable link etc.
 	activateBuffer(id, currentView(), true);
+
+	if (NppParameters::getInstance().getSVP()._isChangeHistoryEnabled4NextSession)
+		clearChangesHistory();
+
 	return res;
 }
 


### PR DESCRIPTION
The code for fixing is from Change Lines plugin:
https://github.com/vinsworldcom/nppChangedLines/blob/main/PluginDefinition.cpp

Fix #12319, fix #12261, fix #13735