### PR TITLE
Update extensions for the "web script" file associations

### DIFF
--- a/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
@@ -25,7 +25,7 @@ const TCHAR* nppBackup = TEXT("Notepad++_backup");
 const TCHAR* nppDoc    = TEXT("Notepad++ Document");
 
 const int nbSupportedLang = 10;
-const int nbExtMax = 27;
+const int nbExtMax = 28;
 const int extNameMax = 18;
 
 
@@ -48,7 +48,7 @@ const TCHAR defExtArray[nbSupportedLang][nbExtMax][extNameMax] =
 	{TEXT("web script"),
 		TEXT(".html"), TEXT(".htm"), TEXT(".shtml"), TEXT(".shtm"), TEXT(".hta"),
 		TEXT(".asp"), TEXT(".aspx"),
-		TEXT(".css"), TEXT(".js"), TEXT(".json"), TEXT(".jsm"), TEXT(".jsp"),
+		TEXT(".css"), TEXT(".js"), TEXT(".json"), TEXT(".mjs"), TEXT(".jsm"), TEXT(".jsp"),
 		TEXT(".php"), TEXT(".php3"), TEXT(".php4"), TEXT(".php5"), TEXT(".phps"), TEXT(".phpt"), TEXT(".phtml"),
 		TEXT(".xml"), TEXT(".xhtml"), TEXT(".xht"), TEXT(".xul"), TEXT(".kml"), TEXT(".xaml"), TEXT(".xsml")
 	},

--- a/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
@@ -25,7 +25,7 @@ const TCHAR* nppBackup = TEXT("Notepad++_backup");
 const TCHAR* nppDoc    = TEXT("Notepad++ Document");
 
 const int nbSupportedLang = 10;
-const int nbExtMax = 28;
+const int nbExtMax = 27;
 const int extNameMax = 18;
 
 
@@ -49,7 +49,7 @@ const TCHAR defExtArray[nbSupportedLang][nbExtMax][extNameMax] =
 		TEXT(".html"), TEXT(".htm"), TEXT(".shtml"), TEXT(".shtm"), TEXT(".hta"),
 		TEXT(".asp"), TEXT(".aspx"),
 		TEXT(".css"), TEXT(".js"), TEXT(".json"), TEXT(".mjs"), TEXT(".jsm"), TEXT(".jsp"),
-		TEXT(".php"), TEXT(".php3"), TEXT(".php4"), TEXT(".php5"), TEXT(".phps"), TEXT(".phpt"), TEXT(".phtml"),
+		TEXT(".php"), TEXT(".php3"), TEXT(".php4"), TEXT(".php5"), TEXT(".phps"), TEXT(".phpt"),
 		TEXT(".xml"), TEXT(".xhtml"), TEXT(".xht"), TEXT(".xul"), TEXT(".kml"), TEXT(".xaml"), TEXT(".xsml")
 	},
 	{TEXT("public script"),


### PR DESCRIPTION
Add `.mjs` extension to the "web script" file associations.

Related: #10746 (fixed by #12704).

Refs: [JavaScript modules#Aside — .mjs versus .js](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#aside_%E2%80%94_.mjs_versus_.js) on MDN

Side notes:
* `.jsm` seems to be a legacy extension for the same thing, dating back from when the module specs weren't fixed yet. I haven't looked into it further.
* `.jsp` is unrelated to JavaScript, it's [JavaServer Pages](https://en.wikipedia.org/wiki/Jakarta_Server_Pages) (basically Java embedded in HTML content, just like PHP embedded in HTML content in `.php` files).

