### PR TITLE
Improve handling of symbolic links and hard links. Addresses issue #14030.

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -28,6 +28,7 @@
 #include "fileBrowser.h"
 #include <tchar.h>
 #include <unordered_set>
+#include <filesystem>
 #include "Common.h"
 
 using namespace std;
@@ -123,6 +124,11 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 
 bool resolveLinkFile(generic_string& linkFilePath)
 {
+	if (std::error_code symlink_error; std::filesystem::is_symlink(linkFilePath, symlink_error)) {
+		generic_string target = std::filesystem::read_symlink(linkFilePath, symlink_error);
+		if (!symlink_error) linkFilePath = target;
+	}
+
 	bool isResolved = false;
 
 	IShellLink* psl = nullptr;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -20,6 +20,7 @@
 #include <locale>
 #include <codecvt>
 #include <sys/stat.h>
+#include <filesystem>
 #include "Buffer.h"
 #include "Scintilla.h"
 #include "ILexer.h"
@@ -1711,6 +1712,7 @@ BufferID FileManager::getBufferFromName(const TCHAR* name)
 				return buf->getID();
 			}
 		}
+		if (std::error_code ec; std::filesystem::equivalent(name, buf->getFullPathName(), ec)) return buf->getID();
 	}
 	return BUFFER_INVALID;
 }


### PR DESCRIPTION
Symbolic links don’t always resolve to the target file before Notepad++ has collected the file path and name it uses to label the tab and to identify when a new file to be opened is actually an already open file. Since the process used for shortcuts works perfectly, this patch adds logic at the beginning of `ResolveLinkFile` in `NppIO.cpp` to check for and resolve symlinks as well.

Hard links cannot be resolved in this way as they reference the file itself, not the original name. Still, the same file shouldn’t be opened twice. This patch adds logic to `FileManager::getBufferFromName` so that as it loops through open files, after checking to see if the requested path+name matches an open file, it uses `std::filesystem::equivalent` to check whether two different path+name specifications refer to the same physical file.