### PR TITLE
Fix crash on Windows Core Server

### DIFF
--- a/PowerEditor/src/dpiManagerV2.cpp
+++ b/PowerEditor/src/dpiManagerV2.cpp
@@ -286,4 +286,10 @@ void DPIManagerV2::loadIcon(HINSTANCE hinst, const wchar_t* pszName, int cx, int
 	{
 		*phico = static_cast<HICON>(::LoadImage(hinst, pszName, IMAGE_ICON, cx, cy, fuLoad));
 	}
+
+	// in case of LoadIconWithScaleDown is not compatible on Windows version: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/15313
+	if (!*phico)
+	{
+		*phico = ::LoadIcon(hinst, pszName);
+	}
 }


### PR DESCRIPTION
LoadIconWithScaleDown function could not be in runtime of Windows Core Server. 
In order to prevent Notepad++ from crash, this commit use the old call (LoadIcon) in case of loading failed.

Fix #15313