### PR TITLE
Enable shortcut mapper to filter keycombos for scintilla commands

### DIFF
--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -224,37 +224,17 @@ bool ShortcutMapper::isFilterValid(PluginCmdShortcut sc)
 
 bool ShortcutMapper::isFilterValid(ScintillaKeyMap sc)
 {
-	// do a classic search on shortcut name, then see if *any* keycombo in _keyCombos matches
+	// do a classic search on shortcut name,
+	// then see if the list of keycombos matches (e.g. "Ctrl+X or Alt+Y" matches "or" and "Alt" and "Ctrl+")
 	if (_shortcutFilter.empty())
 		return true;
 
 	wstring shortcut_name = stringToLower(string2wstring(sc.getName(), CP_UTF8));
 	if (shortcut_name.find(_shortcutFilter) != std::string::npos)
-		return true; // name matches; don't have to check shortcuts
+		return true; // name matches
 
-	for (size_t i = 0; i < sc.getSize(); ++i)
-	{
-		KeyCombo keyCombo = sc.getKeyComboByIndex(i);
-		if (keyCombo._key != 0)
-		{
-			// check if this stringified shortcut matches 
-			string sc;
-			if (keyCombo._isCtrl)
-				sc += "Ctrl+";
-			if (keyCombo._isAlt)
-				sc += "Alt+";
-			if (keyCombo._isShift)
-				sc += "Shift+";
-
-			string keyString;
-			getKeyStrFromVal(keyCombo._key, keyString);
-			sc += keyString;
-			wstring combo_value = stringToLower(string2wstring(sc, CP_UTF8));
-			if (combo_value.find(_shortcutFilter) != std::string::npos)
-				return true;
-		}
-	}
-	return false;
+	wstring shortcut_value = stringToLower(string2wstring(sc.toString(), CP_UTF8));
+	return shortcut_value.find(_shortcutFilter) != std::string::npos; // list of shortcuts matches
 }
 
 void ShortcutMapper::fillOutBabyGrid()

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -222,6 +222,41 @@ bool ShortcutMapper::isFilterValid(PluginCmdShortcut sc)
 	return match;
 }
 
+bool ShortcutMapper::isFilterValid(ScintillaKeyMap sc)
+{
+	// do a classic search on shortcut name, then see if *any* keycombo in _keyCombos matches
+	if (_shortcutFilter.empty())
+		return true;
+
+	wstring shortcut_name = stringToLower(string2wstring(sc.getName(), CP_UTF8));
+	if (shortcut_name.find(_shortcutFilter) != std::string::npos)
+		return true; // name matches; don't have to check shortcuts
+
+	for (size_t i = 0; i < sc.getSize(); ++i)
+	{
+		KeyCombo keyCombo = sc.getKeyComboByIndex(i);
+		if (keyCombo._key != 0)
+		{
+			// check if this stringified shortcut matches 
+			string sc;
+			if (keyCombo._isCtrl)
+				sc += "Ctrl+";
+			if (keyCombo._isAlt)
+				sc += "Alt+";
+			if (keyCombo._isShift)
+				sc += "Shift+";
+
+			string keyString;
+			getKeyStrFromVal(keyCombo._key, keyString);
+			sc += keyString;
+			wstring combo_value = stringToLower(string2wstring(sc, CP_UTF8));
+			if (combo_value.find(_shortcutFilter) != std::string::npos)
+				return true;
+		}
+	}
+	return false;
+}
+
 void ShortcutMapper::fillOutBabyGrid()
 {
 	NppParameters& nppParam = NppParameters::getInstance();

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
@@ -57,6 +57,7 @@ public:
 	generic_string getTextFromCombo(HWND hCombo);
 	bool isFilterValid(Shortcut);
 	bool isFilterValid(PluginCmdShortcut sc);
+	bool isFilterValid(ScintillaKeyMap sc);
 
 protected :
 	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
Previously the shortcut mapper filtered the keycombo for every other type of command, but not scintilla commands.
Fix #12557
Fix #10486

__To test this PR:__
1. Open up the Shortcut Mapper.
2. Navigate to the `Scintilla commands` tab.
3. Enter the search term `Ctrl+` in the `Filter:` textbox.
4. Verify that all Scintilla commands that include `Control` in any one of their keyboard shortcut(s) (including a second or third shortcut) are shown in the grid.