### PR TITLE
Fix unintended Afrikaans installer language

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -184,23 +184,18 @@ updaterDone:
 	Var /GLOBAL tempLng
 	ReadRegStr $tempLng HKLM "SOFTWARE\${APPNAME}" 'InstallerLanguage'
 	${IfNot} ${Errors}
-		${If} "$tempLng" == "Installer Language" ; check for the possible previous inappropriate value (from some of the 'Afrikaans' issues...)
-			WriteRegStr HKLM "SOFTWARE\${APPNAME}" 'InstallerLanguage' '${LANG_ENGLISH}' ; bad, so repair that with our factory default
-			StrCpy $LANGUAGE "${LANG_ENGLISH}" ; and preset accordingly to the above
-		${Else}
-			StrCpy $LANGUAGE "$tempLng" ; ok, so offer that previously used language as the installer default
-		${EndIf}
+		StrCpy $LANGUAGE "$tempLng" ; set default language
 	${EndIf}
+	
+	Call unsupportedLanguageToEnglish
 	
 	!insertmacro MUI_LANGDLL_DISPLAY
 	
 	; check for the possible NSIS lang-engine fault
 	; - some users (maybe with some Windows server editions?) reported a complete omission of the installer language-selection dlg
 	;   (the Welcome Screen is then shown directly instead and the $LANGUAGE var is filled up with the "Installer Language" nonsense)
-	${If} "$LANGUAGE" == "Installer Language"
-		StrCpy $LANGUAGE "${LANG_ENGLISH}" ; a NSIS inherent failure(?!), at least repair that to our factory default
-	${EndIf}
-
+	Call unsupportedLanguageToEnglish
+	
 	; save selected language to registry
 	WriteRegStr HKLM "SOFTWARE\${APPNAME}" 'InstallerLanguage' '$Language'
 

--- a/PowerEditor/installer/nsisInclude/langs4Installer.nsh
+++ b/PowerEditor/installer/nsisInclude/langs4Installer.nsh
@@ -15,11 +15,12 @@
 ; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-; Set languages (first is default language)
-;!insertmacro MUI_LANGUAGE "English"
+!define MUI_LANGDLL_ALWAYSSHOW
 !define MUI_LANGDLL_ALLLANGUAGES
 ;Languages
 
+  ; Set the Notepad++ static languages list
+  !insertmacro MUI_LANGUAGE "English" ; first is the default language (important for a possible language preselection failure...)
   !insertmacro MUI_LANGUAGE "Afrikaans"
   !insertmacro MUI_LANGUAGE "Albanian"
   !insertmacro MUI_LANGUAGE "Arabic"
@@ -35,7 +36,6 @@
   !insertmacro MUI_LANGUAGE "Czech"
   !insertmacro MUI_LANGUAGE "Danish"
   !insertmacro MUI_LANGUAGE "Dutch"
-  !insertmacro MUI_LANGUAGE "English"
   !insertmacro MUI_LANGUAGE "Farsi"
   !insertmacro MUI_LANGUAGE "Finnish"
   !insertmacro MUI_LANGUAGE "Estonian"

--- a/PowerEditor/installer/nsisInclude/langs4Installer.nsh
+++ b/PowerEditor/installer/nsisInclude/langs4Installer.nsh
@@ -143,3 +143,73 @@ LangString langFileName ${LANG_VIETNAMESE} "vietnamese.xml"
 LangString langFileName ${LANG_WELSH} "welsh.xml"
 LangString langFileName ${LANG_KURDISH} "kurdish.xml"
 LangString langFileName ${LANG_IRISH} "irish.xml"
+
+
+Function unsupportedLanguageToEnglish
+  ${Switch} $LANGUAGE
+    ${Case} ${LANG_AFRIKAANS}
+    ${Case} ${LANG_ALBANIAN}
+    ${Case} ${LANG_ARABIC}
+    ${Case} ${LANG_BASQUE}
+    ${Case} ${LANG_BELARUSIAN}
+    ${Case} ${LANG_BOSNIAN}
+    ${Case} ${LANG_BRETON}
+    ${Case} ${LANG_BULGARIAN}
+    ${Case} ${LANG_CATALAN}
+    ${Case} ${LANG_CORSICAN}
+    ${Case} ${LANG_CROATIAN}
+    ${Case} ${LANG_CZECH}
+    ${Case} ${LANG_DANISH}
+    ${Case} ${LANG_DUTCH}
+    ${Case} ${LANG_ENGLISH}
+    ${Case} ${LANG_ESTONIAN}
+    ${Case} ${LANG_FARSI}
+    ${Case} ${LANG_FINNISH}
+    ${Case} ${LANG_FRENCH}
+    ${Case} ${LANG_GALICIAN}
+    ${Case} ${LANG_GEORGIAN}
+    ${Case} ${LANG_GERMAN}
+    ${Case} ${LANG_GREEK}
+    ${Case} ${LANG_HEBREW}
+    ${Case} ${LANG_HINDI}
+    ${Case} ${LANG_HUNGARIAN}
+    ${Case} ${LANG_INDONESIAN}
+    ${Case} ${LANG_IRISH}
+    ${Case} ${LANG_ITALIAN}
+    ${Case} ${LANG_JAPANESE}
+    ${Case} ${LANG_KOREAN}
+    ${Case} ${LANG_KURDISH}
+    ${Case} ${LANG_LATVIAN}
+    ${Case} ${LANG_LITHUANIAN}
+    ${Case} ${LANG_LUXEMBOURGISH}
+    ${Case} ${LANG_MACEDONIAN}
+    ${Case} ${LANG_MALAY}
+    ${Case} ${LANG_MONGOLIAN}
+    ${Case} ${LANG_NORWEGIANNYNORSK}
+    ${Case} ${LANG_NORWEGIAN}
+    ${Case} ${LANG_POLISH}
+    ${Case} ${LANG_PORTUGUESEBR}
+    ${Case} ${LANG_PORTUGUESE}
+    ${Case} ${LANG_ROMANIAN}
+    ${Case} ${LANG_RUSSIAN}
+    ${Case} ${LANG_SERBIAN}
+    ${Case} ${LANG_SIMPCHINESE}
+    ${Case} ${LANG_SLOVAK}
+    ${Case} ${LANG_SLOVENIAN}
+    ${Case} ${LANG_SPANISH}
+    ${Case} ${LANG_SWEDISH}
+    ${Case} ${LANG_THAI}
+    ${Case} ${LANG_TRADCHINESE}
+    ${Case} ${LANG_TURKISH}
+    ${Case} ${LANG_UKRAINIAN}
+    ${Case} ${LANG_UZBEK}
+    ${Case} ${LANG_VIETNAMESE}
+    ${Case} ${LANG_WELSH}
+      ; Ok, the current $LANGUAGE is supported, nothing to do
+      ${Break}
+    ${Default}
+      ; unsupported or invalid, so reset to our 'factory default'
+      StrCpy $LANGUAGE "${LANG_ENGLISH}"
+      ${Break}
+  ${EndSwitch}
+FunctionEnd


### PR DESCRIPTION
Fix (partially) #3844 #7574 

Some users (probably with some Windows installations like a server edition etc. or with some specific Windows locales like Icelandic) have reported a problem with unwanted Afrikaans Notepad++ installer language.

Partial-fix note:
Some users with such 'Afrikaans' problem also reported a complete omission of the installer language-selection dialog (the Welcome Screen was then shown directly in the Afrikaans language and the Notepad++ Registry lang-key had been set to the "Installer Language" nonsense value). For these users this PR fixes the Afrikaans language preselection (to English), but still the installer language selection dialog will not be shown at all. This currently looks like a NSIS-failure and it needs further investigation (and possibly a future NSIS upstream bug-report ...).