### PR TITLE
[xml] correct wrong German translation of multi-select feature

### DIFF
--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -169,7 +169,7 @@ Translation note:
 					<Item id="42091" name="Nur Übereinstimmung Groß- und Kleinschreibung"/>
 					<Item id="42092" name="Nur Übereinstimmung ganzes Wort"/>
 					<Item id="42093" name="Übereinstimmung Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>
-					<Item id="42094" name="Ignoriere Übereinstimmung Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>
+					<Item id="42094" name="Ignoriere Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>
 					<Item id="42095" name="Nur Übereinstimmung Groß- und Kleinschreibung"/>
 					<Item id="42096" name="Nur Übereinstimmung ganzes Wort"/>
 					<Item id="42097" name="Übereinstimmung Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>

--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -48,8 +48,8 @@ Translation note:
 					<Item subMenuId="edit-blankOperations" name="Nicht &amp;druckbare Zeichen"/>
 					<Item subMenuId="edit-pasteSpecial" name="Einf&amp;ügen speziell"/>
 					<Item subMenuId="edit-onSelection" name="Mit Auswahl"/>
-					<Item subMenuId="edit-multiSelectALL" name="Mehrfach-Auswahl ALLE"/>
-					<Item subMenuId="edit-multiSelectNext" name="Mehrfach-Auswahl Nächstes"/>
+					<Item subMenuId="edit-multiSelectALL" name="Mehrfachauswahl ALLE"/>
+					<Item subMenuId="edit-multiSelectNext" name="Mehrfachauswahl Nächstes"/>
 					<Item subMenuId="search-changeHistory" name="Änderungs-Historie"/>
 					<Item subMenuId="search-markAll" name="&amp;Alle Vorkommen hervorheben"/>
 					<Item subMenuId="search-markOne" name="Di&amp;eses Vorkommen hervorheben"/>
@@ -165,16 +165,16 @@ Translation note:
 					<Item id="42074" name="Verzeichnis im Explorer öffnen"/>
 					<Item id="42075" name="Im Internet suchen"/>
 					<Item id="42076" name="Andere Suchmaschine wählen …"/>
-					<Item id="42090" name="Ignoriere Übereinstimmung &amp;&amp; ganzes Wort"/>
-					<Item id="42091" name="Nur Übereinstimmung"/>
+					<Item id="42090" name="Ignoriere Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>
+					<Item id="42091" name="Nur Übereinstimmung Groß- und Kleinschreibung"/>
 					<Item id="42092" name="Nur Übereinstimmung ganzes Wort"/>
-					<Item id="42093" name="Übereinstimmung &amp;&amp; ganzes Wort"/>
-					<Item id="42094" name="Ignoriere Übereinstimmung &amp;&amp; ganzes Wort"/>
-					<Item id="42095" name="Nur Übereinstimmung"/>
+					<Item id="42093" name="Übereinstimmung Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>
+					<Item id="42094" name="Ignoriere Übereinstimmung Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>
+					<Item id="42095" name="Nur Übereinstimmung Groß- und Kleinschreibung"/>
 					<Item id="42096" name="Nur Übereinstimmung ganzes Wort"/>
-					<Item id="42097" name="Übereinstimmung &amp;&amp; ganzes Wort"/>
-					<Item id="42098" name="Letzte Mehrfach-Auswahl rückgängig machen"/>
-					<Item id="42099" name="Aktuelle überspringen &amp;&amp; zur nächsten Mehrfach-Auswahl gehen"/>
+					<Item id="42097" name="Übereinstimmung Groß- und Kleinschreibung &amp;&amp; ganzes Wort"/>
+					<Item id="42098" name="Letzte Mehrfachauswahl rückgängig machen"/>
+					<Item id="42099" name="Aktuelle überspringen &amp;&amp; zur nächsten Mehrfachauswahl gehen"/>
 					<Item id="42018" name="Aufzei&amp;chnung starten"/>
 					<Item id="42019" name="Aufzeichnung s&amp;toppen"/>
 					<Item id="42021" name="Makro ausfüh&amp;ren"/>


### PR DESCRIPTION
The German translation is completely missing the word "case" (meant is "upper/lower case"). The literally translation of "Nur Übereinstimmung" would be "Match only", which doesn't capture the essence of the phrase. Also it's "Mehrfachauswahl", not "Mehrfach-Auswahl".
CC: @schnurlos 

English original: https://github.com/notepad-plus-plus/notepad-plus-plus/commit/cecd161570eb22ef8bc6f730f725d81ec67fbf7e /  #14301
German Translation: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14250/commits/3e14fa040b2a4c55e1addf77d1a583be8d7f61a5 / #14250