### PR TITLE
Add dpi messages

### DIFF
--- a/PowerEditor/src/NppDarkMode.h
+++ b/PowerEditor/src/NppDarkMode.h
@@ -122,7 +122,6 @@ namespace NppDarkMode
 	DWORD getWindowsBuildNumber();
 
 	COLORREF invertLightness(COLORREF c);
-	COLORREF invertLightnessSofter(COLORREF c);
 	double calculatePerceivedLightness(COLORREF c);
 
 	void setDarkTone(ColorTone colorToneChoice);

--- a/PowerEditor/src/WinControls/StatusBar/StatusBar.cpp
+++ b/PowerEditor/src/WinControls/StatusBar/StatusBar.cpp
@@ -241,13 +241,14 @@ static LRESULT CALLBACK StatusBarSubclass(HWND hWnd, UINT uMsg, WPARAM wParam, L
 		}
 
 		case WM_DPICHANGED:
+		case WM_DPICHANGED_AFTERPARENT:
 		case WM_THEMECHANGED:
 		{
 			pStatusBarInfo->closeTheme();
 			LOGFONT lf{ DPIManagerV2::getDefaultGUIFontForDpi(::GetParent(hWnd), DPIManagerV2::FontType::status) };
 			pStatusBarInfo->setFont(::CreateFontIndirect(&lf));
 			
-			if (uMsg == WM_DPICHANGED)
+			if (uMsg != WM_THEMECHANGED)
 			{
 				return 0;
 			}

--- a/PowerEditor/src/dpiManagerV2.h
+++ b/PowerEditor/src/dpiManagerV2.h
@@ -18,6 +18,22 @@
 #pragma once
 #include "NppDarkMode.h"
 
+#ifndef WM_DPICHANGED
+#define WM_DPICHANGED 0x02E0
+#endif
+
+#ifndef WM_DPICHANGED_BEFOREPARENT
+#define WM_DPICHANGED_BEFOREPARENT 0x02E2
+#endif
+
+#ifndef WM_DPICHANGED_AFTERPARENT
+#define WM_DPICHANGED_AFTERPARENT 0x02E3
+#endif
+
+#ifndef WM_GETDPISCALEDSIZE
+#define WM_GETDPISCALEDSIZE 0x02E4
+#endif
+
 class DPIManagerV2
 {
 public:


### PR DESCRIPTION
- process WM_DPICHANGED_AFTERPARENT message
- remove unused function
- tweak 2 switches, which use enums to avoid warnings

ref #14959