### PR TITLE
Make "line copy/cut/delete while no selection" optional

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -360,10 +360,14 @@ void Notepad_plus::command(int id)
 			HWND focusedHwnd = ::GetFocus();
 			if (focusedHwnd == _pEditView->getHSelf())
 			{
-				if (!_pEditView->hasSelection()) // Ctrl + X: without selected text, it will cut the whole line.
-					_pEditView->execute(SCI_LINECUT);
-				else
+				if (_pEditView->hasSelection())
 					_pEditView->execute(WM_CUT);
+				else
+				{
+					bool useLinCopyCut = (NppParameters::getInstance()).useLineCopyCutDelete();
+					if (useLinCopyCut)
+						_pEditView->execute(SCI_LINECUT); // Ctrl + X: without selected text, it will cut the whole line.
+				}
 			}
 			break;
 		}
@@ -373,10 +377,14 @@ void Notepad_plus::command(int id)
 			HWND focusedHwnd = ::GetFocus();
 			if (focusedHwnd == _pEditView->getHSelf())
 			{
-				if (!_pEditView->hasSelection()) // Ctrl + C: without selected text, it will copy the whole line.
-					_pEditView->execute(SCI_LINECOPY);
-				else
+				if (_pEditView->hasSelection())
 					_pEditView->execute(WM_COPY);
+				else
+				{
+					bool useLinCopyCut = (NppParameters::getInstance()).useLineCopyCutDelete();
+					if (useLinCopyCut)
+						_pEditView->execute(SCI_LINECOPY); // Ctrl + C: without selected text, it will copy the whole line.
+				}
 			}
 			else  // Search result
 			{

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -35,27 +35,14 @@ namespace // anonymous namespace
 {
 
 
-struct WinMenuKeyDefinition //more or less matches accelerator table definition, easy copy/paste
+struct WinMenuKeyDefinition // more or less matches accelerator table definition, easy copy/paste
 {
-	//const TCHAR * name;	//name retrieved from menu?
-	int vKey;
-	int functionId;
-	bool isCtrl;
-	bool isAlt;
-	bool isShift;
-	const TCHAR * specialName;		//Used when no real menu name exists (in case of toggle for example)
-};
-
-
-struct ScintillaKeyDefinition
-{
-	const TCHAR * name;
-	int functionId;
-	bool isCtrl;
-	bool isAlt;
-	bool isShift;
-	int vKey;
-	int redirFunctionId;	//this gets set  when a function is being redirected through Notepad++ if Scintilla doesnt do it properly :)
+	int vKey = 0;
+	int functionId = 0;
+	bool isCtrl = false;
+	bool isAlt = false;
+	bool isShift = false;
+	const TCHAR * specialName = nullptr; // Used when no real menu name exists (in case of toggle for example)
 };
 
 
@@ -464,6 +451,16 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 
 
 
+struct ScintillaKeyDefinition
+{
+	const TCHAR* name = nullptr;
+	int functionId = 0;
+	bool isCtrl = false;
+	bool isAlt = false;
+	bool isShift = false;
+	int vKey = 0;
+	int redirFunctionId = 0; // this gets set when a function is being redirected through Notepad++ if Scintilla doesnt do it properly :)
+};
 
 /*!
 ** \brief array of accelerator keys for all possible scintilla functions
@@ -475,12 +472,11 @@ static const ScintillaKeyDefinition scintKeyDefs[] =
     //Scintilla command name,             SCINTILLA_CMD_ID,            Ctrl,  Alt,   Shift, V_KEY,       NOTEPAD++_CMD_ID
 	// -------------------------------------------------------------------------------------------------------------------
 	//
-//	{TEXT("SCI_CUT"),                     SCI_CUT,                     true,  false, false, VK_X,        IDM_EDIT_CUT},
-//	{TEXT(""),                            SCI_CUT,                     false, false, true,  VK_DELETE,   0},
-//	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_C,        IDM_EDIT_COPY},
-//	{TEXT(""),                            SCI_COPY,                    true,  false, false, VK_INSERT,   0},
-//	{TEXT("SCI_PASTE"),                   SCI_PASTE,                   true,  false, false, VK_V,        IDM_EDIT_PASTE},
-//	{TEXT(""),                            SCI_PASTE,                   false, false, true,  VK_INSERT,   0},
+//	{TEXT("SCI_CUT"),                     SCI_CUT,                     false, false, true,  VK_DELETE,   0},
+//	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_INSERT,   0},
+//	{TEXT("SCI_PASTE"),                   SCI_PASTE,                   false, false, true,  VK_INSERT,   0},
+//	the above 3 shortcuts will be added dynamically if "disableLineCopyCutDelete.xml" is present.
+
 	{TEXT("SCI_SELECTALL"),               SCI_SELECTALL,               true,  false, false, VK_A,        IDM_EDIT_SELECTALL},
 	{TEXT("SCI_CLEAR"),                   SCI_CLEAR,                   false, false, false, VK_DELETE,   IDM_EDIT_DELETE},
 	{TEXT("SCI_CLEARALL"),                SCI_CLEARALL,                false, false, false, 0,           0},
@@ -1480,6 +1476,35 @@ bool NppParameters::load()
 		isAllLaoded = false;
 	}
 
+
+	//-----------------------------------------------------------------------------------//
+	// disableLineCopyCutDelete.xml                                                      //
+	// This empty xml file is optional - user adds this empty file manually to :         //
+	// 1. prevent hard coded Shift-DEL shortcut deletes whole line while no selection.   //
+	// 2. prevent Copy command (Ctrl-C) copies whole line (without selection).           //
+	// 3. prevent Cut command (Ctrl-X) cuts whole line (without selection).              //
+	// 4. add SCI_CUT (Shift-DEL), SCI_COPY (Ctrl-INS) & SCI_PASTE (Shift-INS) shortcuts //
+	//-----------------------------------------------------------------------------------//
+	std::wstring disableLineCopyCutDeletePath = _userPath;
+	pathAppend(disableLineCopyCutDeletePath, TEXT("disableLineCopyCutDelete.xml"));
+
+	if (PathFileExists(disableLineCopyCutDeletePath.c_str()))
+	{
+		_useLineCopyCutDelete = false;
+		
+		//
+		// Add back SCI_CUT (Shift-DEL), SCI_COPY (Ctrl-INS) & SCI_PASTE (Shift-INS) shortcuts
+		//
+		ScintillaKeyMap sci_cut = ScintillaKeyMap(Shortcut("SCI_CUT", false, false, true, static_cast<unsigned char>(VK_DELETE)), SCI_CUT, 0);
+		_scintillaKeyCommands.push_back(sci_cut);
+
+		ScintillaKeyMap sci_copy = ScintillaKeyMap(Shortcut("SCI_COPY", true, false, false, static_cast<unsigned char>(VK_INSERT)), SCI_COPY, 0);
+		_scintillaKeyCommands.push_back(sci_copy);
+
+		ScintillaKeyMap sci_paste = ScintillaKeyMap(Shortcut("SCI_PASTE", false, false, true, static_cast<unsigned char>(VK_INSERT)), SCI_PASTE, 0);
+		_scintillaKeyCommands.push_back(sci_paste);
+	}
+
 	//------------------------------//
 	// shortcuts.xml : for per user //
 	//------------------------------//
@@ -1661,21 +1686,6 @@ bool NppParameters::load()
 	if (PathFileExists(disableColumn2MultiSelectPath.c_str()))
 	{
 		_column2MultiSelect = false;
-	}
-
-	//----------------------------------------------------------------------------------//
-	// disableLineCopyCutDelete.xml                                                     //
-	// This empty xml file is optional - user adds this empty file manually to prevent: //
-	// 1. Hard coded Shift-DEL shortcut delete whole line while no selection.           //
-	// 2. Copy command (Ctrl-C) copy whole line (without selection).                    //
-	// 3. Cut command (Ctrl-X) cut whole line (without selection).                      //
-	//----------------------------------------------------------------------------------//
-	std::wstring disableLineCopyCutDeletePath = _userPath;
-	pathAppend(disableLineCopyCutDeletePath, TEXT("disableLineCopyCutDelete.xml"));
-
-	if (PathFileExists(disableLineCopyCutDeletePath.c_str()))
-	{
-		_useLineCopyCutDelete = false;
 	}
 
 	return isAllLaoded;
@@ -2131,6 +2141,7 @@ void NppParameters::initScintillaKeys()
 		prevID = skd.functionId;
 	}
 }
+
 bool NppParameters::reloadContextMenuFromXmlTree(HMENU mainMenuHadle, HMENU pluginsMenu)
 {
 	_contextMenuItems.clear();

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1663,18 +1663,19 @@ bool NppParameters::load()
 		_column2MultiSelect = false;
 	}
 
-	//-------------------------------------------------------------//
-	// disableHardCodedShiftDelete.xml                             //
-	// This empty xml file is optional - user adds this empty file //
-	// manually in order to prevent hard coded Shift-DEL shortcut  //
-	// delete whole line while no selection.                       //
-	//-------------------------------------------------------------//
-	std::wstring disableHardCodedShiftDeletePath = _userPath;
-	pathAppend(disableHardCodedShiftDeletePath, TEXT("disableHardCodedShiftDelete.xml"));
+	//----------------------------------------------------------------------------------//
+	// disableLineCopyCutDelete.xml                                                     //
+	// This empty xml file is optional - user adds this empty file manually to prevent: //
+	// 1. Hard coded Shift-DEL shortcut delete whole line while no selection.           //
+	// 2. Copy command (Ctrl-C) copy whole line (without selection).                    //
+	// 3. Cut command (Ctrl-X) cut whole line (without selection).                      //
+	//----------------------------------------------------------------------------------//
+	std::wstring disableLineCopyCutDeletePath = _userPath;
+	pathAppend(disableLineCopyCutDeletePath, TEXT("disableLineCopyCutDelete.xml"));
 
-	if (PathFileExists(disableHardCodedShiftDeletePath.c_str()))
+	if (PathFileExists(disableLineCopyCutDeletePath.c_str()))
 	{
-		_useHardCodedShiftDelete = false;
+		_useLineCopyCutDelete = false;
 	}
 
 	return isAllLaoded;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1878,7 +1878,7 @@ public:
 	bool isSelectFgColorEnabled() const { return _isSelectFgColorEnabled; };
 	bool isRegForOSAppRestartDisabled() const { return _isRegForOSAppRestartDisabled; };
 	bool doColumn2MultiSelect() const { return _column2MultiSelect; };
-	bool useHardCodedShiftDelete() const { return _useHardCodedShiftDelete; };
+	bool useLineCopyCutDelete() const { return _useLineCopyCutDelete; };
 
 private:
 	bool _isAnyShortcutModified = false;
@@ -1947,7 +1947,7 @@ private:
 	bool _isSelectFgColorEnabled = false;
 	bool _isRegForOSAppRestartDisabled = false;
 	bool _column2MultiSelect = true;
-	bool _useHardCodedShiftDelete = true;
+	bool _useLineCopyCutDelete = true;
 
 	bool _doNppLogNetworkDriveIssue = false;
 	bool _doNppLogNulContentCorruptionIssue = false;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -525,7 +525,7 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			SHORT shift = GetKeyState(VK_SHIFT);
 			bool isColumnSelection = (execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE) || (execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN);
 			bool column2MultSelect = (NppParameters::getInstance()).doColumn2MultiSelect();
-			bool useHardCodedShiftDelete = (NppParameters::getInstance()).useHardCodedShiftDelete();
+			bool useHardCodedShiftDelete = (NppParameters::getInstance()).useLineCopyCutDelete();
 
 			if (wParam == VK_DELETE)
 			{


### PR DESCRIPTION
By adding disableLineCopyCutDelete.xml in "%APPDATA%\Notepad++\" directory (or in the Notepad++ installed directory in portable mode) to:
1. prevent hard coded Shift-DEL shortcut deletes whole line while no selection.  
2. prevent Copy command (Ctrl-C) copies whole line (without selection).          
3. prevent Cut command (Ctrl-X) cuts whole line (without selection).             
4. add SCI_CUT (Shift-DEL), SCI_COPY (Ctrl-INS) & SCI_PASTE (Shift-INS) shortcuts


Note: the old disableHardCodedShiftDelete.xml (of 53b5055118caa5934b535c5521f04f991c13143b) is canceled, the new disableLineCopyCutDelete.xml is used instead.

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14296#issuecomment-1866679990
Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14401#issuecomment-1833326429