### PR TITLE
Add indicator allocation for plugins

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -368,7 +368,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 
 	#define NPPM_ALLOCATEMARKER  (NPPMSG + 82)
     // BOOL NPPM_ALLOCATEMARKER(int numberRequested, int* startNumber)
-    // sets startNumber to the initial command ID if successful
+    // sets startNumber to the initial marker ID if successful
     // Allocates a marker number to a plugin: if a plugin need to add a marker on Notepad++'s Scintilla marker margin,
 	// it has to use this message to get marker number, in order to prevent from the conflict with the other plugins.
     // Returns: TRUE if successful, FALSE otherwise. startNumber will also be set to 0 if unsuccessful
@@ -591,6 +591,12 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//	}
 	//}
 
+	#define NPPM_ALLOCATEINDICATOR  (NPPMSG + 113)
+	// BOOL NPPM_ALLOCATEINDICATOR(int numberRequested, int* startNumber)
+	// sets startNumber to the initial indicator ID if successful
+	// Allocates an indicator number to a plugin: if a plugin needs to add an indicator,
+	// it has to use this message to get the indicator number, in order to prevent a conflict with the other plugins.
+	// Returns: TRUE if successful, FALSE otherwise.
 
 	// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -833,6 +833,18 @@ bool PluginsManager::allocateMarker(int numberRequired, int* start)
 	return retVal;
 }
 
+bool PluginsManager::allocateIndicator(int numberRequired, int* start)
+{
+	bool retVal = false;
+	int possibleStart = _indicatorAlloc.allocate(numberRequired);
+	if (possibleStart != -1)
+	{
+		*start = possibleStart;
+		retVal = true;
+	}
+	return retVal;
+}
+
 generic_string PluginsManager::getLoadedPluginNames() const
 {
 	generic_string pluginPaths;

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -79,7 +79,8 @@ class PluginsManager
 friend class PluginsAdminDlg;
 public:
 	PluginsManager() : _dynamicIDAlloc(ID_PLUGINS_CMD_DYNAMIC, ID_PLUGINS_CMD_DYNAMIC_LIMIT),
-					   _markerAlloc(MARKER_PLUGINS, MARKER_PLUGINS_LIMIT)	{}
+					   _markerAlloc(MARKER_PLUGINS, MARKER_PLUGINS_LIMIT),
+					   _indicatorAlloc(INDICATOR_PLUGINS, INDICATOR_PLUGINS_LIMIT + 1)	{}
 	~PluginsManager()
 	{
 		for (size_t i = 0, len = _pluginInfos.size(); i < len; ++i)
@@ -117,6 +118,7 @@ public:
 	bool inDynamicRange(int id) { return _dynamicIDAlloc.isInRange(id); }
 
 	bool allocateMarker(int numberRequired, int* start);
+	bool allocateIndicator(int numberRequired, int* start);
 	generic_string getLoadedPluginNames() const;
 
 private:
@@ -129,6 +131,7 @@ private:
 	bool _isDisabled = false;
 	IDAllocator _dynamicIDAlloc;
 	IDAllocator _markerAlloc;
+	IDAllocator _indicatorAlloc;
 	bool _noMoreNotification = false;
 
 	int loadPluginFromPath(const TCHAR* pluginFilePath);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2811,6 +2811,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return _pluginsManager.allocateMarker(static_cast<int32_t>(wParam), reinterpret_cast<int *>(lParam));
 		}
 
+		case NPPM_ALLOCATEINDICATOR:
+		{
+			return _pluginsManager.allocateIndicator(static_cast<int32_t>(wParam), reinterpret_cast<int *>(lParam));
+		}
+
 		case NPPM_GETBOOKMARKID:
 		{
 			return MARK_BOOKMARK;

--- a/PowerEditor/src/resource.h
+++ b/PowerEditor/src/resource.h
@@ -418,6 +418,9 @@
 #define MARKER_PLUGINS          1
 #define MARKER_PLUGINS_LIMIT   15
 
+#define INDICATOR_PLUGINS          9  // indicators 8 and below are reserved by Notepad++ (URL_INDIC=8)
+#define INDICATOR_PLUGINS_LIMIT   20  // indicators 21 and up are reserved by Notepad++ (SCE_UNIVERSAL_FOUND_STYLE_EXT5=21)
+
 
 
 //#define IDM 40000


### PR DESCRIPTION
Fix #5744 

Note that the issue calls for ability to "release" indicator allocations, but since releasing isn't possible in N++ for command id allocation or marker allocation, it was not done for new indicator allocation.