### PR TITLE
Convert negative "repeat" values in Column Editor to 1

### DIFF
--- a/PowerEditor/src/ScintillaComponent/columnEditor.cpp
+++ b/PowerEditor/src/ScintillaComponent/columnEditor.cpp
@@ -242,7 +242,7 @@ intptr_t CALLBACK ColumnEditorDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 						int initialNumber = ::GetDlgItemInt(_hSelf, IDC_COL_INITNUM_EDIT, NULL, TRUE);
 						int increaseNumber = ::GetDlgItemInt(_hSelf, IDC_COL_INCREASENUM_EDIT, NULL, TRUE);
 						int repeat = ::GetDlgItemInt(_hSelf, IDC_COL_REPEATNUM_EDIT, NULL, TRUE);
-						if (repeat == 0)
+						if (repeat <= 0)
 						{
 							repeat = 1; // Without this we might get an infinite loop while calculating the set "numbers" below.
 						}


### PR DESCRIPTION
Fix #15153
Now all negative `repeat` values in the Column Editor will be converted to 1, along with 0.
Probably it would be a good idea to check if there are similar issues elsewhere in the codebase.

To test: try pasting any negative number into the `repeat` box of the Column Editor. Observe that this is treated as if the user entered 1.