### PR TITLE
Enable Copy & Cut commands on menu all the time

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2561,11 +2561,8 @@ void Notepad_plus::checkClipboard()
 {
 	bool hasSelection = _pEditView->hasSelection();
 	bool canPaste = (_pEditView->execute(SCI_CANPASTE) != 0);
-	enableCommand(IDM_EDIT_CUT, hasSelection, MENU | TOOLBAR);
-	enableCommand(IDM_EDIT_COPY, hasSelection, MENU | TOOLBAR);
 
 	enableCommand(IDM_EDIT_PASTE, canPaste, MENU | TOOLBAR);
-	enableCommand(IDM_EDIT_DELETE, hasSelection, MENU | TOOLBAR);
 	enableCommand(IDM_EDIT_UPPERCASE, hasSelection, MENU);
 	enableCommand(IDM_EDIT_LOWERCASE, hasSelection, MENU);
 	enableCommand(IDM_EDIT_PROPERCASE_FORCE, hasSelection, MENU);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -354,15 +354,21 @@ void Notepad_plus::command(int id)
 			checkUndoState();
 			break;
 		}
-
+		
 		case IDM_EDIT_CUT:
-			_pEditView->execute(WM_CUT);
-			checkClipboard();
+			if (!_pEditView->hasSelection()) // Ctrl + X: without selected text, it will cut the whole line.
+				_pEditView->execute(SCI_LINECUT);
+			else
+				_pEditView->execute(WM_CUT);
+
 			break;
 
 		case IDM_EDIT_COPY:
-			_pEditView->execute(WM_COPY);
-			checkClipboard();
+			if (!_pEditView->hasSelection()) // Ctrl + C: without selected text, it will copy the whole line.
+				_pEditView->execute(SCI_LINECOPY);
+			else
+				_pEditView->execute(WM_COPY);
+
 			break;
 
 		case IDM_EDIT_COPY_LINK:

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -468,6 +468,9 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 */
 static const ScintillaKeyDefinition scintKeyDefs[] =
 {
+    //Scintilla command name,             SCINTILLA_CMD_ID,            Ctrl,  Alt,   Shift, V_KEY,       NOTEPAD++_CMD_ID
+	// -------------------------------------------------------------------------------------------------------------------
+	//
 	{TEXT("SCI_CUT"),                     SCI_CUT,                     true,  false, false, VK_X,        IDM_EDIT_CUT},
 	{TEXT(""),                            SCI_CUT,                     false, false, true,  VK_DELETE,   0},
 	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_C,        IDM_EDIT_COPY},

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -650,28 +650,8 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			}
 			else
 			{
-				//
-				// 2 shortcuts:
-				// Ctrl + C: without selected text, it will copy the whole line.
-				// Ctrl + X: without selected text, it will cut the whole line.
-				//
 				switch (wParam)
 				{
-					case 'C':
-					case 'X':
-					{
-						if ((ctrl & 0x8000) && !(alt & 0x8000) && !(shift & 0x8000))
-						{
-							if (!hasSelection())
-							{
-								execute(wParam == 'C' ? SCI_LINECOPY : SCI_LINECUT);
-								//return TRUE;
-								// No return and let Scintilla procedure to continue
-							}
-						}
-					}
-					break;
-
 					case 'V':
 					{
 						if ((ctrl & 0x8000) && !(alt & 0x8000) && !(shift & 0x8000))

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -652,6 +652,23 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			{
 				switch (wParam)
 				{
+					//
+					// 2 shortcuts:
+					// Ctrl + C: without selected text, it will copy the whole line.
+					// Ctrl + X: without selected text, it will cut the whole line.
+					//
+					case 'C':
+					case 'X':
+					{
+						if (((ctrl & 0x8000) && !(alt & 0x8000) && !(shift & 0x8000)) && !hasSelection())
+						{
+							execute(wParam == 'C' ? SCI_LINECOPY : SCI_LINECUT);
+							//return TRUE;
+							// No return and let Scintilla procedure to continue
+						}
+					}
+					break;
+
 					case 'V':
 					{
 						if ((ctrl & 0x8000) && !(alt & 0x8000) && !(shift & 0x8000))

--- a/PowerEditor/src/keys.h
+++ b/PowerEditor/src/keys.h
@@ -1,5 +1,5 @@
 // This file is part of Notepad++ project
-// Copyright (C)2021 Don HO <don.h@free.fr>
+// Copyright (C)2023 Don HO <don.h@free.fr>
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,58 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <winuser.h>
 
 /*
 See winuser.h
-Altered list to support VK_0-9 and VK_A-Z
+Altered list to support VK_0-9 and VK_A-Z, plus VK_NULL
 */
 
 #define VK_NULL           0x00
 
-#define VK_CANCEL         0x03
-
-#define VK_BACK           0x08
-#define VK_TAB            0x09
-
-#define VK_CLEAR          0x0C
-#define VK_RETURN         0x0D
-
-#define VK_SHIFT          0x10
-#define VK_CONTROL        0x11
-#define VK_MENU           0x12
-#define VK_PAUSE          0x13
-#define VK_CAPITAL        0x14
-
-#define VK_KANA           0x15
-#define VK_HANGUL         0x15
-#define VK_JUNJA          0x17
-#define VK_FINAL          0x18
-#define VK_HANJA          0x19
-#define VK_KANJI          0x19
-
-#define VK_ESCAPE         0x1B
-
-#define VK_CONVERT        0x1C
-#define VK_NONCONVERT     0x1D
-#define VK_ACCEPT         0x1E
-#define VK_MODECHANGE     0x1F
-
-#define VK_SPACE          0x20
-#define VK_PRIOR          0x21
-#define VK_NEXT           0x22
-#define VK_END            0x23
-#define VK_HOME           0x24
-#define VK_LEFT           0x25
-#define VK_UP             0x26
-#define VK_RIGHT          0x27
-#define VK_DOWN           0x28
-#define VK_SELECT         0x29
-#define VK_PRINT          0x2A
-#define VK_EXECUTE        0x2B
-#define VK_SNAPSHOT       0x2C
-#define VK_INSERT         0x2D
-#define VK_DELETE         0x2E
-#define VK_HELP           0x2F
 
 #define VK_0              0x30
 #define VK_1              0x31
@@ -103,93 +60,3 @@ Altered list to support VK_0-9 and VK_A-Z
 #define VK_X              0x58
 #define VK_Y              0x59
 #define VK_Z              0x5A
-
-#define VK_LWIN           0x5B
-#define VK_RWIN           0x5C
-#define VK_APPS           0x5D
-
-
-#define VK_SLEEP          0x5F
-
-#define VK_NUMPAD0        0x60
-#define VK_NUMPAD1        0x61
-#define VK_NUMPAD2        0x62
-#define VK_NUMPAD3        0x63
-#define VK_NUMPAD4        0x64
-#define VK_NUMPAD5        0x65
-#define VK_NUMPAD6        0x66
-#define VK_NUMPAD7        0x67
-#define VK_NUMPAD8        0x68
-#define VK_NUMPAD9        0x69
-#define VK_MULTIPLY       0x6A
-#define VK_ADD            0x6B
-#define VK_SEPARATOR      0x6C
-#define VK_SUBTRACT       0x6D
-#define VK_DECIMAL        0x6E
-#define VK_DIVIDE         0x6F
-#define VK_F1             0x70
-#define VK_F2             0x71
-#define VK_F3             0x72
-#define VK_F4             0x73
-#define VK_F5             0x74
-#define VK_F6             0x75
-#define VK_F7             0x76
-#define VK_F8             0x77
-#define VK_F9             0x78
-#define VK_F10            0x79
-#define VK_F11            0x7A
-#define VK_F12            0x7B
-#define VK_F13            0x7C
-#define VK_F14            0x7D
-#define VK_F15            0x7E
-#define VK_F16            0x7F
-#define VK_F17            0x80
-#define VK_F18            0x81
-#define VK_F19            0x82
-#define VK_F20            0x83
-#define VK_F21            0x84
-#define VK_F22            0x85
-#define VK_F23            0x86
-#define VK_F24            0x87
-
-#define VK_NUMLOCK        0x90
-#define VK_SCROLL         0x91
-
-#define VK_OEM_1          0xBA   // ';:' for US
-#define VK_OEM_PLUS       0xBB   // '+' any country
-#define VK_OEM_COMMA      0xBC   // ',' any country
-#define VK_OEM_MINUS      0xBD   // '-' any country
-#define VK_OEM_PERIOD     0xBE   // '.' any country
-#define VK_OEM_2          0xBF   // '/?' for US
-#define VK_OEM_3          0xC0   // '`~' for US
-
-#define VK_OEM_4          0xDB  //  '[{' for US
-#define VK_OEM_5          0xDC  //  '\|' for US
-#define VK_OEM_6          0xDD  //  ']}' for US
-#define VK_OEM_7          0xDE  //  ''"' for US
-#define VK_OEM_8          0xDF
-
-#define VK_OEM_102        0xE2  //  "<>" or "\|" on RT 102-key kbd.
-
-#define VK_OEM_RESET      0xE9
-#define VK_OEM_JUMP       0xEA
-#define VK_OEM_PA1        0xEB
-#define VK_OEM_PA2        0xEC
-#define VK_OEM_PA3        0xED
-#define VK_OEM_WSCTRL     0xEE
-#define VK_OEM_CUSEL      0xEF
-#define VK_OEM_ATTN       0xF0
-#define VK_OEM_FINISH     0xF1
-#define VK_OEM_COPY       0xF2
-#define VK_OEM_AUTO       0xF3
-#define VK_OEM_ENLW       0xF4
-#define VK_OEM_BACKTAB    0xF5
-#define VK_ATTN           0xF6
-#define VK_CRSEL          0xF7
-#define VK_EXSEL          0xF8
-#define VK_EREOF          0xF9
-#define VK_PLAY           0xFA
-#define VK_ZOOM           0xFB
-#define VK_NONAME         0xFC
-#define VK_PA1            0xFD
-#define VK_OEM_CLEAR      0xFE


### PR DESCRIPTION
Before the implementation of https://github.com/notepad-plus-plus/notepad-plus-plus/commit/e9c50ed967fe44c758cd25c3907ef8aee37e6f05, Copy & Cut command were disabled when there were no selection, which makes sense because there was nothing to be copied & cut. Now users can copy/cut current line without selection.

Fix #14401