### PR TITLE
fix tab-closing crash by middle mouse button at unexpected position

### DIFF
--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -849,7 +849,8 @@ LRESULT TabBarPlus::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPara
 			int xPos = LOWORD(lParam);
 			int yPos = HIWORD(lParam);
 			int currentTabOn = getTabIndexAt(xPos, yPos);
-			notify(TCN_TABDELETE, currentTabOn);
+			if (currentTabOn != -1)
+				notify(TCN_TABDELETE, currentTabOn);
 			return TRUE;
 		}
 


### PR DESCRIPTION
Fix #14328 .

The TabBar.h getTabIndexAt(int x, int y) could fail to find the tab-index (the underlying TCM_HITTEST WM returns -1, when there is no tab at the current mouse position).