### PR TITLE
Fix clang compilation error in gcc build

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -587,7 +587,7 @@ struct LangMenuItem final
 	LangMenuItem(LangType lt, int cmdID = 0, const std::wstring& langName = TEXT("")):
 	_langType(lt), _cmdID(cmdID), _langName(langName){};
 
-	bool operator<(const LangMenuItem& rhs)
+	bool operator<(const LangMenuItem& rhs) const
 	{
 		std::wstring lhs_lang(this->_langName.length(), ' '), rhs_lang(rhs._langName.length(), ' ');
 		std::transform(this->_langName.begin(), this->_langName.end(), lhs_lang.begin(), towlower);


### PR DESCRIPTION
When build in MSys2/Clang64 environment the following error occurs, which is fixed with this PR
```
helge@win10pro CLANG64 ~
$ mingw32-make -f notepad-plus-plus/PowerEditor/gcc/makefile
...
+ compiling notepad-plus-plus/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
...
In file included from notepad-plus-plus/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp:18:
In file included from notepad-plus-plus/PowerEditor/src/WinControls/Preference/preferenceDlg.h:20:
In file included from notepad-plus-plus/PowerEditor/src/WinControls/TabBar/ControlsTab.h:22:
In file included from notepad-plus-plus/PowerEditor/src/MISC/Common/Common.h:17:
In file included from C:/msys64/clang64/include/c++/v1/vector:304:
In file included from C:/msys64/clang64/include/c++/v1/__algorithm/copy.h:12:
In file included from C:/msys64/clang64/include/c++/v1/__algorithm/copy_move_common.h:18:
In file included from C:/msys64/clang64/include/c++/v1/__string/constexpr_c_functions.h:25:
In file included from C:/msys64/clang64/include/c++/v1/__utility/is_pointer_in_range.h:12:
C:/msys64/clang64/include/c++/v1/__algorithm/comp.h:41:18: error: invalid operands to binary expression ('const LangMenuItem' and 'const LangMenuItem')
   41 |     return __lhs < __rhs;
      |            ~~~~~ ^ ~~~~~
C:/msys64/clang64/include/c++/v1/__algorithm/sift_down.h:47:34: note: in instantiation of function template specialization 'std::__less<>::operator()<LangMenuItem, LangMenuItem>' requested here
   47 |     if ((__child + 1) < __len && __comp(*__child_i, *(__child_i + difference_type(1)))) {
      |                                  ^
C:/msys64/clang64/include/c++/v1/__algorithm/make_heap.h:39:14: note: in instantiation of function template specialization 'std::__sift_down<std::_ClassicAlgPolicy, std::__less<void, void> &, LangMenuItem *>' requested here
   39 |         std::__sift_down<_AlgPolicy>(__first, __comp_ref, __n, __first + __start);
      |              ^
C:/msys64/clang64/include/c++/v1/__algorithm/partial_sort.h:39:8: note: in instantiation of function template specialization 'std::__make_heap<std::_ClassicAlgPolicy, std::__less<void, void> &, LangMenuItem *>' requested here
   39 |   std::__make_heap<_AlgPolicy>(__first, __middle, __comp);
      |        ^
C:/msys64/clang64/include/c++/v1/__algorithm/partial_sort.h:66:12: note: in instantiation of function template specialization 'std::__partial_sort_impl<std::_ClassicAlgPolicy, std::__less<void, void> &, LangMenuItem *, LangMenuItem *>' requested here
   66 |       std::__partial_sort_impl<_AlgPolicy>(__first, __middle, __last, static_cast<__comp_ref_type<_Compare> >(__comp));
      |            ^
C:/msys64/clang64/include/c++/v1/__algorithm/sort.h:943:10: note: in instantiation of function template specialization 'std::__partial_sort<std::_ClassicAlgPolicy, std::__less<void, void>, LangMenuItem *, LangMenuItem *>' requested here
  943 |     std::__partial_sort<_AlgPolicy>(
      |          ^
C:/msys64/clang64/include/c++/v1/__algorithm/sort.h:954:8: note: in instantiation of function template specialization 'std::__sort_impl<std::_ClassicAlgPolicy, std::__wrap_iter<LangMenuItem *>, std::__less<void, void>>' requested here
  954 |   std::__sort_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
      |        ^
C:/msys64/clang64/include/c++/v1/__algorithm/sort.h:960:8: note: in instantiation of function template specialization 'std::sort<std::__wrap_iter<LangMenuItem *>, std::__less<void, void>>' requested here
  960 |   std::sort(__first, __last, __less<>());
      |        ^
notepad-plus-plus/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp:2870:9: note: in instantiation of function template specialization 'std::sort<std::__wrap_iter<LangMenuItem *>>' requested here
 2870 |                         std::sort(_langList.begin(), _langList.end());
      |                              ^
C:/msys64/clang64/include/c++/v1/__utility/pair.h:623:1: note: candidate template ignored: could not match 'const pair<_T1, _T2>' against 'const LangMenuItem'
  623 | operator<=>(const pair<_T1,_T2>& __x, const pair<_U1,_U2>& __y)
      | ^
C:/msys64/clang64/include/c++/v1/__utility/pair.h:623:1: note: candidate template ignored: could not match 'const pair<_T1, _T2>' against 'const LangMenuItem'
notepad-plus-plus/PowerEditor/src/./Parameters.h:590:7: note: candidate function not viable: 'this' argument has type 'const LangMenuItem', but method is not marked const
  590 |         bool operator<(const LangMenuItem& rhs)
      |              ^
...
mingw32-make: *** [notepad-plus-plus/PowerEditor/gcc/makefile:208: all] Error 2
```