### PR TITLE
Allow " or ' and any character in the CI's message

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -31,7 +31,7 @@ jobs:
         $isMaster = $isPush -and $${{ github.ref_name == github.event.repository.master_branch }}
 
         if ($isPush) {
-          $commit_message = "${{ github.event.head_commit.message }}"
+          $commit_message = (git show -s --format=%B)
         }
         else {
           $last_commit = @(Invoke-RestMethod ${{ github.event.pull_request._links.commits.href }})[0]  | Select-Object -Last 1


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14943#issuecomment-2053716053 https://github.com/notepad-plus-plus/notepad-plus-plus/commit/906f6e4386cf5acebfc1ace3aac9b83b26e7c70a#commitcomment-140944054