### PR TITLE
Fix memory overwriting bug by BabyGrid

### DIFF
--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -1341,7 +1341,7 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 	SelfIndex=FindGrid(GetMenu(hWnd));
 
-	// the following check will prevent memory overwriting bug by BabyGrip during the WM_NCCREATE, WM_NCCALCSIZE, WM_CREATE and WM_NCDESTROY
+	// the following check will prevent memory overwriting bug by BabyGrid during the WM_NCCREATE, WM_NCCALCSIZE, WM_CREATE and WM_NCDESTROY
 	// - TODO: if the above FindGrid can theoretically return -1, the whole BabyGrid code here is theoretically flawed and needs a review
 	//         (luckily it seems it never returns -1 apart from the aforementioned 4 WMs above)
 	if (SelfIndex != -1)

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -1341,14 +1341,16 @@ LRESULT CALLBACK GridProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 	SelfIndex=FindGrid(GetMenu(hWnd));
 
-	//update the grid width and height variable
+	// the following check will prevent memory overwriting bug by BabyGrip during the WM_NCCREATE, WM_NCCALCSIZE, WM_CREATE and WM_NCDESTROY
+	// - TODO: if the above FindGrid can theoretically return -1, the whole BabyGrid code here is theoretically flawed and needs a review
+	//         (luckily it seems it never returns -1 apart from the aforementioned 4 WMs above)
+	if (SelfIndex != -1)
 	{
-	 RECT rect;
-
-	 GetClientRect(hWnd,&rect);
-	 BGHS[SelfIndex].gridwidth = rect.right - rect.left;
-	 BGHS[SelfIndex].gridheight = rect.bottom - rect.top;
-
+		// update the grid width and height variable
+		RECT rect{};
+		::GetClientRect(hWnd, &rect);
+		BGHS[SelfIndex].gridwidth = rect.right - rect.left;
+		BGHS[SelfIndex].gridheight = rect.bottom - rect.top;
 	}
 
 	ReturnValue = 0;


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14855#issuecomment-2001066992 , https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14871#issuecomment-2002485089

BabyGrid code was overwriting foreign memory on its initialization and deinitialization. At that time (WM_NCCREATE, WM_NCCALCSIZE, WM_CREATE and WM_NCDESTROY) the relevant `FindGrid` func returns -1, which was used as an index pointing to a memory area before the whole `BGHS` object (`BGHS[-1]`...)!

This was a long-standing hidden bug that only started to manifest itself probably when the app memory layout shifted somehow and important objects/data started to be overwritten, resulting in the visible app crashes.