### PR TITLE
Make session inaccessible files remembered (part 1/2)

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2145,7 +2145,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, bool shou
 		}
 		else
 		{
-			lastOpened = BUFFER_INVALID;
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW);
 		}
 		if (isWow64Off)
 		{
@@ -2283,7 +2283,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, bool shou
 		}
 		else
 		{
-			lastOpened = BUFFER_INVALID;
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW);
 		}
 		if (isWow64Off)
 		{

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1347,6 +1347,15 @@ BufferID FileManager::newEmptyDocument()
 	return id;
 }
 
+BufferID FileManager::newPlaceholderDocument(const TCHAR* missingFilename, int whichOne)
+{
+	BufferID buf = MainFileManager.newEmptyDocument();
+	_pNotepadPlus->loadBufferIntoView(buf, whichOne);
+	buf->setFileName(missingFilename);
+	buf->_currentStatus = DOC_REGULAR;
+	return buf;
+}
+
 BufferID FileManager::bufferFromDocument(Document doc, bool isMainEditZone)
 {
 	NppParameters& nppParamInst = NppParameters::getInstance();

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -88,6 +88,8 @@ public:
 
 	BufferID loadFile(const TCHAR * filename, Document doc = static_cast<Document>(NULL), int encoding = -1, const TCHAR *backupFileName = nullptr, FILETIME fileNameTimestamp = {});	//ID == BUFFER_INVALID on failure. If Doc == NULL, a new file is created, otherwise data is loaded in given document
 	BufferID newEmptyDocument();
+	// create an empty placeholder for a missing file when loading session
+	BufferID newPlaceholderDocument(const TCHAR * missingFilename, int whichOne);
 
 	//create Buffer from existing Scintilla, used from new Scintillas.
 	BufferID bufferFromDocument(Document doc, bool isMainEditZone);


### PR DESCRIPTION
Fix issue #12079
If a file was not backed up when a session closed, previously when the session was reloaded, those files would simply disappear and the user could not choose to keep them.
Now an empty placeholder buffer will be created for any files without backup with a filename that doesn't exist. This placeholder can be reloaded from hard drive if the file it corresponds to is recreated, and its placeholder status will persist across sessions opening/closing as long as it is unmodified for every session.
The handling of backed-up files that don't exist (e.g., if the user had a *modified* version of a file and that file was deleted outside NPP) will remain the same.

Unfortunately the placeholder buffer will not be backed up, which means that if the user wants to modify the placeholder, their only choice on session close is to save the placeholder with its filename (thus complicating restoration of the original file) or lose all changes made in Notepad++. However, fixes that enable the placeholder to be backed up would greatly complicate the process of determining whether a document should have an empty placeholder.

TO TEST THIS PR:

    Open a file (let's call it file A.txt) in one edit view. Add some text and save it.
    Open a file (call it file B.txt) in the second edit view. Add some text and save it. The purpose of this is to verify that the PR works in both edit views, not just the main one.
    Close Notepad++.
    Delete or rename both file A.txt and file B.txt
    Reopen Notepad++. You should get prompts asking you if you want to keep file A.txt and file B.txt, since those files no longer exist on disk.
    Close the session again, and then reopen Notepad++ again and check for the prompts (this tests that placeholder status persists across sessions opening/closing)
    Restore file A.txt and file B.txt while Notepad++ is still open.
    For each of those files, ensure that you get the usual prompt saying that the file has been modified outside Notepad++ and asking if you want to discard the changes made inside Notepad++.