### PR TITLE
keep missing files on load session

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2140,7 +2140,17 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, bool shou
 		}
 		else
 		{
-			lastOpened = BUFFER_INVALID;
+			// file doesn't exist and has no backup; probably it's a file that was deleted while NPP was closed
+			// as a hack to ensure that the file can be restored without issues, we will create an empty file
+			// with that name, open it normally, and then delete it. This way the user gets a missing file prompt for the file.
+			if (!PathFileExists(pFn) && MainFileManager.createEmptyFile(pFn))
+			{
+				lastOpened = doOpen(pFn, false, false, session._mainViewFiles[i]._encoding, session._mainViewFiles[i]._backupFilePath.c_str(), session._mainViewFiles[i]._originalFileLastModifTimestamp);
+				if (lastOpened->docLength() == 0 && PathFileExists(pFn))
+				{
+					MainFileManager.deleteFile(lastOpened);
+				}
+			}
 		}
 		if (isWow64Off)
 		{
@@ -2278,7 +2288,17 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, bool shou
 		}
 		else
 		{
-			lastOpened = BUFFER_INVALID;
+			// file doesn't exist and has no backup; probably it's a file that was deleted while NPP was closed
+			// as a hack to ensure that the file can be restored without issues, we will create an empty file
+			// with that name, open it normally, and then delete it. This way the user gets a missing file prompt for the file.
+			if (!PathFileExists(pFn) && MainFileManager.createEmptyFile(pFn))
+			{
+				lastOpened = doOpen(pFn, false, false, session._subViewFiles[k]._encoding, session._subViewFiles[k]._backupFilePath.c_str(), session._subViewFiles[k]._originalFileLastModifTimestamp);
+				if (lastOpened->docLength() == 0 && PathFileExists(pFn))
+				{
+					MainFileManager.deleteFile(lastOpened);
+				}
+			}
 		}
 		if (isWow64Off)
 		{


### PR DESCRIPTION
Many users find it undesirable that Notepad++ simply forgets about files that are missing with no backup at the time a session is loaded.

This PR fixes that issue by creating a new empty file for any file that was not found when loading the session and then deleting that empty file immediately so the user gets a "would you like to keep this deleted file" prompt.

THINGS THAT COULD PROBABLY BE IMPROVED WITH THIS PR:
1. I don't know how this could happen, but there's some concern that __deleting the new empty file that was just created could lead to data loss in some corner case__.
2. This approach is slower and clunkier than a theoretical alternate entirely in-memory approach that does not manipulate the filesystem. However, my attempts that involved creating a `new 1`  - type buffer and renaming it to the name of the missing file did not achieve the desired result.

TO TEST THIS PR:
1. Open a file (let's call it `file A.txt`) in one edit view. Add some text and save it.
2. Open a file (call it `file B.txt`) in the second edit view. Add some text and save it. *The purpose of this is to verify that the PR works in both edit views, not just the main one.*
3. Close Notepad++.
4. Delete or rename both `file A.txt` and `file B.txt`
5. Reopen Notepad++. You should get prompts asking you if you want to keep `file A.txt` and `file B.txt`, since those files no longer exist on disk.
6. Restore `file A.txt` and `file B.txt` __while Notepad++ is still open__.
7. For each of those files, ensure that you get the usual prompt saying that the file has been modified outside Notepad++ and asking if you want to discard the changes made inside Notepad++.

Fix #12079