### PR TITLE
Use newer version of make and show it correctly

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -295,16 +295,15 @@ jobs:
         if ( $${{ matrix.build_platform == 'x86_64'}} ) {$Env:MSYSTEM = 'MINGW64'}
         if ( $${{ matrix.build_platform == 'x86_64'}} ) {$Env:Path = 'C:\msys64\mingw64\bin' + [IO.Path]::PathSeparator + $Env:Path}
         if ( $${{ matrix.build_configuration == 'Debug'}} ) {$Env:DEBUG = '1'}
-        Write-Output "Tools version:"
-        Write-Output (((gcc --version) | select-object -first 1) + " " + (gcc -dumpmachine))
-        Write-Output (make --version) | select-object -first 1
-        Write-Output (sh --version) | select-object -first 1
-        Write-Output ""
         bash -lc "pacman --noconfirm -Syuu"
         bash -lc "pacman --noconfirm -Syuu"
         if ( $${{ matrix.build_platform == 'i686'}} ) {bash -lc "pacman --noconfirm -S mingw-w64-i686-gcc mingw-w64-i686-make"}
         if ( $${{ matrix.build_platform == 'x86_64'}} ) {bash -lc "pacman --noconfirm -S mingw-w64-x86_64-gcc mingw-w64-x86_64-make"}
-        make -f PowerEditor\gcc\makefile
+        Write-Output "Tools version:"
+        Write-Output (((gcc --version) | select-object -first 1) + " " + (gcc -dumpmachine))
+        Write-Output (mingw32-make --version) | select-object -first 1
+        Write-Output (sh --version) | select-object -first 1
+        mingw32-make -f PowerEditor\gcc\makefile
 
     - name: Archive artifacts for ${{ matrix.build_platform}} / Release
       if: matrix.build_configuration == 'Release'


### PR DESCRIPTION
For MSYS2 we update `mingw32-make` but still use older `make` version `4.2.1` from `C:\mingw64\bin\make.exe`. If I remember correctly,https://github.com/notepad-plus-plus/notepad-plus-plus/pull/12481, it was a problem with version `4.4`, but now with `4.4.1` it apparently no longer occurs. I also moved version checking after performing the MSYS2 update.

Edit:

It looks like there are two tools:
- `make` inside `C:\mingw64\bin`
- `mingw32-make` inside `C:\msys64\mingw64\bin` or `C:\msys64\mingw32\bin` 

We should choose only one and update/use it. From what I can see, our `makefile` works properly in both.
