### PR TITLE
Implement OpenTheCopy checkbox on SaveACopyAs dialog

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1636,6 +1636,9 @@ NOTE: Choosing not to create the placeholders or closing them later, your sessio
 			<shift-change-direction-tip value="Use Shift+Enter to search in the opposite direction"/>
 			<two-find-buttons-tip value="2 find buttons mode"/>
 			<file-rename-title value="Rename"/>
+			<file-open-title value="Open"/>
+			<file-save-as-title value="Save As"/>
+			<file-save-as-copy-title value="Save Copy As"/>
 			<find-in-files-filter-tip value="Find in cpp, cxx, h, hxx &amp;&amp; hpp:
 *.cpp *.cxx *.h *.hxx *.hpp
 
@@ -1737,6 +1740,7 @@ Find in all files but exclude all folders log or logs recursively:
 			<session-save-folder-as-workspace value="Save Folder as Workspace"/>
 			<tab-untitled-string value="new "/>
 			<file-save-assign-type value="&amp;Append extension"/>
+			<file-save-open-copy value="&amp;Open copy after saving"/>
 			<close-panel-tip value="Close"/>
 			<IncrementalFind-FSFound value="$INT_REPLACE$ matches"/>
 			<IncrementalFind-FSNotFound value="Phrase not found"/>

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -6124,6 +6124,10 @@ void NppParameters::feedGUIParameters(TiXmlNode *node)
 			if (saveDlgExtFilterToAllTypes)
 				_nppGUI._setSaveDlgExtFiltToAllTypes = (lstrcmp(saveDlgExtFilterToAllTypes, TEXT("yes")) == 0);
 
+			const TCHAR* saveDlgOpenCopy = element->Attribute(TEXT("saveDlgOpenCopy"));
+			if (saveDlgOpenCopy)
+				_nppGUI._setSaveDlgOpenCopyChecked = (lstrcmp(saveDlgOpenCopy, TEXT("yes")) == 0);
+
 			const TCHAR * optMuteSounds = element->Attribute(TEXT("muteSounds"));
 			if (optMuteSounds)
 				_nppGUI._muteSounds = lstrcmp(optMuteSounds, TEXT("yes")) == 0;
@@ -7437,6 +7441,8 @@ void NppParameters::createXmlTreeFromGUIParams()
 		GUIConfigElement->SetAttribute(TEXT("docPeekOnMap"), _nppGUI._isDocPeekOnMap ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("sortFunctionList"), _nppGUI._shouldSortFunctionList ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("saveDlgExtFilterToAllTypes"), _nppGUI._setSaveDlgExtFiltToAllTypes ? TEXT("yes") : TEXT("no"));
+		GUIConfigElement->SetAttribute(TEXT("saveDlgOpenCopy"), _nppGUI._setSaveDlgOpenCopyChecked ? TEXT("yes") : TEXT("no"));
+		
 		GUIConfigElement->SetAttribute(TEXT("muteSounds"), _nppGUI._muteSounds ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("enableFoldCmdToggable"), _nppGUI._enableFoldCmdToggable ? TEXT("yes") : TEXT("no"));
 		GUIConfigElement->SetAttribute(TEXT("hideMenuRightShortcuts"), _nppGUI._hideMenuRightShortcuts ? TEXT("yes") : TEXT("no"));

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -809,6 +809,7 @@ struct NppGUI final
 	bool _detectEncoding = true;
 	bool _saveAllConfirm = true;
 	bool _setSaveDlgExtFiltToAllTypes = false;
+	bool _setSaveDlgOpenCopyChecked = false;
 	bool _doTaskList = true;
 	bool _maitainIndent = true;
 	bool _enableSmartHilite = true;

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -51,6 +51,7 @@ namespace // anonymous
 
 	static const int IDC_FILE_CUSTOM_CHECKBOX = 4;
 	static const int IDC_FILE_TYPE_CHECKBOX = IDC_FILE_CUSTOM_CHECKBOX + 1;
+	static const int IDC_OPEN_THE_COPY_CHECKBOX = IDC_FILE_CUSTOM_CHECKBOX + 2;
 
 	// Returns a first extension from the extension specification string.
 	// Multiple extensions are separated with ';'.
@@ -796,6 +797,9 @@ public:
 		if (_enableFileTypeCheckbox)
 			addCheckbox(IDC_FILE_TYPE_CHECKBOX, _fileTypeCheckboxLabel.c_str(), _fileTypeCheckboxValue);
 
+		if (_includeOpenTheCopyCheckbox)
+			addCheckbox(IDC_OPEN_THE_COPY_CHECKBOX, _openTheCopyCheckboxLabel.c_str(), _openTheCopyCheckboxChecked);
+
 		if (SUCCEEDED(hr))
 			return addControls();
 
@@ -974,6 +978,9 @@ public:
 	bool _enableFileTypeCheckbox = false;
 	bool _fileTypeCheckboxValue = false;	// initial value
 	generic_string _fileTypeCheckboxLabel;
+	bool _includeOpenTheCopyCheckbox = false;
+	bool _openTheCopyCheckboxChecked = false;	// initial value (unchecked)
+	generic_string _openTheCopyCheckboxLabel;
 
 private:
 	com_ptr<IFileDialog> _dialog;
@@ -1085,6 +1092,22 @@ void CustomFileDialog::enableFileTypeCheckbox(const generic_string& text, bool v
 bool CustomFileDialog::getFileTypeCheckboxValue() const
 {
 	return _impl->getCheckboxState(IDC_FILE_TYPE_CHECKBOX);
+}
+
+void CustomFileDialog::includeOpenTheCopyCheckbox(const generic_string& text, bool isChecked)
+{
+	assert(!text.empty());
+	if (!text.empty())
+	{
+		_impl->_includeOpenTheCopyCheckbox = true;
+		_impl->_openTheCopyCheckboxLabel = text;
+		_impl->_openTheCopyCheckboxChecked = isChecked;
+	}
+}
+
+bool CustomFileDialog::getOpenTheCopyCheckboxIsChecked() const
+{
+	return _impl->getCheckboxState(IDC_OPEN_THE_COPY_CHECKBOX);
 }
 
 generic_string CustomFileDialog::doSaveDlg()

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.h
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.h
@@ -41,6 +41,9 @@ public:
 	void enableFileTypeCheckbox(const generic_string& text, bool value);
 	bool getFileTypeCheckboxValue() const;
 
+	void includeOpenTheCopyCheckbox(const generic_string& text, bool isChecked);
+	bool getOpenTheCopyCheckboxIsChecked() const;
+
 	// Empty string is not a valid file name and may signal that the dialog was canceled.
 	generic_string doSaveDlg();
 	generic_string pickFolder();


### PR DESCRIPTION
Fix #11861 

Fix #14737 
Fix #11860

---

UI details of change:

![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/77065706/5aea204b-8ac5-40e8-9666-3854da643e27)

---

Notes:

Fixes for 14737 / 11860 included adding localization for the `Save a copy as` window title bar text.  This joins the existing localization for the `Rename` window title bar text.

For completeness, the `Open` window title bar text and the `Save As` title bar text were also made localization-capable with this change (instead of relying on the OS to choose the title bar text).  If that isn't desired, I can certainly back that out.