### PR TITLE
Restore old paste into rectangular selection behavior

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -487,7 +487,8 @@ void Notepad_plus::command(int id)
 				size_t nbSelections = _pEditView->execute(SCI_GETSELECTIONS);
 				Buffer* buf = getCurrentBuffer();
 				bool isRO = buf->isReadOnly();
-				if (nbSelections > 1 && !isRO)
+				LRESULT selectionMode = _pEditView->execute(SCI_GETSELECTIONMODE);
+				if (nbSelections > 1 && !isRO && selectionMode == SC_SEL_STREAM)
 				{
 					bool isPasteDone = _pEditView->pasteToMultiSelection();
 					if (isPasteDone)


### PR DESCRIPTION
Restore old paste into rectangular selection behavior by only calling pasteIntoMultiSelection for multiple stream selections and not for rectangular selections.

Resolves #15139. Resolves #15151.

It is unclear to me whether the change in behavior when pasting into rectangular selections was intended. If it was an oversight, this restores familiar behavior when pasting into rectangular selections. If it was intentional, then some other resolution for the linked issues is required.