### PR TITLE
[xml] Update Turkish localization

### DIFF
--- a/PowerEditor/installer/nativeLang/turkish.xml
+++ b/PowerEditor/installer/nativeLang/turkish.xml
@@ -254,7 +254,7 @@
 					<Item id="43066" name="5. Stili Kullanarak"/>
 					<Item id="43067" name="Sonraki Değişime Git"/>
 					<Item id="43068" name="Önceki Değişime Git"/>
-					<Item id="43069" name="Değişim Geçmişinin Temizle"/>
+					<Item id="43069" name="Değişim Geçmişini Temizle"/>
 					<Item id="43045" name="Arama Sonuçları Penceresi"/>
 					<Item id="43046" name="Sonraki Arama Sonucu"/>
 					<Item id="43047" name="Önceki Arama Sonucu"/>
@@ -1255,6 +1255,7 @@ Birden fazla sütun işaretçisi belirleyebilmek için, farklı sayılar arasın
 					<Item id="7149" name="Akıllı Vurgulamaya İzin Ver"/>
 					<Item id="7150" name="Sözcük Kaydırmayı Tümden Etkisizleştir"/>
 					<Item id="7151" name="Tıklanabilir URL Linklere İzin Ver"/>
+					<Item id="7152" name="2GB Üstü Dosyaları Açarken Uyarıları Önle"/>
 				</Performance>
 
 				<Cloud title="Bulut &amp; Linki">
@@ -1489,6 +1490,8 @@ Lütfen o komutları test edin ve eğer lazımsa, tekrar düzenleyin.
 Alternatif olarak, Notepad++ v8.5.2 sürümüne düşürebilir ve önceki verilerinizi geri alabilirsiniz.
 Notepad++, eski &quot;shortcuts.xml&quot; dosyasını yedekleyip &quot;shortcuts.xml.v8.5.2.backup&quot; olarak kaydedecektir.
 &quot;shortcuts.xml.v8.5.2.backup&quot; dosyasını -&gt; &quot;shortcuts.xml&quot; olarak yeniden adlandırarak, komutlarınız geri gelecek ve düzgün olarak çalışacaktır."/><!-- NasılTekrarlanır: Notepad++'i kapatın, shortcuts.xml.v8.5.2.backup & eğer varsa v852ShortcutsCompatibilityWarning.xml dosyalarını silin, Notepad++'ı yeniden başlatın, Kısayol Eşleyicisi ile bazı kısayolları silin veya düzenleyin, Notepad++'ı kapatın, mesaj görünecektir -->	
+			<NotEnoughRoom4Saving title="Kaydetme Başarısız" message="Dosya kaydetme başarısız.
+Görünüşe göre, diskinizde dosyayı kaydetmek için yeterli alan yok. Dosyanız kaydedilemedi."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Pano Geçmişi"/>

--- a/PowerEditor/installer/nativeLang/turkish.xml
+++ b/PowerEditor/installer/nativeLang/turkish.xml
@@ -644,17 +644,7 @@
 				<ScintillaCommandsTab name="Scintilla Komutları"/>
 				<ConflictInfoOk name="Bu içerik için hiçbir kısayol çakışması yok."/>
 				<ConflictInfoEditing name="Hiçbir çakışma yok . . ."/>
-				<WindowCategory name="Pencere"/>
-				<FileCategory name="Dosya"/>
-				<EditCategory name="Düzenle"/>
-				<SearchCategory name="Ara"/>
-				<ViewCategory name="Görünüm"/>
-				<FormatCategory name="Biçim"/>
-				<LangCategory name="Dil"/>
 				<AboutCategory name="Hakkında"/>
-				<SettingCategory name="Ayarlar"/>
-				<ToolCategory name="Araç"/>
-				<ExecuteCategory name="Çalıştır"/>
 				<ModifyContextMenu name="Değiştir"/>
 				<DeleteContextMenu name="Sil"/>
 				<ClearContextMenu name="Temizle"/>


### PR DESCRIPTION
* According to cf8ddc18, e30ee852 and 39001d7 commits.
* Fixed wording in line 257:
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/f73cad0065db38a1a089987b7a16bf3f325dd764/PowerEditor/installer/nativeLang/turkish.xml#L257