### PR TITLE
Add plugin command NPPM_GETTABCOLORID

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -964,6 +964,19 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// if isAllocatedSuccessful is TRUE, and value of idBegin is 7
 	// then indicator ID 7 is preserved by Notepad++, and it is safe to be used by the plugin.
 
+	#define NPPM_NPPM_GET_TABCOLORINDEX (NPPMSG + 114)
+	// int NPPM_NPPM_GET_TABCOLORINDEX(int tabIndex, int inView)
+	// Get the current tab color index of the specified tab and view.
+	// wParam[in]: tabIndex; use -1 for currently active tab
+	// lParam[in]: inView, use 0 (main view) or 1 (sub view) or -1 (active view)
+	// Return -1 if the tab has no color, otherwise the current color index (0 - 4).
+
+	#define NPPM_NPPM_SET_TABCOLORINDEX (NPPMSG + 115)
+	// int NPPM_NPPM_SET_TABCOLORINDEX(int colorIndex)
+	// Set a new tab color index for the active tab in the active view.
+	// wParam[in]: colorIndex; use -1 for no color, otherwise 0 - 4
+	// lParam: unused
+	// Return previous color index of the tab (-1 - 4).
 
 	// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -964,19 +964,27 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// if isAllocatedSuccessful is TRUE, and value of idBegin is 7
 	// then indicator ID 7 is preserved by Notepad++, and it is safe to be used by the plugin.
 
-	#define NPPM_NPPM_GET_TABCOLORINDEX (NPPMSG + 114)
-	// int NPPM_NPPM_GET_TABCOLORINDEX(int tabIndex, int inView)
-	// Get the current tab color index of the specified tab and view.
-	// wParam[in]: tabIndex; use -1 for currently active tab
-	// lParam[in]: inView, use 0 (main view) or 1 (sub view) or -1 (active view)
-	// Return -1 if the tab has no color, otherwise the current color index (0 - 4).
-
-	#define NPPM_NPPM_SET_TABCOLORINDEX (NPPMSG + 115)
-	// int NPPM_NPPM_SET_TABCOLORINDEX(int colorIndex)
-	// Set a new tab color index for the active tab in the active view.
-	// wParam[in]: colorIndex; use -1 for no color, otherwise 0 - 4
-	// lParam: unused
-	// Return previous color index of the tab (-1 - 4).
+	#define NPPM_GETTABCOLORID (NPPMSG + 114)
+	// int NPPM_GETTABCOLORID (int view, int tabIndex)
+	// Get the tab color id with given view and tab index.
+	// 
+	// wParam[in]: VIEW
+		// Here's the values for the view:
+		//  MAIN_VIEW 0
+		//  SUB_VIEW  1
+		//  active    -1
+	// 
+	// lParam[in]: TABINDEX
+		// Zero-based, i.e., use 0 for first tab, 1 for second tab, etc.; use -1 for active tab
+	//
+	// Return tab color id
+		// tab color id contains the following values:
+		//  -1 (no color)
+		//   0 (yellow)
+		//   1 (green)
+		//   2 (blue)
+		//   3 (orange)
+		//   4 (pink)
 
 	// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2955,9 +2955,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_GETTABCOLORID:
 		{
-			const auto view = static_cast<INT>(wParam);
-			auto tabIndex = static_cast<INT>(lParam);
+			const auto view = static_cast<int>(wParam);
+			auto tabIndex = static_cast<int>(lParam);
+
 			auto colorId = -1;  // no color (or unknown)
+
 			auto pDt = _pDocTab;  // active view
 			if (view == MAIN_VIEW)
 			{
@@ -2967,14 +2969,17 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			{
 				pDt = &_subDocTab;
 			}
+
 			if (tabIndex == -1)
 			{
 				tabIndex = pDt->getCurrentTabIndex();
 			}
-			if ((tabIndex >= 0) && (tabIndex < static_cast<INT>(pDt->nbItem())))
+			
+			if ((tabIndex >= 0) && (tabIndex < static_cast<int>(pDt->nbItem())))
 			{
 				colorId = pDt->getIndividualTabColour(tabIndex);
 			}
+			
 			return colorId;
 		}
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2953,6 +2953,51 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return _pluginsManager.allocateIndicator(static_cast<int32_t>(wParam), reinterpret_cast<int *>(lParam));
 		}
 
+		case NPPM_NPPM_GET_TABCOLORINDEX:
+		{
+			auto tabIndex = static_cast<INT>(wParam);
+			const auto view = static_cast<INT>(lParam);
+			auto colorIndex = -1;  // no color (or unknown)
+			auto pDt = _pDocTab;  // active view
+			if (view == MAIN_VIEW)
+			{
+				pDt = &_mainDocTab;
+			}
+			else if (view == SUB_VIEW)
+			{
+				pDt = &_subDocTab;
+			}
+			if (tabIndex == -1)
+			{
+				tabIndex = pDt->getCurrentTabIndex();
+			}
+			if ((tabIndex >= 0) && (tabIndex < pDt->nbItem()))
+			{
+				colorIndex = pDt->getIndividualTabColour(tabIndex);
+			}
+			return colorIndex;
+		}
+
+		case NPPM_NPPM_SET_TABCOLORINDEX:
+		{
+			// operates only upon active tab in active view
+			const auto newColorIndex = static_cast<INT>(wParam);
+			const auto currentTabIndex = _pDocTab->getCurrentTabIndex();
+			const auto oldColorIndex = _pDocTab->getIndividualTabColour(currentTabIndex);
+			if ((newColorIndex != oldColorIndex) && (newColorIndex >= -1) &&
+				(newColorIndex <= IDM_VIEW_TAB_COLOUR_5 - IDM_VIEW_TAB_COLOUR_NONE - 1))
+			{
+				const auto bufferID = _pDocTab->getBufferByIndex(currentTabIndex);
+				_pDocTab->setIndividualTabColour(bufferID, newColorIndex);
+				_pDocTab->redraw();
+				if (_pDocumentListPanel != nullptr)
+				{
+					_pDocumentListPanel->setItemColor(bufferID);
+				}
+			}
+			return oldColorIndex;
+		}
+
 		case NPPM_GETBOOKMARKID:
 		{
 			return MARK_BOOKMARK;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2953,11 +2953,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return _pluginsManager.allocateIndicator(static_cast<int32_t>(wParam), reinterpret_cast<int *>(lParam));
 		}
 
-		case NPPM_NPPM_GET_TABCOLORINDEX:
+		case NPPM_GETTABCOLORID:
 		{
-			auto tabIndex = static_cast<INT>(wParam);
-			const auto view = static_cast<INT>(lParam);
-			auto colorIndex = -1;  // no color (or unknown)
+			const auto view = static_cast<INT>(wParam);
+			auto tabIndex = static_cast<INT>(lParam);
+			auto colorId = -1;  // no color (or unknown)
 			auto pDt = _pDocTab;  // active view
 			if (view == MAIN_VIEW)
 			{
@@ -2971,31 +2971,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			{
 				tabIndex = pDt->getCurrentTabIndex();
 			}
-			if ((tabIndex >= 0) && (tabIndex < pDt->nbItem()))
+			if ((tabIndex >= 0) && (tabIndex < static_cast<INT>(pDt->nbItem())))
 			{
-				colorIndex = pDt->getIndividualTabColour(tabIndex);
+				colorId = pDt->getIndividualTabColour(tabIndex);
 			}
-			return colorIndex;
-		}
-
-		case NPPM_NPPM_SET_TABCOLORINDEX:
-		{
-			// operates only upon active tab in active view
-			const auto newColorIndex = static_cast<INT>(wParam);
-			const auto currentTabIndex = _pDocTab->getCurrentTabIndex();
-			const auto oldColorIndex = _pDocTab->getIndividualTabColour(currentTabIndex);
-			if ((newColorIndex != oldColorIndex) && (newColorIndex >= -1) &&
-				(newColorIndex <= IDM_VIEW_TAB_COLOUR_5 - IDM_VIEW_TAB_COLOUR_NONE - 1))
-			{
-				const auto bufferID = _pDocTab->getBufferByIndex(currentTabIndex);
-				_pDocTab->setIndividualTabColour(bufferID, newColorIndex);
-				_pDocTab->redraw();
-				if (_pDocumentListPanel != nullptr)
-				{
-					_pDocumentListPanel->setItemColor(bufferID);
-				}
-			}
-			return oldColorIndex;
+			return colorId;
 		}
 
 		case NPPM_GETBOOKMARKID:


### PR DESCRIPTION
Fix #15115 

Note that the implementation I chose was to allow "setting" only for the active tab in the active view.  "Getting", however, can be done on any tab in either view.  Mainly this choice was to "keep it simple", but in reality it isn't that big of an "ask" to whatever calls the "set" to make the tab active first.

Other choices were arbitrary as well, e.g. using `-1` to refer to the active tab (or view).  I don't know if these choices will be liked.