### PR TITLE
Fix loosing all open files after restarting as Admin to save a file

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -655,9 +655,12 @@ bool Notepad_plus::doSave(BufferID id, const TCHAR * filename, bool isCopy)
 		else
 		{
 			// try to open Notepad++ in admin mode
-			bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
-			if (isSnapshotMode) // if both rememberSession && backup mode are enabled
-			{                   // Open the 2nd Notepad++ instance in Admin mode, then close the 1st instance.
+			NppGUI& nppGui = NppParameters::getInstance().getNppGUI();
+			bool isSnapshotMode = nppGui.isSnapshotMode();
+			bool isAlwaysInMultiInstMode = nppGui._multiInstSetting == multiInst;
+			if (isSnapshotMode && !isAlwaysInMultiInstMode) // if both rememberSession && backup mode are enabled and "Always In Multi-Instance Mode" option not activated
+			{                                               // Open the 2nd Notepad++ instance in Admin mode, then close the 1st instance.
+
 				int openInAdminModeRes = _nativeLangSpeaker.messageBox("OpenInAdminMode",
 				_pPublicInterface->getHSelf(),
 				TEXT("This file cannot be saved and it may be protected.\rDo you want to launch Notepad++ in Administrator mode?"),


### PR DESCRIPTION
While saving a file needs the admin privilege, and if "Always In Multi-Instance Mode" option is activated, the current Notepad++ instance will be closed and a new instance with admin privilege contains no file is launched.

This commit fixes the issue by keeping the 1st instance opened, and launching the 2nd instance (with admin privilege) which contains the file in question - so user can modify it and save it.

Such behaviour not only fixes the issue, but also makes more sense, since it's "Always In Multi-Instance Mode". Note that the same behaviour happens if the session & periodical backup feature is disabled.

Fix #14694