### PR TITLE
Ignore = at the end of a file name

### DIFF
--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -111,7 +111,7 @@ void parseCommandLine(const TCHAR* commandLine, ParamVector& paramVector)
 		{
 			case '\"': //quoted filename, ignore any following whitespace
 			{
-				if (!isStringInArg && i > 0 && cmdLinePtr[i-1] == '=')
+				if (!isStringInArg && !isInFile && i > 0 && cmdLinePtr[i-1] == '=')
 				{
 					isStringInArg = true;
 				}


### PR DESCRIPTION
Opening a file that ends with '=', with quotes around the filepath, caused an extra quote to remain at the end of the string, as the code would enter the if on line 114, instead of line 133. Further on, the extra quote would be separated into an empty filepath by FileNameStringSplitter, and then opening would fail and present an error dialog (before the error dialog was introduced in #12613, the error would be silently ignored).

This commit prevents the code from entering the arg if (line 114) when it knows it's evaluating a file, and instead it'll go to the file if (line 133) and remove the extra quote.

Fix #13344