### PR TITLE
Add log while flush file buffers action fails

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -100,6 +100,7 @@ void Win32_IO_File::close()
 			if (!::FlushFileBuffers(_hFile))
 			{
 				flushError = ::GetLastError();
+				std::wstring errNumberMsg = std::to_wstring(flushError) + L" - " + GetLastErrorAsString(flushError);
 
 				if (!nppParam.isEndSessionCritical())
 				{
@@ -133,8 +134,20 @@ void Win32_IO_File::close()
 					errMsg += L"\n\nThat file, temporarily stored in the system cache, cannot be finally committed to the storage device selected! \
 This is probably a storage driver or hardware issue, beyond the control of the Notepad++. \
 Please try using another storage and also check if your saved data is not corrupted.\n\nError Code reported: ";
-					errMsg += std::to_wstring(flushError) + L" - " + GetLastErrorAsString(flushError);
+					errMsg += errNumberMsg;
 					::MessageBoxW(NULL, errMsg.c_str(), L"WARNING - filebuffer flushing fail!", MB_OK | MB_ICONWARNING | MB_SYSTEMMODAL);
+				}
+				else
+				{
+					// writing breif log here
+					std::wstring nppFlushFileBuffersFailsLog = L"nppFlushFileBuffersFails.log";
+					std::wstring nppIssueLog = nppParam.getUserPath();
+					pathAppend(nppIssueLog, nppFlushFileBuffersFailsLog);
+
+					std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+					std::string errNumberMsgA = converter.to_bytes(errNumberMsg);
+
+					writeLog(nppIssueLog.c_str(), errNumberMsgA.c_str());
 				}
 			}
 		}

--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -165,6 +165,8 @@ Please try using another storage and also check if your saved data is not corrup
 			std::string msg;
 			if (flushError != NOERROR)
 			{
+				msg = "FlushFileBuffers failed with the error code: " + std::to_string(flushError) + " - ";
+
 				LPSTR messageBuffer = nullptr;
 				FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 					nullptr, flushError, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, nullptr);

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -139,7 +139,7 @@ void Buffer::setLangType(LangType lang, const TCHAR* userLangName)
 
 void Buffer::updateTimeStamp()
 {
-	FILETIME timeStampLive = {};
+	FILETIME timeStampLive {};
 	WIN32_FILE_ATTRIBUTE_DATA attributes{};
 	if (GetFileAttributesEx(_fullPathName.c_str(), GetFileExInfoStandard, &attributes) != 0)
 	{


### PR DESCRIPTION
Currently while flush file buffers action fails at not critical end session, a error message dialog display the problem. It raises the problem of some external process interfering with the Notepad++ file saving (via NppSaveAsAdmin plugin).

This commit logs this error at critical end session, so if NUL characters content issue happens to the users again, we can try to know what was happening, plus users' plugin list.

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14990#issuecomment-2054242025