### PR TITLE
Fix exception/crash on Windows Server Core 2022

### DIFF
--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.h
@@ -39,7 +39,7 @@ public :
 	};
 
 	HIMAGELIST getHandle() const {return _hImglst;};
-	void addIcon(int iconID, int cx = 32, int cy = 32) const;
+	void addIcon(int iconID, int cx = 16, int cy = 16, int failIconID = -1) const;
 	void addIcon(HICON hIcon) const;
 
 	bool changeIcon(size_t index, const TCHAR *iconLocation) const;


### PR DESCRIPTION
Make loading icons fail-safe.

Fix #15313