### PR TITLE
Do not recognize files without lnk-extension as Windows shortcuts

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1552,11 +1552,7 @@ bool isUnsupportedFileName(const generic_string& fileName)
 					fileNameOnly = fileNameOnly.substr(pos + 1);
 
 				// upperize because the std::find is case sensitive unlike the Windows OS filesystem
-#ifdef UNICODE
 				std::transform(fileNameOnly.begin(), fileNameOnly.end(), fileNameOnly.begin(), ::towupper);
-#else
-				std::transform(fileNameOnly.begin(), fileNameOnly.end(), fileNameOnly.begin(), ::toupper);
-#endif
 
 				const std::vector<generic_string>  reservedWin32NamespaceDeviceList{
 				TEXT("CON"), TEXT("PRN"), TEXT("AUX"), TEXT("NUL"),

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1551,6 +1551,13 @@ bool isUnsupportedFileName(const generic_string& fileName)
 				if (pos != std::string::npos)
 					fileNameOnly = fileNameOnly.substr(pos + 1);
 
+				// upperize because the std::find is case sensitive unlike the Windows OS filesystem
+#ifdef UNICODE
+				std::transform(fileNameOnly.begin(), fileNameOnly.end(), fileNameOnly.begin(), ::towupper);
+#else
+				std::transform(fileNameOnly.begin(), fileNameOnly.end(), fileNameOnly.begin(), ::toupper);
+#endif
+
 				const std::vector<generic_string>  reservedWin32NamespaceDeviceList{
 				TEXT("CON"), TEXT("PRN"), TEXT("AUX"), TEXT("NUL"),
 				TEXT("COM1"), TEXT("COM2"), TEXT("COM3"), TEXT("COM4"), TEXT("COM5"), TEXT("COM6"), TEXT("COM7"), TEXT("COM8"), TEXT("COM9"),

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -128,6 +128,16 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 
 bool resolveLinkFile(generic_string& linkFilePath)
 {
+	// upperize for the following comparison because the ends_with is case sensitive unlike the Windows OS filesystem
+	generic_string linkFilePathUp = linkFilePath;
+#ifdef UNICODE
+	std::transform(linkFilePathUp.begin(), linkFilePathUp.end(), linkFilePathUp.begin(), ::towupper);
+#else
+	std::transform(linkFilePathUp.begin(), linkFilePathUp.end(), linkFilePathUp.begin(), ::toupper);
+#endif
+	if (!linkFilePathUp.ends_with(TEXT(".LNK")))
+		return false; // we will not check the renamed shortcuts like "file.lnk.txt"
+
 	bool isResolved = false;
 
 	IShellLink* psl = nullptr;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -126,16 +126,12 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 	return EXIT_SUCCESS;
 }
 
-bool resolveLinkFile(generic_string& linkFilePath)
+bool resolveLinkFile(std::wstring& linkFilePath)
 {
 	// upperize for the following comparison because the ends_with is case sensitive unlike the Windows OS filesystem
-	generic_string linkFilePathUp = linkFilePath;
-#ifdef UNICODE
+	std::wstring linkFilePathUp = linkFilePath;
 	std::transform(linkFilePathUp.begin(), linkFilePathUp.end(), linkFilePathUp.begin(), ::towupper);
-#else
-	std::transform(linkFilePathUp.begin(), linkFilePathUp.end(), linkFilePathUp.begin(), ::toupper);
-#endif
-	if (!linkFilePathUp.ends_with(TEXT(".LNK")))
+	if (!linkFilePathUp.ends_with(L".LNK"))
 		return false; // we will not check the renamed shortcuts like "file.lnk.txt"
 
 	bool isResolved = false;


### PR DESCRIPTION
Fix #11089, fix #10139, fix #9643

Also contains minor fix (using the same "Upperize" method) for the reported https://github.com/notepad-plus-plus/notepad-plus-plus/pull/15211#issuecomment-2156495651 .