### PR TITLE
Use dark theme on checkbox buttons on Windows 11

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -864,7 +864,7 @@ namespace NppDarkMode
 
 			if (!g_menuTheme)
 			{
-				g_menuTheme = OpenThemeData(hWnd, L"Menu");
+				g_menuTheme = OpenThemeData(hWnd, VSCLASS_MENU);
 			}
 
 			switch (iBackgroundStateID)
@@ -1017,7 +1017,7 @@ namespace NppDarkMode
 		{
 			if (!hTheme)
 			{
-				hTheme = OpenThemeData(hwnd, WC_BUTTON);
+				hTheme = OpenThemeData(hwnd, VSCLASS_BUTTON);
 			}
 			return hTheme != nullptr;
 		}
@@ -2290,12 +2290,12 @@ namespace NppDarkMode
 				return TRUE;
 			}
 
-			if (wcscmp(className, L"Static") == 0)
+			if (wcscmp(className, WC_STATIC) == 0)
 			{
 				return TRUE;
 			}
 
-			if (wcscmp(className, L"msctls_trackbar32") == 0)
+			if (wcscmp(className, TRACKBAR_CLASS) == 0)
 			{
 				return TRUE;
 			}
@@ -2331,6 +2331,12 @@ namespace NppDarkMode
 					}
 					break;
 				}
+
+				if (NppDarkMode::isWindows11() && p._theme)
+				{
+					SetWindowTheme(hwnd, p._themeClassName, nullptr);
+				}
+
 				if (p._subclass)
 				{
 					NppDarkMode::subclassButtonControl(hwnd);


### PR DESCRIPTION
-  replace style and class strings with macro

fix #14929

![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/55940305/6b49dbc1-bfe4-4915-a5fc-414fe2150cae)
