### PR TITLE
Fix python wrong decorator attribute colors

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -887,6 +887,7 @@ protected:
 	void setPythonLexer() {
 		setLexer(L_PYTHON, LIST_0 | LIST_1);
 		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("fold.quotes.python"), reinterpret_cast<LPARAM>("1"));
+		execute(SCI_SETPROPERTY, reinterpret_cast<WPARAM>("lexer.python.decorator.attributes"), reinterpret_cast<LPARAM>("1"));
 	};
 	
 	void setGDScriptLexer() {


### PR DESCRIPTION
Fix #5894

Decorator color are now displayed correctly:
![01](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/7983249/6b358fcb-a50e-4cad-884a-048104e8aa27)

The solution to the problem was suggested here:
https://github.com/ScintillaOrg/lexilla/pull/219#issuecomment-1849782847