### PR TITLE
Show tooltip for performance preferences already klicking the button

### DIFF
--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -5362,6 +5362,10 @@ intptr_t CALLBACK PerformanceSubDlg::run_dlgProc(UINT message , WPARAM wParam, L
 		{
 			switch (wParam)
 			{
+				case IDD_PERFORMANCE_TIP_QUESTION_BUTTON:
+					SendMessage(_largeFileRestrictionTip, TTM_POPUP, 0, 0);
+				break;
+
 				case IDC_CHECK_PERFORMANCE_ENABLE:
 				{
 					bool largeFileRestrictionEnabled = isCheckedOrNot(IDC_CHECK_PERFORMANCE_ENABLE);


### PR DESCRIPTION
Hovering the button takes some time to see the information in the tooltip. This can be confusing since showing the tooltip is the only job the button has to do.
This will show the tooltip already clicking the button.