### PR TITLE
Update LegalCopyright year to 2023

### DIFF
--- a/PowerEditor/installer/nsisInclude/globalDef.nsh
+++ b/PowerEditor/installer/nsisInclude/globalDef.nsh
@@ -56,7 +56,7 @@
 !define Description		"Notepad++ : a free (GNU) source code editor"
 !define Version		"${nppVer_1}.${nppVer_2}.${nppVer_3}.${nppVer_4}"
 !define ProdVer		"${VERSION_MAJOR}.${VERSION_MINOR}"
-!define LegalCopyright		"Copyleft 1998-2017 by Don HO"
+!define LegalCopyright		"Copyleft 1998-2023 by Don HO"
 
 !define APPWEBSITE "https://notepad-plus-plus.org/"
 


### PR DESCRIPTION
I noticed in the uninstall.exe details information, the copyright year range is still up to 2017. Updating the year to 2023 to reflect the project copyright covers until year 2023.