### PR TITLE
Fix URLs are not detected after a "Replace All" action

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3563,6 +3563,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_INTERNAL_DOCMODIFIEDBYREPLACEALL:
 		{
+			if (wParam == reinterpret_cast<WPARAM>(_pEditView->getCurrentBuffer()))
+				addHotSpot(_pEditView);
 			SCNotification scnN{};
 			scnN.nmhdr.code = NPPN_GLOBALMODIFIED;
 			scnN.nmhdr.hwndFrom = reinterpret_cast<void*>(wParam);


### PR DESCRIPTION
Fix #14864

Note that URLs were already being highlighted after a `Replace All in All Opened Documents` action, and when two views were open. You do not need to test this PR in those cases.

This PR fixes the specific case when `Replace All` is used and only one view is open.

To test:

1. Verify that clickable links are enabled (`Settings->Preferences->Cloud & Link->Clickable Link Settings`, check the `Enable` checkbox).
2. If two views are open, close the second view.
3. Open a new buffer with the text `foo foo foo`
4. Use `Search->Replace->Replace All` to replace all instances of `foo` with `https://notepad-plus-plus.org`.
5. Verify that all instances of the new URLs are highlighted.