### PR TITLE
Remove extra char on top of french.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/french.xml
+++ b/PowerEditor/installer/nativeLang/french.xml
@@ -1,4 +1,4 @@
-t<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 The comments are here for explanation, it's not necessary to translate them.
 -->


### PR DESCRIPTION
Hello,

This PR removes an extra character `t` which looks to have been added by mistake at the beginning of the file.

[edited] I just noticed that the previous commit https://github.com/notepad-plus-plus/notepad-plus-plus/commit/c143a4a6ccae395a375a7b6e1550971465876e70 hasn't been merged! So current PR is probably useless.

Best regards,
Patriccollu.