### PR TITLE
Fix FAW-treeview initial sorting for network storage

### DIFF
--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1008,6 +1008,7 @@ void FileBrowser::addRootFolder(wstring rootFolderPath)
 	FolderInfo directoryStructure(rootLabel, nullptr);
 	getDirectoryStructure(rootFolderPath.c_str(), patterns2Match, directoryStructure, true, false);
 	HTREEITEM hRootItem = createFolderItemsFromDirStruct(nullptr, directoryStructure);
+	_treeView.customSorting(_treeView.getRoot(), categorySortFunc, 0, true); // needed here for possible *nix like storages (Samba, WebDAV, WSL, ...)
 	_treeView.expand(hRootItem);
 	_folderUpdaters.push_back(new FolderUpdater(directoryStructure, this));
 	_folderUpdaters[_folderUpdaters.size() - 1]->startWatcher();

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1008,7 +1008,7 @@ void FileBrowser::addRootFolder(wstring rootFolderPath)
 	FolderInfo directoryStructure(rootLabel, nullptr);
 	getDirectoryStructure(rootFolderPath.c_str(), patterns2Match, directoryStructure, true, false);
 	HTREEITEM hRootItem = createFolderItemsFromDirStruct(nullptr, directoryStructure);
-	_treeView.customSorting(_treeView.getRoot(), categorySortFunc, 0, true); // needed here for possible *nix like storages (Samba, WebDAV, WSL, ...)
+	_treeView.customSorting(hRootItem, categorySortFunc, 0, true); // needed here for possible *nix like storages (Samba, WebDAV, WSL, ...)
 	_treeView.expand(hRootItem);
 	_folderUpdaters.push_back(new FolderUpdater(directoryStructure, this));
 	_folderUpdaters[_folderUpdaters.size() - 1]->startWatcher();


### PR DESCRIPTION
Fix #10557, fix #15397 .
Also partially fix #1541 , fix #9238 , fix #11716 .

Now the FAW-treeview initial sorting will be ok even for the possible Samba, WebDAV, WSL, GoogleDrive etc... storage used.

---

For the reported problem replication & PR-testing, I used the [WSL ](https://learn.microsoft.com/en-us/windows/wsl/) Ubuntu VM:

![npp-WSL-FAW-sorting-issue](https://github.com/user-attachments/assets/f0078e5a-c8fb-41b1-89e8-6e4f06078ed2)

Fixed:

![npp-WSL-FAW-sorting-fixed](https://github.com/user-attachments/assets/0a646f8d-0b0b-45c0-80c6-c0e47072c2ca)

"FAW-test" folder structure used for testing:
[FAW-test.zip](https://github.com/user-attachments/files/16288028/FAW-test.zip)





