### PR TITLE
Nullpointer checks

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3122,16 +3122,20 @@ void Notepad_plus::command(int id)
 				// Save the current clipboard content
 				::OpenClipboard(_pPublicInterface->getHSelf());
 				HANDLE clipboardData = ::GetClipboardData(CF_TEXT);
-				int len = static_cast<int32_t>(::GlobalSize(clipboardData));
-				LPVOID clipboardDataPtr = ::GlobalLock(clipboardData);
+				LPVOID clipboardData2 = NULL;
+				if (clipboardData != NULL)
+				{
+					int len = static_cast<int32_t>(::GlobalSize(clipboardData));
+					LPVOID clipboardDataPtr = ::GlobalLock(clipboardData);
 
-				HANDLE allocClipboardData = ::GlobalAlloc(GMEM_MOVEABLE, len);
-				LPVOID clipboardData2 = ::GlobalLock(allocClipboardData);
+					HANDLE allocClipboardData = ::GlobalAlloc(GMEM_MOVEABLE, len);
+					clipboardData2 = ::GlobalLock(allocClipboardData);
 
-				::memcpy(clipboardData2, clipboardDataPtr, len);
-				::GlobalUnlock(clipboardData);
-				::GlobalUnlock(allocClipboardData);
-				::CloseClipboard();
+					::memcpy(clipboardData2, clipboardDataPtr, len);
+					::GlobalUnlock(clipboardData);
+					::GlobalUnlock(allocClipboardData);
+					::CloseClipboard();
+				}
 
 				_pEditView->saveCurrentPos();
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -813,7 +813,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				}
 				else
 				{
-					// Find matching pairs of delimiters (e.g. parantheses).
+					// Find matching pairs of delimiters (e.g. parentheses).
 					// The pair where the distance from the left delimiter to position_of_click is at a minimum is the one we're looking for.
 					// Of course position_of_click must lie between the delimiters.
 
@@ -863,7 +863,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			}
 			else
 			{ // Double click with no modifiers
-				// Check wether cursor is within URL
+				// Check whether cursor is within URL
 				auto indicMsk = notifyView->execute(SCI_INDICATORALLONFOR, notification->position);
 				if (!(indicMsk & (1 << URL_INDIC)))
 					break;
@@ -1103,6 +1103,9 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 		case SCN_AUTOCSELECTION:
 		{
+			if (!notifyView)
+				return FALSE;
+
 			const NppGUI& nppGui = NppParameters::getInstance().getNppGUI();
 
 			// if autocompletion is disabled and it is triggered manually, then both ENTER & TAB will insert the selection 

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -171,7 +171,10 @@ size_t Utf8_16_Read::convert(char* buf, size_t len)
 					delete [] m_pNewBuf;
                 m_pNewBuf  = NULL;
                 m_pNewBuf  = new ubyte[newSize];
-				m_nAllocatedBufSize = newSize;
+				if (m_pNewBuf)
+				{
+					m_nAllocatedBufSize = newSize;
+				}
             }
             
             ubyte* pCur = m_pNewBuf;
@@ -419,18 +422,24 @@ size_t Utf8_16_Write::convert(char* p, size_t _size)
         case uniCookie:
 		{
             // Normal write
-            m_nBufSize = _size;
-            m_pNewBuf = (ubyte*)new ubyte[m_nBufSize];
-            memcpy(m_pNewBuf, p, _size);
+            m_pNewBuf = (ubyte*)new ubyte[_size];
+			if (m_pNewBuf)
+			{
+				m_nBufSize = _size;
+				memcpy(m_pNewBuf, p, _size);
+			}
         }
 		break;
 
         case uniUTF8:
 		{
-            m_nBufSize = _size + 3;
-            m_pNewBuf = (ubyte*)new ubyte[m_nBufSize];
-            memcpy(m_pNewBuf, k_Boms[m_eEncoding], 3);
-            memcpy(&m_pNewBuf[3], p, _size);
+            m_pNewBuf = (ubyte*)new ubyte[_size + 3];
+			if (m_pNewBuf)
+			{
+				m_nBufSize = _size + 3;
+				memcpy(m_pNewBuf, k_Boms[m_eEncoding], 3);
+				memcpy(&m_pNewBuf[3], p, _size);
+			}
         }
 		break;
 
@@ -445,13 +454,19 @@ size_t Utf8_16_Write::convert(char* p, size_t _size)
 			{
                 // Write the BOM
 				m_pNewBuf = (ubyte*)new ubyte[sizeof(utf16) * (_size + 1)];
-                memcpy(m_pNewBuf, k_Boms[m_eEncoding], 2);
-	            pCur = (utf16*)&m_pNewBuf[2];
+				if (m_pNewBuf)
+				{
+					memcpy(m_pNewBuf, k_Boms[m_eEncoding], 2);
+					pCur = (utf16*)&m_pNewBuf[2];
+				}
             }
 			else
 			{
 				m_pNewBuf = (ubyte*)new ubyte[sizeof(utf16) * _size];
-	            pCur = (utf16*)m_pNewBuf;
+				if (m_pNewBuf)
+				{
+					pCur = (utf16*)m_pNewBuf;
+				}
 			}
 
             Utf8_Iter iter8;

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -170,25 +170,29 @@ size_t Utf8_16_Read::convert(char* buf, size_t len)
 				if (m_pNewBuf)
 					delete [] m_pNewBuf;
                 m_pNewBuf  = NULL;
+				m_nAllocatedBufSize = 0;
                 m_pNewBuf  = new ubyte[newSize];
 				if (m_pNewBuf)
 				{
 					m_nAllocatedBufSize = newSize;
 				}
             }
-            
-            ubyte* pCur = m_pNewBuf;
-            
-            m_Iter16.set(m_pBuf + nSkip, len - nSkip, m_eEncoding);
 
-			while (m_Iter16)
+			if (m_nAllocatedBufSize)
 			{
-				++m_Iter16;
-				utf8 c;
-				while (m_Iter16.get(&c))
-					*pCur++ = c;
+				ubyte* pCur = m_pNewBuf;
+
+				m_Iter16.set(m_pBuf + nSkip, len - nSkip, m_eEncoding);
+
+				while (m_Iter16)
+				{
+					++m_Iter16;
+					utf8 c;
+					while (m_Iter16.get(&c))
+						*pCur++ = c;
+				}
+				m_nNewBufSize = pCur - m_pNewBuf;
 			}
-			m_nNewBufSize = pCur - m_pNewBuf;
         }
 		break;
 
@@ -410,83 +414,79 @@ bool Utf8_16_Write::writeFile(const void* p, size_t _size)
 size_t Utf8_16_Write::convert(char* p, size_t _size)
 {
 	if (m_pNewBuf)
-    {
+	{
 		delete [] m_pNewBuf;
 		m_pNewBuf = NULL;
+		m_nBufSize = 0;
 	}
 
-    switch (m_eEncoding)
-    {
+	try
+	{
+		switch (m_eEncoding)
+		{
 		case uni7Bit:
-        case uni8Bit:
-        case uniCookie:
+		case uni8Bit:
+		case uniCookie:
 		{
-            // Normal write
-            m_pNewBuf = new ubyte[_size];
-			if (m_pNewBuf)
-			{
-				m_nBufSize = _size;
-				memcpy(m_pNewBuf, p, _size);
-			}
-        }
+			// Normal write
+			m_pNewBuf = new ubyte[_size];
+			m_nBufSize = _size;
+			memcpy(m_pNewBuf, p, _size);
+		}
 		break;
 
-        case uniUTF8:
+		case uniUTF8:
 		{
-            m_pNewBuf = new ubyte[_size + 3];
-			if (m_pNewBuf)
-			{
-				m_nBufSize = _size + 3;
-				memcpy(m_pNewBuf, k_Boms[m_eEncoding], 3);
-				memcpy(&m_pNewBuf[3], p, _size);
-			}
-        }
+			m_pNewBuf = new ubyte[_size + 3];
+			m_nBufSize = _size + 3;
+			memcpy(m_pNewBuf, k_Boms[m_eEncoding], 3);
+			memcpy(&m_pNewBuf[3], p, _size);
+		}
 		break;
 
-        case uni16BE_NoBOM:
-        case uni16LE_NoBOM:
-        case uni16BE:
-        case uni16LE:
+		case uni16BE_NoBOM:
+		case uni16LE_NoBOM:
+		case uni16BE:
+		case uni16LE:
 		{
 			utf16* pCur = NULL;
-            
-            if (m_eEncoding == uni16BE || m_eEncoding == uni16LE)
+
+			if (m_eEncoding == uni16BE || m_eEncoding == uni16LE)
 			{
-                // Write the BOM
+				// Write the BOM
 				m_pNewBuf = new ubyte[sizeof(utf16) * (_size + 1)];
-				if (m_pNewBuf)
-				{
-					memcpy(m_pNewBuf, k_Boms[m_eEncoding], 2);
-					pCur = (utf16*)&m_pNewBuf[2];
-				}
-            }
+				memcpy(m_pNewBuf, k_Boms[m_eEncoding], 2);
+				pCur = (utf16*)&m_pNewBuf[2];
+			}
 			else
 			{
 				m_pNewBuf = new ubyte[sizeof(utf16) * _size];
-				if (m_pNewBuf)
-				{
-					pCur = (utf16*)m_pNewBuf;
-				}
+				pCur = (utf16*)m_pNewBuf;
 			}
 
-            Utf8_Iter iter8;
-            iter8.set(reinterpret_cast<const ubyte*>(p), _size, m_eEncoding);
-            
-            for (; iter8; ++iter8)
+			Utf8_Iter iter8;
+			iter8.set(reinterpret_cast<const ubyte*>(p), _size, m_eEncoding);
+
+			for (; iter8; ++iter8)
 			{
-                if (iter8.canGet())
+				if (iter8.canGet())
 				{
-                    iter8.get(pCur++);
-                }
-            }
-            m_nBufSize = (const char*)pCur - (const char*)m_pNewBuf;
-        }
+					iter8.get(pCur++);
+				}
+			}
+			m_nBufSize = (const char*)pCur - (const char*)m_pNewBuf;
+		}
 		break;
 
-        default:
-            break;
-    }
-    
+		default:
+			break;
+		}
+	}
+	catch (const std::bad_alloc&)
+	{
+		m_nBufSize = 0;
+	}
+
 	return m_nBufSize;
 }
 

--- a/PowerEditor/src/Utf8_16.cpp
+++ b/PowerEditor/src/Utf8_16.cpp
@@ -422,7 +422,7 @@ size_t Utf8_16_Write::convert(char* p, size_t _size)
         case uniCookie:
 		{
             // Normal write
-            m_pNewBuf = (ubyte*)new ubyte[_size];
+            m_pNewBuf = new ubyte[_size];
 			if (m_pNewBuf)
 			{
 				m_nBufSize = _size;
@@ -433,7 +433,7 @@ size_t Utf8_16_Write::convert(char* p, size_t _size)
 
         case uniUTF8:
 		{
-            m_pNewBuf = (ubyte*)new ubyte[_size + 3];
+            m_pNewBuf = new ubyte[_size + 3];
 			if (m_pNewBuf)
 			{
 				m_nBufSize = _size + 3;
@@ -453,7 +453,7 @@ size_t Utf8_16_Write::convert(char* p, size_t _size)
             if (m_eEncoding == uni16BE || m_eEncoding == uni16LE)
 			{
                 // Write the BOM
-				m_pNewBuf = (ubyte*)new ubyte[sizeof(utf16) * (_size + 1)];
+				m_pNewBuf = new ubyte[sizeof(utf16) * (_size + 1)];
 				if (m_pNewBuf)
 				{
 					memcpy(m_pNewBuf, k_Boms[m_eEncoding], 2);
@@ -462,7 +462,7 @@ size_t Utf8_16_Write::convert(char* p, size_t _size)
             }
 			else
 			{
-				m_pNewBuf = (ubyte*)new ubyte[sizeof(utf16) * _size];
+				m_pNewBuf = new ubyte[sizeof(utf16) * _size];
 				if (m_pNewBuf)
 				{
 					pCur = (utf16*)m_pNewBuf;

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -803,17 +803,20 @@ void WindowsDlg::resetSelection()
 {
 	assert(_pTab != nullptr);
 
-	auto curSel = _pTab->getCurrentTabIndex();
-	int pos = 0;
-	for (vector<int>::iterator itr = _idxMap.begin(), end = _idxMap.end(); itr != end; ++itr, ++pos)
+	if(_pTab)
 	{
-		if (*itr == curSel)
+		auto curSel = _pTab->getCurrentTabIndex();
+		int pos = 0;
+		for (vector<int>::iterator itr = _idxMap.begin(), end = _idxMap.end(); itr != end; ++itr, ++pos)
 		{
-			ListView_SetItemState(_hList, pos, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
-		}
-		else
-		{
-			ListView_SetItemState(_hList, pos, 0, LVIS_SELECTED);
+			if (*itr == curSel)
+			{
+				ListView_SetItemState(_hList, pos, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+			}
+			else
+			{
+				ListView_SetItemState(_hList, pos, 0, LVIS_SELECTED);
+			}
 		}
 	}
 }

--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -155,13 +155,13 @@ struct BufferEquivalent
 			BufferID bid2 = _pTab->getBufferByIndex(i2);
 			Buffer * b1 = MainFileManager.getBufferByID(bid1);
 			Buffer * b2 = MainFileManager.getBufferByID(bid2);
-			
+
 			if (_iColumn == 0)
 			{
 				const TCHAR *s1 = b1->getFileName();
 				const TCHAR *s2 = b2->getFileName();
 				int result = _strequiv(s1, s2);
-				
+
 				if (result != 0) // default to filepath sorting when equivalent
 					return result < 0;
 			}
@@ -179,7 +179,7 @@ struct BufferEquivalent
 				}
 				else
 					s1 = TEXT("");
-				
+
 				Lang *lang2 = nppParameters.getLangFromID(b2->getLangType());
 				if (lang2)
 				{
@@ -187,7 +187,7 @@ struct BufferEquivalent
 				}
 				else
 					s2 = TEXT("");
-				
+
 				int result = _strequiv(s1, s2);
 
 				if (result != 0) // default to filepath sorting when equivalent
@@ -198,11 +198,11 @@ struct BufferEquivalent
 			{
 				auto t1 = b1->docLength();
 				auto t2 = b2->docLength();
-				
+
 				if (t1 != t2) // default to filepath sorting when equivalent
 					return (t1 < t2);
 			}
-			
+
 			// _iColumn == 1
 			const TCHAR *s1 = b1->getFullPathName();
 			const TCHAR *s2 = b2->getFullPathName();
@@ -326,13 +326,13 @@ intptr_t CALLBACK WindowsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 						_currentColumn = 0;
 						_reverseSort = false;
 						_lastSort = _currentColumn;
-						
+
 						updateColumnNames();
 						doColumnSort();
 					}
-					
+
 					doSortToTabs();
-					
+
 					// must re-sort because tab indexes changed
 					doColumnSort();
 					break;
@@ -431,7 +431,7 @@ intptr_t CALLBACK WindowsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 					if (pNMLV->iItem == -1)
 					{
 						_currentColumn = pNMLV->iSubItem;
-						
+
 						if (_lastSort == _currentColumn)
 						{
 							_reverseSort = true;
@@ -442,7 +442,7 @@ intptr_t CALLBACK WindowsDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM lP
 							_reverseSort = false;
 							_lastSort = _currentColumn;
 						}
-						
+
 						updateColumnNames();
 						doColumnSort();
 					}
@@ -512,7 +512,7 @@ void WindowsDlg::doColumnSort()
 {
 	if (_currentColumn == -1)
 		return;
-	
+
 	size_t i = 0;
 	size_t n = _idxMap.size();
 	vector<int> sortMap;
@@ -597,7 +597,7 @@ BOOL WindowsDlg::onInitDialog()
 	LVCOLUMN lvColumn{};
 	lvColumn.mask = LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM | LVCF_FMT;
 	lvColumn.fmt = LVCFMT_LEFT;
-	
+
 	generic_string columnText;
 	NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 
@@ -646,7 +646,7 @@ void WindowsDlg::updateColumnNames()
 
 	generic_string columnText;
 	NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
-	
+
 	columnText = pNativeSpeaker->getAttrNameStr(TEXT("Name"), WD_ROOTNODE, WD_CLMNNAME);
 	if (_currentColumn != 0)
 	{
@@ -801,22 +801,20 @@ void WindowsDlg::fitColumnsToSize()
 
 void WindowsDlg::resetSelection()
 {
-	assert(_pTab != nullptr);
+	if (!_pTab)
+		return;
 
-	if(_pTab)
+	auto curSel = _pTab->getCurrentTabIndex();
+	int pos = 0;
+	for (vector<int>::iterator itr = _idxMap.begin(), end = _idxMap.end(); itr != end; ++itr, ++pos)
 	{
-		auto curSel = _pTab->getCurrentTabIndex();
-		int pos = 0;
-		for (vector<int>::iterator itr = _idxMap.begin(), end = _idxMap.end(); itr != end; ++itr, ++pos)
+		if (*itr == curSel)
 		{
-			if (*itr == curSel)
-			{
-				ListView_SetItemState(_hList, pos, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
-			}
-			else
-			{
-				ListView_SetItemState(_hList, pos, 0, LVIS_SELECTED);
-			}
+			ListView_SetItemState(_hList, pos, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+		}
+		else
+		{
+			ListView_SetItemState(_hList, pos, 0, LVIS_SELECTED);
 		}
 	}
 }
@@ -949,7 +947,7 @@ void WindowsDlg::doCount()
 
 void WindowsDlg::doSort()
 {
-	if (_pTab == NULL)
+	if (!_pTab)
 		return;
 
 	size_t count =  _pTab->nbItem();
@@ -972,7 +970,7 @@ void WindowsDlg::doSort()
 		_idxMap.clear();
 		refreshMap();
 	}
-	
+
 	//After sorting, need to open the active tab before sorting
 	//This will be helpful when large number of documents are opened
 	__int64 newPosition = -1;
@@ -984,7 +982,7 @@ void WindowsDlg::doSort()
 	nmdlg.type = WDT_ACTIVATE;
 	nmdlg.curSel = static_cast<UINT>(newPosition);
 	nmdlg.hwndFrom = _hSelf;
-	nmdlg.code = WDN_NOTIFY;	
+	nmdlg.code = WDN_NOTIFY;
 	SendMessage(_hParent, WDN_NOTIFY, 0, LPARAM(&nmdlg));
 }
 

--- a/lexilla/lexers/LexSearchResult.cxx
+++ b/lexilla/lexers/LexSearchResult.cxx
@@ -108,7 +108,7 @@ static void ColouriseSearchResultLine(SearchResultMarkings* pMarkings, char *lin
 
 static void ColouriseSearchResultDoc(Sci_PositionU startPos, Sci_Position length, int, WordList *[], Accessor &styler) {
 
-	char lineBuffer[SC_SEARCHRESULT_LINEBUFFERMAXLENGTH];
+	char lineBuffer[SC_SEARCHRESULT_LINEBUFFERMAXLENGTH] {};
 	styler.StartAt(startPos);
 	styler.StartSegment(startPos);
 	unsigned int linePos = 0;


### PR DESCRIPTION
- zero init LexSearchResult.cxx lineBuffer
- WindowsDlg::resetSelection() add nullpointer check as assert just triggers on debug builds

>   clang analyzer issue: PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp:806:16: warning: Called C++ object pointer is null [core.CallAndMessage]
>   806 |         auto curSel = _pTab->getCurrentTabIndex();
> 

- added missing nullpointer checks in Utf8_16.cpp on allocated memory
- added missing nullpointer check on notifyView for case SCN_AUTOCSELECTION in NppNotification.cpp

>   clang analyzer issue: PowerEditor/src/NppNotification.cpp:1116:5: warning: Called C++ object pointer is null [core.CallAndMessage]
>  1116 |                                 notifyView->execute(SCI_AUTOCCANCEL);
> 

- added missing nullpointer check on clipboardData in NppCommands.cpp from address sanitizer run

