### PR TITLE
sync Paste and Undo commands with filebuffer R/O status

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6621,6 +6621,10 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
     if (mask & (BufferChangeReadonly))
 	{
 		checkDocState();
+		
+		// enable/disable possible Undo and Paste commands according to the current R/O status
+		checkClipboard();
+		checkUndoState();
 
 		bool isSysReadOnly = buffer->getFileReadOnly();
 		bool isUserReadOnly = buffer->getUserReadOnly();
@@ -6632,7 +6636,6 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 		scnN.nmhdr.idFrom = (uptr_t)  ((isSysReadOnly || isUserReadOnly? DOCSTATUS_READONLY : 0) | (isDirty ? DOCSTATUS_BUFFERDIRTY : 0));
 		scnN.nmhdr.code = NPPN_READONLYCHANGED;
 		_pluginsManager.notify(&scnN);
-
 	}
 
 	if (_pDocumentListPanel)


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13742#issuecomment-2233570312

Previously, after e.g. removing the read-only flag, file editing was possible immediately, but Ctrl-V was not. At least a cursor movement or switching between the N++ tabs or apps-switching was required (SCN_UPDATEUI message generated...).