### PR TITLE
Fix leading & tailling spaces being allowed after renaming tab issue

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1383,6 +1383,7 @@ Continue?"/><!-- HowToReproduce: when you openned file is modified and saved, th
 			<FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
 			<FileAlreadyOpenedInNpp title="" message="The file is already opened in Notepad++."/><!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
 			<RenameTabTemporaryNameAlreadyInUse title="Rename failed" message="The specified name is already in use on another tab."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
+			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="The specified name cannot be empty, or it cannot contain only space(s) or TAB(s)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
 			<DeleteFileFailed title="Delete File" message="Delete File failed"/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1384,6 +1384,7 @@ Continue?"/><!-- HowToReproduce: when you openned file is modified and saved, th
 			<FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
 			<FileAlreadyOpenedInNpp title="" message="The file is already opened in Notepad++."/><!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
 			<RenameTabTemporaryNameAlreadyInUse title="Rename failed" message="The specified name is already in use on another tab."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
+			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="The specified name cannot be empty, or it cannot contain only space(s) or TAB(s)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
 			<DeleteFileFailed title="Delete File" message="Delete File failed"/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.

--- a/PowerEditor/installer/nativeLang/french.xml
+++ b/PowerEditor/installer/nativeLang/french.xml
@@ -1380,6 +1380,7 @@ Continuer ?"/><!-- HowToReproduce: when you opened file is modified and saved, t
 			<FileLockedWarning title="Échec de la sauvegarde" message="Veuillez vérifier si ce fichier est ouvert par un autre programme"/>
 			<FileAlreadyOpenedInNpp title="" message="Le fichier est toujours ouvert dans Notepad++."/><!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
 			<RenameTabTemporaryNameAlreadyInUse title="Échec du renommage" message="Le nom spécifié est déjà utilisé dans un autre onglet."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
+			<RenameTabTemporaryNameIsEmpty title="Échec du renommage" message="Le nom spécifié ne peut pas être vide, ou il ne peut pas contenir uniquement des espaces ou des tabulations."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
 			<DeleteFileFailed title="Suppression du fichier" message="La suppression du fichier a échoué."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Nombre de fichiers à ouvrir trop grand." message="$INT_REPLACE$ fichiers sont sur le point d'être ouverts.

--- a/PowerEditor/installer/nativeLang/taiwaneseMandarin.xml
+++ b/PowerEditor/installer/nativeLang/taiwaneseMandarin.xml
@@ -1316,6 +1316,8 @@
 			<DocReloadWarning title="重新載入" message="你確定要重新載入目前文件，並捨棄在 Notepad++ 中所做的修改嗎？"/>
 			<FileLockedWarning title="儲存失敗" message="請檢查其他應用程式是否已開啟此檔案。"/>
 			<FileAlreadyOpenedInNpp title="已開啟" message="這個檔案已在 Notepad++ 中開啟。"/>
+			<RenameTabTemporaryNameAlreadyInUse title="命名失敗" message="指定的名稱已在另一個頁籤上使用。"/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
+			<RenameTabTemporaryNameIsEmpty title="命名失敗" message="指定的名稱不能為空字串，或者不能只包含空白字元。"/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
 			<DeleteFileFailed title="刪除失敗" message="檔案刪除失敗。"/>
 			<NbFileToOpenImportantWarning title="開啟檔案" message="你確定要開啟全數 $INT_REPLACE$ 個檔案嗎？"/>
 			<SettingsOnCloudError title="雲端設定" message="設定的雲端路徑位於一個唯讀的磁碟或未擁有寫入權限的資料夾，因此你的「雲端」設定將被清除。

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1357,17 +1357,16 @@ void getFilesInFolder(std::vector<generic_string>& files, const generic_string& 
 	::FindClose(hFindFile);
 }
 
-void trim(generic_string& str)
+// remove any leading or trailing spaces from str
+void trim(std::wstring& str)
 {
-	// remove any leading or trailing spaces from str
+	std::wstring::size_type pos = str.find_last_not_of(' ');
 
-	generic_string::size_type pos = str.find_last_not_of(' ');
-
-	if (pos != generic_string::npos)
+	if (pos != std::wstring::npos)
 	{
 		str.erase(pos + 1);
 		pos = str.find_first_not_of(' ');
-		if (pos != generic_string::npos) str.erase(0, pos);
+		if (pos != std::wstring::npos) str.erase(0, pos);
 	}
 	else str.erase(str.begin(), str.end());
 }

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -213,7 +213,7 @@ template<typename T> size_t vecRemoveDuplicates(std::vector<T>& vec, bool isSort
 	return vec.size();
 }
 
-void trim(generic_string& str);
+void trim(std::wstring& str);
 
 int nbDigitsFromNbLines(size_t nbLines);
 

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1909,6 +1909,14 @@ bool Notepad_plus::fileRename(BufferID id)
 					L"Rename failed",
 					MB_OK | MB_ICONSTOP);
 			}
+			else if (tabNewNameStr.empty())
+			{
+				_nativeLangSpeaker.messageBox("RenameTabTemporaryNameIsEmpty",
+					_pPublicInterface->getHSelf(),
+					L"The specified name cannot be empty, or it cannot contain only space(s) or TAB(s).",
+					L"Rename failed",
+					MB_OK | MB_ICONSTOP);
+			}
 			else
 			{
 				success = true;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1866,10 +1866,10 @@ bool Notepad_plus::fileRename(BufferID id)
 		fDlg.setFolder(buf->getFullPathName());
 		fDlg.setDefFileName(buf->getFileName());
 
-		generic_string title = _nativeLangSpeaker.getLocalizedStrFromID("file-rename-title", TEXT("Rename"));
+		std::wstring title = _nativeLangSpeaker.getLocalizedStrFromID("file-rename-title", L"Rename");
 		fDlg.setTitle(title.c_str());
 
-		generic_string fn = fDlg.doSaveDlg();
+		std::wstring fn = fDlg.doSaveDlg();
 
 		if (!fn.empty())
 			success = MainFileManager.moveFile(bufferID, fn.c_str());
@@ -1883,37 +1883,40 @@ bool Notepad_plus::fileRename(BufferID id)
 		// Reserved characters: < > : " / \ | ? *
 		std::wstring reservedChars = TEXT("<>:\"/\\|\?*");
 
-		generic_string staticName = _nativeLangSpeaker.getLocalizedStrFromID("tabrename-newname", TEXT("New name"));
+		std::wstring staticName = _nativeLangSpeaker.getLocalizedStrFromID("tabrename-newname", L"New name");
 
 		StringDlg strDlg;
-		generic_string title = _nativeLangSpeaker.getLocalizedStrFromID("tabrename-title", TEXT("Rename Current Tab"));
+		std::wstring title = _nativeLangSpeaker.getLocalizedStrFromID("tabrename-title", L"Rename Current Tab");
 		strDlg.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), title.c_str(), staticName.c_str(), buf->getFileName(), langNameLenMax - 1, reservedChars.c_str(), true);
 
-		TCHAR *tabNewName = reinterpret_cast<TCHAR *>(strDlg.doDialog());
+		wchar_t *tabNewName = reinterpret_cast<wchar_t *>(strDlg.doDialog());
 		if (tabNewName)
 		{
-			BufferID sameNamedBufferId = _pDocTab->findBufferByName(tabNewName);
+			std::wstring tabNewNameStr = tabNewName;
+			trim(tabNewNameStr); // No leading and tailing space allowed
+
+			BufferID sameNamedBufferId = _pDocTab->findBufferByName(tabNewNameStr.c_str());
 			if (sameNamedBufferId == BUFFER_INVALID)
 			{
-				sameNamedBufferId = _pNonDocTab->findBufferByName(tabNewName);
+				sameNamedBufferId = _pNonDocTab->findBufferByName(tabNewNameStr.c_str());
 			}
 			
 			if (sameNamedBufferId != BUFFER_INVALID)
 			{
 				_nativeLangSpeaker.messageBox("RenameTabTemporaryNameAlreadyInUse",
 					_pPublicInterface->getHSelf(),
-					TEXT("The specified name is already in use on another tab."),
-					TEXT("Rename failed"),
+					L"The specified name is already in use on another tab.",
+					L"Rename failed",
 					MB_OK | MB_ICONSTOP);
 			}
 			else
 			{
 				success = true;
-				buf->setFileName(tabNewName);
+				buf->setFileName(tabNewNameStr.c_str());
 				bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 				if (isSnapshotMode)
 				{
-					generic_string oldBackUpFile = buf->getBackupFileName();
+					std::wstring oldBackUpFile = buf->getBackupFileName();
 
 					// Change the backup file name and let MainFileManager decide the new filename
 					buf->setBackupFileName(TEXT(""));


### PR DESCRIPTION
Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13344#issuecomment-1665687932

Fix #13967