### PR TITLE
Fix data loss issue due to no room on disk for saving

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1490,6 +1490,8 @@ Please test those commands and, if needed, re-edit them.
 Alternatively, you can downgrade to Notepad++ v8.5.2 and restore your previous data.
 Notepad++ will backup your old &quot;shortcuts.xml&quot; and save it as &quot;shortcuts.xml.v8.5.2.backup&quot;.
 Renaming &quot;shortcuts.xml.v8.5.2.backup&quot; -&gt; &quot;shortcuts.xml&quot;, your commands should be restored and work properly."/><!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
+			<NotEnoughRoom4Saving title="Save failed" message="Failed to save file.
+It seems there's not enough space on disk to save file. Your file is not saved."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Clipboard History"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1491,6 +1491,9 @@ Please test those commands and, if needed, re-edit them.
 Alternatively, you can downgrade to Notepad++ v8.5.2 and restore your previous data.
 Notepad++ will backup your old &quot;shortcuts.xml&quot; and save it as &quot;shortcuts.xml.v8.5.2.backup&quot;.
 Renaming &quot;shortcuts.xml.v8.5.2.backup&quot; -&gt; &quot;shortcuts.xml&quot;, your commands should be restored and work properly."/><!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
+			<NotEnoughRoom4Saving title="Save failed" message="Failed to save file.
+It seems there's not enough space on disk to save file. Your file is not saved."/>
+
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Clipboard History"/>

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -628,13 +628,18 @@ bool Notepad_plus::doSave(BufferID id, const TCHAR * filename, bool isCopy)
 		_pluginsManager.notify(&scnN);
 	}
 
-	if (res == SavingStatus::SaveWritingFailed)
+	if (res == SavingStatus::NotEnoughRoom)
 	{
 		_nativeLangSpeaker.messageBox("NotEnoughRoom4Saving",
 			_pPublicInterface->getHSelf(),
-			TEXT("Failed to save file.\nIt seems there's not enough space on disk to save file."),
+			TEXT("Failed to save file.\nIt seems there's not enough space on disk to save file. Your file is not saved"),
 			TEXT("Save failed"),
 			MB_OK);
+	}
+	else if (res == SavingStatus::SaveWritingFailed)
+	{
+		wstring errorMessage = GetLastErrorAsString(GetLastError());
+		::MessageBox(_pPublicInterface->getHSelf(), errorMessage.c_str(), TEXT("Save failed"), MB_OK | MB_ICONWARNING);
 	}
 	else if (res == SavingStatus::SaveOpenFailed)
 	{

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -53,7 +53,8 @@ enum BufferStatusInfo {
 enum SavingStatus {
 	SaveOK             = 0,
 	SaveOpenFailed     = 1,
-	SaveWritingFailed  = 2
+	SaveWritingFailed  = 2,
+	NotEnoughRoom      = 3
 };
 
 struct BufferViewInfo {


### PR DESCRIPTION
This PR is based the solution provided in #5664 by @pnedev (the 2nd one):
> Examine the free space left on disk BEFORE opening the file for writing with fopen...

VeraCrypt is used to crate a 10 MB small drive for testing to validate this PR.

Fix #5664, fix #14089