### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.6.3

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -12,6 +12,7 @@ Additionnal information about Corsican localization:
 
 2. History of Corsican translation for Notepad++:
 
+	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3)
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
 			  Nov. 15th (v8.5.9), Nov. 22nd (v8.6), Dec. 19th (v8.6.1), Dec. 29th (v8.6.1)
@@ -32,7 +33,7 @@ Additionnal information about Corsican localization:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.6.1">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.6.3">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -1011,6 +1012,7 @@ Additionnal information about Corsican localization:
 					<Item id="6236" name="Permette l’affissera dopu à l’ultima linea"/>
 					<Item id="6239" name="Cunservà a selezzione in casu di cliccu dirittu fora di a selezzione"/>
 					<Item id="6245" name="Attivà u spaziu virtuale"/>
+					<Item id="6214" name="Attivà a copia o a tagliatura di linea senza selezzione"/>
 					<Item id="6651" name="Indicadore di linea currente"/>
 					<Item id="6652" name="Nisunu"/>
 					<Item id="6653" name="Culurisce u sfondulu"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commit:

 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/c6e433f70ba2a8d80a3932bc76118d7c2e9707da Update localization files

Cheers,
Patriccollu.