### PR TITLE
Update swedish.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/swedish.xml
+++ b/PowerEditor/installer/nativeLang/swedish.xml
@@ -5,7 +5,7 @@ Translation note:
 2. All the comments are for explanation, they are not for translation.
 -->
 <NotepadPlus>
-	<Native-Langue name="Svenska" filename="swedish.xml" version="8.6.8">
+	<Native-Langue name="Svenska" filename="swedish.xml" version="8.6.9">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -165,7 +165,7 @@ Translation note:
 					<Item id="42096" name="Matcha hela ord"/>
 					<Item id="42097" name="Matcha skiftläge och hela ord"/>
 					<Item id="42098" name="Ångra senast tillagda multimarkering"/>
-					<Item id="42099" name="Hoppa över nuvarande och gå till nästa multimarkering"/>
+					<Item id="42099" name="Hoppa över aktuell och gå till nästa multimarkering"/>
 					<Item id="42018" name="Starta &amp;inspelning"/>
 					<Item id="42019" name="S&amp;toppa inspelning"/>
 					<Item id="42021" name="Spela &amp;upp"/>
@@ -222,7 +222,7 @@ Translation note:
 					<Item id="43051" name="Ta bort rader utan bokmärken"/>
 					<Item id="43050" name="Invertera bokmärken"/>
 					<Item id="43052" name="&amp;Hitta tecken i ett intervall..."/>
-					<Item id="43053" name="Markera alla mellan mat&amp;chande klamrar"/>
+					<Item id="43053" name="Markera alla mellan mat&amp;chande {} [] eller ()"/>
 					<Item id="43009" name="G&amp;å till matchande klamrar"/>
 					<Item id="43010" name="S&amp;ök föregående"/>
 					<Item id="43011" name="Steg&amp;vis sökning..."/>
@@ -355,6 +355,7 @@ Translation note:
 					<Item id="10005" name="Flytta till början"/>
 					<Item id="10006" name="Flytta till slutet"/>
 					<Item id="46001" name="Stilkonfigurering..."/>
+					<Item id="46016" name="Inget (oformaterad text)"/>
 					<Item id="46250" name="Definiera ditt språk..."/>
 					<Item id="46300" name="Öppna mapp för användardefinierade språk..."/>
 					<Item id="46301" name="Samling av användardefinierade språk för Notepad++"/>
@@ -977,7 +978,7 @@ Translation note:
 					<Item id="6219" name="Blinkhastighet:"/>
 					<Item id="6221" name="S"/>
 					<Item id="6222" name="L"/>
-					<Item id="6246" name="Låt kommandon gruppera/avgruppera nuvarande nivå"/>
+					<Item id="6246" name="Låt kommandon gruppera/avgruppera aktuell nivå"/>
 					<Item id="6227" name="Radbrytning"/>
 					<Item id="6228" name="Standard"/>
 					<Item id="6229" name="Justerad"/>
@@ -1001,7 +1002,7 @@ Translation note:
 					<Item id="6523" name="Aktivera kolumnmarkering för att multiredigera"/>
 					<Item id="6247" name="Radslut (CRLF)"/><!-- Don't translate "(CRLF)" -->
 					<Item id="6248" name="Standard"/>
-					<Item id="6249" name="Vanlig text"/>
+					<Item id="6249" name="Oformaterad text"/>
 					<Item id="6250" name="Anpassad färg"/>
 					<Item id="6252" name="Icke utskrivbara tecken"/>
 					<Item id="6260" name="Utseende"/>
@@ -1086,7 +1087,7 @@ Translation note:
 					<Item id="6413" name="Standardmapp (öppna/spara)"/>
 					<Item id="6414" name="Använd aktuellt dokument"/>
 					<Item id="6415" name="Kom ihåg senast använd mapp"/>
-					<Item id="6431" name="Öppna alla filer inuti mappar som släpps i stället för att öppna dem som arbetsytor"/>
+					<Item id="6431" name="Öppna alla filer från mappar som släpps i stället för att öppna dem som arbetsytor"/>
 				</DefaultDir>
 
 				<FileAssoc title="Filassociering">
@@ -1095,11 +1096,20 @@ Translation note:
 					<Item id="4010" name="Registrerade filändelser:"/>
 				</FileAssoc>
 
+
 				<Language title="Språk">
 					<Item id="6505" name="Tillgängliga"/>
 					<Item id="6506" name="Inaktiverade"/>
 					<Item id="6507" name="Gör språkmenyn kompakt"/>
 					<Item id="6508" name="Språkmeny"/>
+					<Item id="6335" name="Behandla omvänt snedstreck som escape-tecken för SQL"/>
+				</Language>
+
+				<Indentation title="Indrag">
+					<Item id="7161" name="Automatiskt indrag"/>
+					<Item id="7162" name="Inget"/>
+					<Item id="7163" name="Enkelt"/>
+					<Item id="7164" name="Avancerat"/>
 					<Item id="6301" name="Indragsinställningar"/>
 					<Item id="6302" name="Blankstegstecken"/>
 					<Item id="6303" name="Indragsstorlek:"/>
@@ -1107,8 +1117,7 @@ Translation note:
 					<Item id="6311" name="Tabb-tecken"/>
 					<Item id="6510" name="Använd standardvärde"/>
 					<Item id="6512" name="Backsteg minskar indrag i stället för att radera blanksteg"/>
-					<Item id="6335" name="Behandla omvänt snedstreck som escape-tecken för SQL"/>
-				</Language>
+				</Indentation>
 
 				<Highlighting title="Markering">
 					<Item id="6351" name="Stilsätt alla förekomster"/>
@@ -1153,7 +1162,7 @@ Translation note:
 					<Item id="6722" name="Hö&amp;gerkant"/>
 					<Item id="6723" name="&amp;Lägg till"/>
 					<ComboBox id="6724">
-						<Element name="Full filsökväg"/>
+						<Element name="Fullständig filsökväg"/>
 						<Element name="Filnamn"/>
 						<Element name="Mappsökväg"/>
 						<Element name="Sidnummer"/>
@@ -1168,7 +1177,7 @@ Translation note:
 
 				<Searching title="Sökning">
 					<Item id="6902" name="Använd typsnitt med fast bredd i sökdialogen (kräver omstart av Notepad++)"/>
-					<Item id="6903" name="Sökdialogen stannar öppen efter sökningar som matar ut till resultatfönstret"/>
+					<Item id="6903" name="Sökdialogen förblir öppen efter sökningar som matar ut till resultatfönstret"/>
 					<Item id="6904" name="Visa bekräftelsedialog för &quot;Ersätt alla i alla öppna dokument&quot;"/>
 					<Item id="6905" name="Ersätt: Hoppa inte till nästa förekomst"/>
 					<Item id="6906" name="Resultatfönstret: Visa endast en post per funnen rad om det är möjligt"/>
@@ -1192,7 +1201,7 @@ Translation note:
 				<Backup title="Säkerhetskopiering">
 					<Item id="6817" name="Sessioner och säkerhetskopiering"/>
 					<Item id="6818" name="Ta ögonblicksbilder av sessioner och säkerhetskopiera regelbundet"/>
-					<Item id="6819" name="Säkerhetskopiera efter"/>
+					<Item id="6819" name="Säkerhetskopiera vid förändring efter"/>
 					<Item id="6821" name="sekund(er)"/>
 					<Item id="6822" name="Sökväg:"/>
 					<Item id="6309" name="Kom ihåg aktuell session vid nästa uppstart"/>
@@ -1236,7 +1245,7 @@ Translation note:
 					<Item id="6154" name="Standard (en enda instans)"/>
 					<Item id="6155" name="* En omstart av Notepad++ krävs om denna inställning ändras"/>
 					<Item id="6171" name="Anpassa datum och tid att infoga"/>
-					<Item id="6175" name="Omvänd standardordning av datum och tid (kort och lång format)"/>
+					<Item id="6175" name="Omvänd standardordning av datum och tid (kort och långt format)"/>
 					<Item id="6172" name="Anpassat format:"/>
 					<Item id="6181" name="Paneltillstånd och [-nosession] *"/>
 					<Item id="6182" name="Kom ihåg paneltillstånden (om de är öppna) i andra instanser (vid flera instanser) eller när kommandoradsparametern [-nosession] används"/>
@@ -1254,7 +1263,7 @@ Translation note:
 					<Item id="6251" name="Inställningar för avgränsad markering (Ctrl + dubbelklick)"/>
 					<Item id="6252" name="Början"/>
 					<Item id="6255" name="Slutet"/>
-					<Item id="6256" name="Tillåt på flera rader"/>
+					<Item id="6256" name="Tillåt över flera rader"/>
 					<Item id="6161" name="Lista över ordtecken"/>
 					<Item id="6162" name="Använd standardlistan över ordtecken"/>
 					<Item id="6163" name="Inkludera dina tecken som delar av ord
@@ -1298,7 +1307,7 @@ Translation note:
 
 				<MISC title="Övrigt">
 					<ComboBox id="6347">
-						<Element name="Aktivera"/>
+						<Element name="Aktivera för aktuell fil"/>
 						<Element name="Aktivera för alla öppnade filer"/>
 						<Element name="Inaktivera"/>
 					</ComboBox>
@@ -1387,6 +1396,11 @@ Du kan aktivera denna dialogruta i inställningarna senare."/>
 				<Item id="7" name="N&amp;ej"/>
 				<Item id="4" name="&amp;Alltid"/>
 			</DoSaveAll><!-- HowToReproduce: Check the "Enable Save All confirm dialog" checkbox in Preference->MISC, now click "Save all" -->
+			
+			<DebugInfo title="Felsökningsinformation">
+				<Item id="1752" name="&amp;Kopiera felsökningsinformation till urklipp"/>
+				<Item id="1" name="OK"/>
+			</DebugInfo>
 		</Dialog>
 		<MessageBox>
 			<!-- $INT_REPLACE$ and $STR_REPLACE$ are place holders, don't translate these place holders. -->
@@ -1505,7 +1519,7 @@ Vill du fortsätta?"/>
 			<LanguageMenuCompactWarning title="Kompakt språkmeny" message="Detta alternativ kommer att ändras vid nästa uppstart."/><!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
 			<SwitchUnsavedThemeWarning title="$STR_REPLACE$" message="Osparade ändringar håller på att ignoreras!
 Vill du spara dina ändringar innan du byter tema?"/><!-- HowToReproduce: In the Style Configurator dialog change some theme and switch to other theme without saving. -->
-			<MacroAndRunCmdlWarning title="Kompatibilitet för makron och körbara kommandon" message="Dina makron och körbara kommandon som har sparats i Notepad++ v.8.5.2 (eller äldre) kanske inte är kompatibla med den nuvarande versionen av Notepad++.
+			<MacroAndRunCmdlWarning title="Kompatibilitet för makron och körbara kommandon" message="Dina makron och körbara kommandon som har sparats i Notepad++ v.8.5.2 (eller äldre) kanske inte är kompatibla med den aktuella versionen av Notepad++.
 Var god testa dessa kommandon och redigera dem vid behov.
 
 Annars kan du nedgradera till Notepad++ v8.5.2 och återställa din föregående data.
@@ -1529,6 +1543,7 @@ OBS: Om du inte skapar platshållarna eller stänger dem senare kommer din sessi
 Tryck på OK-knappen för att öppna sökdialogen eller sätta fokus på den.
 			
 Se användarmanualen för instruktioner om hur man aktiverar reguljär bakåtsökning ifall du behöver detta."/>
+<PrintError title="0" message="Kan inte starta utskift av dokument."/><!-- Use title="0" to use Windows OS default translated "Error" title. -->
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Urklippshistorik"/>
@@ -1664,8 +1679,8 @@ Hitta i alla filer men exkludera mapparna &quot;tests&quot;, &quot;bin&quot; och
 Hitta i alla filer men exkludera mapparna &quot;log&quot; eller &quot;logs&quot; rekursivt:
 *.* !+\log*"/><!-- HowToReproduce: Tip of mouse hovered on "Filters" label in "Find in Files" secction of Find dialog. -->
 			<find-in-files-select-folder value="Välj en mapp att söka från"/><!-- HowToReproduce: Search > Find in Files > [...] -->
-			<find-status-top-reached value="Sök: Hittade första förekomsten från slutet. Början av dokumentet har passerats."/>
-			<find-status-end-reached value="Sök: Hittade första förekomsten från början. Slutet av dokumentet har passerats."/>
+			<find-status-top-reached value="Sök: Hittade sista förekomsten från slutet. Början av dokumentet har passerats."/>
+			<find-status-end-reached value="Sök: Hittade sista förekomsten från början. Slutet av dokumentet har passerats."/>
 			<find-status-replaceinfiles-1-replaced value="Ersätt i filer: 1 förekomst ersattes"/>
 			<find-status-replaceinfiles-nb-replaced value="Ersätt i filer: $INT_REPLACE$ förekomster ersattes"/>
 			<find-status-replaceinopenedfiles-1-replaced value="Ersätt i öppna filer: 1 förekomst ersattes"/>
@@ -1679,15 +1694,15 @@ Hitta i alla filer men exkludera mapparna &quot;log&quot; eller &quot;logs&quot;
 			<find-status-replaceall-1-replaced value="Ersätt alla: 1 förekomst ersattes"/>
 			<find-status-replaceall-nb-replaced value="Ersätt alla: $INT_REPLACE$ förekomster ersattes"/>
 			<find-status-replaceall-readonly value="Ersätt alla: Kan inte ersätta text. Aktuellt dokument är skrivskyddat"/>
-			<find-status-replace-end-reached value="Ersätt: Ersatte första förekomsten från början. Slutet av dokumentet har passerats"/>
-			<find-status-replace-top-reached value="Ersätt: Ersatte första förekomsten från slutet. Början av dokumentet har passerats"/>
+			<find-status-replace-end-reached value="Ersätt: Ersatte sista förekomsten från början. Slutet av dokumentet har passerats"/>
+			<find-status-replace-top-reached value="Ersätt: Ersatte sista förekomsten från slutet. Början av dokumentet har passerats"/>
 			<find-status-replaced-next-found value="Ersätt: 1 förekomst har ersatts. Nästa förekomst har hittats"/>
 			<find-status-replaced-without-continuing value="Ersätt: 1 förekomst har ersatts."/>
 			<find-status-replaced-next-not-found value="Ersätt: 1 förekomst har ersatts. Hittade inte nästa förekomst"/>
 			<find-status-replace-not-found value="Ersätt: Inga förekomster hittades"/>
 			<find-status-replace-readonly value="Ersätt: Kan inte ersätta text. Aktuellt dokument är skrivskyddat"/>
 			<find-status-cannot-find value="Sök: Kan inte hitta texten &quot;$STR_REPLACE$&quot;"/>
-			<find-status-cannot-find-pebkac-maybe value="Kan inte hitta förekomsten. Du kanske har glömt att markera &quot;Loopa&quot;, avmarkera &quot;Matcha skiftläge&quot; eller avmarkera &quot;Matcha hela ord&quot;."/>
+			<find-status-cannot-find-pebkac-maybe value="Kan inte hitta förekomsten. Du kanske har glömt att markera &quot;Loopa&quot; eller avmarkera antingen &quot;Matcha skiftläge&quot; eller &quot;Matcha hela ord&quot;."/>
 			<find-status-scope-selection value="inom den markerade texten"/>
 			<find-status-scope-all value="i hela filen"/>
 			<find-status-scope-backward value="från filens början till textmarkören"/>
@@ -1759,10 +1774,10 @@ Hitta i alla filer men exkludera mapparna &quot;log&quot; eller &quot;logs&quot;
 			<contextMenu-styleOneToken value="Stilsätt en förekomst"/>
 			<contextMenu-clearStyle value="Rensa stilsättning"/>
 			<contextMenu-PluginCommands value="Kommandon från insticksprogram"/>
-			<largeFileRestriction-tip value="Vissa funktioner kan förminska prestandan i stora filer. Dessa funktioner kan inaktiveras automatiskt när en stor fil öppnas. Du kan anpassa de här.
+			<largeFileRestriction-tip value="Vissa funktioner kan sänka prestandan i stora filer. Dessa funktioner kan inaktiveras automatiskt när en stor fil öppnas. Du kan anpassa de här.
 
 OBS:
-1. När dessa alternativ modifieras måste de öppnade stora filer stängas och öppnas igen för att fungera ordentligt.
+1. När dessa alternativ modifieras måste alla stora filer stängas och öppnas igen för att fungera ordentligt.
 
 2. Om &quot;Inaktivera radbrytning globalt&quot; markeras och du öppnar en stor fil kommer &quot;Radbrytning&quot; inaktiveras för alla filer. Du kan återaktivera detta via menyn &quot;Visa -&gt; Radbrytning&quot;."/>
 			<npcNote-tip value="Representation av utvalda blanksteg och icke utskrivbara (kontroll)tecken som inte är ASCII.
@@ -1792,7 +1807,12 @@ Klicka på knappen &quot;?&quot; till höger för att öppna webbplatsen med anv
 			<npcCustomColor-tip value="Gå till stilkonfigureringen för att ändra den anpassade standardfärgen för utvalda blanksteg och icke utskrivbara tecken (&quot;Non-printing characters custom color&quot;)."/>
 			<npcIncludeCcUniEol-tip value="Tillämpa utseendeinställningar för icke utskrivbara tecken på C0- och C1-kontrolltecken samt Unicode-radslutstecken (nästa rad, radavgränsare och paragrafavgränsare)."/>
 			<searchingInSelThresh-tip value="Antal markerade tecken i redigeringsområdet att automatiskt kontrollera kryssrutan &quot;I markering&quot; när sökdialogen aktiveras. Det maximala värdet är 1024. Ändra värdet till 0 för att inaktivera automatisk kontroll."/>
-			<verticalEdge-tip value="Lägg till din kolumnmarkör genom att ange dess position med ett decimaltal. Ange flera kolumnmarkörer genom att separera talen med blanksteg."/>
+			<verticalEdge-tip value="Lägg till din kolumnmarkör genom att ange dess position med ett decimaltal. Separera talen med blanksteg för att ange flera kolumnmarkörer."/>
+			<autoIndentBasic-tip value="Ser till att indraget för aktuell rad (d.v.s. radbrytningen som skapas med ENTER-tangenten) stämmer överens med indraget från den föregående raden."/>
+			<autoIndentAdvanced-tip value="Aktiverar smarta indrag för &quot;C-liknande&quot; språk och Python. &quot;C-liknande&quot; språk omfattar:
+C, C++, Java, C#, Objective-C, PHP, JavaScript, JSP, CSS, Perl, Rust, PowerShell och JSON.
+
+Om du väljer avancerat läge men inte redigerar filer i de omfattande språken kommer indraget förbli i enkelt läge."/>
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/swedish.xml
+++ b/PowerEditor/installer/nativeLang/swedish.xml
@@ -1177,10 +1177,10 @@ Translation note:
 
 				<Searching title="Sökning">
 					<Item id="6902" name="Använd typsnitt med fast bredd i sökdialogen (kräver omstart av Notepad++)"/>
-					<Item id="6903" name="Sökdialogen förblir öppen efter sökningar som matar ut till resultatfönstret"/>
+					<Item id="6903" name="Låt sökdialogen förbli öppen efter sökningar som visas i resultatfönstret"/>
 					<Item id="6904" name="Visa bekräftelsedialog för &quot;Ersätt alla i alla öppna dokument&quot;"/>
 					<Item id="6905" name="Ersätt: Hoppa inte till nästa förekomst"/>
-					<Item id="6906" name="Resultatfönstret: Visa endast en post per funnen rad om det är möjligt"/>
+					<Item id="6906" name="Sökresultatsfönstret: Visa endast en post per funnen rad om det är möjligt"/>
 					<Item id="6907" name="När sökdialogen öppnas"/>
 					<Item id="6908" name="Fyll sökfältet med markerad text"/>
 					<Item id="6909" name="Markera ord under textmarkören när ingenting är markerat"/>
@@ -1248,7 +1248,7 @@ Translation note:
 					<Item id="6175" name="Omvänd standardordning av datum och tid (kort och långt format)"/>
 					<Item id="6172" name="Anpassat format:"/>
 					<Item id="6181" name="Paneltillstånd och [-nosession] *"/>
-					<Item id="6182" name="Kom ihåg paneltillstånden (om de är öppna) i andra instanser (vid flera instanser) eller när kommandoradsparametern [-nosession] används"/>
+					<Item id="6182" name="Kom ihåg panelens tillstånd (om den är öppen) i andra instanser (vid flera instanser) eller när kommandoradsparametern [-nosession] används"/>
 					<Item id="6183" name="Urklippshistorik"/>
 					<Item id="6184" name="Dokumentlista"/>
 					<Item id="6185" name="Teckenpanel"/>
@@ -1780,12 +1780,12 @@ OBS:
 1. När dessa alternativ modifieras måste alla stora filer stängas och öppnas igen för att fungera ordentligt.
 
 2. Om &quot;Inaktivera radbrytning globalt&quot; markeras och du öppnar en stor fil kommer &quot;Radbrytning&quot; inaktiveras för alla filer. Du kan återaktivera detta via menyn &quot;Visa -&gt; Radbrytning&quot;."/>
-			<npcNote-tip value="Representation av utvalda blanksteg och icke utskrivbara (kontroll)tecken som inte är ASCII.
+			<npcNote-tip value="Hur utvalda blanksteg och icke utskrivbara (kontroll)tecken som inte är ASCII ska återges.
 
 OBS:
-När representationer används inaktiveras teckeneffekter hos texten.
+När ett utseende används kommer teckeneffekter i texten att inaktiveras.
 
-Se användarmanualen för den fullständiga listan över utvalda blanksteg och icke utskrivbara tecken.
+Se användarmanualen för en fullständig lista över utvalda blanksteg och icke utskrivbara tecken.
 
 Klicka på denna knapp för att öppna webbplatsen med användarmanualen."/>
 			<npcAbbreviation-tip value="Förkortning : namn
@@ -1793,20 +1793,20 @@ NBSP : hårt blanksteg
 ZWSP : breddlöst blanksteg
 ZWNBSP : breddlöst hårt blanksteg
 
-Se användarmanualen för den fullständiga listan.
+Se användarmanualen för en fullständig lista.
 Klicka på knappen &quot;?&quot; till höger för att öppna webbplatsen med användarmanualen."/>
 			<npcCodepoint-tip value="Kodpunkt : namn
 U+00A0 : hårt blanksteg
 U+200B : breddlöst blanksteg
 U+FEFF : breddlöst hårt blanksteg
 
-Se användarmanualen för den fullständiga listan.
+Se användarmanualen för en fullständig lista.
 Klicka på knappen &quot;?&quot; till höger för att öppna webbplatsen med användarmanualen."/>
 
 			<!-- Don't translate "(&quot;Non-printing characters custom color&quot;)" -->
 			<npcCustomColor-tip value="Gå till stilkonfigureringen för att ändra den anpassade standardfärgen för utvalda blanksteg och icke utskrivbara tecken (&quot;Non-printing characters custom color&quot;)."/>
 			<npcIncludeCcUniEol-tip value="Tillämpa utseendeinställningar för icke utskrivbara tecken på C0- och C1-kontrolltecken samt Unicode-radslutstecken (nästa rad, radavgränsare och paragrafavgränsare)."/>
-			<searchingInSelThresh-tip value="Antal markerade tecken i redigeringsområdet att automatiskt kontrollera kryssrutan &quot;I markering&quot; när sökdialogen aktiveras. Det maximala värdet är 1024. Ändra värdet till 0 för att inaktivera automatisk kontroll."/>
+			<searchingInSelThresh-tip value="Antalet markerade tecken i redigeringsområdet för att automatiskt markera kryssrutan &quot;I markering&quot; i sökdialogen. Det maximala värdet är 1024. Ändra värdet till 0 för att inaktivera automatisk kontroll."/>
 			<verticalEdge-tip value="Lägg till din kolumnmarkör genom att ange dess position med ett decimaltal. Separera talen med blanksteg för att ange flera kolumnmarkörer."/>
 			<fileSaveAsCopySaveButton-tip value="Håll ned Shift och klicka på sparaknappen för att öppna kopian efteråt."/>
 			<autoIndentBasic-tip value="Ser till att indraget för aktuell rad (d.v.s. radbrytningen som skapas med ENTER-tangenten) stämmer överens med indraget från den föregående raden."/>

--- a/PowerEditor/installer/nativeLang/swedish.xml
+++ b/PowerEditor/installer/nativeLang/swedish.xml
@@ -967,7 +967,7 @@ Translation note:
 
 					<Item id="6131" name="Meny"/>
 					<Item id="6122" name="Dölj menyraden (använd Alt eller F10 för att visa)"/>
-					<Item id="6132" name="Dölj knapparna ＋ ▼ ✕ på menyfältets högersida (kräver omstart av Notepad++)"/>
+					<Item id="6132" name="Dölj knapparna ＋ ▼ ✕ på menyradens högersida (kräver omstart av Notepad++)"/>
 
 					<Item id="6123" name="Gränssnittsspråk"/>
 				</Global>

--- a/PowerEditor/installer/nativeLang/swedish.xml
+++ b/PowerEditor/installer/nativeLang/swedish.xml
@@ -1808,6 +1808,7 @@ Klicka på knappen &quot;?&quot; till höger för att öppna webbplatsen med anv
 			<npcIncludeCcUniEol-tip value="Tillämpa utseendeinställningar för icke utskrivbara tecken på C0- och C1-kontrolltecken samt Unicode-radslutstecken (nästa rad, radavgränsare och paragrafavgränsare)."/>
 			<searchingInSelThresh-tip value="Antal markerade tecken i redigeringsområdet att automatiskt kontrollera kryssrutan &quot;I markering&quot; när sökdialogen aktiveras. Det maximala värdet är 1024. Ändra värdet till 0 för att inaktivera automatisk kontroll."/>
 			<verticalEdge-tip value="Lägg till din kolumnmarkör genom att ange dess position med ett decimaltal. Separera talen med blanksteg för att ange flera kolumnmarkörer."/>
+			<fileSaveAsCopySaveButton-tip value="Håll ned Shift och klicka på sparaknappen för att öppna kopian efteråt."/>
 			<autoIndentBasic-tip value="Ser till att indraget för aktuell rad (d.v.s. radbrytningen som skapas med ENTER-tangenten) stämmer överens med indraget från den föregående raden."/>
 			<autoIndentAdvanced-tip value="Aktiverar smarta indrag för &quot;C-liknande&quot; språk och Python. &quot;C-liknande&quot; språk omfattar:
 C, C++, Java, C#, Objective-C, PHP, JavaScript, JSP, CSS, Perl, Rust, PowerShell och JSON.


### PR DESCRIPTION
Added new strings, made minor changes to existing strings.

Note: In the 43053 string, I decided to keep the word "matching" in order for this string to have a unique access key / keyboard mnemonic / whatever they are called.

https://github.com/notepad-plus-plus/notepad-plus-plus/blob/f84c6087287382b81c246f54df4b3c93225affe8/PowerEditor/installer/nativeLang/swedish.xml#L225