### PR TITLE
Fix possible PluginsManager FindClose WINAPI errors

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -447,7 +447,7 @@ bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginU
 				pathAppend(pluginsFullPathFilter2, dllName2);
 
 				// get plugin
-				if (hFindDll)
+				if (hFindDll && (hFindDll != INVALID_HANDLE_VALUE))
 				{
 					::FindClose(hFindDll);
 					hFindDll = INVALID_HANDLE_VALUE;
@@ -514,8 +514,10 @@ bool PluginsManager::loadPlugins(const TCHAR* dir, const PluginViewList* pluginU
 		}
 
 	}
-	::FindClose(hFindFolder);
-	::FindClose(hFindDll);
+	if (hFindFolder && (hFindFolder != INVALID_HANDLE_VALUE))
+		::FindClose(hFindFolder);
+	if (hFindDll && (hFindDll != INVALID_HANDLE_VALUE))
+		::FindClose(hFindDll);
 
 	for (size_t i = 0, len = dllNames.size(); i < len; ++i)
 	{


### PR DESCRIPTION
Otherwise the ERROR_INVALID_HANDLE (0x6) can be triggered.

@donho 
I got these (potentially harmless) ERROR_INVALID_HANDLE during my plugin-loading debugging (test for the DockingManager "lost panel" problem: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13084#issuecomment-1789040331 ).

I do not think that this fix deserves its own separate issue report, but if you think otherwise, I will add also the the corresponding issue.(?)