### PR TITLE
Fix GCC reorder warning, use override, remove duplicated code

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -16,7 +16,7 @@
 #pragma once
 #include "Notepad_plus.h"
 
-const int splitterSize = 8;
+constexpr int splitterSize = 8;
 
 const TCHAR COMMAND_ARG_HELP[] = TEXT("Usage :\r\
 \r\
@@ -82,7 +82,7 @@ public:
 		return _notepad_plus_plus_core.getPluginListVerStr();
 	};
 
-	virtual void destroy() {
+	void destroy() override {
 		if (_hIconAbsent)
 			::DestroyIcon(_hIconAbsent);
 		::DestroyWindow(_hSelf);
@@ -100,17 +100,8 @@ public:
 
 	void setStartupBgColor(COLORREF BgColor);
 
-	static void loadIcon(HINSTANCE hinst, wchar_t* pszName, int cx, int cy, HICON* icon)
-	{
-		if (::LoadIconWithScaleDown(hinst, pszName, cx, cy, icon) != S_OK)
-		{
-			*icon = static_cast<HICON>(::LoadImage(hinst, pszName, IMAGE_ICON, cx, cy, LR_DEFAULTCOLOR));
-		}
-	}
-
-	static void loadTrayIcon(HINSTANCE hinst, HICON* icon)
-	{
-		loadIcon(hinst, MAKEINTRESOURCE(IDI_M30ICON), ::GetSystemMetrics(SM_CXSMICON), ::GetSystemMetrics(SM_CYSMICON), icon);
+	static void loadTrayIcon(HINSTANCE hinst, HICON* icon) {
+		DPIManagerV2::loadIcon(hinst, MAKEINTRESOURCE(IDI_M30ICON), ::GetSystemMetrics(SM_CXSMICON), ::GetSystemMetrics(SM_CYSMICON), icon);
 	}
 
 private:

--- a/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
+++ b/PowerEditor/src/WinControls/ReadDirectoryChanges/ReadDirectoryChangesPrivate.h
@@ -77,9 +77,9 @@ protected:
 			LPOVERLAPPED lpOverlapped);					// I/O information buffer
 
 	// Parameters from the caller for ReadDirectoryChangesW().
-	DWORD m_dwFilterFlags = 0;
-	BOOL m_bIncludeChildren = FALSE;
 	std::wstring m_wstrDirectory;
+	BOOL m_bIncludeChildren = FALSE;
+	DWORD m_dwFilterFlags = 0;
 
 	// Result of calling CreateFile().
 	HANDLE		m_hDirectory = nullptr;

--- a/PowerEditor/src/dpiManagerV2.cpp
+++ b/PowerEditor/src/dpiManagerV2.cpp
@@ -265,7 +265,7 @@ void DPIManagerV2::sendMessageToChildControls(HWND hwndParent, UINT msg, WPARAM 
 	}, reinterpret_cast<LPARAM>(&p));
 }
 
-void DPIManagerV2::loadIcon(HINSTANCE hinst, wchar_t* pszName, int cx, int cy, HICON* phico, UINT fuLoad)
+void DPIManagerV2::loadIcon(HINSTANCE hinst, const wchar_t* pszName, int cx, int cy, HICON* phico, UINT fuLoad)
 {
 	if (::LoadIconWithScaleDown(hinst, pszName, cx, cy, phico) != S_OK)
 	{

--- a/PowerEditor/src/dpiManagerV2.h
+++ b/PowerEditor/src/dpiManagerV2.h
@@ -128,7 +128,7 @@ public:
 	}
 
 	static void sendMessageToChildControls(HWND hwndParent, UINT msg, WPARAM wParam, LPARAM lParam);
-	static void loadIcon(HINSTANCE hinst, wchar_t* pszName, int cx, int cy, HICON* phico, UINT fuLoad = LR_DEFAULTCOLOR);
+	static void loadIcon(HINSTANCE hinst, const wchar_t* pszName, int cx, int cy, HICON* phico, UINT fuLoad = LR_DEFAULTCOLOR);
 
 private:
 	UINT _dpi = USER_DEFAULT_SCREEN_DPI;


### PR DESCRIPTION
fix gcc reorder warning 
https://github.com/notepad-plus-plus/notepad-plus-plus/actions/runs/8963463099/job/24613797904#step:4:403
