### PR TITLE
Fix possible missing 'SessionFileInvalidError' message in MultiInst configs

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1297,16 +1297,16 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		{
 			size_t nbSessionFiles = 0;
 			const TCHAR* sessionFileName = reinterpret_cast<const TCHAR*>(lParam);
-			BOOL* pbOut = reinterpret_cast<BOOL*>(wParam);
-			if (pbOut)
-				*pbOut = false;
+			BOOL* pbIsValidXML = reinterpret_cast<BOOL*>(wParam);
+			if (pbIsValidXML)
+				*pbIsValidXML = false;
 			if (sessionFileName && (sessionFileName[0] != '\0'))
 			{
 				Session session2Load;
 				if (nppParam.loadSession(session2Load, sessionFileName, true))
 				{
-					if (pbOut)
-						*pbOut = true;
+					if (pbIsValidXML)
+						*pbIsValidXML = true;
 					nbSessionFiles = session2Load.nbMainFiles() + session2Load.nbSubFiles();
 				}
 			}

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1295,13 +1295,22 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_GETNBSESSIONFILES:
 		{
-			const TCHAR *sessionFileName = reinterpret_cast<const TCHAR *>(lParam);
-			if ((!sessionFileName) || (sessionFileName[0] == '\0'))
-				return 0;
-			Session session2Load;
-			if (nppParam.loadSession(session2Load, sessionFileName))
-				return session2Load.nbMainFiles() + session2Load.nbSubFiles();
-			return 0;
+			size_t nbSessionFiles = 0;
+			const TCHAR* sessionFileName = reinterpret_cast<const TCHAR*>(lParam);
+			BOOL* pbOut = reinterpret_cast<BOOL*>(wParam);
+			if (pbOut)
+				*pbOut = false;
+			if (sessionFileName && (sessionFileName[0] != '\0'))
+			{
+				Session session2Load;
+				if (nppParam.loadSession(session2Load, sessionFileName, true))
+				{
+					if (pbOut)
+						*pbOut = true;
+					nbSessionFiles = session2Load.nbMainFiles() + session2Load.nbSubFiles();
+				}
+			}
+			return nbSessionFiles;
 		}
 
 		case NPPM_GETSESSIONFILES:
@@ -1313,7 +1322,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				return FALSE;
 
 			Session session2Load;
-			if (nppParam.loadSession(session2Load, sessionFileName))
+			if (nppParam.loadSession(session2Load, sessionFileName, true))
 			{
 				size_t i = 0;
 				for ( ; i < session2Load.nbMainFiles() ; )

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2431,7 +2431,6 @@ bool Notepad_plus::fileLoadSession(const TCHAR *fn)
 			sessionFileName = fn;
 	}
 
-
 	NppParameters& nppParam = NppParameters::getInstance();
 	const NppGUI & nppGUI = nppParam.getNppGUI();
 	if (!sessionFileName.empty())
@@ -2448,36 +2447,25 @@ bool Notepad_plus::fileLoadSession(const TCHAR *fn)
 			TCHAR nppFullPath[MAX_PATH]{};
 			::GetModuleFileName(NULL, nppFullPath, MAX_PATH);
 
-
 			generic_string args = TEXT("-multiInst -nosession -openSession ");
 			args += TEXT("\"");
 			args += sessionFileName;
 			args += TEXT("\"");
-			::ShellExecute(_pPublicInterface->getHSelf(), TEXT("open"), nppFullPath, args.c_str(), TEXT("."), SW_SHOW);
-			result = true;
+			if (::ShellExecute(_pPublicInterface->getHSelf(), TEXT("open"), nppFullPath, args.c_str(), TEXT("."), SW_SHOW) > (HINSTANCE)32)
+				result = true;
 		}
 		else
 		{
-			bool isAllSuccessful = true;
 			Session session2Load;
 
 			if (nppParam.loadSession(session2Load, sessionFileName.c_str()))
 			{
 				const bool isSnapshotMode = false;
 				const bool shouldLoadFileBrowser = true;
-				isAllSuccessful = loadSession(session2Load, isSnapshotMode, shouldLoadFileBrowser);
-				result = true;
+				result = loadSession(session2Load, isSnapshotMode, shouldLoadFileBrowser);
 				if (isEmptyNpp && (nppGUI._multiInstSetting == multiInstOnSession || nppGUI._multiInstSetting == multiInst))
 					nppParam.setLoadedSessionFilePath(sessionFileName);
 			}
-		}
-		if (result == false)
-		{
-			_nativeLangSpeaker.messageBox("SessionFileInvalidError",
-				NULL,
-				TEXT("Session file is either corrupted or not valid."),
-				TEXT("Could not Load Session"),
-				MB_OK);
 		}
 	}
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2271,6 +2271,15 @@ bool NppParameters::loadSession(Session & session, const TCHAR *sessionFileName)
 	if (loadOkay)
 		loadOkay = getSessionFromXmlTree(pXmlSessionDocument, session);
 
+	if (!loadOkay)
+	{
+		_pNativeLangSpeaker->messageBox("SessionFileInvalidError",
+			NULL,
+			TEXT("Session file is either corrupted or not valid."),
+			TEXT("Could not Load Session"),
+			MB_OK);
+	}
+
 	delete pXmlSessionDocument;
 	return loadOkay;
 }

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2264,14 +2264,14 @@ void NppParameters::setWorkingDir(const TCHAR * newPath)
 	}
 }
 
-bool NppParameters::loadSession(Session & session, const TCHAR *sessionFileName)
+bool NppParameters::loadSession(Session& session, const TCHAR* sessionFileName, const bool bSuppressErrorMsg)
 {
-	TiXmlDocument *pXmlSessionDocument = new TiXmlDocument(sessionFileName);
+	TiXmlDocument* pXmlSessionDocument = new TiXmlDocument(sessionFileName);
 	bool loadOkay = pXmlSessionDocument->LoadFile();
 	if (loadOkay)
 		loadOkay = getSessionFromXmlTree(pXmlSessionDocument, session);
 
-	if (!loadOkay)
+	if (!loadOkay && !bSuppressErrorMsg)
 	{
 		_pNativeLangSpeaker->messageBox("SessionFileInvalidError",
 			NULL,

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1658,7 +1658,7 @@ public:
 		return _doPrintAndExit;
 	};
 
-	bool loadSession(Session & session, const TCHAR *sessionFileName);
+	bool loadSession(Session& session, const TCHAR* sessionFileName, const bool bSuppressErrorMsg = false);
 
 	void setLoadedSessionFilePath(const std::wstring & loadedSessionFilePath) {
 		_loadedSessionFullFilePath = loadedSessionFilePath;


### PR DESCRIPTION
Fix #14228 

Moving the error-dlg to the `NppParameters::loadSession` is more universal.

Other minor improvements (in `Notepad_plus::fileLoadSession`):
- checking also for a possible ShellExecute error
- removing the `isAllSuccessful` boolean, as it is no longer needed (due to previous patch by @donho )

Enhance also NPPM_GETNBSESSIONFILES API.

[New specs of NPPM_GETNBSESSIONFILES](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14228#issuecomment-1767258536)  (which is retro-compatible):
***********
**NPPM_GETNBSESSIONFILES**

Retrieves the number of files to load in the session sessionFileName. sessionFileName should be a full path name of an xml file.

**Parameters:**

wParam [out]
    BOOL* isValidXML, if this pointer is null, then this parameter will be ignored. TRUE if XML is valid, otherwise FALSE.

lParam [in]
    const TCHAR * sessionFileName

**Return value:**
Returns 0 if sessionFileName is an empty string/NULL, or XML session file is corrupted/invalid, else the number of files.
******************





