### PR TITLE
Remember directory for "remember last used directory" setting across sessions: fix issue 11326 and others

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5735,6 +5735,8 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			{
 				lstrcpyn(_nppGUI._defaultDir, path, MAX_PATH);
 				::ExpandEnvironmentStrings(_nppGUI._defaultDir, _nppGUI._defaultDirExp, MAX_PATH);
+				if (_nppGUI._openSaveDir == dir_last)
+					_currentDirectory = path;
 			}
  		}
 
@@ -7163,7 +7165,10 @@ void NppParameters::createXmlTreeFromGUIParams()
 		TiXmlElement *GUIConfigElement = (newGUIRoot->InsertEndChild(TiXmlElement(TEXT("GUIConfig"))))->ToElement();
 		GUIConfigElement->SetAttribute(TEXT("name"), TEXT("openSaveDir"));
 		GUIConfigElement->SetAttribute(TEXT("value"), _nppGUI._openSaveDir);
-		GUIConfigElement->SetAttribute(TEXT("defaultDirPath"), _nppGUI._defaultDir);
+		const TCHAR* defaultDir = _nppGUI._openSaveDir == dir_last
+			? _currentDirectory.c_str()
+			: _nppGUI._defaultDir;
+		GUIConfigElement->SetAttribute(TEXT("defaultDirPath"), defaultDir);
 	}
 
 	// <GUIConfig name="titleBar" short="no" />

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5735,8 +5735,12 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			{
 				lstrcpyn(_nppGUI._defaultDir, path, MAX_PATH);
 				::ExpandEnvironmentStrings(_nppGUI._defaultDir, _nppGUI._defaultDirExp, MAX_PATH);
-				if (_nppGUI._openSaveDir == dir_last)
-					_currentDirectory = path;
+			}
+
+			const TCHAR* path2 = element->Attribute(TEXT("lastUsedDirPath"));
+			if (path2 && path2[0])
+			{
+				lstrcpyn(_nppGUI._lastUsedDir, path2, MAX_PATH);
 			}
  		}
 
@@ -7165,10 +7169,8 @@ void NppParameters::createXmlTreeFromGUIParams()
 		TiXmlElement *GUIConfigElement = (newGUIRoot->InsertEndChild(TiXmlElement(TEXT("GUIConfig"))))->ToElement();
 		GUIConfigElement->SetAttribute(TEXT("name"), TEXT("openSaveDir"));
 		GUIConfigElement->SetAttribute(TEXT("value"), _nppGUI._openSaveDir);
-		const TCHAR* defaultDir = _nppGUI._openSaveDir == dir_last
-			? _currentDirectory.c_str()
-			: _nppGUI._defaultDir;
-		GUIConfigElement->SetAttribute(TEXT("defaultDirPath"), defaultDir);
+		GUIConfigElement->SetAttribute(TEXT("defaultDirPath"), _nppGUI._defaultDir);
+		GUIConfigElement->SetAttribute(TEXT("lastUsedDirPath"), _nppGUI._lastUsedDir);
 	}
 
 	// <GUIConfig name="titleBar" short="no" />

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1638,7 +1638,7 @@ public:
 	const TCHAR * getPluginRootDir() const { return _pluginRootDir.c_str(); };
 	const TCHAR * getPluginConfDir() const { return _pluginConfDir.c_str(); };
 	const TCHAR * getUserPluginConfDir() const { return _userPluginConfDir.c_str(); };
-	const TCHAR* getWorkingDir() const {return _currentDirectory.c_str();};
+	const TCHAR * getWorkingDir() const {return _currentDirectory.c_str();};
 	const TCHAR * getWorkSpaceFilePath(int i) const {
 		if (i < 0 || i > 2) return nullptr;
 		return _workSpaceFilePathes[i].c_str();

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -888,6 +888,8 @@ struct NppGUI final
 
 	TCHAR _defaultDir[MAX_PATH];
 	TCHAR _defaultDirExp[MAX_PATH];	//expanded environment variables
+	TCHAR _lastUsedDir[MAX_PATH];
+	
 	generic_string _themeName;
 	MultiInstSetting _multiInstSetting = monoInst;
 	bool _clipboardHistoryPanelKeepState = false;
@@ -924,8 +926,6 @@ struct NppGUI final
 	DarkModeConf _darkmode;
 
 	LargeFileRestriction _largeFileRestriction;
-
-	TCHAR _lastUsedDir[MAX_PATH];
 };
 
 
@@ -1638,11 +1638,7 @@ public:
 	const TCHAR * getPluginRootDir() const { return _pluginRootDir.c_str(); };
 	const TCHAR * getPluginConfDir() const { return _pluginConfDir.c_str(); };
 	const TCHAR * getUserPluginConfDir() const { return _userPluginConfDir.c_str(); };
-	const TCHAR* getWorkingDir() const {
-		return _nppGUI._openSaveDir == dir_last
-			? _nppGUI._lastUsedDir
-			: _currentDirectory.c_str();
-	};
+	const TCHAR* getWorkingDir() const { return _currentDirectory.c_str(); };
 	const TCHAR * getWorkSpaceFilePath(int i) const {
 		if (i < 0 || i > 2) return nullptr;
 		return _workSpaceFilePathes[i].c_str();

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1638,7 +1638,7 @@ public:
 	const TCHAR * getPluginRootDir() const { return _pluginRootDir.c_str(); };
 	const TCHAR * getPluginConfDir() const { return _pluginConfDir.c_str(); };
 	const TCHAR * getUserPluginConfDir() const { return _userPluginConfDir.c_str(); };
-	const TCHAR* getWorkingDir() const { return _currentDirectory.c_str(); };
+	const TCHAR* getWorkingDir() const {return _currentDirectory.c_str();};
 	const TCHAR * getWorkSpaceFilePath(int i) const {
 		if (i < 0 || i > 2) return nullptr;
 		return _workSpaceFilePathes[i].c_str();

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -758,6 +758,7 @@ struct NppGUI final
 
 		_defaultDir[0] = 0;
 		_defaultDirExp[0] = 0;
+		_lastUsedDir[0] = 0;
 	}
 
 	toolBarStatusType _toolBarStatus = TB_STANDARD;
@@ -923,6 +924,8 @@ struct NppGUI final
 	DarkModeConf _darkmode;
 
 	LargeFileRestriction _largeFileRestriction;
+
+	TCHAR _lastUsedDir[MAX_PATH];
 };
 
 
@@ -1635,7 +1638,11 @@ public:
 	const TCHAR * getPluginRootDir() const { return _pluginRootDir.c_str(); };
 	const TCHAR * getPluginConfDir() const { return _pluginConfDir.c_str(); };
 	const TCHAR * getUserPluginConfDir() const { return _userPluginConfDir.c_str(); };
-	const TCHAR * getWorkingDir() const {return _currentDirectory.c_str();};
+	const TCHAR* getWorkingDir() const {
+		return _nppGUI._openSaveDir == dir_last
+			? _nppGUI._lastUsedDir
+			: _currentDirectory.c_str();
+	};
 	const TCHAR * getWorkSpaceFilePath(int i) const {
 		if (i < 0 || i > 2) return nullptr;
 		return _workSpaceFilePathes[i].c_str();

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -876,11 +876,12 @@ public:
 			okPressed = SUCCEEDED(hr);
 
 			NppParameters& params = NppParameters::getInstance();
-			if (okPressed && params.getNppGUI()._openSaveDir == dir_last)
+			NppGUI& nppGUI = params.getNppGUI();
+			if (okPressed && nppGUI._openSaveDir == dir_last)
 			{
 				// Note: IFileDialog doesn't modify the current directory.
 				// At least, after it is hidden, the current directory is the same as before it was shown.
-				params.setWorkingDir(_events->getLastUsedFolder().c_str());
+				lstrcpyn(nppGUI._lastUsedDir, _events->getLastUsedFolder().c_str(), MAX_PATH);
 			}
 		}
 

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -882,6 +882,7 @@ public:
 				// Note: IFileDialog doesn't modify the current directory.
 				// At least, after it is hidden, the current directory is the same as before it was shown.
 				lstrcpyn(nppGUI._lastUsedDir, _events->getLastUsedFolder().c_str(), MAX_PATH);
+				params.setWorkingDir(_events->getLastUsedFolder().c_str());
 			}
 		}
 
@@ -988,9 +989,7 @@ CustomFileDialog::CustomFileDialog(HWND hwnd) : _impl{ std::make_unique<Impl>() 
 
 	NppParameters& params = NppParameters::getInstance();
 	NppGUI& nppGUI = params.getNppGUI();
-	const TCHAR* workDir = nppGUI._openSaveDir == dir_last
-		? nppGUI._lastUsedDir
-		: params.getWorkingDir();
+	const TCHAR* workDir = nppGUI._openSaveDir == dir_last ? nppGUI._lastUsedDir : params.getWorkingDir();
 	if (workDir)
 		_impl->_fallbackFolder = workDir;
 }

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -987,7 +987,10 @@ CustomFileDialog::CustomFileDialog(HWND hwnd) : _impl{ std::make_unique<Impl>() 
 	_impl->_hwndOwner = hwnd;
 
 	NppParameters& params = NppParameters::getInstance();
-	const TCHAR* workDir = params.getWorkingDir();
+	NppGUI& nppGUI = params.getNppGUI();
+	const TCHAR* workDir = nppGUI._openSaveDir == dir_last
+		? nppGUI._lastUsedDir
+		: params.getWorkingDir();
 	if (workDir)
 		_impl->_fallbackFolder = workDir;
 }


### PR DESCRIPTION
Would fix #11326
Would fix #10901 
Would fix #4961 
Would fix #4119

Previously config.xml did not remember the last used directory if "Remember last used directory" was chosen for the Default Directory setting. This meant that the last directory used for the `Open`/`Save As`/`Rename` forms was only tracked during the session, and was forgotten when the user quit Notepad++.

### To test:
1. Open a session with files in at least three directories open (call them directories `foo`, `bar`, and `baz`)
2. Set the `Default Directory` setting to `Remember last used directory`
3. Use `Open` to open a file in directory `foo`.
4. Quit Notepad++.
5. Switch to a tab in directory `bar`.
6. Use the `Open`, `Save As`, or `Rename` forms. __The starting directory should be `foo`, because that was the last used directory in the previous session.__
7. *While still staying in the `bar` file,* set the `Default Directory` setting to `baz` using the text box.
8. Verify that the `Open`/`Save As`/`Rename` forms open in directory `baz` *even when the current directory is `bar` or `foo`.*
9. Switch to a tab in directory `bar`.
10. Set the `Default Directory` setting back to `Remember last used directory`.
11. Verify that the `Open`/`Save As`/`Rename` forms open in directory `baz` *because that was the last used directory.*
12. Set the `Default Directory` setting to `Follow current document`.
13. Switch to a tab in directory `foo`.
14. Verify that the `Open`/`Save As`/`Rename` forms all open in directory `foo`.
15. Set the `Default Directory` setting to `Remember last used directory`.
16. Switch to a tab in directory `bar`.
17. Verify that the `Open`/`Save As`/`Rename` forms open in directory `foo` *because that was the last used directory.*
18. Quit Notepad++.
19. Verify that the `Open`/`Save As`/`Rename` forms open in directory `foo` *because that was the last used directory in the previous session.*

### Comments

Arguably it is somewhat undesirable that changing from `Remember last used directory` to `Follow current document` and then back to `Remember last used directory` causes forgetting of the directory that was chosen before the first change, but arguably this makes perfect sense because `Remember last used directory` is doing exactly what it claims to do, and remembering whatever directory was last chosen (whether implicitly or explicitly) by the user.