### PR TITLE
Check if URL is enclosed in apostrophes

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3284,6 +3284,18 @@ void scanToUrlEnd(TCHAR *text, int textLen, int start, int* distance)
 	*distance = p - start;
 }
 
+// removeUnwantedTrailingCharFromEnclosedUrl removes a single unwanted trailing character from a URL if the URL is enclosed by a pair of characters.
+void removeUnwantedTrailingCharFromEnclosedUrl(int start, TCHAR const * text, int * length)
+{
+	// Check if URL is enclosed in apostrophes.
+	if (start > 0 && text [start - 1] == '\'' && text [start + *length - 1] == '\'')
+		*length -= 1;
+
+	// Check if URL is enclosed in grave accents.
+	if (start > 0 && text [start - 1] == '`' && text [start + *length - 1] == '`')
+		*length -= 1;
+}
+
 // removeUnwantedTrailingCharFromUrl removes a single unwanted trailing character from an URL.
 // It has to be called repeatedly, until it returns false, meaning that all unwanted characters are gone.
 bool removeUnwantedTrailingCharFromUrl (TCHAR const *text, int* length)
@@ -3356,9 +3368,7 @@ bool isUrl(TCHAR * text, int textLen, int start, int* segmentLen)
 			bool r  = InternetCrackUrl(& text [start], len, 0, & url);
 			if (r)
 			{
-				// Check if URL is enclosed in apostrophes.
-				if (start > 0 && text [start - 1] == '\'' && text [start + len - 1] == '\'')
-					len--;
+				removeUnwantedTrailingCharFromEnclosedUrl(start, & text [0], & len);
 
 				while (removeUnwantedTrailingCharFromUrl (& text [start], & len));
 				*segmentLen = len;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3356,6 +3356,10 @@ bool isUrl(TCHAR * text, int textLen, int start, int* segmentLen)
 			bool r  = InternetCrackUrl(& text [start], len, 0, & url);
 			if (r)
 			{
+				// Check if URL is enclosed in apostrophes.
+				if (start > 0 && text [start - 1] == '\'' && text [start + len - 1] == '\'')
+					len--;
+
 				while (removeUnwantedTrailingCharFromUrl (& text [start], & len));
 				*segmentLen = len;
 				return true;


### PR DESCRIPTION
Fix #14978, fix #14323, fix #14212.
Check if URL is enclosed in apostrophes. Only if URL is directly preceded by apostrophe and URL ends with apostrophe.