### PR TITLE
Context menu popup location at current text position when invoked via keyboard

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -19,6 +19,7 @@
 #include <shlwapi.h>
 #include <uxtheme.h> // for EnableThemeDialogTexture
 #include <format>
+#include <Windowsx.h> // for GET_X_LPARAM, GET_Y_LPARAM
 #include "Notepad_plus_Window.h"
 #include "TaskListDlg.h"
 #include "ImageListSet.h"
@@ -1975,7 +1976,9 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					scintillaContextmenu.create(hwnd, tmp, _mainMenuHandle, copyLink);
 					
 					POINT p;
-					if (lParam == -1)
+					int xPos = GET_X_LPARAM(lParam);
+					int yPos = GET_Y_LPARAM(lParam);
+					if ((xPos == -1) && (yPos == -1))
 					{
 						// context menu activated via keyboard; pop up at text caret position
 						auto caretPos = _pEditView->execute(SCI_GETCURRENTPOS);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1976,20 +1976,15 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					scintillaContextmenu.create(hwnd, tmp, _mainMenuHandle, copyLink);
 					
 					POINT p;
-					int xPos = GET_X_LPARAM(lParam);
-					int yPos = GET_Y_LPARAM(lParam);
-					if ((xPos == -1) && (yPos == -1))
+					p.x = GET_X_LPARAM(lParam);
+					p.y = GET_Y_LPARAM(lParam);
+					if ((p.x == -1) && (p.y == -1))
 					{
 						// context menu activated via keyboard; pop up at text caret position
 						auto caretPos = _pEditView->execute(SCI_GETCURRENTPOS);
 						p.x = static_cast<LONG>(_pEditView->execute(SCI_POINTXFROMPOSITION, 0, caretPos));
 						p.y = static_cast<LONG>(_pEditView->execute(SCI_POINTYFROMPOSITION, 0, caretPos));
 						::ClientToScreen(activeViewHwnd, &p);
-					}
-					else
-					{
-						// context menu activated via mouse right-click; pop up at click location
-						::GetCursorPos(&p);
 					}
 					scintillaContextmenu.display(p);
 


### PR DESCRIPTION
Fix #14727 

Notes:

* created new HWND variable to avoid casting `wParam` over and over
* moved getting/calculating of `p` closer to where something is done with it

If it is "too much" change, the above noted items are not strictly necessary and can be backed-out if desired.