### PR TITLE
[XML] Update italian.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "utf-8" ?>
 <!--
-    Italian translation for Notepad++ 8.6.7
-    Last modified Sat, May 25th, 2024.
+    Italian translation for Notepad++ 8.6.9
+    Last modified Wen, Jun 5th, 2024.
     For updates, see https://github.com/notepad-plus-plus/notepad-plus-plus/tree/master/PowerEditor/installer/nativeLang
 -->
 <!--
@@ -10,7 +10,7 @@ Translation note:
 2. All the comments are for explanation, they are not for translation.
 -->
 <NotepadPlus>
-	<Native-Langue name="Italiano" filename="italian.xml" version="8.6.7">
+	<Native-Langue name="Italiano" filename="italian.xml" version="8.6.9">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -35,7 +35,7 @@ Translation note:
 					<Item subMenuId="file-recentFiles" name="File recenti"/>
 					<Item subMenuId="edit-insert" name="Inserisci"/>
 					<Item subMenuId="edit-copyToClipboard" name="Copia negli Appunti"/>
-					<Item subMenuId="edit-indent" name="&amp;Indenta"/>
+					<Item subMenuId="edit-indent" name="&amp;Rientro"/>
 					<Item subMenuId="edit-convertCaseTo" name="Con&amp;verti MAIUSCOLO/minuscolo"/>
 					<Item subMenuId="edit-lineOperations" name="Operazioni sulle righe"/>
 					<Item subMenuId="edit-comment" name="Commenta/Rimuovi commenti"/>
@@ -128,8 +128,8 @@ Translation note:
 					<Item id="42084" name="Data e ora (formato ridotto)"/>
 					<Item id="42085" name="Data e ora (formato esteso)"/>
 					<Item id="42086" name="Data e ora (formato personalizzato)"/>
-					<Item id="42008" name="Inserisci tabulazione (indent)"/>
-					<Item id="42009" name="Rimuovi tabulazione (outdent)"/>
+					<Item id="42008" name="Aumenta rientro"/>
+					<Item id="42009" name="Riduci rientro"/>
 					<Item id="42010" name="Duplica la riga corrente"/>
 					<Item id="42079" name="Rimuovi le righe duplicate"/>
 					<Item id="42077" name="Rimuovi le righe duplicate consecutive"/>
@@ -288,12 +288,12 @@ Translation note:
 					<Item id="44019" name="Visualizza tutti i caratteri"/>
 					<Item id="44020" name="Visualizza guide di indentazione"/>
 					<Item id="44022" name="Attiva ritorno a capo automatico"/>
-					<Item id="44023" name="&amp;Ingrandisci testo"/>
-					<Item id="44024" name="&amp;Riduci testo"/>
+					<Item id="44023" name="&amp;Ingrandisci testo (Ctrl+rotellina Mouse Su)"/>
+					<Item id="44024" name="&amp;Riduci testo (Ctrl+rotellina Mouse Giù)"/>
 					<Item id="44025" name="Visualizza gli spazi e le tabulazioni"/>
 					<Item id="44026" name="Visualizza carattere di fine riga"/>
 					<Item id="44029" name="Espandi tutti i livelli"/>
-					<Item id="44030" name="Contrai al livello corrente"/>
+					<Item id="44030" name="Contrai il livello corrente"/>
 					<Item id="44031" name="Espandi il livello corrente"/>
 					<Item id="44049" name="Informazioni file..."/>
 					<Item id="44080" name="Mappa documento"/>
@@ -383,16 +383,16 @@ Translation note:
 					<Item id="48015" name="Gestione plugin..."/>
 					<Item id="48501" name="Genera..."/>
 					<Item id="48502" name="Genera da file..."/>
-					<Item id="48503" name="Genera negli Appunti"/>
+					<Item id="48503" name="Genera dalla selezione negli Appunti"/>
 					<Item id="48504" name="Genera..."/>
 					<Item id="48505" name="Genera da file..."/>
-					<Item id="48506" name="Genera da selezione negli Appunti"/>
+					<Item id="48506" name="Genera dalla selezione negli Appunti"/>
 					<Item id="48507" name="Genera..."/>
 					<Item id="48508" name="Genera da file..."/>
-					<Item id="48509" name="Genera dalla selezione agli Appunti"/>
+					<Item id="48509" name="Genera dalla selezione negli Appunti"/>
 					<Item id="48510" name="Genera..."/>
 					<Item id="48511" name="Genera da file..."/>
-					<Item id="48512" name="Genera dalla selezione agli Appunti"/>
+					<Item id="48512" name="Genera dalla selezione negli Appunti"/>
 					<Item id="49000" name="E&amp;segui..."/>
 
 					<Item id="50000" name="Completa funzione"/>
@@ -553,7 +553,7 @@ Translation note:
 				<Item id="1904" name="Salva..."/>
 			</Run>
 
-			<MD5FromFilesDlg title="Genera firma MD5 di file">
+			<MD5FromFilesDlg title="Genera firma MD5 da file">
 				<Item id="1922" name="Scegli i file da cui &amp;generare MD5..."/>
 				<Item id="1924" name="Co&amp;pia negli Appunti"/>
 				<Item id="2" name="&amp;Chiudi"/>
@@ -590,7 +590,7 @@ Translation note:
 			</SHA1FromTextDlg>
 
 			<SHA512FromFilesDlg title="Genera firma SHA-512 da file">
-				<Item id="1922" name="Scegli i file da cui &amp;generare  SHA-512..."/>
+				<Item id="1922" name="Scegli i file da cui &amp;generare SHA-512..."/>
 				<Item id="1924" name="Co&amp;pia negli Appunti"/>
 				<Item id="2" name="&amp;Chiudi"/>
 			</SHA512FromFilesDlg>
@@ -761,7 +761,7 @@ Translation note:
 				</MainCommandNames>
 			</ShortcutMapper>
 			<ShortcutMapperSubDialg title="Scelta rapida">
-				<Item id="1" name="Ok"/>
+				<Item id="1" name="Conferma"/>
 				<Item id="2" name="Annulla"/>
 				<Item id="5006" name="Nome"/>
 				<Item id="5008" name="Aggiungi"/>
@@ -816,7 +816,7 @@ Translation note:
 					<Item id="25028" name="Numeri"/>
 					<Item id="25033" name="Trasparente"/>
 					<Item id="25034" name="Trasparente"/>
-					<Item id="1" name="OK"/>
+					<Item id="1" name="Conferma"/>
 					<Item id="2" name="Annulla"/>
 				</StylerDialog>
 				<Folder title="Cartelle e Predefiniti">
@@ -1002,7 +1002,7 @@ Translation note:
 
 				<Scintillas2 title="Modifica 2">
 					<Item id="6521" name="Multi-Modifica"/>
-					<Item id="6522" name="Abilita la Multi-Modifica (Ctrl+Mouse click/selection)"/>
+					<Item id="6522" name="Abilita la Multi-Modifica (Ctrl+Clic del mouse/selezione)"/>
 					<Item id="6523" name="Abilita la Selezione colonna alla Multi-Modifica"/>
 					<Item id="6247" name="Fine Riga (CRLF)"/><!-- Don't translate "(CRLF)" -->
 					<Item id="6248" name="Predefinito"/>
@@ -1105,9 +1105,11 @@ Translation note:
 					<Item id="6506" name="Linguaggi disabilitati"/>
 					<Item id="6507" name="Utilizza menu compatto"/>
 					<Item id="6508" name="Menu linguaggio"/>
-					<Item id="6301" name="Impostazioni Tabulazioni"/>
-					<Item id="6302" name="Sostituisci con spazi"/>
-					<Item id="6303" name="Dimensione tabulazione:"/>
+					<Item id="6301" name="Impostazioni di rientro"/>
+					<Item id="6302" name="Spazi"/>
+					<Item id="6303" name="Dimensione rientro:"/>
+					<Item id="6310" name="Il rientro usa:"/>
+					<Item id="6311" name="Tabulazioni"/>
 					<Item id="6510" name="Usa predefinito"/>
 					<Item id="6335" name="Backslash è il carattere di escape in SQL"/>
 				</Language>
@@ -1266,7 +1268,7 @@ Translation note:
 				<Performance title="Prestazioni">
 					<Item id="7141" name="Restrizioni per File di grandi dimensioni"/>
 					<Item id="7143" name="Abilita restrizioni per i file di grandi dimensioni (no evidenziazione sintattica)"/>
-					<Item id="7144" name="Definizione dei file di grandi dimensioni:"/>
+					<Item id="7144" name="Definizione file di grandi dimensioni:"/>
 					<Item id="7146" name="MB   (1 - 2046)"/>
 					<Item id="7147" name="Permetti l&apos;evidenziazione della parentesi corrispondente"/>
 					<Item id="7148" name="Permetti l&apos;attivazione Auto-Completamento"/>
@@ -1334,7 +1336,7 @@ Translation note:
 			</MultiMacro>
 			<Window title="Finestre">
 				<Item id="1" name="Attiva"/>
-				<Item id="2" name="OK"/>
+				<Item id="2" name="Conferma"/>
 				<Item id="7002" name="Salva"/>
 				<Item id="7003" name="Chiudi scheda/e"/>
 				<Item id="7004" name="Ordina schede"/>
@@ -1342,8 +1344,8 @@ Translation note:
 			<ColumnEditor title="Editor a colonne">
 				<Item id="2023" name="&amp;Testo da inserire"/>
 				<Item id="2033" name="&amp;Numero da inserire"/>
-				<Item id="2030" name="Numero &amp;iniziale:"/>
-				<Item id="2031" name="Incrementa di:"/>
+				<Item id="2030" name="N&amp;umero iniziale:"/>
+				<Item id="2031" name="&amp;Incrementa di:"/>
 				<Item id="2038" name="Inizia&amp;li:"/>
 				<ComboBox id="2039">
 					<Element name="Niente"/>
@@ -1354,9 +1356,9 @@ Translation note:
 				<Item id="2032" name="Formato"/>
 				<Item id="2024" name="&amp;Decimale"/>
 				<Item id="2025" name="&amp;Ottale"/>
-				<Item id="2026" name="Esadecimale"/>
+				<Item id="2026" name="&amp;Esadecimale"/>
 				<Item id="2027" name="&amp;Binario"/>
-				<Item id="1" name="OK"/>
+				<Item id="1" name="Conferma"/>
 				<Item id="2" name="Annulla"/>
 			</ColumnEditor>
 			<FindInFinder title="Trova tra i risultati">
@@ -1700,7 +1702,7 @@ Cerca in tutti i file, ma escludi tutte le cartelle o sottocartelle log o logs:
 			<finder-open-all value="Apri tutto"/>
 			<finder-purge-for-every-search value="Pulisci ad ogni ricerca"/>
 			<finder-wrap-long-lines value="Attiva il Ritorno a capo automatico"/>
-			<common-ok value="OK"/>
+			<common-ok value="Conferma"/>
 			<common-cancel value="Annulla"/>
 			<common-name value="Nome"/>
 			<tabrename-title value="Rinomina scheda corrente"/>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -1177,7 +1177,7 @@ Translation note:
 					<Item id="6907" name="Quando viene richiamata la finestra di dialogo Trova"/>
 					<Item id="6908" name="Compila il campo di ricerca con il testo selezionato"/>
 					<Item id="6909" name="Proponi la parola del cursore quando non è selezionato nulla"/>
-					<Item id="6910" name="Dimensione minima per l'abilitazione automatica dell'opzione &quot;Nella selezione&quot;:"/>
+					<Item id="6910" name="Dim. minima per l'abilitazione automatica di &quot;Nella selezione&quot;:"/>
 				</Searching>
 
 				<RecentFilesHistory title="Cronologia File Recenti">

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "utf-8" ?>
 <!--
-    Italian translation for Notepad++ 8.6.5
-    Last modified Tue, March 12th, 2023.
+    Italian translation for Notepad++ 8.6.7
+    Last modified Sat, May 25th, 2024.
     For updates, see https://github.com/notepad-plus-plus/notepad-plus-plus/tree/master/PowerEditor/installer/nativeLang
 -->
 <!--
@@ -10,7 +10,7 @@ Translation note:
 2. All the comments are for explanation, they are not for translation.
 -->
 <NotepadPlus>
-	<Native-Langue name="Italiano" filename="italian.xml" version="8.6.5">
+	<Native-Langue name="Italiano" filename="italian.xml" version="8.6.7">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -123,7 +123,7 @@ Translation note:
 					<Item id="42005" name="&amp;Incolla"/>
 					<Item id="42006" name="&amp;Elimina"/>
 					<Item id="42007" name="Seleziona t&amp;utto"/>
-					<Item id="42020" name="Inizio/Fine selezione"/>
+					<Item id="42020" name="Inizio/Fine &amp;selezione"/>
 					<Item id="42089" name="Inizio/Fine selezione in modalità Selezione-Colonna"/>
 					<Item id="42084" name="Data e ora (formato ridotto)"/>
 					<Item id="42085" name="Data e ora (formato esteso)"/>
@@ -473,11 +473,11 @@ Translation note:
 				<Item id="1" name="Trova Successivo"/>
 				<Item id="1722" name="Ricerca a ritroso"/>
 				<Item id="2" name="Chiudi"/>
-				<Item id="1620" name="Trova:"/>
+				<Item id="1620" name="&amp;Trova:"/>
 				<Item id="1603" name="Solo &amp;parole intere"/>
 				<Item id="1604" name="Distingui tra ma&amp;iuscole e minuscole"/>
-				<Item id="1605" name="Espressione regolare"/>
-				<Item id="1606" name="Torna all'inizio se raggiunta la fine"/>
+				<Item id="1605" name="Espressione re&amp;golare"/>
+				<Item id="1606" name="Torna all'ini&amp;zio se raggiunta la fine"/>
 				<Item id="1614" name="Conta corrispondenze"/>
 				<Item id="1615" name="Trova tutti"/>
 				<Item id="1616" name="Imposta un segnalibro sulla riga"/>
@@ -491,14 +491,14 @@ Translation note:
 				<Item id="1633" name="Pulisci evidenziazioni"/>
 				<Item id="1635" name="Sostituisci in tutti i documenti aperti"/>
 				<Item id="1636" name="Ricerca in tutti i documenti aperti"/>
-				<Item id="1654" name="Filtri:"/>
+				<Item id="1654" name="&amp;Filtri:"/>
 				<Item id="1655" name="Cart&amp;ella:"/>
 				<Item id="1656" name="Trova tutti"/>
-				<Item id="1658" name="Nelle sottocartelle"/>
-				<Item id="1659" name="Nelle cartelle nascoste"/>
+				<Item id="1658" name="Nelle sotto&amp;cartelle"/>
+				<Item id="1659" name="Nelle cartelle &amp;nascoste"/>
 				<Item id="1624" name="Tipo di ricerca"/>
 				<Item id="1625" name="&amp;Normale"/>
-				<Item id="1626" name="Estesa (\n, \r, \t, \0, \x...)"/>
+				<Item id="1626" name="Estesa (\n, \r, \t, \0, \&amp;x...)"/>
 				<Item id="1660" name="Sostituisci nei file"/>
 				<Item id="1665" name="Sostituisci nei Progetti"/>
 				<Item id="1661" name="Segui documento corrente"/>
@@ -520,8 +520,8 @@ Translation note:
 
 			<IncrementalFind title="">
 				<Item id="1681" name="Trova:"/>
-				<Item id="1685" name="MAIUSCOLE/minuscole"/>
-				<Item id="1690" name="Evidenzia tutto"/>
+				<Item id="1685" name="Maiuscole/&amp;minuscole"/>
+				<Item id="1690" name="Evidenzia &amp;tutto"/>
 			</IncrementalFind>
 
 			<FindCharsInRange title="Trova caratteri...">
@@ -530,16 +530,16 @@ Translation note:
 				<Item id="2902" name="Caratteri &amp;ASCII (0 - 127)"/>
 				<Item id="2903" name="Intervallo personalizzato (0-255):"/>
 				<Item id="2906" name="S&amp;u"/>
-				<Item id="2907" name="Giù"/>
+				<Item id="2907" name="&amp;Giù"/>
 				<Item id="2908" name="Direzione"/>
-				<Item id="2909" name="Torna su se raggiunta la fine"/>
-				<Item id="2910" name="Trova"/>
+				<Item id="2909" name="Torna ini&amp;zio se raggiunta la fine"/>
+				<Item id="2910" name="&amp;Trova"/>
 			</FindCharsInRange>
 
 			<GoToLine title="Vai alla riga/posizione #">
 				<Item id="2007" name="Riga"/>
 				<Item id="2008" name="Posizione carattere"/>
-				<Item id="1" name="&amp;Vai !"/>
+				<Item id="1" name="&amp;Vai"/>
 				<Item id="2" name="Annulla"/>
 				<Item id="2004" name="Sei alla riga/posizione:"/>
 				<Item id="2005" name="Vai alla riga/posizione:"/>
@@ -548,7 +548,7 @@ Translation note:
 
 			<Run title="Esegui...">
 				<Item id="1903" name="Programma da eseguire"/>
-				<Item id="1" name="Esegui!"/>
+				<Item id="1" name="Esegui"/>
 				<Item id="2" name="Annulla"/>
 				<Item id="1904" name="Salva..."/>
 			</Run>
@@ -1095,7 +1095,7 @@ Translation note:
 				</DefaultDir>
 
 				<FileAssoc title="Associazione file">
-					<Item id="4008" name="Chiudi e rilancia Notepad++ con privilegi di Amministratore per usare questa funzionalità"/>
+					<Item id="4008" name="Chiudi e rilancia Notepad++ con i privilegi di Amministratore per usare questa funzionalità"/>
 					<Item id="4009" name="Estensioni supportate:"/>
 					<Item id="4010" name="Estensioni registrate:"/>
 				</FileAssoc>
@@ -1369,7 +1369,7 @@ Translation note:
 				<Item id="1716" name="Tipo di ricerca"/>
 				<Item id="1717" name="&amp;Normale"/>
 				<Item id="1719" name="Espressione re&amp;golare"/>
-				<Item id="1718" name="Estesa (\n, \r, \t, \0, \x...)"/>
+				<Item id="1718" name="Estesa (\n, \r, \t, \0, \&amp;x...)"/>
 				<Item id="1720" name="&amp;. significa a capo"/>
 			</FindInFinder>
 			<DoSaveOrNot title="Salva">
@@ -1404,11 +1404,11 @@ Tutte le modifiche salvate non possono essere ripristinate.
 Continuare?"/><!-- HowToReproduce: when you openned file is modified and saved, then you are changing file encoding. -->
 			<CannotMoveDoc title="Invia a una nuova istanza di Notepad++" message="Il documento è stato modificato, salvarlo prima di continuare."/>
 			<DocReloadWarning title="Ricarica" message="Vuoi ricaricare il file? Ogni modifica apportata andrà persa."/>
-			<FileLockedWarning title="Salvataggio fallito" message="Verificare che il file non sia aperto con un altro programma."/>
+			<FileLockedWarning title="Salvataggio non andato a buon fine" message="Verificare che il file non sia aperto da un altro programma."/>
 			<FileAlreadyOpenedInNpp title="" message="Il file è già aperto in Notepad++."/>
-			<RenameTabTemporaryNameAlreadyInUse title="Rinomina fallita" message="Il file specificato è già in uso su un&apos;altra scheda."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
+			<RenameTabTemporaryNameAlreadyInUse title="Rinomina non andata a buon fine" message="Il file specificato è già in uso su un&apos;altra scheda."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
 			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="Il nome inserito non può rimanere vuoto, e non può contenere soltanto spazi o TAB."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
-			<DeleteFileFailed title="Eliminazione file" message="Eliminazione del file fallita."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<DeleteFileFailed title="Eliminazione file non andata a buon fine" message="Eliminazione del file non andata a buon fine."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Il numero di file da aprire è troppo grande" message="Si stanno aprendo $INT_REPLACE$ file.
 Vuoi procedere?"/><!-- HowToReproduce: Check "Open all files of folder instead of launching Folder as Workspace on folder dropping" in "Default Directory" of Preferences dialog, then drop a folder which contains more then 200 files into Notepad++. -->
@@ -1432,7 +1432,7 @@ Esistono 3 modi per passare alla modalità Selezione-Colonna:
        selezionare la funzione &quot;Inizio/Fine selezione in modalità Selezione-Colonna&quot;;
       Spostare il cursore all&apos;estremità del blocco di colonna desiderato, quindi
        eseguire nuovamente il comando &quot;Inizio/Fine selezione in modalità Selezione-Colonna&quot;"/>
-			<BufferInvalidWarning title="Salvataggio fallito" message="Impossibile salvare: il buffer non è valido."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<BufferInvalidWarning title="Salvataggio non andato a buon fine" message="Impossibile salvare: il buffer non è valido."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 			<DoCloseOrNot title="Mantenere file inesistente" message="Il file &quot;$STR_REPLACE$&quot; è inesistente.
 Mantenere il file aperto?"/>
 			<DoDeleteOrNot title="Elimina file" message="Il file &quot;$STR_REPLACE$&quot;
@@ -1452,25 +1452,25 @@ Vuoi ricaricarlo e perdere tutte le modifiche apportate in Notepad++?"/>
 			<PrehistoricSystemDetected title="Sistema preistorico trovato" message="Sembra tu stia usando un sistema preistorico. Questa funzionalità richiede un sistema più moderno, scusaci."/>
 			<XpUpdaterProblem title="Aggiornamento Notepad++" message="L&apos;aggiornamento automatico di Notepad++ non è compatibile con XP a causa di un sistema di permessi obsoleto.
 Vuoi aprire la pagina di Notepad++ per scaricare l&apos;aggiornamento manualmente?"/>
-			<GUpProxyConfNeedAdminMode title="Impostazioni proxy" message="Rilancia Notepad++ con privilegi di amministratore per configurare il proxy."/>
+			<GUpProxyConfNeedAdminMode title="Impostazioni proxy" message="Rilancia Notepad++ con i privilegi di amministratore per configurare il proxy."/>
 			<DocTooDirtyToMonitor title="Problema monitoraggio" message="Il documento è stato modificato. Salva le modifiche prima di avviare il monitoraggio."/>
 			<DocNoExistToMonitor title="Problema monitoraggio" message="Il file deve esistere per essere monitorato."/>
 			<FileTooBigToOpen title="Problema dimensione file" message="Il file è troppo grande per essere aperto con Notepad++"/><!-- HowToReproduce: Try to open a 4GB file (it's not easy to reproduce, it depends on your system). -->
 			<FileLoadingException title="Codice di eccezione: $STR_REPLACE$" message="Si è verificato un errore durante il caricamento del file!"/>
 			<WantToOpenHugeFile title="Apertura file di grandi dimensioni" message="L&apos;apertura di file superiori a 2GB+ potrebbe impegare svariati minuti.
 Vuoi proseguire?"/>
-			<CreateNewFileOrNot title="Crea nuovo file" message="&quot;$STR_REPLACE$&quot; non esiste. Crearlo??"/>
+			<CreateNewFileOrNot title="Crea nuovo file" message="&quot;$STR_REPLACE$&quot; non esiste. Crearlo?"/>
 			<CreateNewFileError title="Crea nuovo file" message="Impossibile creare il file &quot;$STR_REPLACE$&quot;."/>
 			<OpenFileError title="ERRORE" message="Impossibile aprire il file &quot;$STR_REPLACE$&quot;."/>
 			<OpenFileNoFolderError title="Errore nell'apertura del file" message="&quot;$STR_REPLACE1$&quot; non può essere aperto:
 La cartella &quot;$STR_REPLACE2$&quot; non esiste."/>
-			<FileBackupFailed title="Backup File Fallito" message="La versione precedente del file non può essere salvata nella cartella di backup &quot;$STR_REPLACE$&quot;.
+			<FileBackupFailed title="Backup File non andato a buon fine" message="La versione precedente del file non può essere salvata nella cartella di backup &quot;$STR_REPLACE$&quot;.
 
 Vuoi salvare il file ugualmente?"/>
-			<LoadStylersFailed title="Caricamento stylers.xml fallito" message="Il caricamento di &quot;$STR_REPLACE$&quot; è fallito!"/>
-			<LoadLangsFailed title="Configurazione" message="Il caricamento di langs.xml è fallito!
+			<LoadStylersFailed title="Caricamento stylers.xml non andato a buon fine" message="Il caricamento di &quot;$STR_REPLACE$&quot; non è andato a buon fine!"/>
+			<LoadLangsFailed title="Configurazione" message="Il caricamento di langs.xml non è andato a buon fine!
 Vuoi ripristinare il file langs.xml?"/>
-			<LoadLangsFailedFinal title="Configurazione" message="Il caricamento di langs.xml è fallito!"/>
+			<LoadLangsFailedFinal title="Configurazione" message="Il caricamento di langs.xml non è andato a buon fine!"/>
 			<FolderAsWorspaceSubfolderExists title="Problema per Cartella come Area di Lavoro" message="Una sotto cartella della cartella che vuoi aggiungere esiste già.
 Rimuovi la cartella dal pannello prima di aggiungere &quot;$STR_REPLACE$&quot;."/>
 
@@ -1492,11 +1492,11 @@ usane un altro."/>
 			<UDLRemoveCurrentLang title="Rimuovere il linguaggio corrente" message="Vuoi rimuovere il linguaggio corrente?"/>
 			<SCMapperDoDeleteOrNot title="Eliminare scorciatoia" message="Sei sicuro di voler eliminare questa scorciatoia?"/>
 			<FindCharRangeValueError title="Problema nell&apos;intervallo di valori" message="Devi inserire un valore tra 0 e 255."/>
-			<OpenInAdminMode title="Salvataggio fallito" message="Il file non può essere salvato e potrebbe essere protetto.
+			<OpenInAdminMode title="Salvataggio non andato a buon fine" message="Il file non può essere salvato e potrebbe essere protetto.
 Vuoi avviare Notepad++ come amministratore?"/>
-			<OpenInAdminModeWithoutCloseCurrent title="Salvataggio fallito" message="Il file non può essere salvato e potrebbe essere protetto.
+			<OpenInAdminModeWithoutCloseCurrent title="Salvataggio non andato a buon fine" message="Il file non può essere salvato e potrebbe essere protetto.
 Vuoi avviare Notepad++ come amministratore?"/>
-			<OpenInAdminModeFailed title="Apertura come amministratore fallita" message="Notepad++ non può essere aperto come amministratore."/>
+			<OpenInAdminModeFailed title="Apertura come amministratore non andata a buon fine" message="Notepad++ non può essere aperto come amministratore."/>
 			<ViewInBrowser title="Visualizza il file corrente nel browser" message="Applicazione non trovata nel sistema."/>
 			<ExitToUpdatePlugins title="Notepad++ sta per chiudersi" message="Cliccando &quot;Sì&quot;, uscirai da Notepad++ per continuare le operazioni.
 Notepad++ verrà riavviato dopo che le operazioni saranno state completate.
@@ -1646,7 +1646,7 @@ NOTA: Scegliendo di non mantenere il file aperto o chiudendolo successivamente, 
 			<backup-select-folder value="Seleziona un percorso per la cartella di Backup"/><!-- HowToReproduce: Settings > Preferences > Backup > [...] -->
 			<cloud-invalid-warning value="Percorso non valido."/>
 			<cloud-restart-warning value="Riavvia Notepad++ per applicare le modifiche."/>
-			<cloud-select-folder value="Seleziona una cartella da dove Notepad++ possa leggere o scrivere le proprie impostazioni"/><!-- HowToReproduce: In "Cloud" section of Preferences dialog, check "Set your cloud location path here: ", then click the button "...". This message is displayed in the "Browse For Folder" dialog. -->
+			<cloud-select-folder value="Seleziona una cartella dove Notepad++ possa leggere o scrivere le proprie impostazioni"/><!-- HowToReproduce: In "Cloud" section of Preferences dialog, check "Set your cloud location path here: ", then click the button "...". This message is displayed in the "Browse For Folder" dialog. -->
 			<default-open-save-select-folder value="Seleziona un percorso per la cartella predefinita"/><!-- HowToReproduce: Settings > Preferences > Default Directory > [...] -->
 			<shift-change-direction-tip value="Utilizza Shift+Invio per cercare nella direzione opposta"/>
 			<two-find-buttons-tip value="Modalità ricerca a 2 pulsanti"/>
@@ -1669,7 +1669,7 @@ Cerca in tutti i file, ma escludi tutte le cartelle o sottocartelle log o logs:
 			<find-status-replaceinopenedfiles-1-replaced value="Sostituisci nei file aperti: 1 corrispondenza è stata sostituita"/>
 			<find-status-replaceinopenedfiles-nb-replaced value="Sostituisci nei file aperti: $INT_REPLACE$ corrispondenze sono state sostituite"/>
 			<find-status-invalid-re value="Trova: espressione regolare non valida"/>
-			<find-status-search-failed value="Trova: ricerca fallita"/>
+			<find-status-search-failed value="Trova: ricerca non andata a buon fine"/>
 			<find-status-mark-1-match value="Evidenzia: 1 corrispondenza trovata"/>
 			<find-status-mark-nb-matches value="Evidenzia: $INT_REPLACE$ corrispondenze trovate"/>
 			<find-status-count-1-match value="Conta: 1 corrispondenza trovata"/>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -17,9 +17,9 @@ Translation note:
 				<Entries>
 					<Item menuId="file" name="&amp;File"/>
 					<Item menuId="edit" name="&amp;Modifica"/>
-					<Item menuId="search" name="Ri&amp;cerca"/>
+					<Item menuId="search" name="&amp;Ricerca"/>
 					<Item menuId="view" name="&amp;Visualizza"/>
-					<Item menuId="encoding" name="Fo&amp;rmato"/>
+					<Item menuId="encoding" name="Forma&amp;to"/>
 					<Item menuId="language" name="&amp;Linguaggio"/>
 					<Item menuId="settings" name="C&amp;onfigurazione"/>
 					<Item menuId="tools" name="&amp;Strumenti"/>
@@ -32,28 +32,28 @@ Translation note:
 				<SubEntries>
 					<Item subMenuId="file-openFolder" name="Apri cartella &amp;file"/>
 					<Item subMenuId="file-closeMore" name="Chiudi schede &amp;multiple"/>
-					<Item subMenuId="file-recentFiles" name="File recenti"/>
+					<Item subMenuId="file-recentFiles" name="File recen&amp;ti"/>
 					<Item subMenuId="edit-insert" name="Inserisci"/>
 					<Item subMenuId="edit-copyToClipboard" name="Copia negli Appunti"/>
 					<Item subMenuId="edit-indent" name="&amp;Rientro"/>
 					<Item subMenuId="edit-convertCaseTo" name="Con&amp;verti MAIUSCOLO/minuscolo"/>
-					<Item subMenuId="edit-lineOperations" name="Operazioni sulle righe"/>
-					<Item subMenuId="edit-comment" name="Commenta/Rimuovi commenti"/>
-					<Item subMenuId="edit-autoCompletion" name="Auto-completamento"/>
-					<Item subMenuId="edit-eolConversion" name="Converti carattere di fine riga"/>
-					<Item subMenuId="edit-blankOperations" name="Operazioni sugli spazi"/>
-					<Item subMenuId="edit-pasteSpecial" name="Incolla speciale"/>
-					<Item subMenuId="edit-onSelection" name="Testo selezionato"/>
+					<Item subMenuId="edit-lineOperations" name="&amp;Operazioni sulle righe"/>
+					<Item subMenuId="edit-comment" name="Co&amp;mmenta/Rimuovi commenti"/>
+					<Item subMenuId="edit-autoCompletion" name="&amp;Auto-completamento"/>
+					<Item subMenuId="edit-eolConversion" name="Converti carattere di &amp;fine riga"/>
+					<Item subMenuId="edit-blankOperations" name="Operazioni sugli spa&amp;zi"/>
+					<Item subMenuId="edit-pasteSpecial" name="I&amp;ncolla speciale"/>
+					<Item subMenuId="edit-onSelection" name="&amp;Testo selezionato"/>
 					<Item subMenuId="edit-multiSelectALL" name="Effettua la Selezione multipla di tutto"/>
 					<Item subMenuId="edit-multiSelectNext" name="Effettua la Selezione Multipla successiva"/>
-					<Item subMenuId="search-changeHistory" name="Modifica Cronologia"/>
+					<Item subMenuId="search-changeHistory" name="Cronologia delle modific&amp;he"/>
 					<Item subMenuId="search-markAll" name="&amp;Applica Stile per tutte le corrispondenze"/>
 					<Item subMenuId="search-markOne" name="Applica Stile s&amp;olo per la selezione"/>
-					<Item subMenuId="search-unmarkAll" name="Rimuovi applicazione Stile"/>
-					<Item subMenuId="search-jumpUp" name="Vai su"/>
-					<Item subMenuId="search-jumpDown" name="Vai giù"/>
-					<Item subMenuId="search-copyStyledText" name="Copia il testo in stile"/>
-					<Item subMenuId="search-bookmark" name="Segnalibri"/>
+					<Item subMenuId="search-unmarkAll" name="Rimuovi applica&amp;zione Stile"/>
+					<Item subMenuId="search-jumpUp" name="Vai s&amp;u"/>
+					<Item subMenuId="search-jumpDown" name="Vai gi&amp;ù"/>
+					<Item subMenuId="search-copyStyledText" name="Copia il testo in sti&amp;le"/>
+					<Item subMenuId="search-bookmark" name="Segnali&amp;bri"/>
 					<Item subMenuId="view-currentFileIn" name="Visualizza file corrente in"/>
 					<Item subMenuId="view-showSymbol" name="Simboli"/>
 					<Item subMenuId="view-zoom" name="Ingrandimento"/>
@@ -105,7 +105,7 @@ Translation note:
 					<Item id="41007" name="Salva t&amp;utto"/>
 					<Item id="41008" name="S&amp;alva con nome..."/>
 					<Item id="41010" name="Stam&amp;pa..."/>
-					<Item id="1001" name="Stampa su&amp;bito!"/>
+					<Item id="1001" name="Stampa su&amp;bito"/>
 					<Item id="41011" name="&amp;Esci"/>
 					<Item id="41012" name="Apri sess&amp;ione..."/>
 					<Item id="41013" name="Salva sessio&amp;ne..."/>
@@ -113,18 +113,18 @@ Translation note:
 					<Item id="41015" name="Sal&amp;va una copia con nome..."/>
 					<Item id="41016" name="Sp&amp;osta nel cestino"/>
 					<Item id="41017" name="&amp;Rinomina..."/>
-					<Item id="41021" name="Ripristina i file recenti"/>
+					<Item id="41021" name="Ripristina i file recen&amp;ti"/>
 					<Item id="41022" name="Apri cartella come Area di &amp;Lavoro..."/>
 					<Item id="41023" name="Apri con il visuali&amp;zzatore predefinito"/>
 					<Item id="42001" name="Tag&amp;lia"/>
 					<Item id="42002" name="&amp;Copia"/>
-					<Item id="42003" name="Ann&amp;ulla digitazione"/>
+					<Item id="42003" name="Annulla digitazione"/>
 					<Item id="42004" name="&amp;Ripristina digitazione"/>
 					<Item id="42005" name="&amp;Incolla"/>
 					<Item id="42006" name="&amp;Elimina"/>
 					<Item id="42007" name="Seleziona t&amp;utto"/>
 					<Item id="42020" name="Inizio/Fine &amp;selezione"/>
-					<Item id="42089" name="Inizio/Fine selezione in modalità Selezione-Colonna"/>
+					<Item id="42089" name="Inizio/Fine selezione in modalit&amp;à Selezione-Colonna"/>
 					<Item id="42084" name="Data e ora (formato ridotto)"/>
 					<Item id="42085" name="Data e ora (formato esteso)"/>
 					<Item id="42086" name="Data e ora (formato personalizzato)"/>
@@ -149,14 +149,14 @@ Translation note:
 					<Item id="42066" name="Ordina le righe come valori decimali (punto) decrescenti"/>
 					<Item id="42083" name="Inverti l&apos;ordine delle righe"/>
 					<Item id="42078" name="Ordina le righe in modo casuale"/>
-					<Item id="42016" name="TUTTO MAIUSCOLE"/>
-					<Item id="42017" name="tutto minuscole"/>
-					<Item id="42067" name="Iniziali Maiuscole"/>
-					<Item id="42068" name="Iniziali Maiuscole (intelligente)"/>
-					<Item id="42069" name="Frasi maiuscole"/>
-					<Item id="42070" name="Frasi maiuscole (intelligente)"/>
-					<Item id="42071" name="&amp;iNVERTI mAIUSCOLE/mINUSCOLE"/>
-					<Item id="42072" name="mAiusCole/miNUScoLE casUaLi"/>
+					<Item id="42016" name="TUTTO &amp;MAIUSCOLE"/>
+					<Item id="42017" name="tutto mi&amp;nuscole"/>
+					<Item id="42067" name="&amp;Iniziali Maiuscole"/>
+					<Item id="42068" name="Iniziali Maiuscole (ignora le altre)"/>
+					<Item id="42069" name="&amp;Frasi maiuscole"/>
+					<Item id="42070" name="Frasi maiuscole (ignora le altre)"/>
+					<Item id="42071" name="iN&amp;VERTI mAIUSCOLE/mINUSCOLE"/>
+					<Item id="42072" name="mAiusCole/miNUScoLE &amp;casUaLi"/>
 					<Item id="42073" name="Apri file"/>
 					<Item id="42074" name="Apri cartella in Esplora Risorse"/>
 					<Item id="42075" name="Cerca in Internet"/>
@@ -193,12 +193,12 @@ Translation note:
 					<Item id="42082" name="Copia link"/>
 					<Item id="42037" name="Modalità colonna..."/>
 					<Item id="42034" name="Editor a colonne..."/>
-					<Item id="42051" name="Pannello caratteri"/>
-					<Item id="42052" name="Cronologia Appunti"/>
+					<Item id="42051" name="&amp;Pannello caratteri"/>
+					<Item id="42052" name="Cronolo&amp;gia Appunti"/>
 					<Item id="42025" name="Salva la macro registrata..."/>
 					<Item id="42026" name="Direzione del testo Destra-Sinistra"/>
 					<Item id="42027" name="Direzione del testo Sinistra-Destra"/>
-					<Item id="42028" name="Sessione documento in sola lettura"/>
+					<Item id="42028" name="Sessione &amp;documento in sola lettura"/>
 					<Item id="42029" name="Copia il percorso completo del file corrente"/>
 					<Item id="42030" name="Copia Nome file corrente"/>
 					<Item id="42031" name="Copia il percorso della cartella corrente"/>
@@ -213,11 +213,11 @@ Translation note:
 					<Item id="42057" name="Inserisci riga vuota sopra alla corrente"/>
 					<Item id="42058" name="Inserisci riga vuota sotto alla corrente"/>
 					<Item id="43001" name="&amp;Trova..."/>
-					<Item id="43002" name="Trova &amp;successivo"/>
-					<Item id="43003" name="Sostitu&amp;isci..."/>
-					<Item id="43004" name="Vai alla riga/posizione..."/>
+					<Item id="43002" name="Trova su&amp;ccessivo"/>
+					<Item id="43003" name="&amp;Sostituisci..."/>
+					<Item id="43004" name="Vai alla ri&amp;ga/posizione..."/>
 					<Item id="43005" name="Attiva/Disattiva Segnalibro"/>
-					<Item id="43006" name="Segnalibro seguente"/>
+					<Item id="43006" name="Segnalibro successivo"/>
 					<Item id="43007" name="Segnalibro precedente"/>
 					<Item id="43008" name="Elimina tutti i segnalibri"/>
 					<Item id="43018" name="Taglia le righe con segnalibri"/>
@@ -226,12 +226,12 @@ Translation note:
 					<Item id="43021" name="Elimina le righe con segnalibri"/>
 					<Item id="43051" name="Elimina le righe senza segnalibri"/>
 					<Item id="43050" name="Inverti i segnalibri"/>
-					<Item id="43052" name="Trova caratteri..."/>
+					<Item id="43052" name="Tro&amp;va caratteri..."/>
 					<Item id="43053" name="Seleziona tutto tra le parentesi corrispondenti"/>
 					<Item id="43009" name="Vai alla parentesi corrispondente"/>
-					<Item id="43010" name="Trova precedente"/>
-					<Item id="43011" name="Ricerca veloce"/>
-					<Item id="43013" name="Cerca nei file..."/>
+					<Item id="43010" name="Trova &amp;precedente"/>
+					<Item id="43011" name="&amp;Ricerca veloce"/>
+					<Item id="43013" name="Cerca nei &amp;file..."/>
 					<Item id="43014" name="Trova (volatile) successivo"/>
 					<Item id="43015" name="Trova (volatile) precedente"/>
 					<Item id="43022" name="Applica stile 1"/>
@@ -272,12 +272,12 @@ Translation note:
 					<Item id="43067" name="Vai alla modifica successiva"/>
 					<Item id="43068" name="Vai alla modifica precedente"/>
 					<Item id="43069" name="Pulisci la cronologia delle modifiche"/>
-					<Item id="43045" name="Finestra dei risultati di ricerca"/>
+					<Item id="43045" name="&amp;Finestra dei risultati di ricerca"/>
 					<Item id="43046" name="Vai al successivo risultato di ricerca"/>
 					<Item id="43047" name="Vai al precedente risultato di ricerca"/>
-					<Item id="43048" name="&amp;Seleziona e trova successivo"/>
-					<Item id="43049" name="&amp;Seleziona e trova precedente"/>
-					<Item id="43054" name="Evidenzia..."/>
+					<Item id="43048" name="Selez&amp;iona e trova successivo"/>
+					<Item id="43049" name="Selezio&amp;na e trova precedente"/>
+					<Item id="43054" name="&amp;Evidenzia..."/>
 					<Item id="43501" name="Chiudi i selezionati"/>
 					<Item id="43502" name="Chiudi gli altri"/>
 					<Item id="43503" name="Copia i nomi file dei selezionati"/>
@@ -482,7 +482,7 @@ Translation note:
 				<Item id="1615" name="Trova tutti"/>
 				<Item id="1616" name="Imposta un segnali&amp;bro sulla riga"/>
 				<Item id="1618" name="Pulisci ad ogni ricerca"/>
-				<Item id="1611" name="S&amp;ostituisci con :"/>
+				<Item id="1611" name="S&amp;ostituisci con:"/>
 				<Item id="1608" name="&amp;Sostituisci"/>
 				<Item id="1609" name="Sostituisci &amp;tutti"/>
 				<Item id="1687" name="Alla perdita del focus"/>
@@ -621,10 +621,10 @@ Translation note:
 				<SubDialog>
 					<Item id="2204" name="Grassetto"/>
 					<Item id="2205" name="Corsivo"/>
-					<Item id="2206" name="Primo piano: "/>
-					<Item id="2207" name="Sfondo: "/>
-					<Item id="2208" name="Nome: "/>
-					<Item id="2209" name="Dimensione: "/>
+					<Item id="2206" name="Primo piano"/>
+					<Item id="2207" name="Sfondo"/>
+					<Item id="2208" name="Nome:"/>
+					<Item id="2209" name="Dimensione:"/>
 					<Item id="2211" name="Stile:"/>
 					<Item id="2212" name="Colore"/>
 					<Item id="2213" name="Carattere"/>
@@ -633,7 +633,7 @@ Translation note:
 					<Item id="2218" name="Sottolineato"/>
 					<Item id="2219" name="Parole chiave predefinite"/>
 					<Item id="2221" name="Parole chiave definite dall&apos;utente"/>
-					<Item id="2225" name="Linguaggio: "/>
+					<Item id="2225" name="Linguaggio:"/>
 					<Item id="2226" name="Abilita colore globale in primo piano"/>
 					<Item id="2227" name="Abilita colore globale per lo sfondo"/>
 					<Item id="2228" name="Abilita stile globale del carattere"/>
@@ -776,7 +776,7 @@ Translation note:
 				<Item id="20003" name="Crea nuovo..."/>
 				<Item id="20004" name="Rimuovi"/>
 				<Item id="20005" name="Salva con nome..."/>
-				<Item id="20007" name="Linguaggio personalizzato: "/>
+				<Item id="20007" name="Linguaggio personalizzato"/>
 				<Item id="20009" name="Estensione:"/>
 				<Item id="20012" name="Ignora Maius./Minus."/>
 				<Item id="20011" name="Trasparenza"/>
@@ -784,9 +784,9 @@ Translation note:
 				<Item id="20016" name="Esporta..."/>
 				<Item id="20017" name="Disancora"/>
 				<StylerDialog title="Configuratore di stili">
-					<Item id="25030" name="Opzioni carattere:"/>
-					<Item id="25006" name="Colore primo piano:"/>
-					<Item id="25007" name="Colore sfondo:"/>
+					<Item id="25030" name="Opzioni carattere"/>
+					<Item id="25006" name="Colore primo piano"/>
+					<Item id="25007" name="Colore sfondo"/>
 					<Item id="25031" name="Nome:"/>
 					<Item id="25032" name="Dimensione:"/>
 					<Item id="25001" name="Grassetto"/>
@@ -822,19 +822,19 @@ Translation note:
 				<Folder title="Cartelle e Predefiniti">
 					<Item id="21101" name="Impostazioni stile predefinito"/>
 					<Item id="21102" name="Stile"/>
-					<Item id="21105" name="Documentazione:"/>
+					<Item id="21105" name="Documentazione"/>
 					<Item id="21106" name="Delimita compatto (racchiudi righe vuote)"/>
-					<Item id="21220" name="Delimitatori nel codice 1° stile:"/>
+					<Item id="21220" name="Delimitatori nel codice 1° stile"/>
 					<Item id="21224" name="Apri:"/>
 					<Item id="21225" name="Centro:"/>
 					<Item id="21226" name="Chiudi:"/>
 					<Item id="21227" name="Stile"/>
-					<Item id="21320" name="Delimitatori nel codice 2° stile (con separatori):"/>
+					<Item id="21320" name="Delimitatori nel codice 2° stile (con separatori)"/>
 					<Item id="21324" name="Apri:"/>
 					<Item id="21325" name="Centro:"/>
 					<Item id="21326" name="Chiudi:"/>
 					<Item id="21327" name="Stile"/>
-					<Item id="21420" name="Delimitatori per i commenti:"/>
+					<Item id="21420" name="Delimitatori per i commenti"/>
 					<Item id="21424" name="Apri:"/>
 					<Item id="21425" name="Centro:"/>
 					<Item id="21426" name="Chiudi:"/>
@@ -883,12 +883,12 @@ Translation note:
 					<Item id="23101" name="Stile commenti"/>
 					<Item id="23201" name="Stile numeri"/>
 					<Item id="23220" name="Stile"/>
-					<Item id="23230" name="Prefisso 1:"/>
-					<Item id="23232" name="Prefisso 2:"/>
-					<Item id="23234" name="Extra 1:"/>
-					<Item id="23236" name="Extra 2:"/>
-					<Item id="23238" name="Suffisso 1:"/>
-					<Item id="23240" name="Suffisso 2:"/>
+					<Item id="23230" name="Prefisso 1"/>
+					<Item id="23232" name="Prefisso 2"/>
+					<Item id="23234" name="Extra 1"/>
+					<Item id="23236" name="Extra 2"/>
+					<Item id="23238" name="Suffisso 1"/>
+					<Item id="23240" name="Suffisso 2"/>
 					<Item id="23242" name="Intervallo:"/>
 					<Item id="23244" name="Separatore decimale"/>
 					<Item id="23245" name="Punto"/>
@@ -1710,7 +1710,7 @@ Cerca in tutti i file, ma escludi tutte le cartelle o sottocartelle log o logs:
 			<common-cancel value="Annulla"/>
 			<common-name value="Nome"/>
 			<tabrename-title value="Rinomina scheda corrente"/>
-			<tabrename-newname value="Nuovo nome: "/>
+			<tabrename-newname value="Nuovo nome"/>
 			<splitter-rotate-left value="Ruota a sinistra"/>
 			<splitter-rotate-right value="Ruota a destra"/>
 			<userdefined-title-new value="Crea nuovo linguaggio..."/>
@@ -1727,12 +1727,12 @@ Cerca in tutti i file, ma escludi tutte le cartelle o sottocartelle log o logs:
 			<summary-nbsel1 value=" caratteri selezionati ("/>
 			<summary-nbsel2 value=" byte) in "/>
 			<summary-nbrange value=" intervalli"/>
-			<progress-hits-title value="Corrispondenze :"/>
+			<progress-hits-title value="Corrispondenze:"/>
 			<progress-cancel-info value="Annullamento operazione, attendere..."/>
 			<find-in-files-progress-title value="Ricerca nei file in corso..."/>
 			<replace-in-files-confirm-title value="Conferma"/>
-			<replace-in-files-confirm-directory value="Vuoi sostituire tutte le corrispondenze in: "/>
-			<replace-in-files-confirm-filetype value="Per i tipi di file: "/>
+			<replace-in-files-confirm-directory value="Vuoi sostituire tutte le corrispondenze in:"/>
+			<replace-in-files-confirm-filetype value="Per i tipi di file:"/>
 			<replace-in-files-progress-title value="Sostituisci nei file in corso..."/>
 			<replace-in-projects-confirm-title value="Conferma"/>
 			<replace-in-projects-confirm-message value="Vuoi sostituire tutte le corrispondenze in tutti i pannelli dei progetti selezionati?"/>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -30,8 +30,8 @@ Translation note:
 				</Entries>
 				<!-- Sub Menu Entries -->
 				<SubEntries>
-					<Item subMenuId="file-openFolder" name="Apri cartella file"/>
-					<Item subMenuId="file-closeMore" name="Chiudi schede multiple"/>
+					<Item subMenuId="file-openFolder" name="Apri cartella &amp;file"/>
+					<Item subMenuId="file-closeMore" name="Chiudi schede &amp;multiple"/>
 					<Item subMenuId="file-recentFiles" name="File recenti"/>
 					<Item subMenuId="edit-insert" name="Inserisci"/>
 					<Item subMenuId="edit-copyToClipboard" name="Copia negli Appunti"/>
@@ -104,18 +104,18 @@ Translation note:
 					<Item id="41006" name="&amp;Salva"/>
 					<Item id="41007" name="Salva t&amp;utto"/>
 					<Item id="41008" name="S&amp;alva con nome..."/>
-					<Item id="41010" name="Stampa..."/>
-					<Item id="1001" name="Stampa subito!"/>
+					<Item id="41010" name="Stam&amp;pa..."/>
+					<Item id="1001" name="Stampa su&amp;bito!"/>
 					<Item id="41011" name="&amp;Esci"/>
-					<Item id="41012" name="Apri sessione..."/>
-					<Item id="41013" name="Salva sessione..."/>
-					<Item id="41014" name="Ricarica dal disco"/>
-					<Item id="41015" name="Salva una copia con nome..."/>
-					<Item id="41016" name="Sposta nel cestino"/>
+					<Item id="41012" name="Apri sess&amp;ione..."/>
+					<Item id="41013" name="Salva sessio&amp;ne..."/>
+					<Item id="41014" name="Ricarica dal &amp;disco"/>
+					<Item id="41015" name="Sal&amp;va una copia con nome..."/>
+					<Item id="41016" name="Sp&amp;osta nel cestino"/>
 					<Item id="41017" name="&amp;Rinomina..."/>
 					<Item id="41021" name="Ripristina i file recenti"/>
-					<Item id="41022" name="Apri cartella come Area di Lavoro..."/>
-					<Item id="41023" name="Apri con il visualizzatore predefinito"/>
+					<Item id="41022" name="Apri cartella come Area di &amp;Lavoro..."/>
+					<Item id="41023" name="Apri con il visuali&amp;zzatore predefinito"/>
 					<Item id="42001" name="Tag&amp;lia"/>
 					<Item id="42002" name="&amp;Copia"/>
 					<Item id="42003" name="Ann&amp;ulla digitazione"/>
@@ -478,16 +478,16 @@ Translation note:
 				<Item id="1604" name="Distingui tra ma&amp;iuscole e minuscole"/>
 				<Item id="1605" name="Espressione re&amp;golare"/>
 				<Item id="1606" name="Torna all'ini&amp;zio se raggiunta la fine"/>
-				<Item id="1614" name="Conta corrispondenze"/>
+				<Item id="1614" name="&amp;Conta corrispondenze"/>
 				<Item id="1615" name="Trova tutti"/>
-				<Item id="1616" name="Imposta un segnalibro sulla riga"/>
+				<Item id="1616" name="Imposta un segnali&amp;bro sulla riga"/>
 				<Item id="1618" name="Pulisci ad ogni ricerca"/>
 				<Item id="1611" name="S&amp;ostituisci con :"/>
 				<Item id="1608" name="&amp;Sostituisci"/>
 				<Item id="1609" name="Sostituisci &amp;tutti"/>
 				<Item id="1687" name="Alla perdita del focus"/>
 				<Item id="1688" name="Sempre"/>
-				<Item id="1632" name="Nella selezione"/>
+				<Item id="1632" name="Ne&amp;lla selezione"/>
 				<Item id="1633" name="Pulisci evidenziazioni"/>
 				<Item id="1635" name="Sostituisci in tutti i documenti aperti"/>
 				<Item id="1636" name="Ricerca in tutti i documenti aperti"/>
@@ -505,7 +505,7 @@ Translation note:
 				<Item id="1662" name="Pannello Progetto 1"/>
 				<Item id="1663" name="Pannello Progetto 2"/>
 				<Item id="1664" name="Pannello Progetto 3"/>
-				<Item id="1641" name="Ricerca in tutto il documento corrente"/>
+				<Item id="1641" name="Ricerca in t&amp;utto il documento corrente"/>
 				<Item id="1686" name="T&amp;rasparenza"/>
 				<Item id="1703" name="&amp;. significa &quot;a capo&quot;"/>
 				<Item id="1721" name="▲"/>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0" encoding = "utf-8" ?>
 <!--
     Italian translation for Notepad++ 8.6.9
-    Last modified Wen, Jun 5th, 2024.
+    Last modified Sun, Jun 16th, 2024.
     For updates, see https://github.com/notepad-plus-plus/notepad-plus-plus/tree/master/PowerEditor/installer/nativeLang
 -->
 <!--
@@ -44,7 +44,7 @@ Translation note:
 					<Item subMenuId="edit-blankOperations" name="Operazioni sugli spa&amp;zi"/>
 					<Item subMenuId="edit-pasteSpecial" name="I&amp;ncolla speciale"/>
 					<Item subMenuId="edit-onSelection" name="&amp;Testo selezionato"/>
-					<Item subMenuId="edit-multiSelectALL" name="Effettua la Selezione multipla di tutto"/>
+					<Item subMenuId="edit-multiSelectALL" name="Effettua la Selezione Multipla di tutto"/>
 					<Item subMenuId="edit-multiSelectNext" name="Effettua la Selezione Multipla successiva"/>
 					<Item subMenuId="search-changeHistory" name="Cronologia delle modific&amp;he"/>
 					<Item subMenuId="search-markAll" name="&amp;Applica Stile per tutte le corrispondenze"/>
@@ -52,15 +52,15 @@ Translation note:
 					<Item subMenuId="search-unmarkAll" name="Rimuovi applica&amp;zione Stile"/>
 					<Item subMenuId="search-jumpUp" name="Vai s&amp;u"/>
 					<Item subMenuId="search-jumpDown" name="Vai gi&amp;ù"/>
-					<Item subMenuId="search-copyStyledText" name="Copia il testo in sti&amp;le"/>
+					<Item subMenuId="search-copyStyledText" name="Copia il testo dello sti&amp;le"/>
 					<Item subMenuId="search-bookmark" name="Segnali&amp;bri"/>
 					<Item subMenuId="view-currentFileIn" name="Visualizza file corrente in"/>
 					<Item subMenuId="view-showSymbol" name="Simboli"/>
 					<Item subMenuId="view-zoom" name="Ingrandimento"/>
 					<Item subMenuId="view-moveCloneDocument" name="Sposta/clona la scheda corrente"/>
 					<Item subMenuId="view-tab" name="Schede"/>
-					<Item subMenuId="view-collapseLevel" name="Riduci livello"/>
-					<Item subMenuId="view-uncollapseLevel" name="Non ridurre livello"/>
+					<Item subMenuId="view-collapseLevel" name="Comprimi il livello"/>
+					<Item subMenuId="view-uncollapseLevel" name="Espandi il livello"/>
 					<Item subMenuId="view-project" name="Progetti"/>
 					<Item subMenuId="encoding-characterSets" name="Set caratteri"/>
 					<Item subMenuId="encoding-arabic" name="Arabo"/>
@@ -161,14 +161,14 @@ Translation note:
 					<Item id="42074" name="Apri cartella in Esplora Risorse"/>
 					<Item id="42075" name="Cerca in Internet"/>
 					<Item id="42076" name="Modifica motore di ricerca..."/>
-					<Item id="42090" name="Ignora Maiuscolo/Minuscolo e Parole Intere"/>
+					<Item id="42090" name="Ignora maiuscole/minuscole e Solo Parole Intere"/>
 					<Item id="42091" name="Distingui tra maiuscole e minuscole"/>
 					<Item id="42092" name="Solo Parole Intere"/>
-					<Item id="42093" name="Distingui tra maiuscole e minuscole e Solo Parole intere"/>
-					<Item id="42094" name="Distingui tra Maiuscolo/Minuscolo e Solo parole intere"/>
+					<Item id="42093" name="Distingui tra maiuscole/minuscole e Solo Parole intere"/>
+					<Item id="42094" name="Ignora maiuscole/minuscole e Solo Parole Intere"/>
 					<Item id="42095" name="Distingui tra maiuscole e minuscole"/>
 					<Item id="42096" name="Solo Parole Intere"/>
-					<Item id="42097" name="Distingui tra Maiuscolo/Minuscolo e Solo parole intere"/>
+					<Item id="42097" name="Distingui tra maiuscole/minuscole e Solo Parole Intere"/>
 					<Item id="42098" name="Annulla l'ultima Multi-Selezione aggiunta"/>
 					<Item id="42099" name="Ignora Corrente e Vai alla Successiva  Multiselezione"/>
 					<Item id="42018" name="&amp;Inizia registrazione"/>
@@ -191,8 +191,8 @@ Translation note:
 					<Item id="42049" name="Taglia contenuto binario"/>
 					<Item id="42050" name="Incolla contenuto binario"/>
 					<Item id="42082" name="Copia link"/>
-					<Item id="42037" name="Modalità colonna..."/>
-					<Item id="42034" name="Editor a colonne..."/>
+					<Item id="42037" name="Selezione in Modalità colonna..."/>
+					<Item id="42034" name="Modifica alle colonne..."/>
 					<Item id="42051" name="&amp;Pannello caratteri"/>
 					<Item id="42052" name="Cronolo&amp;gia Appunti"/>
 					<Item id="42025" name="Salva la macro registrata..."/>
@@ -234,16 +234,16 @@ Translation note:
 					<Item id="43013" name="Cerca nei &amp;file..."/>
 					<Item id="43014" name="Trova (volatile) successivo"/>
 					<Item id="43015" name="Trova (volatile) precedente"/>
-					<Item id="43022" name="Applica stile 1"/>
-					<Item id="43023" name="Rimuovi stile 1"/>
-					<Item id="43024" name="Applica stile 2"/>
-					<Item id="43025" name="Rimuovi stile 2"/>
-					<Item id="43026" name="Applica stile 3"/>
-					<Item id="43027" name="Rimuovi stile 3"/>
-					<Item id="43028" name="Applica stile 4"/>
-					<Item id="43029" name="Rimuovi stile 4"/>
-					<Item id="43030" name="Applica stile 5"/>
-					<Item id="43031" name="Rimuovi stile 5"/>
+					<Item id="43022" name="Applica lo stile 1"/>
+					<Item id="43023" name="Rimuovi lo stile 1"/>
+					<Item id="43024" name="Applica lo stile 2"/>
+					<Item id="43025" name="Rimuovi lo stile 2"/>
+					<Item id="43026" name="Applica lo stile 3"/>
+					<Item id="43027" name="Rimuovi lo stile 3"/>
+					<Item id="43028" name="Applica lo stile 4"/>
+					<Item id="43029" name="Rimuovi lo stile 4"/>
+					<Item id="43030" name="Applica lo stile 5"/>
+					<Item id="43031" name="Rimuovi lo stile 5"/>
 					<Item id="43032" name="Rimuovi tutti gli stili"/>
 					<Item id="43033" name="stile 1"/>
 					<Item id="43034" name="stile 2"/>
@@ -283,7 +283,7 @@ Translation note:
 					<Item id="43503" name="Copia i nomi file dei selezionati"/>
 					<Item id="43504" name="Copia i percorsi file dei selezionati"/>
 					<Item id="44009" name="Modalità Post-it"/>
-					<Item id="44010" name="Comprimi tutte le strutture"/>
+					<Item id="44010" name="Comprimi tutti i livelli"/>
 					<Item id="44011" name="Modalità &quot;senza distrazioni&quot;"/>
 					<Item id="44019" name="Visualizza tutti i caratteri"/>
 					<Item id="44020" name="Visualizza guide di indentazione"/>
@@ -293,7 +293,7 @@ Translation note:
 					<Item id="44025" name="Visualizza gli spazi e le tabulazioni"/>
 					<Item id="44026" name="Visualizza carattere di fine riga"/>
 					<Item id="44029" name="Espandi tutti i livelli"/>
-					<Item id="44030" name="Contrai il livello corrente"/>
+					<Item id="44030" name="Comprimi il livello corrente"/>
 					<Item id="44031" name="Espandi il livello corrente"/>
 					<Item id="44049" name="Informazioni file..."/>
 					<Item id="44080" name="Mappa documento"/>
@@ -714,14 +714,14 @@ Translation note:
 					<Item id="44102" name="Apri il file corrente in Edge"/>
 					<Item id="50003" name="Passa al documento precedente"/>
 					<Item id="50004" name="Passa al documento successivo"/>
-					<Item id="44051" name="Contrai livello 1"/>
-					<Item id="44052" name="Contrai livello 2"/>
-					<Item id="44053" name="Contrai livello 3"/>
-					<Item id="44054" name="Contrai livello 4"/>
-					<Item id="44055" name="Contrai livello 5"/>
-					<Item id="44056" name="Contrai livello 6"/>
-					<Item id="44057" name="Contrai livello 7"/>
-					<Item id="44058" name="Contrai livello 8"/>
+					<Item id="44051" name="Comprimi livello 1"/>
+					<Item id="44052" name="Comprimi livello 2"/>
+					<Item id="44053" name="Comprimi livello 3"/>
+					<Item id="44054" name="Comprimi livello 4"/>
+					<Item id="44055" name="Comprimi livello 5"/>
+					<Item id="44056" name="Comprimi livello 6"/>
+					<Item id="44057" name="Comprimi livello 7"/>
+					<Item id="44058" name="Comprimi livello 8"/>
 					<Item id="44061" name="Espandi livello 1"/>
 					<Item id="44062" name="Espandi livello 2"/>
 					<Item id="44063" name="Espandi livello 3"/>
@@ -959,7 +959,7 @@ Translation note:
 					<Item id="6109" name="Oscura le schede inattive"/>
 					<Item id="6110" name="Barra colorata sulla scheda attiva"/>
 					<Item id="6112" name="Pulsante di chiusura su ogni scheda"/>
-					<Item id="6113" name="Chiudere una scheda con Doppio clic"/>
+					<Item id="6113" name="Il Doppio clic Chiude la scheda"/>
 					<Item id="6118" name="Nascondi"/>
 					<Item id="6119" name="Utilizza più righe"/>
 					<Item id="6120" name="Verticale"/>
@@ -982,7 +982,7 @@ Translation note:
 					<Item id="6219" name="Velocità:"/>
 					<Item id="6221" name="V"/>
 					<Item id="6222" name="L"/>
-					<Item id="6246" name="Rendi i comandi del livello corrente comprimi/espandi attivabili"/>
+					<Item id="6246" name="Rendi commutabili i due comandi Comprimi ed Espandi il livello corrente"/>
 					<Item id="6227" name="Ritorno a Capo Autom."/>
 					<Item id="6228" name="Predefinito"/>
 					<Item id="6229" name="Allineato"/>
@@ -1342,7 +1342,7 @@ Translation note:
 				<Item id="7003" name="Chiudi scheda/e"/>
 				<Item id="7004" name="Ordina schede"/>
 			</Window>
-			<ColumnEditor title="Editor a colonne">
+			<ColumnEditor title="Modifica alle colonne">
 				<Item id="2023" name="&amp;Testo da inserire"/>
 				<Item id="2033" name="&amp;Numero da inserire"/>
 				<Item id="2030" name="N&amp;umero iniziale:"/>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -325,7 +325,7 @@ Translation note:
 					<Item id="44130" name="Visualizza i caratteri non stampabili"/>
 					<Item id="44131" name="Visualizza i caratteri di controllo e ritorno a capo Unicode"/>
 					<Item id="44032" name="Visualizzazione a tutto schermo"/>
-					<Item id="44033" name="Ripristina lo zoom predefinito"/>
+					<Item id="44033" name="Ripristina l'ingrandimento predefinito"/>
 					<Item id="44034" name="Sempre in primo piano"/>
 					<Item id="44035" name="Sincronizza scorrimento verticale"/>
 					<Item id="44036" name="Sincronizza scorrimento orizzontale"/>
@@ -536,14 +536,14 @@ Translation note:
 				<Item id="2910" name="&amp;Trova"/>
 			</FindCharsInRange>
 
-			<GoToLine title="Vai alla riga/posizione #">
+			<GoToLine title="Vai alla...">
 				<Item id="2007" name="Riga"/>
-				<Item id="2008" name="Posizione carattere"/>
+				<Item id="2008" name="Posizione"/>
 				<Item id="1" name="&amp;Vai"/>
 				<Item id="2" name="Annulla"/>
-				<Item id="2004" name="Sei alla riga/posizione:"/>
-				<Item id="2005" name="Vai alla riga/posizione:"/>
-				<Item id="2006" name="Ultima riga/pos. disponibile:"/>
+				<Item id="2004" name="Sei a:"/>
+				<Item id="2005" name="Vai a:"/>
+				<Item id="2006" name="Ultima disponibile:"/>
 			</GoToLine>
 
 			<Run title="Esegui...">
@@ -583,19 +583,19 @@ Translation note:
 				<Item id="2" name="&amp;Chiudi"/>
 			</SHA1FromFilesDlg>
 
-			<SHA1FromTextDlg title="Generate SHA-1 digest">
+			<SHA1FromTextDlg title="Genera firma SHA-1">
 				<Item id="1932" name="Considera ogni riga come una stringa &amp;separata"/>
 				<Item id="1934" name="Co&amp;pia negli Appunti"/>
 				<Item id="2" name="&amp;Chiudi"/>
 			</SHA1FromTextDlg>
 
-			<SHA512FromFilesDlg title="Generate SHA-512 digest from files">
+			<SHA512FromFilesDlg title="Genera firma SHA-512 da file">
 				<Item id="1922" name="Scegli i file da cui &amp;generare  SHA-512..."/>
 				<Item id="1924" name="Co&amp;pia negli Appunti"/>
 				<Item id="2" name="&amp;Chiudi"/>
 			</SHA512FromFilesDlg>
 
-			<SHA512FromTextDlg title="Generate SHA-512 digest">
+			<SHA512FromTextDlg title="Genera firma SHA-512">
 				<Item id="1932" name="Considera ogni riga come una stringa &amp;separata"/>
 				<Item id="1934" name="Co&amp;pia negli Appunti"/>
 				<Item id="2" name="&amp;Chiudi"/>
@@ -1407,7 +1407,7 @@ Continuare?"/><!-- HowToReproduce: when you openned file is modified and saved, 
 			<FileLockedWarning title="Salvataggio non andato a buon fine" message="Verificare che il file non sia aperto da un altro programma."/>
 			<FileAlreadyOpenedInNpp title="" message="Il file è già aperto in Notepad++."/>
 			<RenameTabTemporaryNameAlreadyInUse title="Rinomina non andata a buon fine" message="Il file specificato è già in uso su un&apos;altra scheda."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
-			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="Il nome inserito non può rimanere vuoto, e non può contenere soltanto spazi o TAB."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
+			<RenameTabTemporaryNameIsEmpty title="Rinomina non andata a buon fine" message="Il nome inserito non può rimanere vuoto, e non può contenere soltanto spazi o TAB."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
 			<DeleteFileFailed title="Eliminazione file non andata a buon fine" message="Eliminazione del file non andata a buon fine."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Il numero di file da aprire è troppo grande" message="Si stanno aprendo $INT_REPLACE$ file.
@@ -1461,7 +1461,7 @@ Vuoi aprire la pagina di Notepad++ per scaricare l&apos;aggiornamento manualment
 Vuoi proseguire?"/>
 			<CreateNewFileOrNot title="Crea nuovo file" message="&quot;$STR_REPLACE$&quot; non esiste. Crearlo?"/>
 			<CreateNewFileError title="Crea nuovo file" message="Impossibile creare il file &quot;$STR_REPLACE$&quot;."/>
-			<OpenFileError title="ERRORE" message="Impossibile aprire il file &quot;$STR_REPLACE$&quot;."/>
+			<OpenFileError title="Errore nell'apertura del file" message="Impossibile aprire il file &quot;$STR_REPLACE$&quot;."/>
 			<OpenFileNoFolderError title="Errore nell'apertura del file" message="&quot;$STR_REPLACE1$&quot; non può essere aperto:
 La cartella &quot;$STR_REPLACE2$&quot; non esiste."/>
 			<FileBackupFailed title="Backup File non andato a buon fine" message="La versione precedente del file non può essere salvata nella cartella di backup &quot;$STR_REPLACE$&quot;.
@@ -1471,7 +1471,7 @@ Vuoi salvare il file ugualmente?"/>
 			<LoadLangsFailed title="Configurazione" message="Il caricamento di langs.xml non è andato a buon fine!
 Vuoi ripristinare il file langs.xml?"/>
 			<LoadLangsFailedFinal title="Configurazione" message="Il caricamento di langs.xml non è andato a buon fine!"/>
-			<FolderAsWorspaceSubfolderExists title="Problema per Cartella come Area di Lavoro" message="Una sotto cartella della cartella che vuoi aggiungere esiste già.
+			<FolderAsWorspaceSubfolderExists title="Errore Aggiunta Cartella come Area di Lavoro" message="La cartella che vuoi aggiungere esiste già.
 Rimuovi la cartella dal pannello prima di aggiungere &quot;$STR_REPLACE$&quot;."/>
 
 			<ProjectPanelChanged title="$STR_REPLACE$" message="L&apos;Area di Lavoro è stata modificata. Vuoi salvarla?"/>
@@ -1482,7 +1482,7 @@ Il file Area di Lavoro non è stato salvato."/>
 			<ProjectPanelOpenFailed title="Apri Area di Lavoro" message="L&apos;Area di Lavoro non può essere aperta.
 Sembra che il file da aprire non sia un file di progetto valido."/>
 			<ProjectPanelRemoveFolderFromProject title="Rimuovi cartella dal progetto" message="Tutti i sotto-elementi saranno rimossi.
-Sei sicuro di voler rimuovere questa cartella dal progetto?"/>
+Vuoi rimuovere questa cartella dal progetto?"/>
 			<ProjectPanelRemoveFileFromProject title="Rimuovi file dal progetto" message="Vuoi rimuovere questo file dal progetto?"/>
 			<ProjectPanelReloadError title="Ricarica Area di Lavoro" message="Impossibile trovare il file da ricaricare."/>
 			<ProjectPanelReloadDirty title="Ricarica Area di Lavoro" message="L&apos;Area di Lavoro corrente è stata modificata. Ricaricandola perderai tutte le modifiche.
@@ -1490,20 +1490,20 @@ Vuoi continuare?"/>
 			<UDLNewNameError title="Errore UDL" message="Questo nome è utilizzato da un altro linguaggio,
 usane un altro."/>
 			<UDLRemoveCurrentLang title="Rimuovere il linguaggio corrente" message="Vuoi rimuovere il linguaggio corrente?"/>
-			<SCMapperDoDeleteOrNot title="Eliminare scorciatoia" message="Sei sicuro di voler eliminare questa scorciatoia?"/>
-			<FindCharRangeValueError title="Problema nell&apos;intervallo di valori" message="Devi inserire un valore tra 0 e 255."/>
+			<SCMapperDoDeleteOrNot title="Eliminare scorciatoia" message="Vuoi eliminare questa scorciatoia?"/>
+			<FindCharRangeValueError title="Intervallo di valori errato" message="Devi inserire un valore tra 0 e 255."/>
 			<OpenInAdminMode title="Salvataggio non andato a buon fine" message="Il file non può essere salvato e potrebbe essere protetto.
 Vuoi avviare Notepad++ come amministratore?"/>
 			<OpenInAdminModeWithoutCloseCurrent title="Salvataggio non andato a buon fine" message="Il file non può essere salvato e potrebbe essere protetto.
 Vuoi avviare Notepad++ come amministratore?"/>
 			<OpenInAdminModeFailed title="Apertura come amministratore non andata a buon fine" message="Notepad++ non può essere aperto come amministratore."/>
 			<ViewInBrowser title="Visualizza il file corrente nel browser" message="Applicazione non trovata nel sistema."/>
-			<ExitToUpdatePlugins title="Notepad++ sta per chiudersi" message="Cliccando &quot;Sì&quot;, uscirai da Notepad++ per continuare le operazioni.
+			<ExitToUpdatePlugins title="Chiusura Notepad++" message="Cliccando &quot;Sì&quot;, uscirai da Notepad++ per continuare le operazioni.
 Notepad++ verrà riavviato dopo che le operazioni saranno state completate.
 Vuoi continuare?"/>
-			<NeedToRestartToLoadPlugins title="Riavvio Notepad++" message="Notepad++ deve essere riavviato per caricare i plugin che sono stati installati."/>
-			<ChangeHistoryEnabledWarning title="Riavvio Notepad++" message="Notepad++ deve essere riavviato per abilitare la cronologia delle modifiche."/><!-- HowToReproduce: uncheck "Display Change History" via Preferences dialog "Marges/Border/Edge. -->
-			<WindowsSessionExit title="Notepad++ - Chiusura della sessione" message="La sessione Windows sta per essere terminata ma ci sono dati non salvati. Vuoi uscire da Notepad++"/>
+			<NeedToRestartToLoadPlugins title="Riavvio Notepad++" message="Per caricare i plugin, Notepad++ deve essere riavviato."/>
+			<ChangeHistoryEnabledWarning title="Riavvio Notepad++" message="Per abilitare la cronologia delle modifiche, Notepad++ deve essere riavviato."/><!-- HowToReproduce: uncheck "Display Change History" via Preferences dialog "Marges/Border/Edge. -->
+			<WindowsSessionExit title="Notepad++ - Chiusura della sessione" message="La sessione Windows sta per essere terminata, ma ci sono dati non salvati. Vuoi uscire da Notepad++"/>
 			<LanguageMenuCompactWarning title="Menù Linguaggio Compatto" message="L&apos;opzione sarà effettiva al riavvio."/><!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
 			<SwitchUnsavedThemeWarning title="$STR_REPLACE$" message="Le modifiche non salvate verranno perse!
 Vuoi salvare le modifiche prima di cambiare tema?"/><!-- HowToReproduce: In the Style Configurator dialog change some theme and switch to other theme without saving. -->
@@ -1724,14 +1724,14 @@ Cerca in tutti i file, ma escludi tutte le cartelle o sottocartelle log o logs:
 			<progress-hits-title value="Corrispondenze :"/>
 			<progress-cancel-info value="Annullamento operazione, attendere..."/>
 			<find-in-files-progress-title value="Ricerca nei file in corso..."/>
-			<replace-in-files-confirm-title value="Sei sicuro?"/>
-			<replace-in-files-confirm-directory value="Sei sicuro di voler sostituire tutte le corrispondenze in: "/>
+			<replace-in-files-confirm-title value="Conferma"/>
+			<replace-in-files-confirm-directory value="Vuoi sostituire tutte le corrispondenze in: "/>
 			<replace-in-files-confirm-filetype value="Per i tipi di file: "/>
 			<replace-in-files-progress-title value="Sostituisci nei file in corso..."/>
 			<replace-in-projects-confirm-title value="Conferma"/>
-			<replace-in-projects-confirm-message value="Sei sicuro di voler sostituire tutte le corrispondenze in tutti i pannelli dei progetti selezionati?"/>
+			<replace-in-projects-confirm-message value="Vuoi sostituire tutte le corrispondenze in tutti i pannelli dei progetti selezionati?"/>
 			<replace-in-open-docs-confirm-title value="Conferma"/>
-			<replace-in-open-docs-confirm-message value="Sei sicuro di voler sostituire tutte le corrispondenze in tutti i file aperti?"/>
+			<replace-in-open-docs-confirm-message value="Vuoi sostituire tutte le corrispondenze in tutti i file aperti?"/>
 			<find-result-caption value="Risultati trovati"/>
 			<find-result-title value="Trova"/><!-- Must not begin with space or tab character -->
 			<find-result-title-info value="($INT_REPLACE1$ corrispondenze trovate in $INT_REPLACE2$ file di $INT_REPLACE3$ cercate)"/>
@@ -1750,7 +1750,7 @@ Cerca in tutti i file, ma escludi tutte le cartelle o sottocartelle log o logs:
 			<file-save-assign-type value="&amp;Accoda estensione"/>
 			<close-panel-tip value="Chiudi"/>
 			<IncrementalFind-FSFound value="$INT_REPLACE$ corrispondenze"/>
-			<IncrementalFind-FSNotFound value="Frase non trovata"/>
+			<IncrementalFind-FSNotFound value="Testo non trovato"/>
 			<IncrementalFind-FSTopReached value="È stato raggiunto l&apos;inizio della pagina, si continuerà dal fondo"/>
 			<IncrementalFind-FSEndReached value="È stata raggiunta la fine della pagina, si continuerà dall&apos;inizio"/>
 			<contextMenu-styleAlloccurrencesOfToken value="Applica stile per tutte le corrispondenze"/>
@@ -1768,20 +1768,20 @@ NOTE:
 NOTA:
 L&apos;uso della rappresentazione disabiliterà l&apos;effetto dei caratteri sul testo.
 
-Per l&apos;elenco completo degli spazi bianchi selezionati e dei caratteri non stampabili, consultare il Manuale dell&apos;utente.
+Per l&apos;elenco completo degli spazi-bianchi selezionati e dei caratteri non stampabili, consultare il Manuale dell&apos;utente.
 
-Fare clic sul pulsante per aprire il sito Web del Manuale Utente."/>
+Fare clic su &quot;?&quot; per aprire il sito Web del Manuale Utente."/>
 			<npcAbbreviation-tip value="Abbreviazione : nome
-NBSP : spazio indivisibile (non-breaking space)
-ZWSP : spazio a larghezza zero (zero-width space)
-ZWNBSP : zero-width no-break space
+NBSP : spazio indivisibile
+ZWSP : spazio a lunghezza zero
+ZWNBSP : spazio indivisibile a lunghezza zero
 
 Per l&apos;elenco completo consultare il Manuale Utente.
 Premere il pulsante &quot;?&quot; a destra per aprire il sito Web con il manuale utente."/>
 			<npcCodepoint-tip value="Codifica : nome
-U+00A0 : spazio indivisibile (non-breaking space)
-U+200B : spazio a larghezza zero (zero-width space)
-U+FEFF : zero-width no-break space
+U+00A0 : spazio indivisibile
+U+200B : spazio a lunghezza zero
+U+FEFF : spazio indivisibile a lunghezza zero
 
 Per l&apos;elenco completo consultare il Manuale Utente.
 Premere il pulsante &quot;?&quot; a destra per aprire il sito Web con il manuale utente."/>
@@ -1789,7 +1789,7 @@ Premere il pulsante &quot;?&quot; a destra per aprire il sito Web con il manuale
 			<!-- Don't translate "(&quot;Non-printing characters custom color&quot;)" -->
 			<npcCustomColor-tip value="Vai a Configura gli Stili per personalizzare il colore predefinito degli spazi e i caratteri non stampabili selezionati(&quot;Non-printing characters custom color&quot;)."/>
 			<npcIncludeCcUniEol-tip value="Applicare le impostazioni dell&apos;aspetto dei caratteri non stampabili ai caratteri di controllo C0, C1 e Ritorno a capo Unicode (riga successiva, separatore di riga e separatore di paragrafo)."/>
-			<searchingInSelThresh-tip value="Il numero di caratteri selezionati nella zona di modifica per controllare automaticamente la casella di controllo &quot;In selezione&quot; quando la finestra di dialogo Trova è attivata. Il valore massimo è 1024. Impostare il valore a 0 per disabilitare il controllo automatico."/>
+			<searchingInSelThresh-tip value="Il numero di caratteri selezionati nella zona di modifica per controllare automaticamente la casella di controllo &quot;Nella selezione&quot; quando la finestra di dialogo Trova è attivata. Il valore massimo è 1024. Impostare il valore a 0 per disabilitare il controllo automatico."/>
 			<verticalEdge-tip value="Aggiungi il tuo indicatore di colonna indicandone la posizione con un numero decimale. È possibile definire diversi delimitatori di colonna utilizzando lo spazio bianco per separare i diversi numeri."/>
 		</MiscStrings>
 	</Native-Langue>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -1111,6 +1111,7 @@ Translation note:
 					<Item id="6310" name="Il rientro usa:"/>
 					<Item id="6311" name="Tabulazioni"/>
 					<Item id="6510" name="Usa predefinito"/>
+					<Item id="6512" name="Backspace rimuove i rientri invece di rimuovere un singolo spazio"/>
 					<Item id="6335" name="Backslash è il carattere di escape in SQL"/>
 				</Language>
 

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -874,7 +874,7 @@ Translation note:
 					<Item id="23001" name="Permetti delimitazione dei commenti"/>
 					<Item id="23326" name="Stile"/>
 					<Item id="23323" name="Apertura"/>
-					<Item id="23324" name="Carattere di continuazione"/>
+					<Item id="23324" name="Continuazione"/>
 					<Item id="23325" name="Chiusura"/>
 					<Item id="23301" name="Stile commenti su riga singola"/>
 					<Item id="23124" name="Stile"/>
@@ -1058,11 +1058,11 @@ Translation note:
 					<Item id="6293" name="Larghezza costante"/>
 					<Item id="6207" name="Visualizza i segnalibri"/>
 					<Item id="6295" name="Cronologia delle modifiche"/>
-					<Item id="6223" name="Mostra Cronologia modifiche"/>
+					<Item id="6223" name="Mostra nel margine"/>
 					<Item id="6296" name="Mostra nel testo"/>
-					<Item id="6211" name="Limite di colonna"/>
+					<Item id="6211" name="Delimitatori di colonna"/>
 					<Item id="6213" name="Modalità &quot;sfondo&quot;"/>
-					<Item id="6231" name="Spessore Bordo Editor"/>
+					<Item id="6231" name="Spessore Bordo Schede"/>
 					<Item id="6235" name="Nessun bordo"/>
 					<Item id="6208" name="Riempimento"/>
 					<Item id="6209" name="Sinistra"/>
@@ -1793,10 +1793,10 @@ Per l&apos;elenco completo consultare il Manuale Utente.
 Premere il pulsante &quot;?&quot; a destra per aprire il sito Web con il manuale utente."/>
 
 			<!-- Don't translate "(&quot;Non-printing characters custom color&quot;)" -->
-			<npcCustomColor-tip value="Vai a Configura gli Stili per personalizzare il colore predefinito degli spazi e i caratteri non stampabili selezionati(&quot;Non-printing characters custom color&quot;)."/>
+			<npcCustomColor-tip value="Per personalizzare il colore predefinito degli spazi e dei caratteri non stampabili selezionati, Vai a Configura gli Stili (&quot;Non-printing characters custom color&quot;)."/>
 			<npcIncludeCcUniEol-tip value="Applicare le impostazioni dell&apos;aspetto dei caratteri non stampabili ai caratteri di controllo C0, C1 e Ritorno a capo Unicode (riga successiva, separatore di riga e separatore di paragrafo)."/>
 			<searchingInSelThresh-tip value="Il numero di caratteri selezionati nella zona di modifica per controllare automaticamente la casella di controllo &quot;Nella selezione&quot; quando la finestra di dialogo Trova è attivata. Il valore massimo è 1024. Impostare il valore a 0 per disabilitare il controllo automatico."/>
-			<verticalEdge-tip value="Aggiungi il tuo indicatore di colonna indicandone la posizione con un numero decimale. È possibile definire diversi delimitatori di colonna utilizzando lo spazio bianco per separare i diversi numeri."/>
+			<verticalEdge-tip value="Aggiungi le posizioni dei tuoi delimitatori di colonna, separati da spazi. Indicali con dei numeri interi."/>
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/italian.xml
+++ b/PowerEditor/installer/nativeLang/italian.xml
@@ -1529,6 +1529,10 @@ si vuole mantenere il file aperto ?
 NOTA: Scegliendo di non mantenere il file aperto o chiudendolo successivamente, la sessione verrà MODIFICATA ALL'USCITA! si suggerisce di effetture adesso il backup di  &quot;session.xml&quot;."/>
 			<RTLvsDirectWrite title="Non è possibile eseguire RTL" message="RTL non è compatibile con la modalità DirectWrite. Disabilita DirectWrite mode in Preferenze, sezione Varie, riavvia Notepad++, and prova questo comando nuovamente."/>
 			<FileMemoryAllocationFailed title="Eccezione: errore nell'Allocazione della memoria del File" message="Sembra non esserci sufficiente memoria contigua libera affinché il file possa essere caricato da Notepad++."/><!-- HowToReproduce: Try to open multiple files with total size > ~700MB in the x86 Notepad++ (it will depend on the PC memory configuration and the current system memory usage...). -->
+			<FindRegexBackwardDisabled title="Disabilitata la Ricerca a ritroso con espressione regolare" message="Per impostazione predefinita, la ricerca Espressione Regolare a ritroso è disabilitata a causa di risultati potenzialmente imprevisti. Per eseguire una ricerca all'indietro, aprire la finestra di dialogo Trova e selezionare la modalità di ricerca normale o estesa anziché l'espressione regolare.
+Premere il pulsante Conferma per aprire o attivare la finestra di dialogo Trova.
+
+Nel caso fosse necessaria la funzione di ricerca Espressione regolare a ritroso, consultare il manuale dell'utente per istruzioni su come abilitarla."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Cronologia Appunti"/>


### PR DESCRIPTION
- [912c5ee](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/912c5ee3003eb7bfeef7ca2a8eb3ba5e32b32bb4) Make english language text with colon (':') consistent 
- [9f6e9c0](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/9f6e9c0cfcd5e4a996e6fe365ba2f13cfe3ccaa4) Update English translation for v8.6.8 (indentation setting)
- [07e9503](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/07e95038cb1bde67db973df24b4767d06f68d19b) Add message box with information about disabled backward regex searching
- [7a6768b](https://github.com/notepad-plus-plus/notepad-plus-plus/commit/7a6768b029df2ed8f09004648841fe64a83d6326) Add Backspace unident option 

- improved translation of [ff2b3cc](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/14838/commits/ff2b3cc045fcff45c04725baf12154f84dd06610) Add support for Change History in the text  (e.g.  wrong translation of change history, from "modifica cronologia" to "cronologia delle modifiche") 
- change increase/decrease line indent ("tabulazione" to "rientro")
- improved "case (blend)" from "intelligente"(smart) to "ignora le altre"
- translated "next" always in "successivo" (1 hit for "seguente")
- removed always the Italish word Zoom (Ingrandimento) and add text missing (ctrl+ mouse up/down)
- fixed text not translated tool Menu /generate (genera firma) and made it coherent 
- removed exclamation marks from text
- updated "go to..." Dialog to the English version
- ok-->always "Conferma"
- fixed text not translated "(Ctrl+Mouse click/selection)"
- update translation Indent
- Made translation "Minimum Size for Auto-Checking In selection" shorter (it was truncated)
- translated "failed" always in "non andato a buon fine" (sometimes it was translated "fallito")
- Removed "Are you sure" with a direct question (it is not usual in Italian)
- Improved messages with non-printable characters
- fixed label truncated  UDL, Continue character
- used the sam collocation for level; verb: espandi/comprimi (sometimes it was used also "contrai","riduci); noun: livello (sometimes strutture) 
-Translated with the same words/phrases
- Make phrases more natural
- keyboard hotkeys in search/replace dialog
- keyboard HotKeys in Column Editor
- keyboard hotkeys in File menu
- keyboard hotkeys in Edit menu
- keyboard hotkeys in Search menu