### PR TITLE
filter shortcut mapper by words (split filter by whitespace) - resubmission

### DIFF
--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -194,47 +194,76 @@ generic_string ShortcutMapper::getTextFromCombo(HWND hCombo)
 
 bool ShortcutMapper::isFilterValid(Shortcut sc)
 {
-	if (_shortcutFilter.empty())
+	// all words in _shortcutFilter must be in the name or keycombo
+	// For example, the shortcut with name "foo bar baz" and keycombo "Ctrl+A"
+	// would be matched by the filter "foo ctrl" and the filter "bar +a"
+	// but *not* by the filter "foo shift" or the filter "quz +a"
+	size_t filterSize = _shortcutFilter.size();
+	if (filterSize == 0)
 		return true;
 
 	wstring shortcut_name = stringToLower(string2wstring(sc.getName(), CP_UTF8));
 	wstring shortcut_value = stringToLower(string2wstring(sc.toString(), CP_UTF8));
 
-	// test the filter on the shortcut name and value
-	return (shortcut_name.find(_shortcutFilter) != std::string::npos) || 
-		(shortcut_value.find(_shortcutFilter) != std::string::npos);
+	for (size_t i = 0; i < filterSize; ++i)
+	{
+		generic_string filterWord = _shortcutFilter.at(i);
+		// every word must be matched by keycombo or name
+		if (shortcut_name.find(filterWord) == std::string::npos &&
+			shortcut_value.find(filterWord) == std::string::npos)
+			return false;
+	}
+	return true;
 }
 
 bool ShortcutMapper::isFilterValid(PluginCmdShortcut sc)
 {
-	// Do like a classic search on shortcut name, then search on the plugin name.
-	Shortcut shortcut = sc;
-	bool match = false;
-	wstring module_name = stringToLower(string2wstring(sc.getModuleName(), CP_UTF8));
-	if (isFilterValid(shortcut)){
+	// all words in _shortcutFilter must be in the name or the keycombo or the plugin name
+	// For example, the shortcut with name "foo bar baz" and keycombo "Ctrl+A" and plugin "BlahLint"
+	// would be matched by the filter "foo ctrl" and the filter "bar +a blah"
+	// but *not* by the filter "baz shift" or the filter "lint quz" 
+	size_t filterSize = _shortcutFilter.size();
+	if (filterSize == 0)
 		return true;
-	}
-	size_t match_pos = module_name.find(_shortcutFilter);
-	if (match_pos != std::string::npos){
-		match = true;
-	}
 
-	return match;
+	wstring shortcut_name = stringToLower(string2wstring(sc.getName(), CP_UTF8));
+	wstring shortcut_value = stringToLower(string2wstring(sc.toString(), CP_UTF8));
+	wstring module_name = stringToLower(string2wstring(sc.getModuleName(), CP_UTF8));
+	
+	for (size_t i = 0; i < filterSize; ++i)
+	{
+		generic_string filterWord = _shortcutFilter.at(i);
+		// every word must be matched by keycombo or name or plugin name
+		if (shortcut_name.find(filterWord) == std::string::npos &&
+			shortcut_value.find(filterWord) == std::string::npos &&
+			module_name.find(filterWord) == std::string::npos)
+			return false;
+	}
+	return true;
 }
 
 bool ShortcutMapper::isFilterValid(ScintillaKeyMap sc)
 {
-	// do a classic search on shortcut name,
-	// then see if the list of keycombos matches (e.g. "Ctrl+X or Alt+Y" matches "or" and "Alt" and "Ctrl+")
-	if (_shortcutFilter.empty())
+	// all words in _shortcutFilter must be in the name or the list of keycombos
+	// For example, the shortcut with name "foo bar baz" and keycombo "Ctrl+A or Alt+G"
+	// would be matched by the filter "foo ctrl" and the filter "bar alt or"
+	// but *not* by the filter "foo shift" or the filter "quz +a"
+	size_t filterSize = _shortcutFilter.size();
+	if (filterSize == 0)
 		return true;
 
 	wstring shortcut_name = stringToLower(string2wstring(sc.getName(), CP_UTF8));
-	if (shortcut_name.find(_shortcutFilter) != std::string::npos)
-		return true; // name matches
-
 	wstring shortcut_value = stringToLower(string2wstring(sc.toString(), CP_UTF8));
-	return shortcut_value.find(_shortcutFilter) != std::string::npos; // list of shortcuts matches
+
+	for (size_t i = 0; i < filterSize; ++i)
+	{
+		generic_string filterWord = _shortcutFilter.at(i);
+		// every word must be matched by keycombo or name
+		if (shortcut_name.find(filterWord) == std::string::npos &&
+			shortcut_value.find(filterWord) == std::string::npos)
+			return false;
+	}
+	return true;
 }
 
 void ShortcutMapper::fillOutBabyGrid()
@@ -296,7 +325,20 @@ void ShortcutMapper::fillOutBabyGrid()
 
 	bool isMarker = false;
 	size_t cs_index = 0;
-	_shortcutFilter = getTextFromCombo(::GetDlgItem(_hSelf, IDC_BABYGRID_FILTER));
+	
+	// make _shortcutFilter a list of the words in IDC_BABYGRID_FILTER
+	generic_string shortcutFilterStr = getTextFromCombo(::GetDlgItem(_hSelf, IDC_BABYGRID_FILTER));
+	const generic_string whitespace(TEXT(" "));
+	std::vector<generic_string> shortcutFilterWithEmpties;
+	stringSplit(shortcutFilterStr, whitespace, shortcutFilterWithEmpties);
+	// now add only the non-empty strings in the split list to _shortcutFilter
+	_shortcutFilter = std::vector<generic_string>();
+	for (size_t i = 0; i < shortcutFilterWithEmpties.size(); ++i)
+	{
+		generic_string filterWord = shortcutFilterWithEmpties.at(i);
+		if (!filterWord.empty())
+			_shortcutFilter.push_back(filterWord);
+	}
 
 	switch(_currentState) 
 	{

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.h
@@ -27,7 +27,7 @@ enum GridState {STATE_MENU, STATE_MACRO, STATE_USER, STATE_PLUGIN, STATE_SCINTIL
 class ShortcutMapper : public StaticDialog {
 public:
 	ShortcutMapper() : StaticDialog(), _currentState(STATE_MENU) {
-		_shortcutFilter = TEXT("");
+		_shortcutFilter = std::vector<generic_string>();
 		_dialogInitDone = false;
 	};
 	~ShortcutMapper() = default;
@@ -71,7 +71,7 @@ private:
 
 	const static int _nbTab = 5;
 	generic_string _tabNames[_nbTab];
-	generic_string _shortcutFilter;
+	std::vector<generic_string> _shortcutFilter;
 	std::vector<size_t> _shortcutIndex;
 
 	//save/restore the last view


### PR DESCRIPTION
Fix #14743 
This is a re-submission of #14816. CI on that PR failed because I forgot to sync my master with notepad-plus-plus/master before submitting that one.

### What this changes
Rather than requiring that at least one field for a command match the entire contents of the Filter text box, the Filter text box will be split into a list of words, each of which must be matched by at least one field of the command.

### To test this PR

1. Open the shortcut mapper.
2. If you don't have any plugins installed, install the `mimeTools` plugin.
3. In the `Macros` tab, verify that the macro `Trim Trailing Space and Save` (and no others) is matched by the filter "trim +S" (note that this assumes that the default keycombo is bound here)
4. In the `Main menu` tab, verify that the menu command `New` (and no others) is matched by the filter `w +n`
5. In the `Main menu` tab, verify that the menu command `Reload from Disk` (and no others) is matched by the filter `load disk ctrl`
6. In the `Run commands` tab, verify that the `Get PHP help` command (and no others) is matched by `f1 php help`
7. Verify that filters match all the Plugin commands fields (name, plugin, shortcut)
8. Verify that filters match all the Scintilla commands fields (name, shortcuts)

### Examples of how the new behavior should work
__1. Consider a plugin command named "do thing" with plugin "BlahLint" and keycombo "Alt+G"__
    Filters that match:
    - "lint do +" (the "+" is matched by "alt+g")
    - "+G thing blah"
    Filters that *do not* match:
    - "lint foo +g" ("foo" is not in any field)
    - "thing alt quz" ("quz" is not in any field)
__2. Consider a Scintilla command named "foo baz" with keycombos "Alt+H or Ctrl+Shift+Q"__
    Filters that match:
    - "baz or" (the "or" is matched by "Alt+H or Ctrl+Shift+Q")
    - "+q foo"
    Filters that *do not* match:
    - "+q +z" ("+z" is not in any field)
    - "quz"
    - "baz Tab" ("tab" is not in any field)
__3. Consider any other type of command named "cute kitty" with keycombo "Alt+K"__
    Filters that match:
    - "alt k" matches ("k" is matched by "kitty" *and* "alt+k")
    - "kit alt"
    Filters that *do not* match:
    - "cute q" ("q" is not in any field)
    - "z kit"

### ideas for future changes

- maybe add a checkbox next to the filter text box, to change the way text is filtered?
- maybe create a method with a variable number of arguments that tests each word of the filter on each arg, to reduce repetitiveness of code in implementation