### PR TITLE
Make column to multi-select be abled to be disabled

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1635,6 +1635,21 @@ bool NppParameters::load()
 		_isRegForOSAppRestartDisabled = (::PathFileExists(filePath.c_str()) == TRUE);
 	}
 
+
+	//-------------------------------------------------------------//
+	// noColumnToMultiSelect.xml                                   //
+	// This empty xml file is optional - user adds this empty file //
+	// manually in order to prevent Notepad++ transform column     //
+	// selection into multi-select.                                //
+	//-------------------------------------------------------------//
+	std::wstring enableNoColumn2MultiSelectPath = _userPath;
+	pathAppend(enableNoColumn2MultiSelectPath, TEXT("noColumnToMultiSelect.xml"));
+
+	if (PathFileExists(enableNoColumn2MultiSelectPath.c_str()))
+	{
+		_column2MultiSelect = false;
+	}
+
 	return isAllLaoded;
 }
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1877,6 +1877,7 @@ public:
 	bool regexBackward4PowerUser() const { return _findHistory._regexBackward4PowerUser; }
 	bool isSelectFgColorEnabled() const { return _isSelectFgColorEnabled; };
 	bool isRegForOSAppRestartDisabled() const { return _isRegForOSAppRestartDisabled; };
+	bool doColumn2MultiSelect() const { return _column2MultiSelect; };
 
 private:
 	bool _isAnyShortcutModified = false;
@@ -1944,10 +1945,11 @@ private:
 
 	bool _isSelectFgColorEnabled = false;
 	bool _isRegForOSAppRestartDisabled = false;
+	bool _column2MultiSelect = true;
 
 	bool _doNppLogNetworkDriveIssue = false;
-
 	bool _doNppLogNulContentCorruptionIssue = false;
+
 	bool _isEndSessionStarted = false;
 	bool _isEndSessionCritical = false;
 

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -524,6 +524,7 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			SHORT alt = GetKeyState(VK_MENU);
 			SHORT shift = GetKeyState(VK_SHIFT);
 			bool isColumnSelection = (execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE) || (execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN);
+			bool column2MultSelect = (NppParameters::getInstance()).doColumn2MultiSelect();
 
 			if (wParam == VK_DELETE)
 			{
@@ -610,7 +611,7 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 					}
 				}
 			}
-			else if (isColumnSelection)
+			else if (isColumnSelection && column2MultSelect)
 			{
 				//
 				// Transform the column selection to multi-edit
@@ -628,8 +629,8 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 						execute(SCI_SETSELECTIONMODE, SC_SEL_STREAM); // When it's rectangular selection and the arrow keys are pressed, we switch the mode for having multiple carets.
 
 						execute(SCI_SETSELECTIONMODE, SC_SEL_STREAM); // the 2nd call for removing the unwanted selection while moving carets.
-						                                              // Solution suggested by Neil Hodgson. See:
-						                                              // https://sourceforge.net/p/scintilla/bugs/2412/
+																	  // Solution suggested by Neil Hodgson. See:
+																	  // https://sourceforge.net/p/scintilla/bugs/2412/
 						break;
 
 					default:


### PR DESCRIPTION
In order to disable the "Column to multi-select" ability (new feature introduced in v8.6), users must add an empty file named "noColumnToMultiSelect.xml", in "%APPDATA%\Notepad++\" directory (or in the Notepad++ installed directory in portable mode) to prevent this behaviour.

ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14296#issuecomment-1848076816

Fix #14464