### PR TITLE
Removing obsolete _isRestartedByOS member variable

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -283,7 +283,6 @@ struct CmdLineParamsDTO
 	bool _isRecursive = false;
 	bool _openFoldersAsWorkspace = false;
 	bool _monitorFiles = false;
-	bool _isRestartedByOS = false;
 
 	intptr_t _line2go = 0;
 	intptr_t _column2go = 0;


### PR DESCRIPTION
This amends the previous #14074 PR.
That PR changed several times and I overlooked this, sorry.