### PR TITLE
Allow Window Windows command to be assigned a shortcut

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -421,6 +421,7 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 
 	{ VK_F5,      IDM_EXECUTE,                                  false, false, false, nullptr },
 
+	{ VK_NULL,    IDM_WINDOW_WINDOWS,                           false, false, false, nullptr },
 	{ VK_NULL,    IDM_WINDOW_SORT_FN_ASC,                       false, false, false, TEXT("Sort By Name A to Z") },
 	{ VK_NULL,    IDM_WINDOW_SORT_FN_DSC,                       false, false, false, TEXT("Sort By Name Z to A") },
 	{ VK_NULL,    IDM_WINDOW_SORT_FP_ASC,                       false, false, false, TEXT("Sort By Path A to Z") },

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -1228,9 +1228,9 @@ void CommandShortcut::setCategoryFromMenu(HMENU hMenu)
 {
 	NativeLangSpeaker* pNativeSpeaker = NppParameters::getInstance().getNativeLangSpeaker();
 
-	if ( _id >= IDM_WINDOW_SORT_FN_ASC and _id <= IDM_WINDOW_SORT_FS_DSC)
+	if (_id >= IDM_WINDOW_WINDOWS && _id <= IDM_WINDOW_SORT_FS_DSC)
 		pNativeSpeaker->getMainMenuEntryName(_category, hMenu, "Window", L"Window");
-	else if ( _id >= IDM_VIEW_GOTO_ANOTHER_VIEW and _id <= IDM_VIEW_LOAD_IN_NEW_INSTANCE)
+	else if ( _id >= IDM_VIEW_GOTO_ANOTHER_VIEW && _id <= IDM_VIEW_LOAD_IN_NEW_INSTANCE)
 		pNativeSpeaker->getMainMenuEntryName(_category, hMenu, "view", L"View");
 	else if (_id == IDM_EDIT_LTR || _id == IDM_EDIT_RTL)
 		pNativeSpeaker->getMainMenuEntryName(_category, hMenu, "view", L"View");


### PR DESCRIPTION
Fix #14179 

Note:  Modernized boolean logic symbol (to `&&`) because I read in some other issue here that `and` is not to be used (but it was in existing code!)