### PR TITLE
Python smart indent, do not indent when comment line ends in colon

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3768,7 +3768,8 @@ void Notepad_plus::maintainIndentation(wchar_t ch)
 			auto endPos = _pEditView->execute(SCI_GETLINEENDPOSITION, prevLine);
 			_pEditView->execute(SCI_SETTARGETRANGE, startPos, endPos);
 
-			const char colonExpr[] = ":[ \t]*(#|$)";  // colon optionally followed by only whitespace and/or start-of-comment
+			// colon optionally followed by only whitespace and/or start-of-comment, but NOT on a line that is already a comment
+			const char colonExpr[] = "^[^#]*\\K:[ \t]*(#|$)";
 
 			if (_pEditView->execute(SCI_SEARCHINTARGET, strlen(colonExpr), reinterpret_cast<LPARAM>(colonExpr)) >= 0)
 			{


### PR DESCRIPTION
Fix #15528

Comments definitely welcome on the regular expression change this PR makes!