### PR TITLE
Reduce number of document list redraws on reload.

### DIFF
--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.cpp
@@ -169,12 +169,14 @@ void VerticalFileSwitcherListView::initList()
 
 void VerticalFileSwitcherListView::reload()
 {
+	::SendMessage(_hParent, WM_SETREDRAW, false, 0);
 	removeAll();
 	initList();
 
 	RECT rc{};
 	::GetClientRect(_hParent, &rc);
 	resizeColumns(rc.right - rc.left);
+	::SendMessage(_hParent, WM_SETREDRAW, true, 0);
 }
 
 BufferID VerticalFileSwitcherListView::getBufferInfoFromIndex(int index, int & view) const
@@ -298,6 +300,8 @@ int VerticalFileSwitcherListView::closeItem(BufferID bufferID, int iView)
 
 void VerticalFileSwitcherListView::activateItem(BufferID bufferID, int iView)
 {
+	::SendMessage(_hParent, WM_SETREDRAW, false, 0);
+
 	// Clean all selection
 	int nbItem = ListView_GetItemCount(_hSelf);
 	for (int i = 0; i < nbItem; ++i)
@@ -305,7 +309,9 @@ void VerticalFileSwitcherListView::activateItem(BufferID bufferID, int iView)
 
 	_currentIndex = newItem(bufferID, iView);
 	selectCurrentItem();
+	::SendMessage(_hParent, WM_SETREDRAW, true, 0);
 	ensureVisibleCurrentItem();
+	::SendMessage(_hSelf, WM_PAINT, 0, 0);
 }
 
 int VerticalFileSwitcherListView::add(BufferID bufferID, int iView)

--- a/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
+++ b/PowerEditor/src/WinControls/VerticalFileSwitcher/VerticalFileSwitcherListView.h
@@ -63,6 +63,7 @@ public:
 
 	std::vector<BufferViewInfo> getSelectedFiles(bool reverse = false) const;
 	void reload();
+	void redrawItems();
 	void ensureVisibleCurrentItem() const {
 		ListView_EnsureVisible(_hSelf, _currentIndex, false);
 	};


### PR DESCRIPTION
Made as a follow up to https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14080#issuecomment-1716522593
This is basically what I wanted to do from the start, but I couldn't figure out how to control redraws myself.

Example on a list of about 80 documents: https://streamable.com/r5j5gc (that one slight hiccup is caused by recording software).
Like this it seems to go at a rate of about 15 items per second with no notable slowdown as the list gets longer/farther down, it's another step up from the previous version though not massively (~1.5x at most for my PC). However, because of these heavily reduced redraws, the document list no longer flickers when you are moving items like this. Previously you'd usually see flickers at the bottom or the scroll bar, as well as sometimes just the list in general.

I ended up completely disabling the redraws during the `reload` method, because if you trigger redraw from that method then the selected item won't have correctly updated yet, which then causes the darkened selection to always be off-by-one during the scrolling. From what I could tell every single thing that triggers a reload will immediately trigger a redraw afterwards for one reason or another anyway, so it didn't seem harmful to me, though by all means suggest a better approach (adding a `::SendMessage(_hSelf, WM_PAINT, 0, 0);` at the end seems fine?).