### PR TITLE
C26819: Unannotated fallthrough between switch labels (es.78).

### DIFF
--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -3368,7 +3368,7 @@ intptr_t CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 				}
 			}
 		}
-
+		[[fallthrough]];
 		default:
 		{
 			break;


### PR DESCRIPTION
With VS 2022 17.7 this error appears
Z:\DevStudio\Work\notepad-plus-plus\PowerEditor\src\WinControls\Preference\preferenceDlg.cpp(3374): error C26819: Unannotated fallthrough between switch labels (es.78). [Z:\DevStudio\Work\notepad-plus-plus\PowerEditor\visual.net\notepadPlus.vcxproj]