### PR TITLE
fix potential crash when crossing the 2GB file size threshold

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -728,8 +728,9 @@ BufferID FileManager::loadFile(const TCHAR* filename, Document doc, int encoding
 	bool ownDoc = false;
 	if (!doc)
 	{
-		// If file exceeds 200MB, activate large file mode
-		doc = (Document)_pscratchTilla->execute(SCI_CREATEDOCUMENT, 0, isLargeFile ? SC_DOCUMENTOPTION_STYLES_NONE | SC_DOCUMENTOPTION_TEXT_LARGE : 0);
+		// if file exceeds the _largeFileSizeDefInByte, disable the Scintilla styling (results in half memory consumption)
+		doc = static_cast<Document>(_pscratchTilla->execute(SCI_CREATEDOCUMENT, 0,
+			isLargeFile ? SC_DOCUMENTOPTION_STYLES_NONE | SC_DOCUMENTOPTION_TEXT_LARGE : SC_DOCUMENTOPTION_TEXT_LARGE));
 		ownDoc = true;
 	}
 
@@ -1354,7 +1355,7 @@ BufferID FileManager::newEmptyDocument()
 	wsprintf(nb, TEXT("%d"), static_cast<int>(nextUntitledNewNumber()));
 	newTitle += nb;
 
-	Document doc = (Document)_pscratchTilla->execute(SCI_CREATEDOCUMENT);	//this already sets a reference for filemanager
+	Document doc = static_cast<Document>(_pscratchTilla->execute(SCI_CREATEDOCUMENT, 0, SC_DOCUMENTOPTION_TEXT_LARGE)); // this already sets a reference for filemanager
 	Buffer* newBuf = new Buffer(this, _nextBufferID, doc, DOC_UNNAMED, newTitle.c_str(), false);
 
 	NppParameters& nppParamInst = NppParameters::getInstance();


### PR DESCRIPTION
Fix #14981 .

Side-effects analysis: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14944#issuecomment-2041506779
Implemented as per previous discussion: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14944#issuecomment-2044726350

To be able to work with 2GB+ files, we have to use the Scintilla `SC_DOCUMENTOPTION_TEXT_LARGE` flag.

Until now, this flag was only used if a file > 2GB was to be loaded. For files smaller than 2GB or newly created empty ones, it was not used. This left the room for a Notepad++ crash situation because of the user has been left the possibility to cross this threshold (e.g. by pasting a data which in sum with the already existing ones in the Notepad++ filebuffer exceeds that 2GB...)

So one has two options: either a complex monitoring of the Notepad++ filebuffers size and reloading these with that large-flag when reaching the 2GB or simply using that large-flag as the default one from the start (which is what this patch does...).