### PR TITLE
Fix: The getFileContent function does not contain error checking. This may cause the application to crash

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -59,6 +59,8 @@ std::string getFileContent(const TCHAR *file2read)
 	char data[blockSize];
 	std::string wholeFileContent = "";
 	FILE *fp = _wfopen(file2read, TEXT("rb"));
+	if(!fp)
+		return "";
 
 	size_t lenFile = 0;
 	do


### PR DESCRIPTION
## The `getFileContent` function does not contain error checking. This may cause the application to crash.

This PR fixes https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14131

### Description:

PowerEditor\src\MISC\Common\Common.cpp: 53:
```
std::string getFileContent(const TCHAR *file2read)
{
	if (!::PathFileExists(file2read))
		return "";

	const size_t blockSize = 1024;
	char data[blockSize];
	std::string wholeFileContent = "";
	FILE *fp = _wfopen(file2read, TEXT("rb"));

	size_t lenFile = 0;
	do
	{
		lenFile = fread(data, 1, blockSize, fp);
		if (lenFile <= 0) break;
		wholeFileContent.append(data, lenFile);
	}
	while (lenFile > 0);

	fclose(fp);
	return wholeFileContent;
}
```

1. The `FILE *fp = _wfopen(file2read, TEXT("rb"));` does not contain error checking.
2. The `fread` does not contain error checking. (See [fread](https://en.cppreference.com/w/c/io/fread))
3. lenFile value cannot be less than 0. 


### Fast way to reproduce the crash issue:

1. Open the `Portable` Notepad++
2. Go to the menu Setting -> Preferences -> Cloud & Link -> Set your cloud location path here
3. Select the path (can be any path) and Click on the "Close" button
4. Go to the "<path_to_the_root_of_notepad>\cloud\"
5. Select right click on the "choice" file and select "Properties"
6. Click on the "Security" -> "Edit" button
7. Select the current user and click on deny for "Full control"
8. Start the Notepad++ without administrator rights 

Thus the application will not have permissions to read the file and _wfopen will fail.

`Expected behavior`:

The Notepad++ should start normally.

`Actual behavior`:

The Notepad++ crashes.

Stack trace:

```
	notepad++.exe!_invoke_watson(const wchar_t * expression, const wchar_t * function_name, const wchar_t * file_name, unsigned int line_number, unsigned __int64 reserved) Line 237	C++
 	notepad++.exe!_invalid_parameter_internal(const wchar_t * expression, const wchar_t * function_name, const wchar_t * file_name, unsigned int line_number, unsigned __int64 reserved, __crt_cached_ptd_host & ptd) Line 114	C++
 	notepad++.exe!_invalid_parameter(const wchar_t * expression, const wchar_t * function_name, const wchar_t * file_name, unsigned int line_number, unsigned __int64 reserved) Line 125	C++
 	notepad++.exe!fread_s(void * buffer, unsigned __int64 buffer_size, unsigned __int64 element_size, unsigned __int64 element_count, _iobuf * stream) Line 48	C++
 	notepad++.exe!fread(void * buffer, unsigned __int64 element_size, unsigned __int64 element_count, _iobuf * stream) Line 240	C++
 	notepad++.exe!getFileContent(const wchar_t * file2read) Line 66	C++
 	notepad++.exe!NppParameters::load() Line 1193	C++
 	notepad++.exe!wWinMain(HINSTANCE__ * hInstance, HINSTANCE__ * __formal, wchar_t * pCmdLine, int __formal) Line 499	C++
```

### What has been changed:

- Using fstream instead of fopen
- Check for errors