### PR TITLE
Fix: unselected lines may become hidden

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -3663,9 +3663,9 @@ void ScintillaEditView::hideLines()
 	int scope = 0;
 	bool recentMarkerWasOpen = false;
 
-	auto removeMarker = [this, &scope, &recentMarkerWasOpen](size_t line)
+	auto removeMarker = [this, &scope, &recentMarkerWasOpen](size_t line, int markerMask)
 	{
-		auto state = execute(SCI_MARKERGET, line);
+		auto state = execute(SCI_MARKERGET, line) & markerMask;
 		bool closePresent = (state & (1 << MARK_HIDELINESEND)) != 0;
 		bool openPresent = (state & (1 << MARK_HIDELINESBEGIN)) != 0;
 
@@ -3688,8 +3688,8 @@ void ScintillaEditView::hideLines()
 	size_t endMarker = endLine + 1;
 
 	// Remove all previous markers in between new ones
-	for (size_t i = startMarker + 1; i < endMarker; ++i)
-		removeMarker(i);
+	for (size_t i = startLine; i <= endLine; ++i)
+		removeMarker(i, (1 << MARK_HIDELINESBEGIN) | (1 << MARK_HIDELINESEND));
 
 	// When hiding lines just below/above other hidden lines,
 	// merge them into one hidden section:
@@ -3700,10 +3700,10 @@ void ScintillaEditView::hideLines()
 		// Both "while" loops are executed (merge with above AND below hidden section):
 
 		while (scope == 0)
-			removeMarker(--startMarker);
+			removeMarker(--startMarker, 1 << MARK_HIDELINESBEGIN);
 
 		while (scope != 0)
-			removeMarker(++endMarker);
+			removeMarker(++endMarker, 1 << MARK_HIDELINESEND);
 	}
 	else
 	{
@@ -3711,10 +3711,10 @@ void ScintillaEditView::hideLines()
 		// If true, only one "while" loop is executed (merge with adjacent hidden section):
 
 		while (scope < 0)
-			removeMarker(--startMarker);
+			removeMarker(--startMarker, 1 << MARK_HIDELINESBEGIN);
 
 		while (scope > 0)
-			removeMarker(++endMarker);
+			removeMarker(++endMarker, 1 << MARK_HIDELINESEND);
 	}
 
 	execute(SCI_MARKERADD, startMarker, MARK_HIDELINESBEGIN);


### PR DESCRIPTION
Fix #14166

To solve this issue, lambda `removeMarker` can be set to only remove just begin or end marker. By doing so, the process of merging adjacent hidden sections is limited and as a result, lines that shouldn't be hidden remain visible.