### PR TITLE
[XML] Update romanian.xml part3

### DIFF
--- a/PowerEditor/installer/nativeLang/romanian.xml
+++ b/PowerEditor/installer/nativeLang/romanian.xml
@@ -1228,562 +1228,546 @@ Se pot defini mai mulți marcatori de coloană utilizând spațiul alb pentru a 
                 </AutoCompletion>
 
                 <MultiInstance title="Instanțe multiple">
-                    <Item id="6151" name="Setări instanțe multiple"/>
-                    <Item id="6152" name="Deschidere sesiune în instanță nouă Notepad++"/>
-                    <Item id="6153" name="Totdeauna în mod instanță multiplă"/>
-                    <Item id="6154" name="Implicit (instanță unică)"/>
-                    <Item id="6155" name="* Modificarea acestor setări necesită repornirea Notepad++"/>
-                    <Item id="6171" name="Personalizarea inserării datei și timpului"/>
-                    <Item id="6175" name="Inversarea ordinii implicite a datei și timpului (formatele scurte &amp;&amp; lungi)"/>
-                    <Item id="6172" name="Format personalizat:"/>
-                    <Item id="6181" name="Stadiul panoului și [-nosession (fără sesiune)] *"/>
-                    <Item id="6182" name="Amintirea stării panoului (panoul este deschis) în alte cazuri (modul cu mai multe instanțe) sau când se folosește parametrul liniei de comandă [-nosession (fără sesiune)]"/>
-                    <Item id="6183" name="Istoricul clipboard-ului"/>
-                    <Item id="6184" name="Lista documentelor"/>
-                    <Item id="6185" name="Panoul caracterelor"/>
-                    <Item id="6186" name="Folder ca spațiu de lucru"/>
-                    <Item id="6187" name="Panourile de proiect"/>
-                    <Item id="6188" name="Harta documentului"/>
-                    <Item id="6189" name="Lista funcțiilor"/>
-                    <Item id="6190" name="Panoul de module"/>
-                </MultiInstance>
+					<Item id="6151" name="Setări instanțe multiple"/>
+					<Item id="6152" name="Deschidere sesiune în instanță nouă (și salvare automată sesiune la ieșire)"/>
+					<Item id="6153" name="Totdeauna în mod instanțe multiple"/>
+					<Item id="6154" name="Implicit (instanță unică)"/>
+					<Item id="6155" name="* Modificarea acestor setări necesită repornirea Notepad++"/>
+					<Item id="6171" name="Personalizare inserare dată și oră"/>
+					<Item id="6175" name="Inversare ordine implicită dată și oră (formatul scurt și lung)"/>
+					<Item id="6172" name="Format personal:"/>
+					<Item id="6181" name="Stare panou și [-nosession] *"/>
+					<Item id="6182" name="Memorare stare panou (deschis / închis) în alte instanțe (în modul instanțe multiple) sau când se folosește parametrul liniei de comandă [-nosession]"/>
+					<Item id="6183" name="Istoric conținut memorie"/>
+					<Item id="6184" name="Listă documente"/>
+					<Item id="6185" name="Panou caractere"/>
+					<Item id="6186" name="Folder ca spațiu de lucru"/>
+					<Item id="6187" name="Panouri proiect"/>
+					<Item id="6188" name="Hartă document"/>
+					<Item id="6189" name="Listă funcții"/>
+					<Item id="6190" name="Panou module"/>
+				</MultiInstance>
 
-                <Delimiter title="Separatori">
-                    <Item id="6251" name="Setări separatori selecție (Ctrl + dublu clic maus)"/>
-                    <Item id="6252" name="Început"/>
-                    <Item id="6255" name="Sfârșit"/>
-                    <Item id="6256" name="Permitere pe linii multiple"/>
-                    <Item id="6161" name="Listă caractere"/>
-                    <Item id="6162" name="Folosire listă caractere implicită așa cum e"/>
-                    <Item id="6163" name="Adăugare caractere personale la listă
+				<Delimiter title="Separatori">
+					<Item id="6251" name="Setări separatori selecție (Ctrl + clic dublu)"/>
+					<Item id="6252" name="Început"/>
+					<Item id="6255" name="Sfârșit"/>
+					<Item id="6256" name="Permitere pe linii multiple"/>
+					<Item id="6161" name="Listă caractere"/>
+					<Item id="6162" name="Folosire listă caractere implicită așa cum e"/>
+					<Item id="6163" name="Adăugare caracter personal ca parte a cuvântului
 (nu alegeți decât dacă știți bine ce înseamnă)"/>
-                </Delimiter>
-				
-                <Performance title="Performanță">
-                    <Item id="7141" name="Restricția fișierelor mari"/>
-                    <Item id="7143" name="Permiterea restricției fișierelor mari (fără sintaxă evidențiată)"/>
-                    <Item id="7144" name="Definirea mărimii fișierelor mari:"/>
-                    <Item id="7146" name="MB   (1 - 4096)"/>
-                    <Item id="7147" name="Permite potrivirea acoladelor"/>
-                    <Item id="7148" name="Permite autocompletarea"/>
-                    <Item id="7149" name="Permite evidențierea inteligentă"/>
-                    <Item id="7150" name="Dezactivarea globală a încadrării cuvintelor"/>
-                    <Item id="7151" name="Permite legăturile apăsabile de URL-uri"/>
-                </Performance>
+				</Delimiter>
 
-                 <Cloud title="Cloud și legături">
-                    <Item id="6262" name="Setări pentru cloud"/>
-                    <Item id="6263" name="Fără Cloud"/>
-                    <Item id="6267" name="Stabilire cale localizare cloud:"/>
-                    <Item id="6318" name="Setări de legătură pe care se poate da clic"/>
-                    <Item id="6319" name="Activare"/>
-                    <Item id="6320" name="Fără subliniere"/>
-                    <Item id="6350" name="Activarea modului cutiei întregi"/>
-                    <Item id="6264" name="Scheme personalizate URI:"/>
-                </Cloud>
+				<Performance title="Performanță">
+					<Item id="7141" name="Restricție fișiere mari"/>
+					<Item id="7143" name="Activare restricție fișiere mari (fără sintaxă evidențiată)"/>
+					<Item id="7144" name="Definire mărime fișiere mari:"/>
+					<Item id="7146" name="MiB   (1 - 4096)"/>
+					<Item id="7147" name="Permitere potrivire acolade"/>
+					<Item id="7148" name="Permitere autocompletare"/>
+					<Item id="7149" name="Permitere evidențiere inteligentă"/>
+					<Item id="7150" name="Dezactivare globală încadrare cuvinte"/>
+					<Item id="7151" name="Permitere legături web active"/>
+				</Performance>
 
-                <SearchEngine title="Motor de căutare">
-                    <Item id="6271" name="Motor de căutare (pentru comanda &quot;Căutare pe Internet&quot;)"/>
-                    <Item id="6272" name="DuckDuckGo"/>
-                    <Item id="6273" name="Google"/>
-                    <Item id="6274" name="Bing"/>
-                    <Item id="6275" name="Yahoo!"/>
-                    <Item id="6276" name="Stabilire motor de căutare:"/>
-                    <!-- Don't change anything after Example: -->
-                    <Item id="6278" name="Exemplu: https://www.google.com/search?q=$(CURRENT_WORD)"/>
-                </SearchEngine>
+				<Cloud title="Cloud și legături web">
+					<Item id="6262" name="Setări pentru cloud"/>
+					<Item id="6263" name="Fără Cloud"/>
+					<Item id="6267" name="Stabilire cale cloud:"/>
+					<Item id="6318" name="Setări legături web active"/>
+					<Item id="6319" name="Activare"/>
+					<Item id="6320" name="Fără subliniere"/>
+					<Item id="6350" name="Evidențiere la survolarea cu cursorul"/>
+					<Item id="6264" name="Scheme personalizate URI:"/>
+				</Cloud>
 
-                <MISC title="DIVERSE">
-                    <ComboBox id="6347">
-                        <Element name="Activare"/>
-                        <Element name="Activare pentru toate fişierele deschise"/>
-                        <Element name="Dezactivare"/>
-                    </ComboBox>
-                    <Item id="6308" name="Micșorare în zona de sistem"/>
-                    <Item id="6312" name="Autodetectare stare fișier"/>
-                    <Item id="6313" name="Actualizare silențioasă"/>
-                    <Item id="6325" name="Derulare la ultima linie după actualizare"/>
-                    <Item id="6322" name="Extensie fișier sesiune:"/>
-                    <Item id="6323" name="Activare autoactualizare Notepad++"/>
-                    <Item id="6324" name="Comutare documente (Ctrl+Tab)"/>
-                    <Item id="6331" name="Afișare doar nume fișier în bara de titlu"/>
-                    <Item id="6334" name="Autodetectare codificare caractere"/>
-                    <Item id="6349" name="Folosire DirectWrite (Poate îmbunătăți afișarea caracterelor speciale, necesită repornirea Notepad++)"/>
-                    <Item id="6337" name="Extensie fișier spațiu de lucru:" />
-                    <Item id="6114" name="Activare"/>
-                    <Item id="6117" name="În ordinea utilizării"/>             
-                    <Item id="6344" name="Previzualizare document"/>
-                    <Item id="6345" name="Previzualizare pe filă"/>
-                    <Item id="6346" name="Previzualizare pe hartă document"/>
-                    <Item id="6360" name="Punerea pe mut a tuturor sunetelor"/>
-                    <Item id="6361" name="Activarea dialogului de confirmare Salvare tot"/>
-                </MISC>
-            </Preference>
-            <MultiMacro title="Executare macro în mod repetat">
-                <Item id="1" name="E&amp;xecutare"/>
-                <Item id="2" name="&amp;Anulare"/>
-                <Item id="8006" name="Macro:"/>
-                <Item id="8001" name="Executare"/>
-                <Item id="8005" name="ori"/>
-                <Item id="8002" name="Executare până la &amp;sfârșitul fișierului"/>
-            </MultiMacro>
-            <Window title="Ferestre">
-                <Item id="1" name="&amp;Activare"/>
-                <Item id="2" name="&amp;OK"/>
-                <Item id="7002" name="&amp;Salvare"/>
-                <Item id="7003" name="În&amp;chide selectate"/>
-                <Item id="7004" name="Sortare &amp;ferestre"/>
-            </Window>
-            <ColumnEditor title="Editor coloane">
-                <Item id="2023" name="Text de inserat"/>
-                <Item id="2033" name="Număr de inserat"/>
-                <Item id="2030" name="Număr inițial:"/>
-                <Item id="2031" name="Incrementare cu:"/>
+				<SearchEngine title="Motor de căutare">
+					<Item id="6271" name="Motor de căutare (pentru comanda „Căutare pe Internet”)"/>
+					<Item id="6272" name="DuckDuckGo"/>
+					<Item id="6273" name="Google"/>
+					<Item id="6274" name="Bing"/>
+					<Item id="6275" name="Yahoo!"/>
+					<Item id="6276" name="Stabilire motor de căutare:"/>
+					<!-- Don't change anything after Example: -->
+					<Item id="6278" name="Exemplu: https://www.google.com/search?q=$(CURRENT_WORD)"/>
+				</SearchEngine>
+
+				<MISC title="Diverse">
+					<ComboBox id="6347">
+						<Element name="Activare"/>
+						<Element name="Activare la toate fișierele deschise"/>
+						<Element name="Dezactivare"/>
+					</ComboBox>
+					<Item id="6308" name="Micșorare în zona de notificare"/>
+					<Item id="6312" name="Autodetectare stare fișier"/>
+					<Item id="6313" name="Actualizare silențioasă"/>
+					<Item id="6325" name="Derulare la ultima linie după actualizare"/>
+					<Item id="6322" name="Extensie fișier sesiune:"/>
+					<Item id="6323" name="Activare autoactualizare Notepad++"/>
+					<Item id="6324" name="Comutare documente (Ctrl+Tab)"/>
+					<Item id="6331" name="Afișare doar nume fișier în bara de titlu"/>
+					<Item id="6334" name="Autodetectare codificare caractere"/>
+					<Item id="6349" name="Folosire DirectWrite (Poate îmbunătăți afișarea caracterelor speciale. Se aplică după repornirea Notepad++.)"/>
+					<Item id="6337" name="Extensie fișier spațiu de lucru:"/>
+					<Item id="6114" name="Activare"/>
+					<Item id="6117" name="În ordinea utilizării"/>
+					<Item id="6344" name="Miniatură document"/>
+					<Item id="6345" name="Miniatură pe nume filă"/>
+					<Item id="6346" name="Miniatură pe hartă document"/>
+					<Item id="6360" name="Oprire toate sunetele"/>
+					<Item id="6361" name="Activare dialog de confirmare salvare toate"/>
+				</MISC>
+			</Preference>
+			<MultiMacro title="Executare macro în mod repetat">
+				<Item id="1" name="Executa&amp;re"/>
+				<Item id="2" name="&amp;Anulare"/>
+				<Item id="8006" name="Macro de executat"/>
+				<Item id="8001" name="Execută de"/>
+				<Item id="8005" name="ori"/>
+				<Item id="8002" name="Ex&amp;ecutare până la sfârșitul fișierului"/>
+			</MultiMacro>
+			<Window title="Ferestre">
+				<Item id="1" name="&amp;Activare"/>
+				<Item id="2" name="&amp;OK"/>
+				<Item id="7002" name="&amp;Salvare"/>
+				<Item id="7003" name="În&amp;chide selectate"/>
+				<Item id="7004" name="Sortare &amp;file"/>
+			</Window>
+			<ColumnEditor title="Editor coloane">
+				<Item id="2023" name="&amp;Text de inserat"/>
+				<Item id="2033" name="&amp;Număr de inserat"/>
+				<Item id="2030" name="Număr &amp;inițial:"/>
+				<Item id="2031" name="Incrementare c&amp;u:"/>
+				<Item id="2038" name="&amp;Prefixare cu:"/>
 				<ComboBox id="2039">
 					<Element name="Nimic"/>
 					<Element name="Zerouri"/>
 					<Element name="Spații"/>
 				</ComboBox>
-                <Item id="2035" name="Precede zerouri"/>
-                <Item id="2036" name="Repetare :"/>
-                <Item id="2032" name="Formatare"/>
-                <Item id="2024" name="Zecimal"/>
-                <Item id="2025" name="Octal"/>
-                <Item id="2026" name="Hexazecimal"/>
-                <Item id="2027" name="Binar"/>
-                <Item id="1" name="OK"/>
-                <Item id="2" name="Anulare"/>
-				</ColumnEditor>
-	            <FindInFinder title="Găsește în rezultatele găsite">
-					<Item id="1"    name="Găsește toate"/>
-					<Item id="2"    name="Închidere"/>
-					<Item id="1711" name="&amp;Căutare :"/>
-					<Item id="1713" name="Căutare doar în liniile &amp;găsite"/>
-					<Item id="1714" name="Potrivire doar cu&amp;vinte întregi"/>
-					<Item id="1715" name="Potrivire &amp;litere"/>
-					<Item id="1716" name="Mod căutare"/>
-					<Item id="1717" name="&amp;Normal"/>
-					<Item id="1719" name="&amp;Expresie regulată"/>
-					<Item id="1718" name="E&amp;xtins (\n, \r, \t, \0, \x...)"/>
-					<Item id="1720" name="&amp;. este \r sau \n"/>
-            </FindInFinder>
-			<DoSaveOrNot title="Salvează">
-				<Item id="1761" name="Salvează fișierul &quot;$STR_REPLACE$&quot; ?"/>
+				<Item id="2036" name="&amp;Repetare:"/>
+				<Item id="2032" name="Formatare"/>
+				<Item id="2024" name="&amp;Zecimal"/>
+				<Item id="2025" name="&amp;Octal"/>
+				<Item id="2026" name="&amp;Hexazecimal"/>
+				<Item id="2027" name="&amp;Binar"/>
+				<Item id="1" name="OK"/>
+				<Item id="2" name="Anulare"/>
+			</ColumnEditor>
+			<FindInFinder title="Căutare în rezultatele găsite">
+				<Item id="1" name="Căutare toate"/>
+				<Item id="2" name="Închidere"/>
+				<Item id="1711" name="&amp;Căutare:"/>
+				<Item id="1713" name="Căutare doar în liniile &amp;găsite"/>
+				<Item id="1714" name="Potrivire doar cu&amp;vinte întregi"/>
+				<Item id="1715" name="Potrivire &amp;litere"/>
+				<Item id="1716" name="Mod căutare"/>
+				<Item id="1717" name="&amp;Normal"/>
+				<Item id="1719" name="E&amp;xpresie regulată"/>
+				<Item id="1718" name="&amp;Extins (\n, \r, \t, \0, \x...)"/>
+				<Item id="1720" name="&amp;. este \r sau \n"/>
+			</FindInFinder>
+			<DoSaveOrNot title="Salvare">
+				<Item id="1761" name="Salvați fișierul „$STR_REPLACE$”?"/>
 				<Item id="6" name="&amp;Da"/>
 				<Item id="7" name="&amp;Nu"/>
-				<Item id="2" name="&amp;Anulează"/>
+				<Item id="2" name="&amp;Anulare"/>
 				<Item id="4" name="Da la &amp;toate"/>
 				<Item id="5" name="N&amp;u la toate"/>
 			</DoSaveOrNot>
-			<DoSaveAll title="Confirmarea de salvează tot">
-				<Item id="1766" name="Ești sigur că vrei să salvezi toate documentele modificate?
+			<DoSaveAll title="Confirmare salvare toate">
+				<Item id="1766" name="Sigur doriți să salvați toate fișierele modificate?
 
-Alege &quot;Întotdeauna da&quot; dacă nu vrei să vezi acest dialog din nou.
-Poți reactiva acest dialog mai târziu, în Preferințe."/>
+Alegeți «Da la toate» dacă nu doriți să mai vedeți acest mesaj.
+Puteți reactiva acest dialog mai târziu din „Setări > Preferințe > Diverse: Activare dialog de confirmare salvare toate”."/>
 				<Item id="6" name="&amp;Da"/>
 				<Item id="7" name="&amp;Nu"/>
-				<Item id="4" name="&amp;Întotdeauna da"/>
+				<Item id="4" name="Da la &amp;toate"/>
 			</DoSaveAll><!-- HowToReproduce: Check the 'Enable Save All confirm dialog' checkbox in Preference->MISC, now click 'Save all' -->
-        </Dialog>
-        <MessageBox> 
-		<!-- $INT_REPLACE$ is a place holder, don't translate it -->
-            <ContextMenuXmlEditWarning title="Editare meniu contextual" message="Editarea fișierului contextMenu.xml vă permite să modificați meniul contextual al Notepad++.
+		</Dialog>
+		<MessageBox>
+			<!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders. -->
+			<ContextMenuXmlEditWarning title="Editare meniu contextual" message="Editarea fișierului contextMenu.xml vă permite să modificați meniul contextual al Notepad++.
 Trebuie să reporniți Notepad++ pentru a se aplica modificările efectuate în contextMenu.xml."/>
-            <NppHelpAbsentWarning title="Fișierul nu există" message="
-nu există. Vă rugăm să-l descărcați de pe site-ul Notepad++."/>
-            <SaveCurrentModifWarning title="Salvare modificare curentă" message="Ar trebui să salvați modificările curente.
-Toate modificările salvate nu vor putea fi refăcute.
+			<SaveCurrentModifWarning title="Salvare modificare curentă" message="Ar trebui să salvați modificările curente.
+Toate modificările salvate nu vor putea fi anulate.
 
-Continuați?"/>
-            <LoseUndoAbilityWarning title="Atenționare pierdere posibilitate revenire" message="Ar trebui să salvați modificările curente.
-Toate modificările salvate nu vor putea fi refăcute.
+Continuați?"/><!-- HowToReproduce: when you openned file is modified but unsaved yet, and you are changing file encoding. -->
+			<LoseUndoAbilityWarning title="Atenționare pierdere posibilitate revenire" message="Ar trebui să salvați modificările curente.
+Toate modificările salvate nu vor putea fi anulate.
 
-Continuați?"/>
-            <CannotMoveDoc title="Mutare în instanță nouă Notepad++" message="Documentul este modificat, salvați-l și încercați din nou."/>
-            <DocReloadWarning title="Reîncărcare" message="Sigur doriți să reîncărcați fișierul curent și să pierdeți modificările efectuate în Notepad++?"/>
-            <FileLockedWarning title="Salvare eșuată" message="Verificați dacă acest fișier nu este accesat și de un alt program."/>
-            <FileAlreadyOpenedInNpp title="" message="Fișierul este deja deschis în Notepad++."/>
+Continuați?"/><!-- HowToReproduce: when you openned file is modified and saved, then you are changing file encoding. -->
+			<CannotMoveDoc title="Mutare în instanță nouă Notepad++" message="Documentul este modificat. Salvați-l și reîncercați."/><!--HowToReproduce: From your Notepad++ drag & drop a clean (not dirty) file to outside of Notepad++, another instance of Notepad++ will be created. Then from your first Notepad++ drag & drop an unsaved file to the new instance.-->
+			<DocReloadWarning title="Reîncărcare" message="Sigur doriți să reîncărcați fișierul curent și să pierdeți modificările efectuate în Notepad++?"/>
+			<FileLockedWarning title="Salvare eșuată" message="Verificați dacă acest fișier nu este accesat și de către un alt program."/>
+			<FileAlreadyOpenedInNpp title="" message="Fișierul este deja deschis în Notepad++."/><!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
 			<RenameTabTemporaryNameAlreadyInUse title="Redenumire eșuată" message="Numele specificat este deja folosit într-o altă filă."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
-			<RenameTabTemporaryNameIsEmpty title="Redenumire eșuată" message="Numele specificat nu poate fi gol sau nu poate conține numai spațiu(i) sau tabulație(i)/TAB(-uri)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
-            <DeleteFileFailed title="Ștergerea fișierului" message="Ștergerea fișierului eșuată."/>
+			<RenameTabTemporaryNameIsEmpty title="Redenumire eșuată" message="Numele specificat nu poate fi gol sau nu poate conține doar spații sau caractere TAB."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
+			<DeleteFileFailed title="Ștergere fișier" message="Ștergerea fișierului a eșuat."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
-            <NbFileToOpenImportantWarning title="Numărul fișierelor de deschis este prea mare" message="$INT_REPLACE$ fișiere sunt pe cale să fie deschise.
-Sigur doriți să le deschideți?"/>
-            <SettingsOnCloudError title="Setări pentru Cloud" message="Calea setărilor pentru Cloud se află pe o unitate doar cu drepturi de citire
-sau într-un folder ce are nevoie de drepturi de acces pentru scriere.
-Setările pentru cloud vor fi anulate. Reintroduceți o cale validă în panoul [Preferințe]."/>
-             <FilePathNotFoundWarning title="Deschidere fișier" message="Fișierul pe care doriți să-l deschideți nu există."/>
-             <SessionFileInvalidError title="Nu s-a putut încărca sesiunea" message="Sesiunea fișierului este fie coruptă, fie nevalidă."/>
-            <DroppingFolderAsProjectModeWarning title="Acțiune nevalidă" message="Puteți plasa doar fișiere sau doar foldere, dar nu ambele deodată, deoarece sunteți în modul &quot;Folder ca proiect&quot;.
-Pentru a putea efectua această operație, trebuie să activați opțiunea &quot;La plasarea unui folder, se deschid fișierele din el, fără a-l stabili ca spațiu de lucru&quot; din secțiunea &quot;Folder implicit&quot; din panoul [Preferințe]."/>
-            <SortingError title="Eroare sortare" message="Nu se poate executa sortarea numerică datorită liniei $INT_REPLACE$."/>
-            <ColumnModeTip title="Pont mod coloană" message="
-Sunt trei moduri de a comuta în modul de selectare a coloanei:
+			<NbFileToOpenImportantWarning title="Număr fișiere de deschis prea mare" message="Urmează să fie deschise $INT_REPLACE$ fișiere.
+Sigur doriți să le deschideți?"/><!-- HowToReproduce: Check "Open all files of folder instead of launching Folder as Workspace on folder dropping" in "Default Directory" of Preferences dialog, then drop a folder which contains more then 200 files into Notepad++. -->
+			<SettingsOnCloudError title="Setări pentru Cloud" message="Calea setărilor pentru Cloud se află pe o unitate doar cu drepturi de citire
+sau într-un folder care are nevoie de drepturi de acces pentru scriere.
+Setările pentru cloud vor fi anulate. Reintroduceți o cale validă în „Setări->Preferințe->Cloud și legături web”."/>
+			<FilePathNotFoundWarning title="Deschidere fișier" message="Fișierul pe care doriți să-l deschideți nu există."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<SessionFileInvalidError title="Nu s-a putut încărca sesiunea" message="Sesiunea fișierului este fie coruptă, fie nevalidă."/><!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
+			<DroppingFolderAsProjectModeWarning title="Acțiune nevalidă" message="Puteți plasa doar fișiere sau doar foldere, dar nu ambele deodată, deoarece este activat modul „Folder ca proiect”.
+Pentru a putea efectua această operație, trebuie să activați opțiunea „La plasarea unui folder, se deschid fișierele din el, fără a-l stabili ca spațiu de lucru” din „Setări->Preferințe->Folder implicit”."/>
+			<SortingError title="Eroare sortare" message="Nu se poate executa sortarea numerică datorită liniei $INT_REPLACE$."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<ColumnModeTip title="Pont mod coloană" message="
+Există trei posibilități de a comuta la modul de selectare a coloanei:
 
-1. (Tastatură și mouse)  Ține apăsată tasta Alt în timp ce tragi dând clic pe stânga
+1. Tastatură și mouse:
+   Țineți apăsată tasta Alt în timp ce trageți cu clic stânga.
 
-2. (Numai tastaură)  Apasă Alt+Shift în timp ce folosești tastele cu săgeți
+2. Numai tastaură:
+   Apăsați Alt + Shift în timp ce folosiți tastele cu săgeți.
 
-3. (Tastatură sau mouse)
-      Pune marcajul la începutul dorit al poziției blocului coloanei, apoi
-       execută &quot;comanda Selectează Început/Sfârșit în Modul coloană&quot;
-      Pune marcajul la sfârșitul dorit al poziției blocului coloanei, apoi
-       execută &quot;din nou, comanda Selectează Început/Sfârșit în Modul coloană&quot;"/>
-            <BufferInvalidWarning title="Salvare eșuată" message="Nu se poate salva: Bufferul nu este valid."/>
-            <DoSaveOrNot title="Salvare" message="Salvați fișierul &quot;$STR_REPLACE$&quot; ?"/>
-            <DoCloseOrNot title="Păstrare fișiere inexistente" message="Fișierul &quot;$STR_REPLACE$&quot; nu mai există.
+3. Tastatură sau mouse:
+   - Puneți cursorul la începutul dorit al poziției blocului coloanei,
+   apoi executați comanda „Începere / Terminare selectare în mod coloană” (meniul Editare).
+   - Puneți cursorul la sfârșitul dorit al poziției blocului coloanei,
+   apoi executați din nou comanda „Începere / Terminare selectare în mod coloană”."/>
+			<BufferInvalidWarning title="Salvare eșuată" message="Nu se poate salva: bufferul nu este valid."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<DoCloseOrNot title="Păstrare fișier inexistent" message="Fișierul „$STR_REPLACE$” nu mai există.
 Îl păstrați în editor?"/>
-            <DoDeleteOrNot title="Ștergere fișier" message="Fișierul &quot;$STR_REPLACE$&quot;
-va fi mutat în coșul de reciclare și acest document va fi închis.
+			<DoDeleteOrNot title="Ștergere fișier" message="Fișierul „$STR_REPLACE$”
+va fi șters și acest document va fi închis.
 Continuați?"/>
-            <NoBackupDoSaveFile title="Salvare" message="Fișierul de rezervă nu poate fi găsit (a fost șters cu alt program).
+			<NoBackupDoSaveFile title="Salvare" message="Fișierul de rezervă nu poate fi găsit (a fost șters cu alt program).
 Salvați-l sau veți pierde datele.
-Doriți să salvați fișierul &quot;$STR_REPLACE$&quot;?"/>
-            <DoReloadOrNot title="Reîncărcare" message="&quot;$STR_REPLACE$&quot;
+Doriți să salvați fișierul „$STR_REPLACE$”?"/>
+			<DoReloadOrNot title="Reîncărcare" message="„$STR_REPLACE$”
 
 Acest fișier a fost modificat de un alt program.
 Doriți să-l reîncărcați?"/>
-            <DoReloadOrNotAndLooseChange title="Reîncărcare" message="&quot;$STR_REPLACE$&quot;
+			<DoReloadOrNotAndLooseChange title="Reîncărcare" message="„$STR_REPLACE$”
 
 Acest fișier a fost modificat de un alt program.
 Doriți să-l reîncărcați și să anulați modificările efectuate în Notepad++?"/>
-            <PrehistoricSystemDetected title="S-a detectat un sistem preistoric" message="Se pare că încă folosiți un sistem foarte vechi. Această funcție se poate executa doar pe un sistem modern."/>
-            <XpUpdaterProblem title="Actualizator Notepad++" message="Actualizatorul Notepad++ nu este compatibil cu Windows XP datorită nivelelor de securitate depășite ale acestuia.
-Doriți să vizitați pagina de descărcare a Notepad++ pentru a descărca ultima versiune?"/>
-			<GUpProxyConfNeedAdminMode title="Setări proxy" message="Te rugăm să repornești Notepad++ în modul Admin pentru a configura setările proxy."/>
+			<PrehistoricSystemDetected title="S-a detectat un sistem foarte vechi" message="Se pare că încă folosiți un sistem foarte vechi. Această funcție se poate executa doar pe un sistem modern."/><!-- HowToReproduce: Launch "Document Map" under Windows XP. -->
+			<XpUpdaterProblem title="Actualizator Notepad++" message="Actualizatorul Notepad++ nu este compatibil cu Windows XP datorită nivelului de securitate depășit al acestuia.
+Doriți să vizitați pagina de descărcare a Notepad++ pentru a descărca ultima versiune?"/><!-- HowToReproduce: Run menu "? -> Update Notepad++" under Windows XP. -->
+			<GUpProxyConfNeedAdminMode title="Setări proxy" message="Reporniți Notepad++ ca administrator pentru a configura setările proxy."/>
 			<DocTooDirtyToMonitor title="Problemă monitorizare" message="Documentul este necorespunzător. Salvați modificările înainte de a-l monitoriza."/>
-            <DocNoExistToMonitor title="Problemă monitorizare" message="Pentru a putea fi monitorizat fișierul trebuie să existe."/>
-            <FileTooBigToOpen title="Problemă dimensiune fișier" message="Fișierul este prea mare pentru a fi deschis cu Notepad++"/>
+			<DocNoExistToMonitor title="Problemă monitorizare" message="Pentru a putea fi monitorizat fișierul trebuie să existe."/>
+			<FileTooBigToOpen title="Problemă dimensiune fișier" message="Fișierul este prea mare pentru a fi deschis cu Notepad++"/><!-- HowToReproduce: Try to open a 4GB file (it's not easy to reproduce, it depends on your system). -->
 			<FileLoadingException title="Cod de excepție: $STR_REPLACE$" message="A apărut o eroare în timpul încărcării fișierului!"/>
-			<WantToOpenHugeFile title="Avertizare de deschidere a unui fișier uriaș" message="Dechiderea unui fișier uriaș de peste 2GB ar putea dura câteva minute.
-Vrei să îl deschizi?"/>
-            <CreateNewFileOrNot title="Creare fișier nou" message="Fișierul &quot;$STR_REPLACE$&quot; nu există. Îl creați?."/>
-            <CreateNewFileError title="Creare fișier nou" message="Nu se poate crea fișierul &quot;$STR_REPLACE$&quot;."/>
-            <OpenFileError title="EROARE" message="Nu se poate deschide fișierul &quot;$STR_REPLACE$&quot;."/>
-			<OpenFileNoFolderError title="Nu se poate deschide fișierul" message="&quot;$STR_REPLACE1$&quot; nu poate fi deschis:
-Dosarul &quot;$STR_REPLACE2$&quot; nu există."/>
-            <FileBackupFailed title="Eșuare conservare fișier" message="Versiunea anterioară a fișierului nu a putut fi salvată în folderul de conservări aflat în &quot;$STR_REPLACE$&quot;.
+			<WantToOpenHugeFile title="Avertizare deschidere fișier mare" message="Dechiderea unui fișier mare de peste 2 GiB ar putea dura câteva minute.
+Doriți să îl deschideți?"/>
+			<CreateNewFileOrNot title="Creare fișier nou" message="Fișierul „$STR_REPLACE$” nu există. Îl creați?."/>
+			<CreateNewFileError title="Creare fișier nou" message="Nu se poate crea fișierul „$STR_REPLACE$”."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<OpenFileError title="EROARE" message="Nu se poate deschide fișierul „$STR_REPLACE$”."/>
+			<OpenFileNoFolderError title="Nu se poate deschide fișierul" message="Nu se poate deschide „$STR_REPLACE1$”.
+Folderul „$STR_REPLACE2$” nu există."/>
+			<FileBackupFailed title="Eșuare conservare fișier" message="Versiunea anterioară a fișierului nu a putut fi salvată în folderul de conservări aflat în „$STR_REPLACE$”.
 
-Doriți totuși să salvați fișierul curent?"/>
-            <LoadStylersFailed title="Eșuare încărcare stylers.xml" message="Încărcare eșuată &quot;$STR_REPLACE$&quot;!"/>
-            <LoadLangsFailed title="Configurator" message="Eșuare încărcare langs.xml!
-Doriți să recuperați fișierul langs.xml?"/>
-            <LoadLangsFailedFinal title="Configurator" message="Eșuare încărcare langs.xml!"/>
-            <FolderAsWorspaceSubfolderExists title="Problemă la adăugarea folderului ca spațiu de lucru" message="Există un subfolder al folderului pe care doriți să-l adăugați.
-Eliminați rădăcina acestuia din panou înainte de a adăuga folderul &quot;$STR_REPLACE$&quot;."/>
+Doriți totuși să salvați fișierul curent?"/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<LoadStylersFailed title="Eșuare încărcare stylers.xml" message="Încărcarea fișierului „$STR_REPLACE$” a eșuat!"/>
+			<LoadLangsFailed title="Configurator" message="Eșuare încărcare fișier langs.xml!
+Doriți să recuperați fișierul langs.xml?"/><!-- HowToReproduce: Close Notepad++. Use another editor to remove all content of "langs.xml" (0 length) then save it. Open Notepad++. -->
+			<LoadLangsFailedFinal title="Configurator" message="Eșuare încărcare langs.xml!"/><!-- HowToReproduce: Close Notepad++. Use another editor to make "langs.xml" an invalid xml file then save it. Open Notepad++. -->
+			<FolderAsWorspaceSubfolderExists title="Problemă adăugare folder ca spațiu de lucru" message="Un subfolder al folderului pe care doriți să-l adăugați există deja.
+Eliminați rădăcina acestuia din panou înainte de a adăuga folderul „$STR_REPLACE$”."/><!-- HowToReproduce: Add a folder like "c:\temp\aFolder\" into "Folder as Workspace" panel, then try to add "c:\temp\". -->
 
-            <ProjectPanelChanged title="$STR_REPLACE$" message="Spațiul de lucru a fost modificat. Doriți să-l salvați?"/>
-            <ProjectPanelChangedSaveError title="$STR_REPLACE$" message="Spațiul de lucru nu a fost salvat."/>
-			<ProjectPanelSaveError title="$STR_REPLACE$" message="A apărut o eroare în timp ce s-a scris în fișierul spațiului tău de lucru.
-Spațiul tău de lucru nu a putut fi salvat."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
-            <ProjectPanelOpenDoSaveDirtyWsOrNot title="Deschidere spațiu de lucru" message="Spațiul de lucru curent a fost modificat. Doriți să salvați proiectul curent?"/>
-            <ProjectPanelNewDoSaveDirtyWsOrNot title="Spațiu de lucru nou" message="Spațiul de lucru curent a fost modificat. Doriți să salvați proiectul curent?"/>
-            <ProjectPanelOpenFailed title="Deschidere spațiu de lucru" message="Spațiul de lucru nu a putut fi deschis.
-Se pare că fișierul ce trebuie dschis nu este un fișier de proiect valid."/>
-            <ProjectPanelRemoveFolderFromProject title="Eliminare folder din proiect" message="Toate subelementele acestuia vor fi eliminate.
+			<ProjectPanelChanged title="$STR_REPLACE$" message="Spațiul de lucru a fost modificat. Doriți să-l salvați?"/>
+			<ProjectPanelSaveError title="$STR_REPLACE$" message="A apărut o eroare în timpul scrierii fișierului spațiului de lucru.
+Spațiul de lucru nu a putut fi salvat."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<ProjectPanelOpenDoSaveDirtyWsOrNot title="Deschidere spațiu de lucru" message="Spațiul de lucru curent a fost modificat. Doriți să salvați proiectul curent?"/>
+			<ProjectPanelNewDoSaveDirtyWsOrNot title="Spațiu de lucru nou" message="Spațiul de lucru curent a fost modificat. Doriți să salvați proiectul curent?"/>
+			<ProjectPanelOpenFailed title="Deschidere spațiu de lucru" message="Spațiul de lucru nu a putut fi deschis.
+Se pare că fișierul care trebuie deschis nu este un fișier de proiect valid."/>
+			<ProjectPanelRemoveFolderFromProject title="Eliminare folder din proiect" message="Toate subelementele acestuia vor fi eliminate.
 Sigur doriți să eliminați acest folder din proiect?"/>
-            <ProjectPanelRemoveFileFromProject title="Eliminare fișier din proiect" message="Sigur doriți să eliminați acest fișier din proiect?"/>
-            <ProjectPanelReloadError title="Reîncărcare spațiu de lucru" message="Nu se poate găsi fișierul ce trebuie reîncărcat."/>
-            <ProjectPanelReloadDirty title="Reîncărcare spațiu de lucru" message="Spațiul de lucru a fost modificat. Reîncărcarea va ignora toate modificările efectuate.
+			<ProjectPanelRemoveFileFromProject title="Eliminare fișier din proiect" message="Sigur doriți să eliminați acest fișier din proiect?"/>
+			<ProjectPanelReloadError title="Reîncărcare spațiu de lucru" message="Nu se poate găsi fișierul care trebuie reîncărcat."/>
+			<ProjectPanelReloadDirty title="Reîncărcare spațiu de lucru" message="Spațiul de lucru a fost modificat. Reîncărcarea va ignora toate modificările efectuate.
 Doriți să continuați?"/>
-            <UDLNewNameError title="Eroare UDL" message="Acest nume este utilizat de alt limbaj,
-alegeți altul."/>
-            <UDLRemoveCurrentLang title="Eliminare limbaj curent" message="Sunteți sigur?"/>
-            <SCMapperDoDeleteOrNot title="Sunteți sigur?" message="Sigur doriți să eliminați această combinație de taste?"/>
-            <FindCharRangeValueError title="Problemă valoare interval" message="Ar trebui să introduceți o valoare între 0 și 255."/>
-            <OpenInAdminMode title="Salvare eșuată" message="Fișierul nu poate fi salvat și s-ar putea să fie protejat.
-Doriți să lansați Notepad++ în mod Administrator?"/>
-            <OpenInAdminModeWithoutCloseCurrent title="Salvare eșuată" message="Fișierul nu poate fi salvat și s-ar putea să fie protejat.
-Doriți să lansați Notepad++ în mod Administrator?"/>
-            <OpenInAdminModeFailed title="Deschidere în mod Administrator eșuat" message="Notepad++ nu poate fi deschis în mod Administrator."/>        
-            <ViewInBrowser title="Afişare fişier curent în navigator" message="Aplicaţia nu poate fi găsită în sistem."/>
-			<ExitToUpdatePlugins title="Urmează să ieși din Notepad++" message="Dacă apeși DA, o să ieși din Notepad++ pentru a continua operațiunile.
-Notepad++ va fi repornit după ce toate operațiunile vor fi terminate.
-Vrei să continui?"/>
-			<NeedToRestartToLoadPlugins title="Notepad++ trebuie să fie relansat" message="Trebuie să repornești Notepad++ pentru a încărcarca modulele instalate."/><!-- HowToReproduce: Import a plugin via menu "Settings->Import->Import Plugin(s)...". -->
-			<ChangeHistoryEnabledWarning title="Notepad++ trebuie să fie relansat" message="Trebuie să repornești Notepad++ pentru a activa Istoricul schimbărilor."/><!-- HowToReproduce: uncheck "Display Change History" via Preferences dialog "Marges/Border/Edge. -->
-			<WindowsSessionExit title="Notepad++ - Ieșirea sesiunii Windows" message="Sesiunea Windows este pe cale de a se termina, dar ai anumite date nesavate. Vre să ieși din Notepad++ acum?"/>
-			<LanguageMenuCompactWarning title="Meniul de limbi compact" message="Această opțiune va fi schimbată la următoarea lansare."/><!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
-			<SwitchUnsavedThemeWarning title="$STR_REPLACE$" message="Schimbările nesalvate urmează să fie anulate!
-Vreți să salvați schimbările înainte de a schimba tema?"/><!-- HowToReproduce: In the Style Configurator dialog change some theme and switch to other theme without saving. -->
-			<MacroAndRunCmdlWarning title="Compatibilitatea comenzilor Macro și Rulează" message="Comenzile tale Macro și Rulează salvate în Notepad++ v.8.5.2 (sau mai vechi) pot să nu fie compatibilie cu versiunea curentă de Notepad++.
-Te rugăm să testezi comenzile și dacă e nevoie, să le re-editezi.
-
-Alternativ, poți să revii la Notepad++ v8.5.2 și poți restaura datele anterioare.
-Notepad++ îți va restaura vechiul &quot;shortcuts.xml&quot; și îl va salva ca &quot;shortcuts.xml.v8.5.2.backup&quot;.
-Redenumind &quot;shortcuts.xml.v8.5.2.backup&quot; -&gt; &quot;shortcuts.xml&quot;, comenzile tale ar trebui restaurate și să lucreze perfect."/><!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
+			<UDLNewNameError title="Eroare UDL" message="Acest nume este utilizat de alt limbaj.
+Alegeți altul."/>
+			<UDLRemoveCurrentLang title="Eliminare limbaj curent" message="Confirmați eliminarea?"/>
+			<SCMapperDoDeleteOrNot title="Confirmare?" message="Sigur doriți să ștergeți această combinație de taste?"/>
+			<FindCharRangeValueError title="Problemă valoare interval" message="Ar trebui să introduceți o valoare între 0 și 255."/>
+			<OpenInAdminMode title="Salvare eșuată" message="Fișierul nu poate fi salvat și s-ar putea să fie protejat.
+Doriți să lansați Notepad++ în mod administrator?"/>
+			<OpenInAdminModeWithoutCloseCurrent title="Salvare eșuată" message="Fișierul nu poate fi salvat și s-ar putea să fie protejat.
+Doriți să lansați Notepad++ în mod administrator?"/>
+			<OpenInAdminModeFailed title="Deschidere în mod administrator eșuată" message="Notepad++ nu poate fi deschis în mod administrator."/><!-- HowToReproduce: When you have no Admin privilege and you try to save a modified file in a protected location (for example: any file in sub-folder of "C:\Program Files\". This message will appear after replying "Yes" to "Open in Admin mode" dialog. -->
+			<ViewInBrowser title="Afișare fișier curent în navigator web" message="Aplicația nu poate fi găsită în sistem."/>
+			<ExitToUpdatePlugins title="Notepad++ urmează să fie închis" message="Dacă apăsați pe «Da», Notepad++ va fi închis pentru a continua operațiunile.
+Apoi va fi repornit după terminarea acestora.
+Continuați?"/>
+			<NeedToRestartToLoadPlugins title="Notepad++ trebuie repornit" message="Notepad++ trebuie repornit pentru a încărcarca modulele instalate."/><!-- HowToReproduce: Import a plugin via menu "Settings->Import->Import Plugin(s)...". -->
+			<ChangeHistoryEnabledWarning title="Notepad++ trebuie repornit" message="Notepad++ trebuie repornit pentru a activa istoricul modificărilor."/><!-- HowToReproduce: uncheck "Display Change History" via Preferences dialog "Margines/Border/Edge.. -->
+			<WindowsSessionExit title="Notepad++ - Închidere sesiune Windows" message="Sesiunea Windows este pe cale să fie închisă, dar există anumite date nesalvate. Închideți Notepad++ acum?"/>
+			<LanguageMenuCompactWarning title="Meniu de limbi compact" message="Această opțiune va fi modificată la următoarea lansare."/><!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
+			<SwitchUnsavedThemeWarning title="$STR_REPLACE$" message="Modificările nesalvate vor fi anulate!
+Doriți să salvați modificările înainte de a schimba tema?"/><!-- HowToReproduce: In the Style Configurator dialog change some theme and switch to other theme without saving. -->
+			<MacroAndRunCmdlWarning title="Compatibilitate comenzi Macro și Executare" message="Comenzile pentru funcțiile „Macro” și „Execuatre” salvate în Notepad++ v.8.5.2 (sau mai vechi) pot să nu fie compatibilie cu versiunea curentă a Notepad++.
+Testați comenzile și dacă e nevoie reeditați-le.
+Alternativ, puteți reveni la Notepad++ v8.5.2 și restaura datele anterioare.
+Notepad++ va restaura vechiul fișier „shortcuts.xml” și îl va salva ca
+„shortcuts.xml.v8.5.2.backup”;.
+Redenumind „shortcuts.xml.v8.5.2.backup” în „shortcuts.xml”, comenzile vor fi restaurate și vor funcționa ca înainte."/><!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
 		</MessageBox>
-        <ClipboardHistory>
-            <PanelTitle name="Istoricul clipboard-ului"/>
-        </ClipboardHistory>
-        <DocList>
-            <PanelTitle name="Comutare document"/>
-            <ColumnName name="Nume"/>
-            <ColumnExt name="Ext."/>
+		<ClipboardHistory>
+			<PanelTitle name="Istoric conținut memorie"/>
+		</ClipboardHistory>
+		<DocList>
+			<PanelTitle name="Listă documente"/>
+			<ColumnName name="Nume"/>
+			<ColumnExt name="Extensie"/>
 			<ColumnPath name="Cale"/>
-			<ListGroups name="Grupare după vizualizare"/>
-        </DocList>
-        <WindowsDlg>
-            <ColumnName name="Nume"/>
-            <ColumnPath name="Cale"/>
-            <ColumnType name="Tip"/>
-            <ColumnSize name="Mărime"/>
-            <NbDocsTotal name="documente totale:"/>
-            <MenuCopyName name="Numele de copiat"/>
-            <MenuCopyPath name="Numele căii/căilor de copiat"/>
-        </WindowsDlg>	
-        <AsciiInsertion>
-            <PanelTitle name="Panou inserare ASCII"/>
-            <ColumnVal name="Valoare"/>
-            <ColumnHex name="Hex"/>
-            <ColumnChar name="Caracter"/>
-            <ColumnHtmlName name="Nume HTML"/>
-            <ColumnHtmlNumber name="Număr zecimal HTML"/>
-            <ColumnHtmlHexNb name="Număr hexazecimal HTML"/>
-        </AsciiInsertion>
-        <DocumentMap>
-            <PanelTitle name="Hartă document"/>
-        </DocumentMap>
-        <FunctionList>
-            <PanelTitle name="Listă funcții"/>
-            <SortTip name="Sortare" />
-            <ReloadTip name="Reactualizare" />
+			<ListGroups name="Grupare după panou"/>
+		</DocList>
+		<WindowsDlg>
+			<ColumnName name="Nume"/>
+			<ColumnPath name="Cale"/>
+			<ColumnType name="Tip"/>
+			<ColumnSize name="Mărime"/>
+			<NbDocsTotal name="documente totale:"/>
+			<MenuCopyName name="Copiere nume fișier"/>
+			<MenuCopyPath name="Copiere cale fișier"/>
+		</WindowsDlg>
+		<AsciiInsertion>
+			<PanelTitle name="Panou inserare coduri ASCII"/>
+			<ColumnVal name="Valoare"/>
+			<ColumnHex name="Hex"/>
+			<ColumnChar name="Caracter"/>
+			<ColumnHtmlName name="Nume HTML"/>
+			<ColumnHtmlNumber name="Zecimal HTML"/>
+			<ColumnHtmlHexNb name="Hex HTML"/>
+		</AsciiInsertion>
+		<DocumentMap>
+			<PanelTitle name="Hartă document"/>
+		</DocumentMap>
+		<FunctionList>
+			<PanelTitle name="Listă funcții"/>
+			<SortTip name="Sortare"/>
+			<ReloadTip name="Reîncărcare"/>
 			<PreferencesTip name="Preferințe"/>
-			<PreferencesInitialSort name="Funcțiile de sortare (de la A la Z), implicit"/>
-        </FunctionList>
-        <FolderAsWorkspace>
-            <PanelTitle name="Folder ca spațiu de lucru"/>
-            <SelectFolderFromBrowserString name="Selectare folder adăugat în panoul [Folder ca spațiu de lucru]"/>
-			<ExpandAllFoldersTip name="Desfășurare totală"/>
-			<CollapseAllFoldersTip name="Înfășurare totală"/>
-			<LocateCurrentFileTip name="Localizează fișierul curent"/>
-            <Menu>
-                <Item id="3511" name="Eliminare"/>
-                <Item id="3512" name="Eliminare toate"/>
-                <Item id="3513" name="Adăugare"/>
-                <Item id="3514" name="Executat de sistem"/>
-                <Item id="3515" name="Deschidere"/>
-                <Item id="3516" name="Copiere cale"/>
-                <Item id="3517" name="Căutare în fișiere..."/>
-                <Item id="3518" name="Explorer aici"/>
-                <Item id="3519" name="CMD aici"/>
-				<Item id="3520" name="Copiază numele fișierului"/>
-            </Menu>
-        </FolderAsWorkspace>
-        <ProjectManager>
-            <PanelTitle name="Proiect"/>
-            <WorkspaceRootName name="Spațiu de lucru"/>
-            <NewProjectName name="Nume proiect"/>
-            <NewFolderName name="Nume folder"/>
-            <Menus>
-                <Entries>
-                    <Item id="0" name="Spațiu de lucru"/>
-                    <Item id="1" name="Editare"/>
-                </Entries>
-                <WorkspaceMenu>
-                    <Item id="3122" name="Spațiu de lucru nou"/>
-                    <Item id="3123" name="Deschidere spațiu de lucru"/>
-                    <Item id="3124" name="Reîncărcate spațiu de lucru"/>
-                    <Item id="3125" name="Salvare"/>
-                    <Item id="3126" name="Salvare ca..."/>
-                    <Item id="3127" name="Salvare copie ca..."/>
-                    <Item id="3121" name="Adăugare proiect nou"/>
-					<Item id="3128" name="Găsește în proiecte..."/>
-                </WorkspaceMenu>
-                <ProjectMenu>
-                    <Item id="3111" name="Redenumire"/>
-                    <Item id="3112" name="Adăugare folder"/>
-                    <Item id="3113" name="Adăugare fișiere..."/>
-                    <Item id="3117" name="Adăugare fișiere din folder..."/>
-                    <Item id="3114" name="Eliminare"/>
-                    <Item id="3118" name="Urcare"/>
-                    <Item id="3119" name="Coborâre"/>
-                </ProjectMenu>
-                <FolderMenu>
-                    <Item id="3111" name="Redenumire"/>
-                    <Item id="3112" name="Adăugare folder"/>
-                    <Item id="3113" name="Adăugare fișiere..."/>
-                    <Item id="3117" name="Adăugare fișiere din folder..."/>
-                    <Item id="3114" name="Eliminare"/>
-                    <Item id="3118" name="Urcare"/>
-                    <Item id="3119" name="Coborâre"/>
-                </FolderMenu>
-                <FileMenu>
-                    <Item id="3111" name="Redenumire"/>
-                    <Item id="3115" name="Eliminare"/>
-                    <Item id="3116" name="Modificare cale fișier"/>
-                    <Item id="3118" name="Urcare"/>
-                    <Item id="3119" name="Coborâre"/>
-                </FileMenu>
-            </Menus>
-        </ProjectManager>
-        <MiscStrings>
-            <!-- $INT_REPLACE$ și $STR_REPLACE$ sunt variabile, nu le traduceți -->
-            <word-chars-list-tip value="Se permite includerea de caractere adiționale în lista curentă de caractere când se dă dublu clic pe o selectare la căutarea cu opțiunea &quot;Potrivire doar cuvinte&quot; activată."/><!-- HowToReproduce: In "Delimiter" section of Preferences dialog, hover your mouse on the "?" button. -->
-			
+			<PreferencesInitialSort name="Sortare funcții implicită (A la Z)"/>
+		</FunctionList>
+		<FolderAsWorkspace>
+			<PanelTitle name="Folder ca spațiu de lucru"/>
+			<SelectFolderFromBrowserString name="Selectare folder de adăugat în panoul [Folder ca spațiu de lucru]"/>
+			<ExpandAllFoldersTip name="Depliere totală"/>
+			<CollapseAllFoldersTip name="Pliere totală"/>
+			<LocateCurrentFileTip name="Găsire fișier curent"/>
+			<Menu>
+				<Item id="3511" name="Eliminare"/>
+				<Item id="3512" name="Eliminare toate"/>
+				<Item id="3513" name="Adăugare"/>
+				<Item id="3514" name="Executat de sistem"/>
+				<Item id="3515" name="Deschidere"/>
+				<Item id="3516" name="Copiere cale"/>
+				<Item id="3517" name="Căutare în fișiere..."/>
+				<Item id="3518" name="Explorer aici"/>
+				<Item id="3519" name="CMD aici"/>
+				<Item id="3520" name="Copiere nume fișier"/>
+			</Menu>
+		</FolderAsWorkspace>
+		<ProjectManager>
+			<PanelTitle name="Proiect"/>
+			<WorkspaceRootName name="Spațiu de lucru"/>
+			<NewProjectName name="Nume proiect"/>
+			<NewFolderName name="Nume folder"/>
+			<Menus>
+				<Entries>
+					<Item id="0" name="Spațiu de lucru"/>
+					<Item id="1" name="Editare"/>
+				</Entries>
+				<WorkspaceMenu>
+					<Item id="3122" name="Spațiu de lucru nou"/>
+					<Item id="3123" name="Deschidere spațiu de lucru"/>
+					<Item id="3124" name="Reîncărcate spațiu de lucru"/>
+					<Item id="3125" name="Salvare"/>
+					<Item id="3126" name="Salvare ca..."/>
+					<Item id="3127" name="Salvare copie ca..."/>
+					<Item id="3121" name="Adăugare proiect nou"/>
+					<Item id="3128" name="Căutare în proiecte..."/>
+				</WorkspaceMenu>
+				<ProjectMenu>
+					<Item id="3111" name="Redenumire"/>
+					<Item id="3112" name="Adăugare folder"/>
+					<Item id="3113" name="Adăugare fișiere..."/>
+					<Item id="3117" name="Adăugare fișiere din folder..."/>
+					<Item id="3114" name="Eliminare"/>
+					<Item id="3118" name="Urcare"/>
+					<Item id="3119" name="Coborâre"/>
+				</ProjectMenu>
+				<FolderMenu>
+					<Item id="3111" name="Redenumire"/>
+					<Item id="3112" name="Adăugare folder"/>
+					<Item id="3113" name="Adăugare fișiere..."/>
+					<Item id="3117" name="Adăugare fișiere din folder..."/>
+					<Item id="3114" name="Eliminare"/>
+					<Item id="3118" name="Urcare"/>
+					<Item id="3119" name="Coborâre"/>
+				</FolderMenu>
+				<FileMenu>
+					<Item id="3111" name="Redenumire"/>
+					<Item id="3115" name="Eliminare"/>
+					<Item id="3116" name="Modificare cale fișier"/>
+					<Item id="3118" name="Urcare"/>
+					<Item id="3119" name="Coborâre"/>
+				</FileMenu>
+			</Menus>
+		</ProjectManager>
+		<MiscStrings>
+			<!-- $INT_REPLACE$ și $STR_REPLACE$ sunt variabile, nu le traduceți -->
+			<word-chars-list-tip value="Se permite includerea de caractere adiționale în lista curentă de caractere când se dă clic dublu pe o selectare la căutarea cu opțiunea „Potrivire cuvinte” activată."/><!-- HowToReproduce: In "Delimiter" section of Preferences dialog, hover your mouse on the "?" button. -->
+
 			<!-- Don't translate "(&quot;EOL custom color&quot;)" -->
-			<eol-custom-color-tip value="Mergi în Configuratorul de stiluri pentru a schimba culoarea particularizată a EOL-ului implicit(&quot;EOL culoare particularizată&quot;).."/>
-			
-            <word-chars-list-warning-begin value="Atenție: "/>
-            <word-chars-list-space-warning value="$INT_REPLACE$ spațiu(i)"/>
-            <word-chars-list-tab-warning value="$INT_REPLACE$ Tab(-uri)"/>
-            <word-chars-list-warning-end value="  în lista ta de caractere."/>
-			<backup-select-folder value="Selectează un dosar ca director pentru copii de rezervă"/><!-- HowToReproduce: Settings > Preferences > Backup > [...] -->
-            <cloud-invalid-warning value="Cale nevalidă."/>
-            <cloud-restart-warning value="Reporniți Notepad++ pentru aplicare modificări."/>
-            <cloud-select-folder value="Selectare folder din/în care Notepad++ citește/scrie setările sale"/>
-			<default-open-save-select-folder value="Selectează un dosar ca director implicit"/><!-- HowToReproduce: Settings > Preferences > Default Directory > [...] -->
-            <shift-change-direction-tip value="Folosiți Shift+Enter pentru a căuta în direcția opusă"/>
-            <two-find-buttons-tip value="Mod găsire cu 2 butoane"/>
-			<file-rename-title value="Redenumește"/>
-			<find-in-files-filter-tip value="Găsește în cpp, cxx, h, hxx &amp;&amp; hpp:
+			<eol-custom-color-tip value="Accesați „Configurator stiluri...” pentru a schimba culoarea implicită pentru sfârșit de linie (&quot;EOL custom color&quot;)."/>
+
+			<word-chars-list-warning-begin value="Atenție: "/>
+			<word-chars-list-space-warning value="$INT_REPLACE$ spațiu(i)"/>
+			<word-chars-list-tab-warning value="$INT_REPLACE$ Tab(-uri)"/>
+			<word-chars-list-warning-end value="  în lista de caractere."/><!--HowToReproduce: In "Delimiter" section of Preferences dialog, check "Add your character as part of word\r(don't choose it unless you know what you're doing)", then type a white-space in the text field.-->
+			<backup-select-folder value="Selectați folderul pentru stocarea conservărilor"/><!-- HowToReproduce: Settings > Preferences > Backup > [...] -->
+			<cloud-invalid-warning value="Cale nevalidă."/>
+			<cloud-restart-warning value="Reporniți Notepad++ pentru aplicare modificări."/>
+			<cloud-select-folder value="Selectare folder din / în care Notepad++ își citește / scrie setările"/><!--HowToReproduce: In "Cloud" section of Preferences dialog, check "Set your cloud location path here: ", then click the button "...". This message is displayed in the "Browse For Folder" dialog.-->
+			<default-open-save-select-folder value="Selectați folderul implicit"/><!-- HowToReproduce: Settings > Preferences > Default Directory > [...] -->
+			<shift-change-direction-tip value="Folosiți Shift + Enter pentru a căuta în direcția opusă"/>
+			<two-find-buttons-tip value="Mod căutare cu două butoane"/>
+			<file-rename-title value="Redenumire"/>
+			<find-in-files-filter-tip value="Căutare în cpp, cxx, h, hxx și hpp:
 *.cpp *.cxx *.h *.hxx *.hpp
 
-Găsește în toate fișierele, exceptând exe, obj &amp;&amp; log:
+Căutare în toate fișierele, exceptând exe, obj și log:
 *.* !*.exe !*.obj !*.log
 
-Găsește în toate fișierele, dar exclude dosarele tests, bin &amp;&amp; bin64:
+Căutare în toate fișierele, dar exclude foldere tests, bin și bin64:
 *.* !\tests !\bin*
 
-Găsește în toate fișierele, dar exclude toate dosarele log sau logs în mod recursiv:
+Căutare în toate fișierele, dar exclude toate folderele log sau logs în mod recursiv:
 *.* !+\log*"/><!-- HowToReproduce: Tip of mouse hovered on "Filters" label in "Find in Files" section of Find dialog. -->
-			<find-in-files-select-folder value="Selectează un dosar de căutare în"/><!-- HowToReproduce: Search > Find in Files > [...] -->
-            <find-status-top-reached value="Căutare: S-a găsit prima potrivire de jos.S-a ajuns la începutul documentului."/>
-            <find-status-end-reached value="Căutare: S-a găsit prima potrivire de sus. S-a ajuns la sfârșitul documentului."/>
-            <find-status-replaceinfiles-1-replaced value="Înlocuire în fișiere: a fost înlocuită o potrivire"/>
-            <find-status-replaceinfiles-nb-replaced value="Înlocuire în fișiere: s-au înlocuit $INT_REPLACE$ potriviri."/>
-            <find-status-replaceinfiles-re-malformed value="Înlocuire în fișierele deschise: expresia regulată este eronată."/>
-            <find-status-replaceinopenedfiles-1-replaced value="Înlocuire în fișierele deschise: a fost înlocuită o potrivire"/>
-            <find-status-replaceinopenedfiles-nb-replaced value="Înlocuire în fișierele deschise: s-au înlocuit $INT_REPLACE$ potriviri."/>
-            <find-status-mark-re-malformed value="Marcare: expresia regulată de căutare este eronată."/>
-            <find-status-invalid-re value="Căutare: expresie regulată nevalidă."/>
-			<find-status-search-failed value="Găsește: căutare eșuată"/>
-            <find-status-mark-1-match value="O potrivire"/>
-            <find-status-mark-nb-matches value="$INT_REPLACE$ potriviri"/>
-            <find-status-count-re-malformed value="Contorizare: expresia regulată de căutare este eronată."/>
-            <find-status-count-1-match value="Contorizare: o potrivire."/>
-            <find-status-count-nb-matches value="Contorizare: $INT_REPLACE$ potriviri."/>
-            <find-status-replaceall-re-malformed value="Înlocuire toate: expresia regulată este eronată."/>
-            <find-status-replaceall-1-replaced value="Înlocuire toate: a fost înlocuită o potrivire."/>
-            <find-status-replaceall-nb-replaced value="Înlocuire toate: s-au înlocuit $INT_REPLACE$ potriviri."/>
-			<find-status-replaceall-re-malformed value="Înlocuire toate: Expresia regulată este defectă"/>
-			<find-status-replaceall-1-replaced value="Înlocuire toate: 1 potrivire a fost înlocuită"/>
-			<find-status-replaceall-nb-replaced value="Înlocuire toate: $INT_REPLACE$ potriviri au fost înlocuite"/>
-            <find-status-replaceall-readonly value="Înlocuire toate: textul nu poate fi înlocuit. Documentul curent are blocată salvarea modificărilor."/>
-            <find-status-replace-end-reached value="Înlocuire: s-a înlocuit prima potrivire de sus. S-a atins sfârșitul documentului."/>
-            <find-status-replace-top-reached value="Înlocuire: s-a înlocuit prima potrivire de jos. S-a atins începutul documentului."/>
-            <find-status-replaced-next-found value="Înlocuire: s-a înlocuit o potrivire. S-a mai găsit o potrivire."/>
-			<find-status-replaced-without-continuing value="Înlocuire: 1 potrivire a fost înlocuită."/>
-            <find-status-replaced-next-not-found value="Înlocuire: s-a înlocuit o potrivire. Nu s-au mai găsit potriviri."/>
-            <find-status-replace-not-found value="Înlocuire: nu s-au găsit potriviri"/>
-            <find-status-replace-readonly value="Înlocuire: textul nu poate fi înlocuit. Documentul curent are blocată salvarea modificărilor."/>
-            <find-status-cannot-find value="Căutare: nu se poate găsi textul &quot;$STR_REPLACE$&quot;."/>
-            <find-status-scope-selection value="în textul selectat"/>
-            <find-status-scope-all value="în întregul fișier"/>
-            <find-status-scope-backward value="de la începutul fișierului la semnul de omisiune"/>
-            <find-status-scope-forward value="de la semnul de omisiune la sfârșitul fișierului"/>
-            <finder-find-in-finder value="Căutare în rezultatele găsite..."/>
-            <finder-close-this value="Închidere căutător"/>
-            <finder-collapse-all value="Restrângere toate"/>
-            <finder-uncollapse-all value="Extindere toate"/>
-            <finder-copy value="Copiere"/>
+			<find-in-files-select-folder value="Selectați folderul în care se caută"/><!-- HowToReproduce: Search > Find in Files > [...] -->
+			<find-status-top-reached value="[Căutare] S-a găsit prima potrivire de jos. S-a atins începutul documentului."/>
+			<find-status-end-reached value="[Căutare] S-a găsit prima potrivire de sus. S-a atins sfârșitul documentului."/>
+			<find-status-replaceinfiles-1-replaced value="[Înlocuire în fișiere] S-a efectuat o înlocuire."/>
+			<find-status-replaceinfiles-nb-replaced value="[Înlocuire în fișiere] Înlocuiri efectuate: $INT_REPLACE$"/>
+			<find-status-replaceinopenedfiles-1-replaced value="[Înlocuire în fișiere deschise] S-a efectuat o înlocuire."/>
+			<find-status-replaceinopenedfiles-nb-replaced value="[Înlocuire în fișiere deschise] Înlocuiri efectuate: $INT_REPLACE$"/>
+			<find-status-invalid-re value="[Căutare] Expresie regulată nevalidă."/>
+			<find-status-search-failed value="[Căutare] Căutarea a eșuat."/>
+			<find-status-mark-1-match value="[Marcare] S-a găsit o potrivire"/>
+			<find-status-mark-nb-matches value="[Marcare] Marcări efectuate: $INT_REPLACE$"/>
+			<find-status-count-1-match value="[Numărare] S-a găsit o potrivire"/>
+			<find-status-count-nb-matches value="[Numărare] Total potriviri numărate: $INT_REPLACE$"/>
+			<find-status-replaceall-1-replaced value="[Înlocuire toate] S-a efectuat o înlocuire"/>
+			<find-status-replaceall-nb-replaced value="[Înlocuire toate] Înlocuiri efectuate: $INT_REPLACE$"/>
+			<find-status-replaceall-readonly value="[Înlocuire toate] Textul nu poate fi înlocuit. Documentul este doar în mod citire."/>
+			<find-status-replace-end-reached value="[Înlocuire] S-a înlocuit prima potrivire de sus. S-a atins sfârșitul documentului."/>
+			<find-status-replace-top-reached value="[Înlocuire] S-a înlocuit prima potrivire de jos. S-a atins începutul documentului."/>
+			<find-status-replaced-next-found value="[Înlocuire] S-a efectuat o înlocuire. S-a mai găsit o potrivire."/>
+			<find-status-replaced-without-continuing value="[Înlocuire] S-a efectuat o înlocuire."/>
+			<find-status-replaced-next-not-found value="[Înlocuire] S-a efectuat o înlocuire. Nu s-au mai găsit potriviri."/>
+			<find-status-replace-not-found value="[Înlocuire] Nu s-au găsit potriviri."/>
+			<find-status-replace-readonly value="[Înlocuire] Textul nu poate fi înlocuit. Documentul este doar în mod citire."/>
+			<find-status-cannot-find value="[Căutare] Nu se poate găsi textul „$STR_REPLACE$”."/>
+			<find-status-scope-selection value="în textul selectat."/>
+			<find-status-scope-all value="în întregul fișier."/>
+			<find-status-scope-backward value="de la începutul fișierului la cursor."/>
+			<find-status-scope-forward value="de la cursor la sfârșitul fișierului."/>
+			<finder-find-in-finder value="Căutare în rezultatele găsite..."/>
+			<finder-close-this value="Închidere rezultate găsite"/>
+			<finder-collapse-all value="Pliere toate"/>
+			<finder-uncollapse-all value="Depliere toate"/>
+			<finder-copy value="Copiere linii selectate"/>
 			<finder-copy-verbatim value="Copiere"/>
-			<finder-copy-paths value="Copiază numele căii(ilor)"/>
-            <finder-select-all value="Selectare toate"/>
-            <finder-clear-all value="Golire toate"/>
-            <finder-open-all value="Deschidere toate"/>
-			<finder-purge-for-every-search value="Curăță pentru fiecare căutare"/>
-			<finder-wrap-long-lines value="Limitarea lungimii liniilor pentru cuvintele lungi"/>
-            <common-ok value="OK"/>
-            <common-cancel value="Anulare"/>
-            <common-name value="Nume: "/>
-            <tabrename-title value="Redenumire filă curentă"/>
-            <tabrename-newname value="Nume nou: "/>
+			<finder-copy-paths value="Copiere cale"/>
+			<finder-select-all value="Selectare toate"/>
+			<finder-clear-all value="Golire toate"/>
+			<finder-open-all value="Deschidere toate"/>
+			<finder-purge-for-every-search value="Golire la fiecare căutare"/>
+			<finder-wrap-long-lines value="Limitare lungime linii pentru linii lungi"/>
+			<common-ok value="OK"/>
+			<common-cancel value="Anulare"/>
+			<common-name value="Nume"/>
+			<tabrename-title value="Redenumire filă curentă"/>
+			<tabrename-newname value="Nume nou"/>
 			<splitter-rotate-left value="Rotire la stânga"/>
 			<splitter-rotate-right value="Rotire la dreapta"/>
-            <recent-file-history-maxfile value="Maxim fişiere: "/>
-            <language-tabsize value="Mărime filă: "/>
-            <userdefined-title-new value="Creare limbaj nou..."/>
-            <userdefined-title-save value="Salvare limbaj curent ca..."/>
-            <userdefined-title-rename value="Redenumire limbaj curent"/>
-            <autocomplete-nb-char value="Nr. car.: "/>
-            <edit-verticaledge-nb-col value="Nr. coloane:"/>
-			
+			<userdefined-title-new value="Creare limbaj nou..."/>
+			<userdefined-title-save value="Salvare limbaj curent ca..."/>
+			<userdefined-title-rename value="Redenumire limbaj curent"/>
 			<summary value="Rezumat"/>
-			<summary-filepath value="Calea întreagă a fișierului: "/>
+			<summary-filepath value="Cale completă fișier: "/>
 			<summary-filecreatetime value="Creat: "/>
 			<summary-filemodifytime value="Modificat: "/>
-			<summary-nbchar value="Caractere (fără sfârșiturile de linie): "/>
+			<summary-nbchar value="Caractere (fără sfârșituri de linie): "/>
 			<summary-nbword value="Cuvinte: "/>
 			<summary-nbline value="Linii: "/>
-			<summary-nbbyte value="Lungimea documentului: "/>
+			<summary-nbbyte value="Lungime document: "/>
 			<summary-nbsel1 value=" caracterele selectate ("/>
-			<summary-nbsel2 value=" octeți) in "/>
-			<summary-nbrange value=" intervale"/>
-			<progress-hits-title value="Coincidențe:"/>
-			<progress-cancel-button value="Anulează"/>
-			<progress-cancel-info value="Se anulează operația, te rugăm să aștepți..."/>
-			<find-in-files-progress-title value="Progresul funcției Găsire în fișiere..."/>
-			<replace-in-files-confirm-title value="Ești sigur?"/>
-			<replace-in-files-confirm-directory value="Ești sigur că vrei să înlocuișeti toate aparițiile în :"/>
-			<replace-in-files-confirm-filetype value="Pentru tipul de fișier :"/>
-			<replace-in-files-progress-title value="Progresul funcției Înlouire în fișiere în fișiere..."/>
-			<replace-in-projects-confirm-title value="Ești sigur?"/>
-			<replace-in-projects-confirm-message value="Vrei să înlocuișeti toate aparițiile în toate documentele în Panoul(urile) de proiecte selectat(e)?"/>
-			<replace-in-open-docs-confirm-title value="Ești sigur?"/>
-			<replace-in-open-docs-confirm-message value="Ești sigur că vrei să înlocuiești toate aparițiile în toate documentele deschise?"/>
-			<find-result-caption value="Rezultatele căutării"/>
+			<summary-nbsel2 value=" octeți) în "/>
+			<summary-nbrange value=" interval(e)."/>
+			<progress-hits-title value="Potriviri:"/>
+			<progress-cancel-button value="Anulare"/>
+			<progress-cancel-info value="Se anulează operația, așteptați..."/>
+			<find-in-files-progress-title value="Progres funcție de căutare în fișiere..."/>
+			<replace-in-files-confirm-title value="Confirmați?"/>
+			<replace-in-files-confirm-directory value="Sigur doriți să înlocuiți toate aparițiile în:"/>
+			<replace-in-files-confirm-filetype value="Pentru tipul de fișier:"/>
+			<replace-in-files-progress-title value="Progres funcție de înlocuire în fișiere..."/>
+			<replace-in-projects-confirm-title value="Confirmați?"/>
+			<replace-in-projects-confirm-message value="Doriți să înlocuiți toate aparițiile în toate documentele din panourile proiectelor selectate?"/>
+			<replace-in-open-docs-confirm-title value="Confirmați?"/>
+			<replace-in-open-docs-confirm-message value="Sigur doriți să înlocuiți toate aparițiile în toate documentele deschise?"/>
+			<find-result-caption value="Rezultate căutare"/>
 			<find-result-title value="Căutare"/><!-- Must not begin with space or tab character -->
-			<find-result-title-info value="($INT_REPLACE1$ coincidențe în $INT_REPLACE2$ fișiere de $INT_REPLACE3$ căutate)"/>
-			<find-result-title-info-selections value="($INT_REPLACE1$ coincidențe în $INT_REPLACE2$ selecții de $INT_REPLACE3$ căutate)"/>
-			<find-result-title-info-extra value=" - Modul de filtrare de linie: se afișează numai rezultatele filtrate"/>
-			<find-result-hits value="($INT_REPLACE$ coincidențe)"/>
-			<find-result-line-prefix value="Linie"/><!-- Must not begin with space or tab character -->
-			<find-regex-zero-length-match value="potrivire de lungime zero"/>
-			<session-save-folder-as-workspace value="Salvează dosarul ca Spațiu de lucru"/>
+			<find-result-title-info value="($INT_REPLACE1$ potriviri în $INT_REPLACE2$ fișiere din $INT_REPLACE3$ căutate)"/>
+			<find-result-title-info-selections value="($INT_REPLACE1$ potriviri în $INT_REPLACE2$ selecții din $INT_REPLACE3$ căutate)"/>
+			<find-result-title-info-extra value=" - Mod filtrare linie: se afișează numai rezultatele filtrate"/>
+			<find-result-hits value="($INT_REPLACE$ potriviri)"/>
+			<find-result-line-prefix value="Linia"/><!-- Must not begin with space or tab character -->
+			<find-regex-zero-length-match value="potrivire lungime zero"/>
+			<session-save-folder-as-workspace value="Salvare folder ca spațiu de lucru"/>
 			<tab-untitled-string value="nou "/>
-			<file-save-assign-type value="&amp;Adaugă extensia"/>
-			<close-panel-tip value="Închide"/>
+			<file-save-assign-type value="&amp;Adăugare modul"/>
+			<close-panel-tip value="Închidere"/>
 			<IncrementalFind-FSFound value="$INT_REPLACE$ potriviri"/>
 			<IncrementalFind-FSNotFound value="Expresia nu a fost găsită"/>
-			<IncrementalFind-FSTopReached value="S-a ajuns la începutul paginii, a continuat de jos"/>
-			<IncrementalFind-FSEndReached value="S-a ajuns la sfârșitul paginii, a continuat de sus"/>
-			<contextMenu-styleAlloccurrencesOfToken value="Stilarea tuturor aparițiiilor semnului"/>
-			<contextMenu-styleOneToken value="Semnul cu stilul unu"/>
-			<contextMenu-clearStyle value="Șterge stilul"/>
-			<contextMenu-PluginCommands value="Comenzile de module"/>
-			<largeFileRestriction-tip value="Câteva caracteristici pot încetini performanța în fișierele mari. Aceste caracteristici pot fi dezactivate automat la deschiderea fișierelor mari. Le poți personaliza aici.
+			<IncrementalFind-FSTopReached value="S-a ajuns la începutul paginii. S-a continuat de jos."/>
+			<IncrementalFind-FSEndReached value="S-a ajuns la sfârșitul paginii. S-a continuat de sus."/>
+			<contextMenu-styleAlloccurrencesOfToken value="Stilizare toate aparițiile"/>
+			<contextMenu-styleOneToken value="Stilizare o apariție"/>
+			<contextMenu-clearStyle value="Eliminare stil"/>
+			<contextMenu-PluginCommands value="Comenzi modul"/>
+			<largeFileRestriction-tip value="Performanța cu fișierele mari poate fi încetinită datorită unor funcții care se pot dezactiva automat la deschiderea acestui tip de fișiere.
+Aceste funcții le puteți seta aici.
+NOTĂ:
+1. Opțiunile modificate aici necesită redeschiderea fișierelor mari pentru a obține rezultatul dorit.
+2. Dacă este bifată opțiunea „Dezactivare globală încadrare cuvinte” și deschideți un fișier mare, funcția „Limitare lungime linii” va fi dezactivată pentru toate fișierele. O puteți reactiva folosind meniul „Afișare > Limitare lungime linii”."/>
+			<npcNote-tip value="Reprezentarea caracterelor spațiu „non-ASCII” și a celor netipăribile (de control) selectate.
 
 NOTĂ:
-1. Modificând aici opțiunile necesită repornirea fișierelor mari deschise pentru a obține un comportament adecvat.
+Folosind reprezentarea va dezactiva efectele de caracter dintr-un text.
 
-2. Dacă &quot;funcția Dezactivează Limitare lungime linii global&quot; este bifată și deschizi un fișier mare, &quot;funcția Limitare lungime linii&quot; va fi dezactivată pentru toate fișierle. O poți reactiva folosind meniul &quot;Afișare-&gt;Limitare lungime linii&quot;."/>
-			<npcNote-tip value="Reprezentarea caracterelor &quot;non-ASCII&quot; spațiu alb și a celor neafișabile (de control) selectate.
+Pentru lista completă a spațiilor și a caracterelor netipăribile selectate consultați manualul de utilizare.
 
-NOTĂ:
-Folosind reprezentarea se vor dezactiva efectele de caracter dintr-un text.
+Apăsați pe acest buton pentru a deschide site-ul web cu manualul de utilizare."/>
+			<npcAbbreviation-tip value="Abreviere: nume
+NBSP: spațiu neîntrerupt
+ZWSP: spațiu cu lățime zero
+ZWNBSP: spațiu cu lățime zero și neîntrerupt
 
-Pentru lista completă a spațiilor albe și a caracterelor neimprimabile selectate verifică Manualul utilizatorului.
+Pentru lista completă consultați manualul de utilizare.
+Apăsați pe butonul «?» din dreapta pentru a deschide site-ul web cu manualul de utilizare."/>
+			<npcCodepoint-tip value="Cod Unicode: nume
+U+00A0: spațiu neîntrerupt
+U+200B: spațiu cu lățime zero
+U+FEFF: spațiu cu lățime zero și neîntrerupt
 
-Apasă pe acest buton pentru a deschide site-ul web cu Manualul utilizatorului."/>
-			<npcAbbreviation-tip value="Abreviere : nume
-NBSP : spațiu fără pauză
-ZWSP : spațiu cu lățime zero
-ZWNBSP : spațiu cu lățime zero și fără pauză
-
-Pentru lista completă verifică Manualul utilizatorului.
-Apasă pe &quot;?&quot; butonul din dreapta pentru a deschide site-ul web cu Manualul utilizatorului."/>
-			<npcCodepoint-tip value="Punct de cod : nume
-U+00A0 : spațiu fără pauză
-U+200B : spațiu cu lățime zero
-U+FEFF : spațiu cu lățime zero și fără pauză
-
-Pentru lista completă verifică Manualul utilizatorului.
-Apasă pe &quot;?&quot; butonul din dreapta pentru a deschide site-ul web cu Manualul utilizatorului."/>
-
+Pentru lista completă consultați manualul de utilizare.
+Apăsați pe butonul «?» din dreapta pentru a deschide site-ul web cu manualul de utilizare."/>
 			<!-- Don't translate "(&quot;Non-printing characters custom color&quot;)" -->
-			<npcCustomColor-tip value="Mergi la Configurator de stiluri pentru a schimba culorile personalizate implicite pentru caracterele selectate de spațiu alb și a celor neimprimabile (&quot;Culoare personalizată a caracterelor neimprimabile&quot;)."/>
-			<npcIncludeCcUniEol-tip value="Aplică setările de aparență ale caracterelor neimprimabile la controalele C0, C1 și a caracterelor Unicode EOL (linie următoare, separator de linie și separator de paragraf)."/>
-        </MiscStrings>
-    </Native-Langue>
+			<npcCustomColor-tip value="Accesați „Setări > Configurator stiluri...” pentru a modifica culorile personale implicite pentru caracterele selectate de spațiu și a celor netipăribile (&quot;Non-printing characters custom color&quot;)."/>
+			<npcIncludeCcUniEol-tip value="Aplicare setări de afișare ale caracterelor netipăribile la controalele C0 și C1 și la caracterele de tip EOL Unicode (linie următoare, separator de linie și separator de paragraf)."/>
+		</MiscStrings>
+	</Native-Langue>
 </NotepadPlus>


### PR DESCRIPTION
Part 3 of 3
Update localization and make it pretty printed.

Because the actual Romanian file is not pretty printed the GitHub comparison will not match correct some stings. I compared it against the english version and is a perfect match. The file is tested in the Notepad++, too.

Also, because the differences can't be viewed with full file changed, I split the file in 3 parts. P.S. If it is rejected again, I want a clear reason for why, not some generic link with too many instructions that does not apply to translations.