### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.5.9

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -14,7 +14,7 @@ Additionnal information about Corsican localization:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
-			  Nov. 3rd (v8.5.9)
+			  Nov. 15th (v8.5.9)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -1695,6 +1695,7 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
 			<find-status-replace-not-found value="Rimpiazzà : alcuna occurrenza trova"/>
 			<find-status-replace-readonly value="Rimpiazzà : Ùn si pò rimpiazzà u testu. U ducumentu attuale pò solu si leghje"/>
 			<find-status-cannot-find value="Circà : Ùn si pò truvà u testu « $STR_REPLACE$ »"/>
+			<find-status-cannot-find-pebkac-maybe value="Ùn si pò truvà l’occurrenza pruvista. Forse vi site scurdati di selezziunà « Circunvoglie » (attivatu), « Rispettà Maiuscule è minuscule » (disattivatu), o « Currispundenza solu di a parolla sana » (disattivatu)."/>
 			<find-status-scope-selection value="in u testu selezziunatu"/>
 			<find-status-scope-all value="in u schedariu sanu"/>
 			<find-status-scope-backward value="da u principiu di schedariu à u cursore"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -14,7 +14,7 @@ Additionnal information about Corsican localization:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
-			  Oct. 29th (v8.5.9)
+			  Oct. 30th (v8.5.9)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -986,7 +986,6 @@ Additionnal information about Corsican localization:
 					<Item id="6221" name="10"/><!-- Prestu (3 caratteri à u più) -->
 					<Item id="6222" name="0"/><!-- Lentu (3 caratteri à u più) -->
 					<Item id="6246" name="Rende cummutevule e cumande di piegatura è spiegatura di u livellu attuale"/>
-					<Item id="6225" name="Attivà a mudificazione multiple (Ctrl+cliccu/selez. cù topu)"/>
 					<Item id="6227" name="Ritornu à a linea"/>
 					<Item id="6228" name="Predefinitu"/>
 					<Item id="6229" name="Aliniatu"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -14,7 +14,7 @@ Additionnal information about Corsican localization:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
-			  Oct. 30th (v8.5.9)
+			  Nov. 3rd (v8.5.9)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -66,6 +66,8 @@ Additionnal information about Corsican localization:
 					<Item subMenuId="edit-blankOperations" name="&amp;Operazioni nant’à u spaziu"/>
 					<Item subMenuId="edit-pasteSpecial" name="Incullatura spe&amp;ziale"/>
 					<Item subMenuId="edit-onSelection" name="Per &amp;a selezzione"/>
+					<Item subMenuId="edit-multiSelectALL" name="Selezzione multiple di tuttu"/>
+					<Item subMenuId="edit-multiSelectNext" name="Selezzione multiple di a prossima"/>
 					<Item subMenuId="search-changeHistory" name="Cronolugia di i cambiamenti"/>
 					<Item subMenuId="search-markAll" name="Marcà &amp;tutte l’occurenze di testu"/>
 					<Item subMenuId="search-markOne" name="Stilizà una occu&amp;renza di testu"/>
@@ -181,6 +183,16 @@ Additionnal information about Corsican localization:
 					<Item id="42074" name="Apre cù l’espluratore u cartulare cuntenendu u schedariu"/>
 					<Item id="42075" name="Circà nant’à Internet"/>
 					<Item id="42076" name="Cambià u mutore di ricerca…"/>
+					<Item id="42090" name="Ignurà a cassa è a parolla sana"/>
+					<Item id="42091" name="Currispundenza solu di a cassa"/>
+					<Item id="42092" name="Currispundenza solu di a parolla sana"/>
+					<Item id="42093" name="Currispundenza di a cassa è di a parolla sana"/>
+					<Item id="42094" name="Ignurà a cassa è a parolla sana"/>
+					<Item id="42095" name="Currispundenza solu di a cassa"/>
+					<Item id="42096" name="Currispundenza solu di a parolla sana"/>
+					<Item id="42097" name="Currispundenza di a cassa è di a parolla sana"/>
+					<Item id="42098" name="Disfà l’ultima selezzione multiple aghjunta"/>
+					<Item id="42099" name="Tralascià l’attuale è andà à a prossima selezzione multiple"/>
 					<Item id="42018" name="&amp;Principià u ricordu"/>
 					<Item id="42019" name="&amp;Fermà u ricordu"/>
 					<Item id="42021" name="&amp;Ripruduce"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,8 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
-			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8)
+			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
+			  Oct. 29th (v8.5.9)
 	- Updated in 2022 by Patriccollu di Santa Maria è Sichè: Jan. 11th (v8.2.1), Feb. 8th (v8.3.1), Feb. 21st (v8.3.2),
 			  Sep. 21st (v8.4.6), Apr. 7th (v8.3.4), Apr. 27th (v8.4.1), May 25th (v8.4.2), June 27th (v8.4.3),
 			  Aug. 24th (v8.4.5), Oct. 22nd (v8.4.7), Dec. 1st (v8.4.8), Dec. 31st (v8.4.9)
@@ -31,7 +32,7 @@ Additionnal information about Corsican localization:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.5.8">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.5.9">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -1191,6 +1192,7 @@ Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà
 					<Item id="6821" name="seconde"/>
 					<Item id="6822" name="Chjassu :"/>
 					<Item id="6309" name="Arricurdassi di a sessione currente per u prossimu lanciu"/>
+					<Item id="6825" name="Arricurdassi di i schedarii inaccessibile d’una sessione anziana"/>
 					<Item id="6801" name="Salvaguardia à l’arregistramentu"/>
 					<Item id="6315" name="Alcuna"/>
 					<Item id="6316" name="Salvaguardia simplice"/>
@@ -1382,7 +1384,7 @@ Pudete attivà torna st’ozzione in u dialogu di e preferenze."/>
 				<Item id="6" name="&amp;Sì"/>
 				<Item id="7" name="&amp;Nò"/>
 				<Item id="4" name="S&amp;empre sì"/>
-			</DoSaveAll><!-- HowToReproduce: Check the 'Enable Save All confirm dialog' checkbox in Preference->MISC, now click 'Save all' -->
+			</DoSaveAll><!-- HowToReproduce: Check the "Enable Save All confirm dialog" checkbox in Preference->MISC, now click "Save all" -->
 		</Dialog>
 		<MessageBox>
 			<!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders. -->
@@ -1509,8 +1511,20 @@ Ci vole à pruvà ste cumande è, s’ella hè bisognu, à mudificalle.
 Un altra pussibilità hè di rivene à a versione Notepad++ v8.5.2 è risturà i vostri dati anteriore.
 Notepad++ hà da fà una salvaguardia di u vostru « shortcuts.xml » è arregistrallu cù u nome « shortcuts.xml.v8.5.2.backup ».
 Rinuminendu « shortcuts.xml.v8.5.2.backup » in « shortcuts.xml », e vostre cumande duverianu funziunà currettamente."/><!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
+			<NbFileToOpenImportantWarning title="A quantità di schedarii à apre hè troppu maiò" message="$INT_REPLACE$ schedarii stanu per esse aperti.
+Da veru, vulete apreli ?"/>
 			<NotEnoughRoom4Saving title="Fiascu di l’arregistramentu" message="Fiascu à l’arregistramentu di u schedariu.
 Pare ch’ella ùn ci sia abbastanza piazza nant’à u discu per arregistrà u schedariu. U vostru schedariu ùn hè micca arregistratu."/>
+			<FileInaccessibleUserSession title="Schedariu inaccessibile" message="Certi schedarii di a vostra sessione arregistrata manualmente « $STR_REPLACE$ » sò inaccessibile. Ponu esse aperti cum’è ducumenti vioti è in lettura sola tale spazii riservati.
+			
+Vulete creà sti spazii riservati per elli ?
+
+NOTA : S’è vo sciglite d’ùn micca creà i spazii riservati o di chjodeli dopu, a vostra sessione arregistrata manualmente ùn serà MICCA mudificata à l’esce."/>
+			<FileInaccessibleDefaultSessionXml title="Schedariu inaccessibile" message="Certi schedarii di a vostra sessione anziana sò inaccessibile. Ponu esse aperti cum’è ducumenti vioti è in lettura sola tale spazii riservati.
+			
+Vulete creà sti spazii riservati per elli ?
+
+NOTA : S’è vo sciglite d’ùn micca creà i spazii riservati o di chjodeli dopu, u vostru schedariu di sessione serà mudificatu à l’esce. Vi ricumandemu di fà subitu una salvaguardia di u vostru schedariu di sessione « session.xml »."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Cronolugia di u preme’papei"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/08794510bec63bb0f4aec0c9f497f6b0f5422fd8 Make session inaccessible files remembered (part 2/2)
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/1c27e64126603672babe3489eff85407067e8e9b Use double quot instead of single quot

Updated on October 30<sup>th</sup>:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/89278e1dc70d0171e1868cff359c38bbd0b46e00 Force to enable multi-select feature in Scintilla

Updated on November 3<sup>rd</sup>:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/cecd161570eb22ef8bc6f730f725d81ec67fbf7e Enhance Multi-select feature

Updated on November 15<sup>th</sup>:
 *  https://github.com/notepad-plus-plus/notepad-plus-plus/commit/05f339b0cfe11095dc5590241bc8ff8cc4aec835 Enhance Find Dialog: display extra info in the status bar

Cheers,
Patriccollu.