### PR TITLE
Update Swedish localization

### DIFF
--- a/PowerEditor/installer/nativeLang/swedish.xml
+++ b/PowerEditor/installer/nativeLang/swedish.xml
@@ -474,7 +474,7 @@ Translation note:
 				<Item id="1605" name="&amp;Reguljärt uttryck"/>
 				<Item id="1606" name="L&amp;oopa"/>
 				<Item id="1614" name="Anta&amp;l sökträffar"/>
-				<Item id="1615" name="Markera alla"/>
+				<Item id="1615" name="Markera &amp;alla"/>
 				<Item id="1616" name="&amp;Bokmärk rad"/>
 				<Item id="1618" name="Rensa vid varje sökning"/>
 				<Item id="1611" name="Ers&amp;ätt med: "/>
@@ -483,7 +483,7 @@ Translation note:
 				<Item id="1687" name="Vid förlorat fokus"/>
 				<Item id="1688" name="Alltid"/>
 				<Item id="1632" name="I mar&amp;kering"/>
-				<Item id="1633" name="Rensa alla markeringar"/>
+				<Item id="1633" name="R&amp;ensa alla markeringar"/>
 				<Item id="1635" name="Ersätt alla i alla &amp;öppna dokument"/>
 				<Item id="1636" name="Sök alla i alla ö&amp;ppna dokument"/>
 				<Item id="1654" name="&amp;Filter: "/>
@@ -505,7 +505,7 @@ Translation note:
 				<Item id="1703" name="&amp;. matchar ny rad"/>
 				<Item id="1721" name="▲"/>
 				<Item id="1723" name="▼ Hitta nästa"/>
-				<Item id="1725" name="Kopiera markerad text"/>
+				<Item id="1725" name="Ko&amp;piera markerad text"/>
 				<Menu>
 					<Item id="1726" name="⇅ Byt Sök med Ersätt"/>
 					<Item id="1727" name="⤵ Kopiera från Sök till Ersätt"/>


### PR DESCRIPTION
The Mark dialog has "always" been missing a few keyboard hotkeys in the Swedish translation.

I've added them, and tried to adhere to letters used for similar command elsewhere.

I've tried to make sure there are no key collisions (before my changes, the keys I chose produced a Windows "ding" sound when I tried them).