### PR TITLE
Temporarily disable new DPI API for MSVC 32bit release build

### DIFF
--- a/PowerEditor/src/dpiManagerV2.h
+++ b/PowerEditor/src/dpiManagerV2.h
@@ -16,7 +16,7 @@
 
 
 #pragma once
-#include <windows.h>
+#include "NppDarkMode.h"
 
 class DPIManagerV2
 {

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -503,7 +503,13 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 	NppGUI & nppGui = nppParameters.getNppGUI();
 
 	NppDarkMode::initDarkMode();
+
+	// There is issue with MSVC x86 release build,
+	// some optimalization will cause crash when opening shortcut mapper.
+	// Needs further investigation.
+#if defined(_WIN32) && (defined(_WIN64) || defined(DEBUG))
 	DPIManagerV2::initDpiAPI();
+#endif
 
 	bool doUpdateNpp = nppGui._autoUpdateOpt._doAutoUpdate;
 	bool doUpdatePluginList = nppGui._autoUpdateOpt._doAutoUpdate;


### PR DESCRIPTION
 to avoid crash with Shortcut mapper

ref https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14855#issuecomment-2002031940