### PR TITLE
Fix 'Generate MD5 digest from files' 1st dlg show (v855 regression)

### DIFF
--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -245,6 +245,13 @@ void HashFromFilesDlg::doDialog(bool isRTL)
 
 		switch (_ht)
 		{
+			case hash_md5:
+			{
+				title = TEXT("Generate MD5 digest from files");
+				buttonText = TEXT("Choose files to &generate MD5...");
+			}
+			break;
+
 			case hash_sha1:
 			{
 				title = TEXT("Generate SHA-1 digest from files");


### PR DESCRIPTION
@donho 
During testing of my new translation I have found a regression in the new v8.5.5 code. As it is not published yet, I will not create a new issue, ok? It was caused by the previous 'Add SHA-512 hash features' commit https://github.com/notepad-plus-plus/notepad-plus-plus/commit/4ffd897ccf8d30d8dd945c42907e61381c590d08
The [dlg centering code](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/ebdc910dcd7bf0577b8d54f6c6cb0fd2e1f6f703/PowerEditor/src/MISC/md5/md5Dlgs.cpp#L277) needed had been skipped for the 1st time only ...