### PR TITLE
Enhance multi-select commands

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -39,6 +39,8 @@ Translation note:
 					<Item subMenuId="edit-blankOperations" name="&amp;Blank Operations"/>
 					<Item subMenuId="edit-pasteSpecial" name="&amp;Paste Special"/>
 					<Item subMenuId="edit-onSelection" name="&amp;On Selection"/>
+					<Item subMenuId="edit-multiSelectALL" name="Multi-select ALL"/>
+					<Item subMenuId="edit-multiSelectNext" name="Multi-select Next"/>
 					<Item subMenuId="search-changeHistory" name="Change History"/>
 					<Item subMenuId="search-markAll" name="Style &amp;All Occurrences of Token"/>
 					<Item subMenuId="search-markOne" name="Style &amp;One Token"/>
@@ -154,6 +156,16 @@ Translation note:
 					<Item id="42074" name="Open Containing Folder in Explorer"/>
 					<Item id="42075" name="Search on Internet"/>
 					<Item id="42076" name="Change Search Engine..."/>
+					<Item id="42090" name="Ignore Case &amp;&amp; Whole Word"/>
+					<Item id="42091" name="Match Case Only"/>
+					<Item id="42092" name="Match Whole Word Only"/>
+					<Item id="42093" name="Match Case &amp;&amp; Whole Word"/>
+					<Item id="42094" name="Ignore Case &amp;&amp; Whole Word"/>
+					<Item id="42095" name="Match Case Only"/>
+					<Item id="42096" name="Match Whole Word Only"/>
+					<Item id="42097" name="Match Case &amp;&amp; Whole Word"/>
+					<Item id="42098" name="Undo the Latest Added Multi-Select"/>
+					<Item id="42099" name="Skip Current &amp;&amp; Go to Next Multi-select"/>
 					<Item id="42018" name="Start Re&amp;cording"/>
 					<Item id="42019" name="S&amp;top Recording"/>
 					<Item id="42021" name="&amp;Playback"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -39,6 +39,8 @@ Translation note:
 					<Item subMenuId="edit-blankOperations" name="&amp;Blank Operations"/>
 					<Item subMenuId="edit-pasteSpecial" name="&amp;Paste Special"/>
 					<Item subMenuId="edit-onSelection" name="&amp;On Selection"/>
+					<Item subMenuId="edit-multiSelectALL" name="Multi-select ALL"/>
+					<Item subMenuId="edit-multiSelectNext" name="Multi-select Next"/>
 					<Item subMenuId="search-changeHistory" name="Change History"/>
 					<Item subMenuId="search-markAll" name="Style &amp;All Occurrences of Token"/>
 					<Item subMenuId="search-markOne" name="Style &amp;One Token"/>
@@ -118,6 +120,16 @@ Translation note:
 					<Item id="42007" name="&amp;Select All"/>
 					<Item id="42020" name="Begin/End &amp;Select"/>
 					<Item id="42089" name="Begin/End Select in Column Mode"/>
+					<Item id="42090" name="Ignore Case &amp;&amp; Whole Word"/>
+					<Item id="42091" name="Match Case Only"/>
+					<Item id="42092" name="Match Whole Word Only"/>
+					<Item id="42093" name="Match Case &amp;&amp; Whole Word"/>
+					<Item id="42094" name="Ignore Case &amp;&amp; Whole Word"/>
+					<Item id="42095" name="Match Case Only"/>
+					<Item id="42096" name="Match Whole Word Only"/>
+					<Item id="42097" name="Match Case &amp;&amp; Whole Word"/>
+					<Item id="42098" name="Undo the Latest Added Multi-Select"/>
+					<Item id="42099" name="Skip Current &amp;&amp; Go to Next Multi-select"/>
 					<Item id="42084" name="Date Time (short)"/>
 					<Item id="42085" name="Date Time (long)"/>
 					<Item id="42086" name="Date Time (customized)"/>

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2012,7 +2012,9 @@ void Notepad_plus::command(int id)
 				(id == IDM_EDIT_MULTISELECTALLMATCHCASE ? SCFIND_MATCHCASE :
 					(id == IDM_EDIT_MULTISELECTALLWHOLEWORD ? SCFIND_WHOLEWORD: SCFIND_MATCHCASE| SCFIND_WHOLEWORD));
 
-			_pEditView->expandWordSelection();
+			bool hasSelection = (_pEditView->execute(SCI_GETSELECTIONSTART) != _pEditView->execute(SCI_GETSELECTIONEND));
+			if (!hasSelection)
+				_pEditView->expandWordSelection();
 
 			_pEditView->execute(SCI_TARGETWHOLEDOCUMENT);
 
@@ -4289,6 +4291,14 @@ void Notepad_plus::command(int id)
 			case IDM_VIEW_IN_IE      :
 			case IDM_EDIT_COPY_ALL_NAMES:
 			case IDM_EDIT_COPY_ALL_PATHS:
+			case IDM_EDIT_MULTISELECTALLWHOLEWORD:
+			case IDM_EDIT_MULTISELECTALLMATCHCASEWHOLEWORD:
+			case IDM_EDIT_MULTISELECTNEXT:
+			case IDM_EDIT_MULTISELECTNEXTMATCHCASE:
+			case IDM_EDIT_MULTISELECTNEXTWHOLEWORD:
+			case IDM_EDIT_MULTISELECTNEXTMATCHCASEWHOLEWORD:
+			case IDM_EDIT_MULTISELECTUNDO:
+			case IDM_EDIT_MULTISELECTSSKIP:
 				_macro.push_back(recordedMacroStep(id));
 				break;
 

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -57,6 +57,8 @@ MenuPosition menuPos[] = {
 	{ 1,  19, -1, "edit-blankOperations" },
 	{ 1,  20, -1, "edit-pasteSpecial" },
 	{ 1,  21, -1, "edit-onSelection" },
+	{ 1,  23, -1, "edit-multiSelectALL" },
+	{ 1,  24, -1, "edit-multiSelectNext" },
 
 	{ 2,  18, -1, "search-changeHistory" },
 	{ 2,  20, -1, "search-markAll" },


### PR DESCRIPTION
1. Make "Multi-select all" expand the word only when there's no selection.
2. Make Multi-select command set macro-able.
3. Make Multi-select command set translatable.

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14295#issuecomment-1791688412