### PR TITLE
Move input focus to editor when clicking on already-active tab

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -371,24 +371,30 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					_statusBar.setText((_pEditView->execute(SCI_GETOVERTYPE)) ? L"OVR" : L"INS", STATUSBAR_TYPING_MODE);
 				}
 			}
-			else if (notification->nmhdr.hwndFrom == _mainDocTab.getHSelf() && _activeView == SUB_VIEW)
+			else if (notification->nmhdr.hwndFrom == _mainDocTab.getHSelf())
 			{
-				bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
-				if (isSnapshotMode)
+				if (_activeView == SUB_VIEW)
 				{
-					// Before switching off, synchronize backup file
-					MainFileManager.backupCurrentBuffer();
+					bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
+					if (isSnapshotMode)
+					{
+						// Before switching off, synchronize backup file
+						MainFileManager.backupCurrentBuffer();
+					}
 				}
 				// Switch off
 				switchEditViewTo(MAIN_VIEW);
 			}
-			else if (notification->nmhdr.hwndFrom == _subDocTab.getHSelf() && _activeView == MAIN_VIEW)
+			else if (notification->nmhdr.hwndFrom == _subDocTab.getHSelf())
 			{
-				bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
-				if (isSnapshotMode)
+				if (_activeView == MAIN_VIEW)
 				{
-					// Before switching off, synchronize backup file
-					MainFileManager.backupCurrentBuffer();
+					bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
+					if (isSnapshotMode)
+					{
+						// Before switching off, synchronize backup file
+						MainFileManager.backupCurrentBuffer();
+					}
 				}
 				// Switch off
 				switchEditViewTo(SUB_VIEW);


### PR DESCRIPTION
Fix #8446