### PR TITLE
"-loadingTime" cmdline param enhancement

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -43,6 +43,8 @@
 
 using namespace std;
 
+chrono::steady_clock::duration g_pluginsLoadingTime{};
+
 enum tb_stat {tb_saved, tb_unsaved, tb_ro, tb_monitored};
 #define DIR_LEFT true
 #define DIR_RIGHT false
@@ -457,7 +459,9 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_pluginsManager.init(nppData);
 
 	bool enablePluginAdmin = _pluginsAdminDlg.initFromJson();
+	std::chrono::steady_clock::time_point pluginsLoadingStartTP = std::chrono::steady_clock::now();
 	_pluginsManager.loadPlugins(nppParam.getPluginRootDir(), enablePluginAdmin ? &_pluginsAdminDlg.getAvailablePluginUpdateInfoList() : nullptr, enablePluginAdmin ? &_pluginsAdminDlg.getIncompatibleList() : nullptr);
+	g_pluginsLoadingTime = std::chrono::steady_clock::now() - pluginsLoadingStartTP;
 	_restoreButton.init(_pPublicInterface->getHinst(), hwnd);
 
 	// ------------ //

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -48,6 +48,10 @@
 #include <chrono>
 
 extern std::chrono::steady_clock::time_point g_nppStartTimePoint;
+extern std::chrono::steady_clock::duration g_nppInitTime;
+extern std::chrono::steady_clock::duration g_pluginsLoadingTime;
+extern std::chrono::steady_clock::duration g_sessionLoadingTime;
+extern std::chrono::steady_clock::duration g_cmdlineParamsLoadingTime;
 
 
 #define MENU 0x01

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -48,10 +48,7 @@
 #include <chrono>
 
 extern std::chrono::steady_clock::time_point g_nppStartTimePoint;
-extern std::chrono::steady_clock::duration g_nppInitTime;
 extern std::chrono::steady_clock::duration g_pluginsLoadingTime;
-extern std::chrono::steady_clock::duration g_sessionLoadingTime;
-extern std::chrono::steady_clock::duration g_cmdlineParamsLoadingTime;
 
 
 #define MENU 0x01

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -45,6 +45,9 @@
 #include "md5Dlgs.h"
 #include <vector>
 #include <iso646.h>
+#include <chrono>
+
+extern std::chrono::steady_clock::time_point g_nppStartTimePoint;
 
 
 #define MENU 0x01

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -21,10 +21,6 @@
 const TCHAR Notepad_plus_Window::_className[32] = TEXT("Notepad++");
 HWND Notepad_plus_Window::gNppHWND = NULL;
 
-std::chrono::steady_clock::duration g_nppInitTime{};
-std::chrono::steady_clock::duration g_sessionLoadingTime{};
-std::chrono::steady_clock::duration g_cmdlineParamsLoadingTime{};
-
 
 namespace // anonymous
 {

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-#include <time.h>
 #include <shlwapi.h>
 #include "Notepad_plus_Window.h"
 
@@ -65,10 +64,6 @@ void Notepad_plus_Window::setStartupBgColor(COLORREF BgColor)
 
 void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLine, CmdLineParams *cmdLineParams)
 {
-	time_t timestampBegin = 0;
-	if (cmdLineParams->_showLoadingTime)
-		timestampBegin = time(NULL);
-
 	Window::init(hInst, parent);
 	WNDCLASS nppClass{};
 
@@ -172,8 +167,13 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	if (cmdLineParams->_alwaysOnTop)
 		::SendMessage(_hSelf, WM_COMMAND, IDM_VIEW_ALWAYSONTOP, 0);
 
+	std::chrono::steady_clock::duration sessionLoadingTime{};
 	if (nppGUI._rememberLastSession && !nppGUI._isCmdlineNosessionActivated)
+	{
+		std::chrono::steady_clock::time_point sessionLoadingStartTP = std::chrono::steady_clock::now();
 		_notepad_plus_plus_core.loadLastSession();
+		sessionLoadingTime = std::chrono::steady_clock::now() - sessionLoadingStartTP;
+	}
 
 	if (nppParams.doFunctionListExport() || nppParams.doPrintAndExit())
 	{
@@ -297,9 +297,14 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	for (size_t i = 0, len = _notepad_plus_plus_core._internalFuncIDs.size() ; i < len ; ++i)
 		::SendMessage(_hSelf, WM_COMMAND, _notepad_plus_plus_core._internalFuncIDs[i], 0);
 
+	std::chrono::steady_clock::duration cmdlineParamsLoadingTime{};
 	std::vector<generic_string> fns;
 	if (cmdLine)
+	{
+		std::chrono::steady_clock::time_point cmdlineParamsLoadingStartTP = std::chrono::steady_clock::now();
 		fns = _notepad_plus_plus_core.loadCommandlineParams(cmdLine, cmdLineParams);
+		cmdlineParamsLoadingTime = std::chrono::steady_clock::now() - cmdlineParamsLoadingStartTP;
+	}
 
 	// Launch folder as workspace after all this dockable panel being restored from the last session
 	// To avoid dockable panel toggle problem.
@@ -385,12 +390,13 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 
 	if (cmdLineParams->_showLoadingTime)
 	{
-		time_t timestampEnd = time(NULL);
-		double loadTime = difftime(timestampEnd, timestampBegin);
-
-		char dest[256];
-		sprintf(dest, "Loading time : %.0lf seconds", loadTime);
-		::MessageBoxA(NULL, dest, "", MB_OK);
+		std::chrono::steady_clock::duration nppInitTime = (std::chrono::steady_clock::now() - g_nppStartTimePoint) - sessionLoadingTime - cmdlineParamsLoadingTime;
+		std::wstringstream wss;
+		wss << L"app & plugin(s) initialization: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(nppInitTime) } << std::endl;
+		wss << L"last session loading: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(sessionLoadingTime) } << std::endl;
+		wss << L"cmdline params handling: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(cmdlineParamsLoadingTime) } << std::endl << std::endl;
+		wss << L"overall: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(nppInitTime + sessionLoadingTime + cmdlineParamsLoadingTime) };
+		::MessageBoxW(NULL, wss.str().c_str(), L"Notepad++ loading time (hh:mm:ss.ms)", MB_OK);
 	}
 
 	bool isSnapshotMode = nppGUI.isSnapshotMode();

--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -21,6 +21,9 @@
 const TCHAR Notepad_plus_Window::_className[32] = TEXT("Notepad++");
 HWND Notepad_plus_Window::gNppHWND = NULL;
 
+std::chrono::steady_clock::duration g_nppInitTime{};
+std::chrono::steady_clock::duration g_sessionLoadingTime{};
+std::chrono::steady_clock::duration g_cmdlineParamsLoadingTime{};
 
 
 namespace // anonymous
@@ -167,12 +170,11 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	if (cmdLineParams->_alwaysOnTop)
 		::SendMessage(_hSelf, WM_COMMAND, IDM_VIEW_ALWAYSONTOP, 0);
 
-	std::chrono::steady_clock::duration sessionLoadingTime{};
 	if (nppGUI._rememberLastSession && !nppGUI._isCmdlineNosessionActivated)
 	{
 		std::chrono::steady_clock::time_point sessionLoadingStartTP = std::chrono::steady_clock::now();
 		_notepad_plus_plus_core.loadLastSession();
-		sessionLoadingTime = std::chrono::steady_clock::now() - sessionLoadingStartTP;
+		g_sessionLoadingTime = std::chrono::steady_clock::now() - sessionLoadingStartTP;
 	}
 
 	if (nppParams.doFunctionListExport() || nppParams.doPrintAndExit())
@@ -297,13 +299,12 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 	for (size_t i = 0, len = _notepad_plus_plus_core._internalFuncIDs.size() ; i < len ; ++i)
 		::SendMessage(_hSelf, WM_COMMAND, _notepad_plus_plus_core._internalFuncIDs[i], 0);
 
-	std::chrono::steady_clock::duration cmdlineParamsLoadingTime{};
 	std::vector<generic_string> fns;
 	if (cmdLine)
 	{
 		std::chrono::steady_clock::time_point cmdlineParamsLoadingStartTP = std::chrono::steady_clock::now();
 		fns = _notepad_plus_plus_core.loadCommandlineParams(cmdLine, cmdLineParams);
-		cmdlineParamsLoadingTime = std::chrono::steady_clock::now() - cmdlineParamsLoadingStartTP;
+		g_cmdlineParamsLoadingTime = std::chrono::steady_clock::now() - cmdlineParamsLoadingStartTP;
 	}
 
 	// Launch folder as workspace after all this dockable panel being restored from the last session
@@ -390,12 +391,13 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const TCHAR *cmdLin
 
 	if (cmdLineParams->_showLoadingTime)
 	{
-		std::chrono::steady_clock::duration nppInitTime = (std::chrono::steady_clock::now() - g_nppStartTimePoint) - sessionLoadingTime - cmdlineParamsLoadingTime;
+		g_nppInitTime = (std::chrono::steady_clock::now() - g_nppStartTimePoint) - g_pluginsLoadingTime - g_sessionLoadingTime - g_cmdlineParamsLoadingTime;
 		std::wstringstream wss;
-		wss << L"app & plugin(s) initialization: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(nppInitTime) } << std::endl;
-		wss << L"last session loading: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(sessionLoadingTime) } << std::endl;
-		wss << L"cmdline params handling: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(cmdlineParamsLoadingTime) } << std::endl << std::endl;
-		wss << L"overall: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(nppInitTime + sessionLoadingTime + cmdlineParamsLoadingTime) };
+		wss << L"Notepad++ initialization: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(g_nppInitTime) } << std::endl;
+		wss << L"Plugins loading: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(g_pluginsLoadingTime) } << std::endl;
+		wss << L"Last session loading: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(g_sessionLoadingTime) } << std::endl;
+		wss << L"Command line params handling: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(g_cmdlineParamsLoadingTime) } << std::endl;
+		wss << L"Total loading time: " << std::chrono::hh_mm_ss{ std::chrono::duration_cast<std::chrono::milliseconds>(g_nppInitTime + g_pluginsLoadingTime + g_sessionLoadingTime + g_cmdlineParamsLoadingTime) };
 		::MessageBoxW(NULL, wss.str().c_str(), L"Notepad++ loading time (hh:mm:ss.ms)", MB_OK);
 	}
 

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -377,10 +377,13 @@ void stripIgnoredParams(ParamVector & params)
 } // namespace
 
 
+std::chrono::steady_clock::time_point g_nppStartTimePoint{};
 
 
 int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*/, _In_ PWSTR pCmdLine, _In_ int /*nShowCmd*/)
 {
+	g_nppStartTimePoint = std::chrono::steady_clock::now();
+
 	bool TheFirstOne = true;
 	::SetLastError(NO_ERROR);
 	::CreateMutex(NULL, false, TEXT("nppInstance"));


### PR DESCRIPTION
Fix #14472

Improves:
- the reported time accuracy (from seconds to milliseconds, now e.g. different N++ settings benchmarking is possible)
- the ability to analyze various problems (now it is possible to distinguish the time taken by the app/plugin code-init from the possible file loading time)