### PR TITLE
Fix visual glichy on multi-paste and make shortcut commands more coherent

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -97,9 +97,9 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 
 //	{ VK_NULL,    IDM_EDIT_UNDO,                                false, false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_REDO,                                false, false, false, nullptr },
-//	{ VK_NULL,    IDM_EDIT_CUT,                                 false, false, false, nullptr },
-//	{ VK_NULL,    IDM_EDIT_COPY,                                false, false, false, nullptr },
-//	{ VK_NULL,    IDM_EDIT_PASTE,                               false, false, false, nullptr },
+	{ VK_X,       IDM_EDIT_CUT,                                 true,  false, false, nullptr },
+	{ VK_C,       IDM_EDIT_COPY,                                true,  false, false, nullptr },
+	{ VK_V,       IDM_EDIT_PASTE,                               true,  false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_DELETE,                              false, false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_SELECTALL,                           false, false, false, nullptr },
 	{ VK_B,       IDM_EDIT_BEGINENDSELECT,                      true,  false, true,  nullptr },
@@ -471,12 +471,12 @@ static const ScintillaKeyDefinition scintKeyDefs[] =
     //Scintilla command name,             SCINTILLA_CMD_ID,            Ctrl,  Alt,   Shift, V_KEY,       NOTEPAD++_CMD_ID
 	// -------------------------------------------------------------------------------------------------------------------
 	//
-	{TEXT("SCI_CUT"),                     SCI_CUT,                     true,  false, false, VK_X,        IDM_EDIT_CUT},
-	{TEXT(""),                            SCI_CUT,                     false, false, true,  VK_DELETE,   0},
-	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_C,        IDM_EDIT_COPY},
-	{TEXT(""),                            SCI_COPY,                    true,  false, false, VK_INSERT,   0},
-	{TEXT("SCI_PASTE"),                   SCI_PASTE,                   true,  false, false, VK_V,        IDM_EDIT_PASTE},
-	{TEXT(""),                            SCI_PASTE,                   false, false, true,  VK_INSERT,   0},
+//	{TEXT("SCI_CUT"),                     SCI_CUT,                     true,  false, false, VK_X,        IDM_EDIT_CUT},
+//	{TEXT(""),                            SCI_CUT,                     false, false, true,  VK_DELETE,   0},
+//	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_C,        IDM_EDIT_COPY},
+//	{TEXT(""),                            SCI_COPY,                    true,  false, false, VK_INSERT,   0},
+//	{TEXT("SCI_PASTE"),                   SCI_PASTE,                   true,  false, false, VK_V,        IDM_EDIT_PASTE},
+//	{TEXT(""),                            SCI_PASTE,                   false, false, true,  VK_INSERT,   0},
 	{TEXT("SCI_SELECTALL"),               SCI_SELECTALL,               true,  false, false, VK_A,        IDM_EDIT_SELECTALL},
 	{TEXT("SCI_CLEAR"),                   SCI_CLEAR,                   false, false, false, VK_DELETE,   IDM_EDIT_DELETE},
 	{TEXT("SCI_CLEARALL"),                SCI_CLEARALL,                false, false, false, 0,           0},

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -3412,6 +3412,26 @@ bool FindReplaceDlg::removeFinder(Finder *finder2remove)
 	return false;
 }
 
+Finder* FindReplaceDlg::getFinderFrom(HWND hwnd)
+{
+	if (_pFinder && _pFinder->isCreated())
+	{
+		if (_pFinder->_scintView.getHSelf() == hwnd)
+			return _pFinder;
+
+		if (!_findersOfFinder.empty())
+		{
+			for (const auto& finder : _findersOfFinder)
+			{
+				if (finder->_scintView.getHSelf() == hwnd)
+					return finder;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
 void FindReplaceDlg::setSearchText(TCHAR * txt2find)
 {
 	HWND hCombo = ::GetDlgItem(_hSelf, IDFINDWHAT);

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -145,6 +145,9 @@ public:
 	void setVolatiled(bool val) { _canBeVolatiled = val; };
 	generic_string getHitsString(int count) const;
 
+	LRESULT scintillaExecute(UINT msg, WPARAM wParam = 0, LPARAM lParam = 0) const {
+		return _scintView.execute(msg, wParam, lParam);
+	}
 protected :
 	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam) override;
 	bool notify(SCNotification *notification);
@@ -282,7 +285,9 @@ public :
 	void findAllIn(InWhat op);
 	void setSearchText(TCHAR * txt2find);
 
-	void gotoNextFoundResult(int direction = 0) {if (_pFinder) _pFinder->gotoNextFoundResult(direction);};
+	void gotoNextFoundResult(int direction = 0) const {
+		if (_pFinder) _pFinder->gotoNextFoundResult(direction);
+	};
 
 	void putFindResult(int result) {
 		_findAllResult = result;
@@ -392,6 +397,7 @@ public :
 	Finder * createFinder();
 	bool removeFinder(Finder *finder2remove);
 	DIALOG_TYPE getCurrentStatus() {return _currentStatus;};
+	Finder* getFinderFrom(HWND hwnd);
 
 protected :
 	void resizeDialogElements(LONG newWidth);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -509,16 +509,6 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 				::SendMessage(_hParent, WM_NOTIFY, LINKTRIGGERED, reinterpret_cast<LPARAM>(&notification));
 
 			}
-			else if (wParam == 'V')
-			{
-				if (_isMultiPasteActive)
-				{
-					Buffer* buf = getCurrentBuffer();
-					buf->setUserReadOnly(false);
-					_isMultiPasteActive = false;
-					::SendMessage(_hParent, NPPM_INTERNAL_CHECKUNDOREDOSTATE, 0, 0);
-				}
-			}
 			break;
 		}
 
@@ -647,48 +637,6 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 
 				}
 
-			}
-			else
-			{
-				switch (wParam)
-				{
-					//
-					// 2 shortcuts:
-					// Ctrl + C: without selected text, it will copy the whole line.
-					// Ctrl + X: without selected text, it will cut the whole line.
-					//
-					case 'C':
-					case 'X':
-					{
-						if (((ctrl & 0x8000) && !(alt & 0x8000) && !(shift & 0x8000)) && !hasSelection())
-						{
-							execute(wParam == 'C' ? SCI_LINECOPY : SCI_LINECUT);
-							//return TRUE;
-							// No return and let Scintilla procedure to continue
-						}
-					}
-					break;
-
-					case 'V':
-					{
-						if ((ctrl & 0x8000) && !(alt & 0x8000) && !(shift & 0x8000))
-						{
-							Buffer* buf = getCurrentBuffer();
-							bool isRO = buf->isReadOnly();
-							size_t nbSelections = execute(SCI_GETSELECTIONS);
-							if (nbSelections > 1 && !isRO)
-							{
-								if (pasteToMultiSelection())
-								{
-									// Hack for preventing the char "SYN" (0x16) from being adding into edit zone 
-									buf->setUserReadOnly(true);
-
-									_isMultiPasteActive = true; // It will be set false with WM_KEYUP message
-								}
-							}
-						}
-					}
-				}
 			}
 			break;
 		}


### PR DESCRIPTION
This PR is the following of #14422

This PR removes **Shift-DEL**, **Ctrl-INS** & **Shift-INS** shortcut from Scintilla. 
Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14401#issuecomment-1830302635

Now for Copy/Cut/Paste commands and their shortcut are coherent. ie. if user remaps the shortcuts of these 3 commands, both single/multiple selection operation with the commands in question will follow the changed shortcuts.

It also fixes 2 bugs:
1. visual glitch problem of read-only while multi-pasting.
2. the shortcut **Ctrl-C** in Search results works now.
 
Fix #14410