### PR TITLE
Make hard-coded shortcut "Shift-DEL" be abled to be disabled

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1593,7 +1593,11 @@ bool NppParameters::load()
 
 
 	std::wstring filePath, filePath2, issueFileName;
-
+	//-------------------------------------------------------------//
+	// nppLogNetworkDriveIssue.xml                                 //
+	// This empty xml file is optional - user adds this empty file //
+	// It's for debugging use only                                 //
+	//-------------------------------------------------------------//
 	filePath = _nppPath;
 	issueFileName = nppLogNetworkDriveIssue;
 	issueFileName += TEXT(".xml");
@@ -1606,6 +1610,11 @@ bool NppParameters::load()
 		_doNppLogNetworkDriveIssue = (PathFileExists(filePath2.c_str()) == TRUE);
 	}
 
+	//-------------------------------------------------------------//
+	// nppLogNulContentCorruptionIssue.xml                         //
+	// This empty xml file is optional - user adds this empty file //
+	// It's for debugging use only                                 //
+	//-------------------------------------------------------------//
 	filePath = _nppPath;
 	issueFileName = nppLogNulContentCorruptionIssue;
 	issueFileName += TEXT(".xml");
@@ -1642,12 +1651,26 @@ bool NppParameters::load()
 	// manually in order to prevent Notepad++ transform column     //
 	// selection into multi-select.                                //
 	//-------------------------------------------------------------//
-	std::wstring enableNoColumn2MultiSelectPath = _userPath;
-	pathAppend(enableNoColumn2MultiSelectPath, TEXT("noColumnToMultiSelect.xml"));
+	std::wstring disableColumn2MultiSelectPath = _userPath;
+	pathAppend(disableColumn2MultiSelectPath, TEXT("noColumnToMultiSelect.xml"));
 
-	if (PathFileExists(enableNoColumn2MultiSelectPath.c_str()))
+	if (PathFileExists(disableColumn2MultiSelectPath.c_str()))
 	{
 		_column2MultiSelect = false;
+	}
+
+	//-------------------------------------------------------------//
+	// disableHardCodedShiftDelete.xml                             //
+	// This empty xml file is optional - user adds this empty file //
+	// manually in order to prevent hard coded Shift-DEL shortcut  //
+	// delete whole line while no selection.                       //
+	//-------------------------------------------------------------//
+	std::wstring disableHardCodedShiftDeletePath = _userPath;
+	pathAppend(disableHardCodedShiftDeletePath, TEXT("disableHardCodedShiftDelete.xml"));
+
+	if (PathFileExists(disableHardCodedShiftDeletePath.c_str()))
+	{
+		_useHardCodedShiftDelete = false;
 	}
 
 	return isAllLaoded;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1878,6 +1878,7 @@ public:
 	bool isSelectFgColorEnabled() const { return _isSelectFgColorEnabled; };
 	bool isRegForOSAppRestartDisabled() const { return _isRegForOSAppRestartDisabled; };
 	bool doColumn2MultiSelect() const { return _column2MultiSelect; };
+	bool useHardCodedShiftDelete() const { return _useHardCodedShiftDelete; };
 
 private:
 	bool _isAnyShortcutModified = false;
@@ -1946,6 +1947,7 @@ private:
 	bool _isSelectFgColorEnabled = false;
 	bool _isRegForOSAppRestartDisabled = false;
 	bool _column2MultiSelect = true;
+	bool _useHardCodedShiftDelete = true;
 
 	bool _doNppLogNetworkDriveIssue = false;
 	bool _doNppLogNulContentCorruptionIssue = false;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -525,13 +525,14 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			SHORT shift = GetKeyState(VK_SHIFT);
 			bool isColumnSelection = (execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE) || (execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN);
 			bool column2MultSelect = (NppParameters::getInstance()).doColumn2MultiSelect();
+			bool useHardCodedShiftDelete = (NppParameters::getInstance()).useHardCodedShiftDelete();
 
 			if (wParam == VK_DELETE)
 			{
 				// 1 shortcut:
 				// Shift + Delete: without selected text, it will delete the whole line.
 				//
-				if ((shift & 0x8000) && !(ctrl & 0x8000) && !(alt & 0x8000) && !hasSelection()) // Shift-DEL & no selection
+				if ((shift & 0x8000) && !(ctrl & 0x8000) && !(alt & 0x8000) && !hasSelection() && useHardCodedShiftDelete) // Shift-DEL & no selection
 				{
 					execute(SCI_LINEDELETE);
 					return TRUE;


### PR DESCRIPTION
In order to disable the hard-coded shortcut "Shift-DEL" ability (new feature introduced in v8.6) which delete current line while no selection, users must add an empty file named "disableHardCodedShiftDelete.xml", in "%APPDATA%\Notepad++\" directory (or in the Notepad++ installed directory in portable mode) to prevent this behaviour.

Fix #14470