### PR TITLE
don't record IDM_EDIT_CUT in macros; fix #14634

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -4193,7 +4193,7 @@ void Notepad_plus::command(int id)
 			case IDM_FILE_RELOAD:
 			case IDM_EDIT_UNDO:
 			case IDM_EDIT_REDO:
-			case IDM_EDIT_CUT:
+			//case IDM_EDIT_CUT:
 			case IDM_EDIT_COPY:
 			//case IDM_EDIT_PASTE:
 			case IDM_EDIT_DELETE:


### PR DESCRIPTION
Recording `IDM_EDIT_CUT` (the menu command that cuts text to clipboard) in macros is unnecessary (and in fact harmful, as illustrated in #14634), because running that menu command triggers the execution of one or more Scintilla messages which are themselves macroable.

Not recording this menu command ensures that macros that cut text work properly, as they did in Notepad++ 8.6.0 and earlier.

Note that recording a macro in which the current line is cut by cutting with no selection (using the new behavior) will still cut the current line, because the menu command triggers `SCI_COPYALLOWLINE` and `SCI_LINEDELETE`, both of which are macroable.

## To test:

### Record a macro that uses the *old* behavior of `Cut` to cut *selected* text

1. Create a new file with the text 
```
abc
def
```
2. Ensure that no text is selected, and move the caret to the beginning of the document.
4. Start recording a macro. __This macro will use cut/paste to swap the two characters in front of the caret.__
5. Hold down Shift, and hit the forward arrow once. You should see the first character of the document selected.
6. Use the `Cut` menu command, or an appropriate keyboard shortcut.
7. Hit the forward arrow once.
8. Use the `Paste` menu command, or and appropriate keyboard shortcut.
9. The document should now look like so:
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/46202915/e353e557-3fe4-4726-9065-d949de975021)
```
bac
def
```
11. Stop recording the macro.
12. Move the character to the beginning of the second line, so that the document looks like so:
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/46202915/276e2432-c079-469e-a7f4-c911abca0c61)
13. Run `Macro->Playback` from the main menu.
15. Confirm that the document looks like so:
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/46202915/57c14b71-5d44-4b04-9977-ba75d87e50c7)
```
bac
edf
```
16. This shouldn't be necessary, but if desired, save the macro, close Notepad++, and run it from the saved macros menu and confirm it still works as intended.

### Record a macro that uses the *new* behavior of `Cut` to cut *the current line*

1. Create a new file with the below text (note that there should be a trailing newline):
```
abc
def
ghi

```
2. Ensure that no text is selected, and move the caret to the beginning of the document.
3. Start recording a macro. __This macro will paste the current line before the last newline of the document.__
4. Use the `Cut` menu command, or the appropriate keyboard shortcut.
5. Select the entire document
6. Hit the forward arrow.
7. Use the `Paste` menu command or an appropriate keyboard shortcut.
8. The document should now look like this:
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/46202915/a8cc4e69-f08d-4729-a3bb-baccc4dcbac9)
```
def
ghi
abc

```
9. Stop recording the macro.
10. Move your caret to the middle of the second line, so the document looks like this:
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/46202915/3c42b9b8-363c-4241-829f-a06ff441976c)

11. Run `Macro->Playback` from the main menu.
12. Confirm that the document looks like this:
![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/46202915/d613105a-8c87-419f-b6d4-64c0f01c374e)
```
def
abc
ghi

```