### PR TITLE
fix gcc compiler warnings\errors

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4399,7 +4399,7 @@ void Notepad_plus::showView(int whichOne)
 	}
 	_pMainWindow->display(true);
 
-	_mainWindowStatus |= (whichOne==MAIN_VIEW)?WindowMainActive:WindowSubActive;
+	_mainWindowStatus |= static_cast<UCHAR>((whichOne==MAIN_VIEW)?WindowMainActive:WindowSubActive);
 
 	//Send sizing info to make windows fit
 	::SendMessage(_pPublicInterface->getHSelf(), WM_SIZE, 0, 0);
@@ -4450,7 +4450,7 @@ void Notepad_plus::hideView(int whichOne)
 
 	switchEditViewTo(otherFromView(whichOne));
 	auto viewToDisable = static_cast<UCHAR>(whichOne == SUB_VIEW ? WindowSubActive : WindowMainActive);
-	_mainWindowStatus &= ~viewToDisable;
+	_mainWindowStatus &= static_cast<UCHAR>(~viewToDisable);
 }
 
 bool Notepad_plus::loadStyles()
@@ -4675,7 +4675,7 @@ void Notepad_plus::undockUserDlg()
 
     ::SendMessage(_pPublicInterface->getHSelf(), WM_SIZE, 0, 0);
 
-    _mainWindowStatus &= ~WindowUserActive;
+    _mainWindowStatus &= static_cast<UCHAR>(~WindowUserActive);
     (ScintillaEditView::getUserDefineDlg())->display();
 }
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -19,7 +19,7 @@
 #include <shlwapi.h>
 #include <uxtheme.h> // for EnableThemeDialogTexture
 #include <format>
-#include <Windowsx.h> // for GET_X_LPARAM, GET_Y_LPARAM
+#include <windowsx.h> // for GET_X_LPARAM, GET_Y_LPARAM
 #include "Notepad_plus_Window.h"
 #include "TaskListDlg.h"
 #include "ImageListSet.h"

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -61,9 +61,9 @@ struct GridHandleStruct
 	COLORREF highlightcolorProtectNoFocus = RGB(200, 200, 200);
 	COLORREF gridlinecolor = RGB(220, 220, 220);
 	COLORREF highlighttextcolor = RGB(255, 255, 255);
-	COLORREF backgroundcolor = GetSysColor(COLOR_BTNFACE);;
+	COLORREF backgroundcolor = GetSysColor(COLOR_BTNFACE);
 	COLORREF titletextcolor = RGB(0, 0, 0);
-	COLORREF titlecolor = GetSysColor(COLOR_BTNFACE);;
+	COLORREF titlecolor = GetSysColor(COLOR_BTNFACE);
 	COLORREF titlegridlinecolor = RGB(120, 120, 120);
 	BOOL DRAWHIGHLIGHT = TRUE;
 	BOOL ADVANCEROW = TRUE;

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -205,7 +205,7 @@ namespace // anonymous
 
 ///////////////////////////////////////////////////////////////////////////////
 
-class FileDialogEventHandler : public IFileDialogEvents, public IFileDialogControlEvents
+class FileDialogEventHandler final : public IFileDialogEvents, public IFileDialogControlEvents
 {
 public:
 	// IUnknown methods

--- a/PowerEditor/src/WinControls/shortcut/shortcut.h
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.h
@@ -95,7 +95,7 @@ public:
 	}
 
 	BYTE getAcceleratorModifiers() {
-		return ( FVIRTKEY | (_keyCombo._isCtrl?FCONTROL:0) | (_keyCombo._isAlt?FALT:0) | (_keyCombo._isShift?FSHIFT:0) );
+		return static_cast<BYTE>( FVIRTKEY | (_keyCombo._isCtrl?FCONTROL:0) | (_keyCombo._isAlt?FALT:0) | (_keyCombo._isShift?FSHIFT:0) );
 	};
 
 	Shortcut & operator=(const Shortcut & sc) {

--- a/lexilla/lexers/LexUser.cxx
+++ b/lexilla/lexers/LexUser.cxx
@@ -623,7 +623,7 @@ static bool IsNumber(StyleContext & sc, vector<string> * numberTokens[], vvstrin
 static inline void SubGroup(const char * s, vvstring & vec, bool group=false)
 {
     size_t length = strlen(s);
-    char * temp = new char[length+1];
+    char * temp = new char[length+1] {};
     unsigned int index = 0;
     vector<string> subvector;
     unsigned int i = 0;
@@ -697,7 +697,7 @@ static inline void SubGroup(const char * s, vvstring & vec, bool group=false)
 static inline void GenerateVector(vvstring & vec, const char * s, const char * prefix, size_t minLength)
 {
     size_t length = strlen(s);
-    char * temp = new char[length];
+    char * temp = new char[length] {};
     unsigned int index = 0;
     bool copy = false;
     bool inGroup = false;


### PR DESCRIPTION
- avoid upper/lowercase issue for #include <windowsx.h>on linux mingw build
- casts to avoid warning: conversion from ‘int’ to ‘UCHAR’ {aka ‘unsigned char’} may change value [-Wconversion]
- cast to avoid warning: conversion from ‘int’ to ‘BYTE’ {aka ‘unsigned char’} may change value [-Wconversion]
- avoid warning : delete called on non-final 'FileDialogEventHandler' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
- init temp in N++ LexUser