### PR TITLE
Fix "Last Used Directory" may not be saved issue

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -773,7 +773,7 @@ struct NppGUI final
 
 	bool _checkHistoryFiles = false;
 
-	RECT _appPos {0, 0, 1500, 1000};
+	RECT _appPos {0, 0, 1024, 700};
 
 	RECT _findWindowPos {};
 	bool _findWindowLessMode = false;

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -877,7 +877,7 @@ public:
 
 			NppParameters& params = NppParameters::getInstance();
 			NppGUI& nppGUI = params.getNppGUI();
-			if (okPressed && nppGUI._openSaveDir == dir_last)
+			if (/*okPressed &&*/ nppGUI._openSaveDir == dir_last)
 			{
 				// Note: IFileDialog doesn't modify the current directory.
 				// At least, after it is hidden, the current directory is the same as before it was shown.

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -877,7 +877,7 @@ public:
 
 			NppParameters& params = NppParameters::getInstance();
 			NppGUI& nppGUI = params.getNppGUI();
-			if (/*okPressed &&*/ nppGUI._openSaveDir == dir_last)
+			if (nppGUI._openSaveDir == dir_last)
 			{
 				// Note: IFileDialog doesn't modify the current directory.
 				// At least, after it is hidden, the current directory is the same as before it was shown.


### PR DESCRIPTION
Also change open/save "Last Used Directory" behaviour - on last changed directory instead on pressing OK in open/save dialog dialog.

Fix  #13914