### PR TITLE
Fix 14245: Alphabetic order for languages

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -586,6 +586,14 @@ struct LangMenuItem final
 
 	LangMenuItem(LangType lt, int cmdID = 0, const std::wstring& langName = TEXT("")):
 	_langType(lt), _cmdID(cmdID), _langName(langName){};
+
+	bool operator<(const LangMenuItem& rhs)
+	{
+		std::wstring lhs_lang(this->_langName.length(), ' '), rhs_lang(rhs._langName.length(), ' ');
+		std::transform(this->_langName.begin(), this->_langName.end(), lhs_lang.begin(), towlower);
+		std::transform(rhs._langName.begin(), rhs._langName.end(), rhs_lang.begin(), towlower);
+		return lhs_lang < rhs_lang;
+	}
 };
 
 struct PrintSettings final {

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -2869,7 +2869,7 @@ intptr_t CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 
 			std::sort(_langList.begin(), _langList.end());
 
-			for (size_t i = 0; i < _langList.size(); ++i)
+			for (size_t i = 0, len = _langList.size(); i < len; ++i)
 			{
 				::SendDlgItemMessage(_hSelf, IDC_LIST_ENABLEDLANG, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(_langList[i]._langName.c_str()));
 			}

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -20,7 +20,6 @@
 #include "EncodingMapper.h"
 #include "localization.h"
 #include <algorithm>
-#include <iostream> // remove before PR
 
 #define MyGetGValue(rgb)      (LOBYTE((rgb)>>8))
 

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -19,6 +19,8 @@
 #include "lesDlgs.h"
 #include "EncodingMapper.h"
 #include "localization.h"
+#include <algorithm>
+#include <iostream> // remove before PR
 
 #define MyGetGValue(rgb)      (LOBYTE((rgb)>>8))
 
@@ -2861,10 +2863,16 @@ intptr_t CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 						if (str.length() > 0)
 						{
 							_langList.push_back(LangMenuItem(static_cast<LangType>(i), cmdID, str));
-							::SendDlgItemMessage(_hSelf, IDC_LIST_ENABLEDLANG, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(str.c_str()));
 						}
 					}
 				}
+			}
+
+			std::sort(_langList.begin(), _langList.end());
+
+			for (size_t i = 0; i < _langList.size(); ++i)
+			{
+				::SendDlgItemMessage(_hSelf, IDC_LIST_ENABLEDLANG, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(_langList[i]._langName.c_str()));
 			}
 
 			for (size_t i = 0, len = nppGUI._excludedLangList.size(); i < len ; ++i)

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -2875,6 +2875,8 @@ intptr_t CALLBACK LanguageSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 				::SendDlgItemMessage(_hSelf, IDC_LIST_ENABLEDLANG, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(_langList[i]._langName.c_str()));
 			}
 
+			std::sort(nppGUI._excludedLangList.begin(), nppGUI._excludedLangList.end());
+				
 			for (size_t i = 0, len = nppGUI._excludedLangList.size(); i < len ; ++i)
 			{
 				::SendDlgItemMessage(_hSelf, IDC_LIST_DISABLEDLANG, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(nppGUI._excludedLangList[i]._langName.c_str()));


### PR DESCRIPTION
#14245 

Feature:
Sort languages (and excluded languages) alphabetically.

Changes:
-Override less than operator for LangMenuItem struct in order to call std::sort on the vector of languages. This operator will sort alphabetically regardless of upper vs. lower case for better navigation.
-Call std::sort on language vector before displaying the language lists.

Results:
-Lists are now sorted each time Notepad++ is opened.
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/97911497/249d4532-8368-4007-98cd-7511f29a1306)
