### PR TITLE
Greatly speed up reloading document list.

### DIFF
--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -352,7 +352,7 @@ int VerticalFileSwitcherListView::add(BufferID bufferID, int iView)
 }
 
 
-void VerticalFileSwitcherListView::remove(int index)
+void VerticalFileSwitcherListView::remove(int index, bool del)
 {
 	LVITEM item{};
 	item.mask = LVIF_PARAM;
@@ -360,7 +360,9 @@ void VerticalFileSwitcherListView::remove(int index)
 	ListView_GetItem(_hSelf, &item);
 	TaskLstFnStatus *tlfs = (TaskLstFnStatus *)item.lParam;
 	delete tlfs;
-	ListView_DeleteItem(_hSelf, index);
+	
+	if (del)
+		ListView_DeleteItem(_hSelf, index);
 }
 
 void VerticalFileSwitcherListView::removeAll()
@@ -369,8 +371,9 @@ void VerticalFileSwitcherListView::removeAll()
 	
 	for (int i = nbItem - 1; i >= 0 ; --i)
 	{
-		remove(i);
+		remove(i, false);
 	}
+	ListView_DeleteAllItems(_hSelf);
 
 	HWND colHeader = reinterpret_cast<HWND>(SendMessage(_hSelf, LVM_GETHEADER, 0, 0));
 	int columnCount = static_cast<int32_t>(SendMessage(colHeader, HDM_GETITEMCOUNT, 0, 0));

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
@@ -88,7 +88,7 @@ protected:
 
 	int find(BufferID bufferID, int iView) const;
 	int add(BufferID bufferID, int iView);
-	void remove(int index);
+	void remove(int index, bool del = true);
 	void removeAll();
 	void selectCurrentItem() const {
 		ListView_SetItemState(_hSelf, _currentIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);


### PR DESCRIPTION
Addresses https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13479 and https://github.com/notepad-plus-plus/notepad-plus-plus/issues/12632
Simply supplies an additional argument to `VerticalFileSwitcherListView::remove` so that it doesn't delete the item, allowing you to do it in bulk later, which greatly reduces the number of redraws required.

This reduces the time it takes to drag a tab from first to last/last to first with 138 files opened from ~1m55s to ~20s. Still a considerable time, but at least it's no longer increasing exponentially with number of files opened (see https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13479#issuecomment-1682160614 for a more detailed explanation).

A more ideal solution would likely be to actively swap items instead of reloading everything, but I'm too inexperienced in C++ to really get anywhere on that, so I just did the best I can to address a thing that's been driving me mad for months to at least a bearable level.