### PR TITLE
add apostrophe to URL check

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3114,6 +3114,7 @@ bool isUrlTextChar(TCHAR const c)
 		case '}':
 		case '?':
 		case '\u007F':
+		case '\'':
 			return false;
 	}
 	return true;


### PR DESCRIPTION
Fix for #14323 for the indicator not terminating when an apostrophe is at the end of a URL.