### PR TITLE
fix linux compiler issues

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1787,7 +1787,7 @@ void Notepad_plus::command(int id)
 					::SendMessage(_pPublicInterface->getHSelf(), WM_SIZE, 0, 0);
 
 					udd->display(false);
-					_mainWindowStatus &= ~WindowUserActive;
+					_mainWindowStatus &= static_cast<UCHAR>(~WindowUserActive);
 				}
 				else if ((isUDDlgDocked)&&(!isUDDlgVisible))
 				{

--- a/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
+++ b/PowerEditor/src/WinControls/Grid/BabyGrid.cpp
@@ -674,7 +674,6 @@ void DrawCursor(HWND hWnd, int SI)
 	if (BGHS[SI].cursorcol < BGHS[SI].homecol) { return; }
 
 	rect = GetCellRect(hWnd, SI, BGHS[SI].cursorrow, BGHS[SI].cursorcol);
-	RECT rectwhole = rect;
 	HDC gdc = GetDC(hWnd);
 	BGHS[SI].activecellrect = rect;
 	int rop = GetROP2(gdc);

--- a/PowerEditor/src/dpiManagerV2.cpp
+++ b/PowerEditor/src/dpiManagerV2.cpp
@@ -17,7 +17,7 @@
 
 #include "dpiManagerV2.h"
 
-#include <CommCtrl.h>
+#include <commctrl.h>
 
 
 #if defined(__GNUC__) && __GNUC__ > 8


### PR DESCRIPTION
- fix linux build on include upper/lowercase issue ../src/dpiManagerV2.cpp:20:10: fatal error: CommCtrl.h: No such file or directory
- avoid clang warning: 5>..\src\WinControls\Grid\BabyGrid.cpp(677,7): warning : unused variable 'rectwhole' [-Wunused-variable]
- avoid ../src/NppCommands.cpp:1790:24: warning: conversion from ‘int’ to ‘UCHAR’ {aka ‘unsigned char’} may change value [-Wconversion]