### PR TITLE
fix search results buffer collision with new buffs

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -346,8 +346,9 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// returned value : TRUE if this function call is successful and shortcut is enable, otherwise FALSE
 
 	#define NPPM_DOOPEN (NPPMSG + 77)
-	// BOOL NPPM_DOOPEN(0, const TCHAR *fullPathName2Open)
+	// BOOL NPPM_DOOPEN(BOOL onlyInEditViews, const TCHAR *fullPathName2Open)
 	// fullPathName2Open indicates the full file path name to be opened.
+	// if onlyInEditViews is true, only files in the two main edit views (not buffers associated with some forms) should be considered.
 	// The return value is TRUE (1) if the operation is successful, otherwise FALSE (0).
 
 	#define NPPM_SAVECURRENTFILEAS (NPPMSG + 78)

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -161,7 +161,7 @@ public:
 	//! \name File Operations
 	//@{
 	//The doXXX functions apply to a single buffer and dont need to worry about views, with the excpetion of doClose, since closing one view doesnt have to mean the document is gone
-	BufferID doOpen(const generic_string& fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const TCHAR *backupFileName = NULL, FILETIME fileNameTimestamp = {});
+	BufferID doOpen(const generic_string& fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const TCHAR *backupFileName = NULL, FILETIME fileNameTimestamp = {}, bool onlyInEditViews = false); // onlyInEditViews means if a file with that name is open, open it only if it's in an edit view.
 	bool doReload(BufferID id, bool alert = true);
 	bool doSave(BufferID, const TCHAR * filename, bool isSaveCopy = false);
 	void doClose(BufferID, int whichOne, bool doDeleteBackup = false);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -437,7 +437,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_DOOPEN:
 		case WM_DOOPEN:
 		{
-			BufferID id = doOpen(reinterpret_cast<const TCHAR *>(lParam));
+			bool onlyInEditViews = wParam == 1;
+			BufferID id = doOpen(reinterpret_cast<const TCHAR*>(lParam), false, false, -1, NULL, {}, onlyInEditViews);
 			if (id != BUFFER_INVALID)
 				return switchToFile(id);
 			break;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -166,7 +166,7 @@ bool resolveLinkFile(generic_string& linkFilePath)
 	return isResolved;
 }
 
-BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, bool isReadOnly, int encoding, const TCHAR *backupFileName, FILETIME fileNameTimestamp)
+BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, bool isReadOnly, int encoding, const TCHAR *backupFileName, FILETIME fileNameTimestamp, bool onlyInEditViews)
 {
 	const rsize_t longFileNameBufferSize = MAX_PATH; // TODO stop using fixed-size buffer
 	if (fileName.size() >= longFileNameBufferSize - 1) // issue with all other sub-routines
@@ -261,14 +261,14 @@ BufferID Notepad_plus::doOpen(const generic_string& fileName, bool isRecursive, 
 	// 3. a file name with relative path to open or create
 
 	// Search case 1 & 2 firstly
-	BufferID foundBufID = MainFileManager.getBufferFromName(targetFileName.c_str());
+	BufferID foundBufID = MainFileManager.getBufferFromName(targetFileName.c_str(), onlyInEditViews);
 
 	if (foundBufID == BUFFER_INVALID)
 		fileName2Find = longFileName;
 
 	// if case 1 & 2 not found, search case 3
 	if (foundBufID == BUFFER_INVALID)
-		foundBufID = MainFileManager.getBufferFromName(fileName2Find.c_str());
+		foundBufID = MainFileManager.getBufferFromName(fileName2Find.c_str(), onlyInEditViews);
 
 	// If we found the document, then we don't open the existing doc. We return the found buffer ID instead.
     if (foundBufID != BUFFER_INVALID && !isSnapshotMode)

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -92,7 +92,9 @@ public:
 	//If dontRef = false, then no extra reference is added for the doc. Its the responsibility of the caller to do so
 	BufferID bufferFromDocument(Document doc,  bool dontIncrease = false, bool dontRef = false);
 
-	BufferID getBufferFromName(const TCHAR * name);
+	// onlyInEditViews means to only get a buffer with the given name if it's in an edit view
+	// (not a buffer associated with some form like the search results form)
+	BufferID getBufferFromName(const TCHAR * name, bool onlyInEditViews = false);
 	BufferID getBufferFromDocument(Document doc);
 
 	void setLoadedBufferEncodingAndEol(Buffer* buf, const Utf8_16_Read& UnicodeConvertor, int encoding, EolType bkformat);
@@ -111,6 +113,10 @@ public:
 	int getFileNameFromBuffer(BufferID id, TCHAR * fn2copy);
 	size_t docLength(Buffer * buffer) const;
 	size_t nextUntitledNewNumber() const;
+	// returns true if the buffer is visible AND in an edit view,
+	// as opposed to the buffers associated with some forms like the document map
+	// and the search results form.
+	bool isVisibleInEditViews(BufferID buf) const;
 
 private:
 	struct LoadedFileFormat {

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -594,35 +594,8 @@ std::pair<intptr_t, intptr_t> Finder::gotoFoundLine(size_t nOccurrence)
 	const FoundInfo& fInfo = *(_pMainFoundInfos->begin() + lno);
 	const SearchResultMarkingLine& markingLine = *(_pMainMarkings->begin() + lno);
 
-	Buffer * finderFormBuffer = _scintView.getCurrentBuffer();
-	generic_string finderFormBufferOldName(finderFormBuffer->getFullPathName());
-	const TCHAR * targetBufferName = fInfo._fullPath.c_str();
-	bool targetBufferHasFinderBufferName = !lstrcmp(finderFormBufferOldName.c_str(), targetBufferName);
-	if (targetBufferHasFinderBufferName)
-	{
-		// the target buffer has the same name as the search results buffer
-		// this could cause problems, so temporarily change the name of the finder form buffer to avoid this collision
-		generic_string finderFormBufferNewName = finderFormBufferOldName;
-		size_t oldNameLen = finderFormBufferOldName.size();
-		for (size_t i = 0; i < oldNameLen; i++)
-		{
-			if (finderFormBufferOldName[i] != '_')
-			{
-				finderFormBufferNewName[i] = '_';
-				break;
-			}
-		}
-		finderFormBuffer->setFileName(finderFormBufferNewName.c_str());
-	}
-	// Switch to another document
-	if (!::SendMessage(_hParent, WM_DOOPEN, 0, reinterpret_cast<LPARAM>(targetBufferName))) return emptyResult;
-
-	if (targetBufferHasFinderBufferName)
-	{
-		// revert the hack we did earlier
-		finderFormBuffer->setFileName(finderFormBufferOldName.c_str());
-	}
-	assert(!lstrcmp(finderFormBuffer->getFullPathName(), finderFormBufferOldName.c_str()));
+	// Switch to another document in the edit views (use 1 as the WPARAM for this call)
+	if (!::SendMessage(_hParent, WM_DOOPEN, 1, reinterpret_cast<LPARAM>(fInfo._fullPath.c_str()))) return emptyResult;
 
 	(*_ppEditView)->_positionRestoreNeeded = false;
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -594,8 +594,35 @@ std::pair<intptr_t, intptr_t> Finder::gotoFoundLine(size_t nOccurrence)
 	const FoundInfo& fInfo = *(_pMainFoundInfos->begin() + lno);
 	const SearchResultMarkingLine& markingLine = *(_pMainMarkings->begin() + lno);
 
+	Buffer * finderFormBuffer = _scintView.getCurrentBuffer();
+	generic_string finderFormBufferOldName(finderFormBuffer->getFullPathName());
+	const TCHAR * targetBufferName = fInfo._fullPath.c_str();
+	bool targetBufferHasFinderBufferName = !lstrcmp(finderFormBufferOldName.c_str(), targetBufferName);
+	if (targetBufferHasFinderBufferName)
+	{
+		// the target buffer has the same name as the search results buffer
+		// this could cause problems, so temporarily change the name of the finder form buffer to avoid this collision
+		generic_string finderFormBufferNewName = finderFormBufferOldName;
+		size_t oldNameLen = finderFormBufferOldName.size();
+		for (size_t i = 0; i < oldNameLen; i++)
+		{
+			if (finderFormBufferOldName[i] != '_')
+			{
+				finderFormBufferNewName[i] = '_';
+				break;
+			}
+		}
+		finderFormBuffer->setFileName(finderFormBufferNewName.c_str());
+	}
 	// Switch to another document
-	if (!::SendMessage(_hParent, WM_DOOPEN, 0, reinterpret_cast<LPARAM>(fInfo._fullPath.c_str()))) return emptyResult;
+	if (!::SendMessage(_hParent, WM_DOOPEN, 0, reinterpret_cast<LPARAM>(targetBufferName))) return emptyResult;
+
+	if (targetBufferHasFinderBufferName)
+	{
+		// revert the hack we did earlier
+		finderFormBuffer->setFileName(finderFormBufferOldName.c_str());
+	}
+	assert(!lstrcmp(finderFormBuffer->getFullPathName(), finderFormBufferOldName.c_str()));
 
 	(*_ppEditView)->_positionRestoreNeeded = false;
 


### PR DESCRIPTION
fix #13636.

To test:
1. Open a file containing at least two instances of some string (say, `foo`)
2. Open a file containing the same string (or just copy/paste into a new buffer)
3. Use `Find All in All Opened Documents` and `Find All in Current Document` and verify that they still work as expected (navigation is possible between matches within the same document, and also between different documents)
4. Use Ctrl+N to create a new buffer, and copy/paste the text of the first file into it.
5. Use `Find All in All Opened Documents` and `Find All in Current Document` and verify that they still work as expected (navigation is possible between matches within the same document, and also between different documents)
6. Also verify that `Use `Find All in All Opened Documents` and `Find All in Current Document` can search within the new file (the first file opened after the search results dialog was first opened)
7. Repeat steps 4 and 5 at least once.