### PR TITLE
Reuse tooltip for Replace when Find fails with an exception

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -2644,7 +2644,8 @@ bool FindReplaceDlg::processReplace(const TCHAR *txt2find, const TCHAR *txt2repl
 	{
 		NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 		generic_string msg = pNativeSpeaker->getLocalizedStrFromID("find-status-replace-not-found", TEXT("Replace: no occurrence was found."));
-		setStatusbarMessage(msg, FSNotFound);
+		// reuse the tooltip from processFindNext
+		setStatusbarMessage(msg, FSNotFound, ws2s(_statusbarTooltipMsg).data());
 	}
 
 	return moreMatches;


### PR DESCRIPTION
In Find/Replace, when you press Replace and the Find step fails, the statusbar message is overriden with Replace's message. This unfortunately also replaces the tooltip if Find failed with an exception (see #13164). This commit reuses the tooltip, letting users get some more information on the problem, as they might not think about testing Find first.