### PR TITLE
faster URL scanning when one very long line is visible

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -897,7 +897,10 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			NppGUI & nppGui = nppParam.getNppGUI();
 
 			// replacement for obsolete custom SCN_SCROLLED
-			if (notification->updated & SC_UPDATE_V_SCROLL)
+			if ((notification->updated & SC_UPDATE_V_SCROLL)
+				// if one line is in view and word wrap is off (so the first line in view is the last line of the document)
+				//    we need to recalculate URLs in response to horizontal scrolling as well as vertical scrolling
+				|| ((notification->updated & SC_UPDATE_H_SCROLL) && notifyView->execute(SCI_GETFIRSTVISIBLELINE) == notifyView->execute(SCI_GETLINECOUNT) - 1))
 			{
 				addHotSpot(notifyView);
 			}


### PR DESCRIPTION
Fix #13916

## Introduction

Currently [`Notepad_plus::addHotSpot`](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/cccd99b791c98ef4a9a729e31da45acb7f9bcdfd/PowerEditor/src/Notepad_plus.cpp#L3401) uses [`ScintillaEditView::getVisibleStartAndEndPosition`](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/cccd99b791c98ef4a9a729e31da45acb7f9bcdfd/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp#L2565) to get the start and end positions to scan for URLs, which sets startPos to the start of the first line in view and endPos to the end of the last line in view.

This means that when a very long line is in view, URL scanning can take an extremely long time, and in some unusual cases (see #13916, original message) can lead to loading or even scrolling a document to take minutes.

This commit fixes this issue by ensuring that, *if only one line is in view*, startPos and endPos are clamped as follows:
- startPos is set to the first character visible MINUS 32767 (see below for why this number is chosen) or the first character of the line, whichever is greater.
- endPos is set to the last character visible PLUS 32767 or the last character of the line, whichever is less.

*If multiple lines are in view*, startPos and endPos are set using the same rules as before.

This means that __a multi-line document similar to the one that originally caused this issue would have the same awful performance as before.__ See this comment by Coises (https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13916#issuecomment-2010952251) for a proposal to change the URL-parsing algorithm in a way that would improve worst-case performance at the cost of introducing a complicated regular expression and noticeably reducing average-case performance. I do not think the proposed algorithmic change is worth the performance hit, but I can understand why others would disagree.

__In addition to eliminating insane latency in the most extreme cases, this commit also noticeably improves the vertical scroll rate (and sometimes improves load speed) on *all* word-wrapped documents when only one very long (>=2MB) line is in view.__

Because of the above-described change, horizontal scrolling now triggers URL scanning *if there is one line in view* (since it is still unnecessary when multiple lines are in view). Horizontal scrolling is still about as fast as it was before whether there was one line in view or multiple.

### An unrelated quality-of-life improvement

This commit turns off URL scanning while Notepad++ is shutting down, to help reduce shutdown time.

## A very slight disadvantage of this change 

Because of the changes in this commit, when only a single line is in view, *if an extremely long URL (longer than approximately 33 thousand characters) is only partially in view, it will not be highlighted.*

However, double-clicking a URL longer than 32767 characters cannot cause the URL to be opened in a web browser due to the behavior of ShellExecuteW (see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry for explanation). *This is the way Notepad++ worked before this commit.* Note that the `Copy link` right-click context menu option *does currently work* for such links. That is the only feature that this commit would break.

Since double-clicking URLs that long already failed to open the page in a browser before this commit,
and since URLs that long are exceedingly rare,
and this commit only breaks highlighting of such URLs when one line is in view,
it seems obvious to me that this is an acceptable sacrifice for a potentially large performance improvement in much more common situations.

## How to test this commit
1. download the test file from the original message of #13916
2. open the test file in Notepad++. Verify that it takes only a short time to open (not minutes).
3. Turn ON word wrap. Try scrolling up and down. Verify that scrolling does not cause long lag.
4. Turn OFF word wrap. Try scrolling side to side. Verify that the scrolling does not cause long lag.
5. try replacing all instances of ":" with " https://".
6. Verify that URLs are highlighted as you scroll through the document. Once again, lag should not be too bad.
7. Turn ON word wrap. Verify that URLs are highlighted as you scroll through the document.
8. Save the test document with the URLs.
9. Close and reopen Notepad++. Verify that load speed is acceptable.
10. Repeat steps 3, 4, and 7.
11. Test URL scanning for a document with multiple lines. Make sure it works as normal.
12. Try creating a document with multiple lines that each have many characters (say, 100 lines with 200 thousand characters each).
13. Verify that horizontal scrolling is not too slow when word wrap is turned *off* and only one line is in view.
14. Verify that vertical scrolling is not too slow when word wrap is turned *on* and only one line is in view.
15. Download [`super long url.txt`](https://github.com/notepad-plus-plus/notepad-plus-plus/files/14716663/super.long.url.txt), which contains a very long URL.
16. Copy the text of `super long url.txt`, and paste it at the end of the file. Do not add a trailing EOL.
17. Turn word wrap off.
18. Place the caret between the two very long URLs.
19. Verify that both URLs can be double-clicked such that the URL is opened on your web browser.
20. Repeat step 19 with word wrap turned on.