### PR TITLE
Remove rounding up to even when computing the number of digits of a hexadecimal value

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -175,9 +175,6 @@ int getNbDigits(int aNum, int base)
 		aNum /= base;
 	} while (aNum != 0);
 
-	if (base == 16 && nbDigits % 2 != 0)
-		++nbDigits;
-
 	return nbDigits;
 }
 


### PR DESCRIPTION
Fix #15168