### PR TITLE
Test - logging file written for losing session issue

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -66,7 +66,7 @@ Win32_IO_File::Win32_IO_File(const wchar_t *fname)
 		}
 
 		NppParameters& nppParam = NppParameters::getInstance();
-		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		//if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");
@@ -104,7 +104,7 @@ void Win32_IO_File::close()
 
 
 		NppParameters& nppParam = NppParameters::getInstance();
-		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		//if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");
@@ -165,7 +165,7 @@ bool Win32_IO_File::write(const void *wbuf, size_t buf_size)
 
 	if (success == FALSE)
 	{
-		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		//if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");
@@ -184,7 +184,7 @@ bool Win32_IO_File::write(const void *wbuf, size_t buf_size)
 	}
 	else
 	{
-		if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
+		//if (nppParam.isEndSessionStarted() && nppParam.doNppLogNulContentCorruptionIssue())
 		{
 			generic_string issueFn = nppLogNulContentCorruptionIssue;
 			issueFn += TEXT(".log");


### PR DESCRIPTION
The cautious conditions for logging are removed in this PR, so any file writing is logged.
The logs help us for understanding the corrupted files issue.

During the life time of Notepad++, the session is saved every time when the opened file is modified (clean->dirty) or saved after being modified (dirty->clean), for saving the backup file state in session.xml.

Based on the above facts I described, I can imagine one scenario to reproduce such issue:
***When user modifies a file at the first time (from clean to dirty) in Notepad++, and the time of periodic backup (7 sec by default) is reached: the backup of modified file and session.xml are being written sequentially - then the power outrage happens at this moment.***

When above scenario happens, the corruption of file could be on the backup of modified file or session.xml, it depends on the precise moment of the power outrage.

Ref: 
1. https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14781
2. https://github.com/notepad-plus-plus/notepad-plus-plus/issues/6133