### PR TITLE
- update CI link from appveyor to GH action

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -52,7 +52,7 @@ uses features from Boost's `Boost.Regex` library.
 
 If you have [MinGW-w64](https://www.mingw-w64.org/) installed, you can compile Notepad++ with GCC. Otherwise MinGW-w64 can be downloaded [here](https://sourceforge.net/projects/mingw-w64/files/). You can also download some collection of tools which supports MinGW-w64, like [MSYS2](https://www.msys2.org/) or [WinLibs](https://winlibs.com/).
 
-Building Notepad++ is regularly tested on a Windows system by using [MSYS2](https://www.msys2.org/) project. Current versions of tools used to building (such as GCC, Make or Bash) can be checked by looking at some logs from the finished building (for example in the [current-build page](https://ci.appveyor.com/project/donho/notepad-plus-plus)). Other versions may also work but are untested.
+Building Notepad++ is regularly tested on a Windows system by using [MSYS2](https://www.msys2.org/) project. Current versions of tools used to building (such as GCC, Clang, Make or Bash) can be checked by looking at some logs from the finished building (for example in the [current-build page](https://github.com/notepad-plus-plus/notepad-plus-plus/actions/workflows/CI_build.yml). Other versions may also work but are untested.
 
 **Note:** Before building make sure that the system `PATH` environment variable contains `$MinGW-root$\bin` directory. Otherwise you have to set this directory yourself in Windows settings. You can also use a command like `set PATH=$MinGW-root$\bin;%PATH%` each time `cmd` is launched. But beware that if `PATH` contains several versions of MinGW-w64 GCC, only the first one will be usable.
 
@@ -70,3 +70,5 @@ Building Notepad++ is regularly tested on a Windows system by using [MSYS2](http
 - To see commands being executed add `VERBOSE=1` to the same command.
 - When a project is built outside of the `PowerEditor/gcc` directory, for example when using `-f` option, then the entire project path must not contain any spaces. Additionally, the path to `makefile` of this project should be listed as first.
 - When a project is built through MinGW-w64 with multilib support, a specific target can be forced by passing `TARGET_CPU` variable with `x86_64` or `i686` as value.
+- To use Clang instead of GCC for compilation provide `CXX` variable with `clang++` as value.
+- To use [Clang analyzer](https://clang-analyzer.llvm.org/) together with Clang provide `CLANGANALYZE=1` to the `mingw32-make` invocation.

--- a/PowerEditor/gcc/makefile
+++ b/PowerEditor/gcc/makefile
@@ -36,7 +36,12 @@ SCINTILLA_TARGET := libscintilla.a
 LEXILLA_DIRECTORY := ../../lexilla
 LEXILLA_TARGET := liblexilla.a
 
-CXX := $(CROSS_COMPILE)g++
+ifeq ($(CXX),clang++)
+  CXX := $(CROSS_COMPILE)clang++
+else
+  CXX := $(CROSS_COMPILE)g++
+endif
+
 CXXFLAGS := -include $(GCC_DIRECTORY)/gcc-fixes.h -std=c++20
 RC := $(CROSS_COMPILE)windres
 RCFLAGS :=
@@ -61,6 +66,10 @@ BUILD_TYPE := debug
 BUILD_SUFFIX := -debug
 CXXFLAGS += -Og -g -Wpedantic -Wall -Wextra -Wno-cast-function-type -Wno-overloaded-virtual -Wconversion
 CPP_DEFINE += DEBUG
+endif
+
+ifneq "$(filter-out 0,$(CLANGANALYZE))" ""
+CXXFLAGS += --analyze -Xanalyzer -analyzer-output=text
 endif
 
 #


### PR DESCRIPTION
- add option to makefile build mingw build also with Clang++ instead of g++
- add option to makefile to enable clang analyzer for the N++ part

Within CI config build_windows_msys2:

https://github.com/chcg/notepad-plus-plus/blob/9c1f972ee38edc8f0114d815e781c024493a3c76/.github/workflows/CI_build.yml#L368

needs to be changed to
`        if ( $${{ matrix.build_platform == 'x86_64'}} ) {bash -lc "pacman --noconfirm -S mingw-w64-x86_64-clang mingw-w64-x86_64-make"}`

and 

https://github.com/chcg/notepad-plus-plus/blob/9c1f972ee38edc8f0114d815e781c024493a3c76/.github/workflows/CI_build.yml#L373

`        mingw32-make -f PowerEditor\gcc\makefile CXX=clang++`
or
`        mingw32-make -f PowerEditor\gcc\makefile CXX=clang++ CLANGANALYZE=1`

for testing. Example run see:

https://github.com/chcg/notepad-plus-plus/actions/runs/9234522582/job/25408282819

with clang and clang analyszer.