### PR TITLE
Implement installer '/closeRunningNpp' cmdline option

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -114,6 +114,7 @@ InstType "Minimalist"
 
 Var diffArchDir2Remove
 Var noUpdater
+Var closeRunningNpp
 
 
 !ifdef ARCH64 || ARCHARM64
@@ -149,6 +150,21 @@ Function .onInit
 !endif
 	;
 	; --- PATCH END ---
+
+	; check for the possible "/closeRunningNpp" cmdline option 1st
+	${GetParameters} $R0 
+	${GetOptions} $R0 "/closeRunningNpp" $R1 ; case insensitive 
+	IfErrors 0 closeRunningNppYes
+	StrCpy $closeRunningNpp "false"
+	Goto closeRunningNppCheckDone
+closeRunningNppYes:
+	StrCpy $closeRunningNpp "true"
+closeRunningNppCheckDone:
+	${If} $closeRunningNpp == "true"
+		; First try to use the usual app-closing by sending the WM_CLOSE.
+		; If that closing fails, use the forceful TerminateProcess way.
+		!insertmacro FindAndCloseOrTerminateRunningNpp ; this has to precede the following silent mode Notepad++ instance mutex check
+	${EndIf}
 
 	; handle the possible Silent Mode (/S) & already running Notepad++ (without this an incorrect partial installation is possible)
 	IfSilent 0 notInSilentMode


### PR DESCRIPTION
Partially fix the #8514 .
The promised followup of the #14251.

If specified on the NSIS installer cmdline:
- it detects a possible running Notepad++ (by FindWindow WINAPI on the Notepad++ registered wnd-class)
- then it first tries to use the usual app-closing by sending the WM_CLOSE message to the running Notepad++ wnd found (it waits for that closing 5 secs max using the WaitForSingleObject WINAPI)
- if that standard closing fails, it uses consequently the forceful TerminateProcess WINAPI way (one can easily simulate this e.g. by suspending a running N++ process via an advanced task manager...)
- it also handles the possible Notepad++ multi-instance mode (it will close all the running instances)

(if accepted, the N++ manual will also need a PR about this new switch)