### PR TITLE
filter shortcut mapper by words (split filter by whitespace)

### DIFF
--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
@@ -27,7 +27,7 @@ enum GridState {STATE_MENU, STATE_MACRO, STATE_USER, STATE_PLUGIN, STATE_SCINTIL
 class ShortcutMapper : public StaticDialog {
 public:
 	ShortcutMapper() : StaticDialog(), _currentState(STATE_MENU) {
-		_shortcutFilter = TEXT("");
+		_shortcutFilter = std::vector<generic_string>();
 		_dialogInitDone = false;
 	};
 	~ShortcutMapper() = default;
@@ -57,6 +57,7 @@ public:
 	generic_string getTextFromCombo(HWND hCombo);
 	bool isFilterValid(Shortcut);
 	bool isFilterValid(PluginCmdShortcut sc);
+	bool isFilterValid(ScintillaKeyMap sc);
 
 protected :
 	intptr_t CALLBACK run_dlgProc(UINT message, WPARAM wParam, LPARAM lParam);
@@ -70,7 +71,7 @@ private:
 
 	const static int _nbTab = 5;
 	generic_string _tabNames[_nbTab];
-	generic_string _shortcutFilter;
+	std::vector<generic_string> _shortcutFilter;
 	std::vector<size_t> _shortcutIndex;
 
 	//save/restore the last view


### PR DESCRIPTION
Fix #14743 
Close #14744 (this is a re-submission with no changes)

@alankilborn you said you were interested in this feature. Want to test it before Don Ho merges it?

### What this changes
Rather than requiring that at least one field for a command match the entire contents of the Filter text box, the Filter text box will be split into a list of words, each of which must be matched by at least one field of the command.

### To test this PR

1. Open the shortcut mapper.
2. If you don't have any plugins installed, install the `mimeTools` plugin.
3. In the `Macros` tab, verify that the macro `Trim Trailing Space and Save` (and no others) is matched by the filter "trim +S" (note that this assumes that the default keycombo is bound here)
4. In the `Main menu` tab, verify that the menu command `New` (and no others) is matched by the filter `w +n`
5. In the `Main menu` tab, verify that the menu command `Reload from Disk` (and no others) is matched by the filter `load disk ctrl`
6. In the `Run commands` tab, verify that the `Get PHP help` command (and no others) is matched by `f1 php help`
7. Verify that filters match all the Plugin commands fields (name, plugin, shortcut)
8. Verify that filters match all the Scintilla commands fields (name, shortcuts)

### Examples of how the new behavior should work
__1. Consider a plugin command named "do thing" with plugin "BlahLint" and keycombo "Alt+G"__
    Filters that match:
    - "lint do +" (the "+" is matched by "alt+g")
    - "+G thing blah"
    Filters that *do not* match:
    - "lint foo +g" ("foo" is not in any field)
    - "thing alt quz" ("quz" is not in any field)
__2. Consider a Scintilla command named "foo baz" with keycombos "Alt+H or Ctrl+Shift+Q"__
    Filters that match:
    - "baz or" (the "or" is matched by "Alt+H or Ctrl+Shift+Q")
    - "+q foo"
    Filters that *do not* match:
    - "+q +z" ("+z" is not in any field)
    - "quz"
    - "baz Tab" ("tab" is not in any field)
__3. Consider any other type of command named "cute kitty" with keycombo "Alt+K"__
    Filters that match:
    - "alt k" matches ("k" is matched by "kitty" *and* "alt+k")
    - "kit alt"
    Filters that *do not* match:
    - "cute q" ("q" is not in any field)
    - "z kit"

### ideas for future changes

- maybe add a checkbox next to the filter text box, to change the way text is filtered?
- maybe create a method with a variable number of arguments that tests each word of the filter on each arg, to reduce repetitiveness of code in implementation