### PR TITLE
Fix: Saving files removes alternate data streams

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.h
+++ b/PowerEditor/src/MISC/Common/FileInterface.h
@@ -58,6 +58,8 @@ private:
 
 	const DWORD _accessParam  { GENERIC_READ | GENERIC_WRITE };
 	const DWORD _shareParam   { FILE_SHARE_READ | FILE_SHARE_WRITE };
-	const DWORD _dispParam    { CREATE_ALWAYS };
+	const DWORD _dispParam    { OPEN_ALWAYS };
 	const DWORD _attribParam  { FILE_ATTRIBUTE_NORMAL };
+	
+	bool truncateFileAfterOpen();
 };


### PR DESCRIPTION
This PR fixes #1498.

How to test this is described in that issue here: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/1498#issuecomment-483194646