### PR TITLE
Fix exception/crash on Windows Server Core 2022 (Datacenter)

### DIFF
--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
@@ -49,7 +49,15 @@ void IconList::addIcon(int iconID, int cx, int cy) const
 	DPIManagerV2::loadIcon(_hInst, MAKEINTRESOURCE(iconID), cx, cy, &hIcon, LR_DEFAULTSIZE);
 
 	if (!hIcon)
-		throw std::runtime_error("IconList::addIcon : LoadIcon() function return null");
+	{
+		static bool keepToLoad = true;
+		if (keepToLoad)
+		{
+			int userAnswer = ::MessageBoxA(NULL, "IconList::addIcon : LoadIcon() function return null.\nKeep showing this message?", std::to_string(iconID).c_str(), MB_YESNO | MB_ICONWARNING);
+			keepToLoad = userAnswer == IDYES;
+		}
+		return;
+	}
 
 	ImageList_AddIcon(_hImglst, hIcon);
 	::DestroyIcon(hIcon);


### PR DESCRIPTION
The exception/crash occurs due to the unsupported icon format in Windows Server Core 2022 (due to the lack of a graphical library). 

The commit represents a balance between the functionality of loading icons and the minimal graphic support required for Notepad++:
In the event of loading problems in a typical Windows version with complete graphical library support (which is unlikely but possible), users will receive alerts, and the ICO ID in question will be displayed in the caption. 
However, under Windows Server Core 2022, multiple alert message boxes may appear during Notepad++ launch, but they can be stopped after the first one, allowing the user to use Notepad++ normally.

![image](https://github.com/notepad-plus-plus/notepad-plus-plus/assets/90293/a09d8095-37c6-44e9-b883-23e74f09c037)


Fix #15313