### PR TITLE
Disallow tab character via pasting when renaming a filetab

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1402,7 +1402,8 @@ Continue?"/><!-- HowToReproduce: when you openned file is modified and saved, th
 			<FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
 			<FileAlreadyOpenedInNpp title="" message="The file is already opened in Notepad++."/><!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
 			<RenameTabTemporaryNameAlreadyInUse title="Rename failed" message="The specified name is already in use on another tab."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
-			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="The specified name cannot be empty, or it cannot contain only space(s)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
+			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="The specified name cannot be empty, or it cannot contain only space(s) or TAB(s)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
+			<RenameTabTemporaryNameGeneralFailure title="Rename failed" message="The specified name is not valid."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a reserved name such as COM1 for the new name. -->
 			<DeleteFileFailed title="Delete File" message="Delete File failed"/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1403,7 +1403,6 @@ Continue?"/><!-- HowToReproduce: when you openned file is modified and saved, th
 			<FileAlreadyOpenedInNpp title="" message="The file is already opened in Notepad++."/><!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
 			<RenameTabTemporaryNameAlreadyInUse title="Rename failed" message="The specified name is already in use on another tab."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
 			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="The specified name cannot be empty, or it cannot contain only space(s) or TAB(s)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
-			<RenameTabTemporaryNameGeneralFailure title="Rename failed" message="The specified name is not valid."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a reserved name such as COM1 for the new name. -->
 			<DeleteFileFailed title="Delete File" message="Delete File failed"/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1402,7 +1402,7 @@ Continue?"/><!-- HowToReproduce: when you openned file is modified and saved, th
 			<FileLockedWarning title="Save failed" message="Please check whether if this file is opened in another program"/>
 			<FileAlreadyOpenedInNpp title="" message="The file is already opened in Notepad++."/><!-- HowToReproduce: Open a new document and open a file "c:/tmp/foo", save this new document by choosing "c:/tmp/foo" as file to save, reply the override popup "yes", then this message appears. -->
 			<RenameTabTemporaryNameAlreadyInUse title="Rename failed" message="The specified name is already in use on another tab."/><!-- HowToReproduce: Rename the tab of an untitled document and provide a name that is the same as an already-existing tab of an untitled document. -->
-			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="The specified name cannot be empty, or it cannot contain only space(s) or TAB(s)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
+			<RenameTabTemporaryNameIsEmpty title="Rename failed" message="The specified name cannot be empty, or it cannot contain only space(s)."/><!-- HowToReproduce: Rename the tab of an untitled document and provide an empty string or only some white speces. -->
 			<DeleteFileFailed title="Delete File" message="Delete File failed"/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
 
 			<NbFileToOpenImportantWarning title="Amount of files to open is too large" message="$INT_REPLACE$ files are about to be opened.

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1901,8 +1901,9 @@ bool Notepad_plus::fileRename(BufferID id)
 		// So just rename the tab and rename the backup file too if applicable
 
 		// https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file
-		// Reserved characters: < > : " / \ | ? *
-		std::wstring reservedChars = TEXT("<>:\"/\\|\?*");
+		// Reserved characters:  < > : " / \ | ? * tab  
+		//  ("tab" is not in the official list, but it is good to avoid it)
+		std::wstring reservedChars = TEXT("<>:\"/\\|\?*\t");
 
 		std::wstring staticName = _nativeLangSpeaker.getLocalizedStrFromID("tabrename-newname", L"New name");
 
@@ -1934,7 +1935,7 @@ bool Notepad_plus::fileRename(BufferID id)
 			{
 				_nativeLangSpeaker.messageBox("RenameTabTemporaryNameIsEmpty",
 					_pPublicInterface->getHSelf(),
-					L"The specified name cannot be empty, or it cannot contain only space(s) or TAB(s).",
+					L"The specified name cannot be empty, or it cannot contain only space(s).",
 					L"Rename failed",
 					MB_OK | MB_ICONSTOP);
 			}

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1935,7 +1935,7 @@ bool Notepad_plus::fileRename(BufferID id)
 			{
 				_nativeLangSpeaker.messageBox("RenameTabTemporaryNameIsEmpty",
 					_pPublicInterface->getHSelf(),
-					L"The specified name cannot be empty, or it cannot contain only space(s).",
+					L"The specified name cannot be empty, or it cannot contain only space(s) or TAB(s).",
 					L"Rename failed",
 					MB_OK | MB_ICONSTOP);
 			}


### PR DESCRIPTION
Fix #15202

Note that since tab characters are prevented from being used, the error message that mentions them has been updated to NOT mention them (as it is unnecessary to mention them).