### PR TITLE
Restore Shift-DEL, Ctrl-INS and Shift-INS and fix Ctrl+V cannot paste into the text fields of forms for certain plugins

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2567,8 +2567,8 @@ void Notepad_plus::checkClipboard()
 {
 	bool hasSelection = _pEditView->hasSelection();
 	bool canPaste = (_pEditView->execute(SCI_CANPASTE) != 0);
-	enableCommand(IDM_EDIT_CUT, hasSelection, MENU | TOOLBAR);
-	enableCommand(IDM_EDIT_COPY, hasSelection, MENU | TOOLBAR);
+	//enableCommand(IDM_EDIT_CUT, hasSelection, MENU | TOOLBAR);
+	//enableCommand(IDM_EDIT_COPY, hasSelection, MENU | TOOLBAR);
 
 	enableCommand(IDM_EDIT_PASTE, canPaste, MENU | TOOLBAR);
 	enableCommand(IDM_EDIT_DELETE, hasSelection, MENU | TOOLBAR);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2567,8 +2567,11 @@ void Notepad_plus::checkClipboard()
 {
 	bool hasSelection = _pEditView->hasSelection();
 	bool canPaste = (_pEditView->execute(SCI_CANPASTE) != 0);
+	enableCommand(IDM_EDIT_CUT, hasSelection, MENU | TOOLBAR);
+	enableCommand(IDM_EDIT_COPY, hasSelection, MENU | TOOLBAR);
 
 	enableCommand(IDM_EDIT_PASTE, canPaste, MENU | TOOLBAR);
+	enableCommand(IDM_EDIT_DELETE, hasSelection, MENU | TOOLBAR);
 	enableCommand(IDM_EDIT_UPPERCASE, hasSelection, MENU);
 	enableCommand(IDM_EDIT_LOWERCASE, hasSelection, MENU);
 	enableCommand(IDM_EDIT_PROPERCASE_FORCE, hasSelection, MENU);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -360,11 +360,19 @@ void Notepad_plus::command(int id)
 			HWND focusedHwnd = ::GetFocus();
 			if (focusedHwnd == _pEditView->getHSelf())
 			{
-				if (_pEditView->hasSelection())
+				if (_pEditView->hasSelection()) // Cut normally
 				{
 					_pEditView->execute(WM_CUT);
-					checkClipboard();
 				}
+				else // Cul the entire line
+				{
+					_pEditView->execute(SCI_COPYALLOWLINE);
+					_pEditView->execute(SCI_LINEDELETE);
+				}
+			}
+			else
+			{
+				::SendMessage(focusedHwnd, WM_CUT, 0, 0);
 			}
 			break;
 		}
@@ -374,17 +382,16 @@ void Notepad_plus::command(int id)
 			HWND focusedHwnd = ::GetFocus();
 			if (focusedHwnd == _pEditView->getHSelf())
 			{
-				if (_pEditView->hasSelection())
-				{
-					_pEditView->execute(WM_COPY);
-					checkClipboard();
-				}
+				_pEditView->execute(SCI_COPYALLOWLINE); // Copy selected text if any.
+														// Otherwise copy the entire line with EOL, for pasting before any line where the caret is.
 			}
-			else  // Search result
+			else
 			{
 				Finder* finder = _findReplaceDlg.getFinderFrom(focusedHwnd);
-				if (finder)
+				if (finder)  // Search result
 					finder->scintillaExecute(WM_COPY);
+				else
+					::SendMessage(focusedHwnd, WM_COPY, 0, 0);
 			}
 
 			break;
@@ -481,6 +488,10 @@ void Notepad_plus::command(int id)
 				}
 
 				_pEditView->execute(SCI_PASTE);
+			}
+			else
+			{
+				::SendMessage(focusedHwnd, WM_PASTE, 0, 0);
 			}
 		}
 		break;

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -361,12 +361,9 @@ void Notepad_plus::command(int id)
 			if (focusedHwnd == _pEditView->getHSelf())
 			{
 				if (_pEditView->hasSelection())
-					_pEditView->execute(WM_CUT);
-				else
 				{
-					bool useLinCopyCut = (NppParameters::getInstance()).useLineCopyCutDelete();
-					if (useLinCopyCut)
-						_pEditView->execute(SCI_LINECUT); // Ctrl + X: without selected text, it will cut the whole line.
+					_pEditView->execute(WM_CUT);
+					checkClipboard();
 				}
 			}
 			break;
@@ -378,12 +375,9 @@ void Notepad_plus::command(int id)
 			if (focusedHwnd == _pEditView->getHSelf())
 			{
 				if (_pEditView->hasSelection())
-					_pEditView->execute(WM_COPY);
-				else
 				{
-					bool useLinCopyCut = (NppParameters::getInstance()).useLineCopyCutDelete();
-					if (useLinCopyCut)
-						_pEditView->execute(SCI_LINECOPY); // Ctrl + C: without selected text, it will copy the whole line.
+					_pEditView->execute(WM_COPY);
+					checkClipboard();
 				}
 			}
 			else  // Search result

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -84,9 +84,9 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 
 //	{ VK_NULL,    IDM_EDIT_UNDO,                                false, false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_REDO,                                false, false, false, nullptr },
-	{ VK_X,       IDM_EDIT_CUT,                                 true,  false, false, nullptr },
-	{ VK_C,       IDM_EDIT_COPY,                                true,  false, false, nullptr },
-	{ VK_V,       IDM_EDIT_PASTE,                               true,  false, false, nullptr },
+//	{ VK_X,       IDM_EDIT_CUT,                                 true,  false, false, nullptr },
+//	{ VK_C,       IDM_EDIT_COPY,                                true,  false, false, nullptr },
+//	{ VK_V,       IDM_EDIT_PASTE,                               true,  false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_DELETE,                              false, false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_SELECTALL,                           false, false, false, nullptr },
 	{ VK_B,       IDM_EDIT_BEGINENDSELECT,                      true,  false, true,  nullptr },
@@ -472,11 +472,12 @@ static const ScintillaKeyDefinition scintKeyDefs[] =
     //Scintilla command name,             SCINTILLA_CMD_ID,            Ctrl,  Alt,   Shift, V_KEY,       NOTEPAD++_CMD_ID
 	// -------------------------------------------------------------------------------------------------------------------
 	//
-//	{TEXT("SCI_CUT"),                     SCI_CUT,                     false, false, true,  VK_DELETE,   0},
-//	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_INSERT,   0},
-//	{TEXT("SCI_PASTE"),                   SCI_PASTE,                   false, false, true,  VK_INSERT,   0},
-//	the above 3 shortcuts will be added dynamically if "disableLineCopyCutDelete.xml" is present.
-
+	{TEXT("SCI_CUT"),                     SCI_CUT,                     true,  false, false, VK_X,        IDM_EDIT_CUT},
+	{TEXT(""),                            SCI_CUT,                     false, false, true,  VK_DELETE,   0},
+	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_C,        IDM_EDIT_COPY},
+	{TEXT(""),                            SCI_COPY,                    true,  false, false, VK_INSERT,   0},
+	{TEXT("SCI_PASTE"),                   SCI_PASTE,                   true,  false, false, VK_V,        IDM_EDIT_PASTE},
+	{TEXT(""),                            SCI_PASTE,                   false, false, true,  VK_INSERT,   0},
 	{TEXT("SCI_SELECTALL"),               SCI_SELECTALL,               true,  false, false, VK_A,        IDM_EDIT_SELECTALL},
 	{TEXT("SCI_CLEAR"),                   SCI_CLEAR,                   false, false, false, VK_DELETE,   IDM_EDIT_DELETE},
 	{TEXT("SCI_CLEARALL"),                SCI_CLEARALL,                false, false, false, 0,           0},
@@ -1474,35 +1475,6 @@ bool NppParameters::load()
 		delete _pXmlToolIconsDoc;
 		_pXmlToolIconsDoc = nullptr;
 		isAllLaoded = false;
-	}
-
-
-	//-----------------------------------------------------------------------------------//
-	// disableLineCopyCutDelete.xml                                                      //
-	// This empty xml file is optional - user adds this empty file manually to :         //
-	// 1. prevent hard coded Shift-DEL shortcut deletes whole line while no selection.   //
-	// 2. prevent Copy command (Ctrl-C) copies whole line (without selection).           //
-	// 3. prevent Cut command (Ctrl-X) cuts whole line (without selection).              //
-	// 4. add SCI_CUT (Shift-DEL), SCI_COPY (Ctrl-INS) & SCI_PASTE (Shift-INS) shortcuts //
-	//-----------------------------------------------------------------------------------//
-	std::wstring disableLineCopyCutDeletePath = _userPath;
-	pathAppend(disableLineCopyCutDeletePath, TEXT("disableLineCopyCutDelete.xml"));
-
-	if (PathFileExists(disableLineCopyCutDeletePath.c_str()))
-	{
-		_useLineCopyCutDelete = false;
-		
-		//
-		// Add back SCI_CUT (Shift-DEL), SCI_COPY (Ctrl-INS) & SCI_PASTE (Shift-INS) shortcuts
-		//
-		ScintillaKeyMap sci_cut = ScintillaKeyMap(Shortcut("SCI_CUT", false, false, true, static_cast<unsigned char>(VK_DELETE)), SCI_CUT, 0);
-		_scintillaKeyCommands.push_back(sci_cut);
-
-		ScintillaKeyMap sci_copy = ScintillaKeyMap(Shortcut("SCI_COPY", true, false, false, static_cast<unsigned char>(VK_INSERT)), SCI_COPY, 0);
-		_scintillaKeyCommands.push_back(sci_copy);
-
-		ScintillaKeyMap sci_paste = ScintillaKeyMap(Shortcut("SCI_PASTE", false, false, true, static_cast<unsigned char>(VK_INSERT)), SCI_PASTE, 0);
-		_scintillaKeyCommands.push_back(sci_paste);
 	}
 
 	//------------------------------//

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -84,9 +84,16 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 
 //	{ VK_NULL,    IDM_EDIT_UNDO,                                false, false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_REDO,                                false, false, false, nullptr },
-//	{ VK_X,       IDM_EDIT_CUT,                                 true,  false, false, nullptr },
-//	{ VK_C,       IDM_EDIT_COPY,                                true,  false, false, nullptr },
-//	{ VK_V,       IDM_EDIT_PASTE,                               true,  false, false, nullptr },
+
+	{ VK_DELETE,  IDM_EDIT_CUT,                                 false, false, true,  nullptr },
+	{ VK_X,       IDM_EDIT_CUT,                                 true,  false, false, nullptr },
+
+	{ VK_INSERT,  IDM_EDIT_COPY,                                true,  false, false, nullptr },
+	{ VK_C,       IDM_EDIT_COPY,                                true,  false, false, nullptr },
+
+	{ VK_INSERT,  IDM_EDIT_PASTE,                               false, false, true,  nullptr },
+	{ VK_V,       IDM_EDIT_PASTE,                               true,  false, false, nullptr },
+
 //	{ VK_NULL,    IDM_EDIT_DELETE,                              false, false, false, nullptr },
 //	{ VK_NULL,    IDM_EDIT_SELECTALL,                           false, false, false, nullptr },
 	{ VK_B,       IDM_EDIT_BEGINENDSELECT,                      true,  false, true,  nullptr },
@@ -472,12 +479,12 @@ static const ScintillaKeyDefinition scintKeyDefs[] =
     //Scintilla command name,             SCINTILLA_CMD_ID,            Ctrl,  Alt,   Shift, V_KEY,       NOTEPAD++_CMD_ID
 	// -------------------------------------------------------------------------------------------------------------------
 	//
-	{TEXT("SCI_CUT"),                     SCI_CUT,                     true,  false, false, VK_X,        IDM_EDIT_CUT},
-	{TEXT(""),                            SCI_CUT,                     false, false, true,  VK_DELETE,   0},
-	{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_C,        IDM_EDIT_COPY},
-	{TEXT(""),                            SCI_COPY,                    true,  false, false, VK_INSERT,   0},
-	{TEXT("SCI_PASTE"),                   SCI_PASTE,                   true,  false, false, VK_V,        IDM_EDIT_PASTE},
-	{TEXT(""),                            SCI_PASTE,                   false, false, true,  VK_INSERT,   0},
+	//{TEXT("SCI_CUT"),                     SCI_CUT,                     true,  false, false, VK_X,        IDM_EDIT_CUT},
+	//{TEXT(""),                            SCI_CUT,                     false, false, true,  VK_DELETE,   0},
+	//{TEXT("SCI_COPY"),                    SCI_COPY,                    true,  false, false, VK_C,        IDM_EDIT_COPY},
+	//{TEXT(""),                            SCI_COPY,                    true,  false, false, VK_INSERT,   0},
+	//{TEXT("SCI_PASTE"),                   SCI_PASTE,                   true,  false, false, VK_V,        IDM_EDIT_PASTE},
+	//{TEXT("SCI_PASTE"),                   SCI_PASTE,                   false, false, true,  VK_INSERT,   IDM_EDIT_PASTE},
 	{TEXT("SCI_SELECTALL"),               SCI_SELECTALL,               true,  false, false, VK_A,        IDM_EDIT_SELECTALL},
 	{TEXT("SCI_CLEAR"),                   SCI_CLEAR,                   false, false, false, VK_DELETE,   IDM_EDIT_DELETE},
 	{TEXT("SCI_CLEARALL"),                SCI_CLEARALL,                false, false, false, 0,           0},

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -525,19 +525,10 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			SHORT shift = GetKeyState(VK_SHIFT);
 			bool isColumnSelection = (execute(SCI_GETSELECTIONMODE) == SC_SEL_RECTANGLE) || (execute(SCI_GETSELECTIONMODE) == SC_SEL_THIN);
 			bool column2MultSelect = (NppParameters::getInstance()).doColumn2MultiSelect();
-			bool useHardCodedShiftDelete = (NppParameters::getInstance()).useLineCopyCutDelete();
 
 			if (wParam == VK_DELETE)
 			{
-				// 1 shortcut:
-				// Shift + Delete: without selected text, it will delete the whole line.
-				//
-				if ((shift & 0x8000) && !(ctrl & 0x8000) && !(alt & 0x8000) && !hasSelection() && useHardCodedShiftDelete) // Shift-DEL & no selection
-				{
-					execute(SCI_LINEDELETE);
-					return TRUE;
-				}
-				else if (!(shift & 0x8000) && !(ctrl & 0x8000) && !(alt & 0x8000)) // DEL & Multi-edit
+				if (!(shift & 0x8000) && !(ctrl & 0x8000) && !(alt & 0x8000)) // DEL & Multi-edit
 				{
 					size_t nbSelections = execute(SCI_GETSELECTIONS);
 					if (nbSelections > 1) // Multi-edit


### PR DESCRIPTION
~~This PR restores Scintilla Cut / Copy / Paste shortcuts. Also, the shortcuts Ctrl-C / Ctrl-X / Shift-DEL without selection to Copy / Cut / DEL entire line are removed in this PR due to several critical issues.~~

~~To Copy / Cut / DEL entire line, the users are encouraged to use Scintilla default shortcuts set in Shortcut Mapper: **Ctrl-Shift-X** (SCI_LINECUT) / **Ctrl-L** (SCI_LINECOPY) / **Ctrl-Shift-L** (SCI_LINEDELETE). User can remap them via Shortcut mapper.~~

This PR restores shortcuts **Shift-DEL**, **Ctrl-INS** and **Shift-INS** for Cut / Copy / Paste respectively.
the action to delete entire line  without selection is removed in this PR due to its shortcut **Shift-DEL** has triggered several critical issues.

To delete entire line, the users are encouraged to use Scintilla default shortcuts set in Shortcut Mapper: **Ctrl-Shift-L** (*SCI_LINEDELETE*). User can remap it to another shortcut via Shortcut mapper.

Fix #14568, fix #14470, fix #14571, close #14557