### PR TITLE
make shutdown faster by not scanning for URLs

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3400,6 +3400,8 @@ bool isUrl(TCHAR * text, int textLen, int start, int* segmentLen)
 
 void Notepad_plus::addHotSpot(ScintillaEditView* view)
 {
+	if (_isAttemptingCloseOnQuit)
+		return; // don't recalculate URLs when shutting down
 	ScintillaEditView* pView = view ? view : _pEditView;
 	Buffer* currentBuf = pView->getCurrentBuffer();
 


### PR DESCRIPTION
[See this comment here](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14894#pullrequestreview-1974719687). I'm opening a new PR rather than editing the old one, because this is a quality-of-life fix that doesn't relate to the issue referenced in that PR.

This does not seem to make a whole lot of difference performance-wise (I tested on a file with one 32MB line with a ton of URLs and I didn't notice much difference between this commit and 8.6.4), but I can't imagine it hurts. AFAIK the only time when the user would see the result of a URL scan after shutdown started would be when shutdown was interrupted, and I currently can't remember how to create a situation where shutdown begins and then is interrupted.