### PR TITLE
Fix "User-defined keywords" not being saved properly in Style Configurator

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -8490,15 +8490,13 @@ void NppParameters::writeStyle2Element(const Style & style2Write, Style & style2
 	}
 
 
-	if (!style2Write._keywords.empty())
-	{
-		TiXmlNode *teteDeNoeud = element->LastChild();
+	TiXmlNode *teteDeNoeud = element->LastChild();
 
-		if (teteDeNoeud)
-			teteDeNoeud->SetValue(style2Write._keywords.c_str());
-		else
-			element->InsertEndChild(TiXmlText(style2Write._keywords.c_str()));
-	}
+	if (teteDeNoeud)
+		teteDeNoeud->SetValue(style2Write._keywords.c_str());
+	else
+		element->InsertEndChild(TiXmlText(style2Write._keywords.c_str()));
+
 }
 
 void NppParameters::insertUserLang2Tree(TiXmlNode *node, UserLangContainer *userLang)


### PR DESCRIPTION
Fix #15543, fix #14303

When "User-defined keywords" field has been set keywords, removing all keywords then saving doesn't have any change (the keywords are kept after saving). The PR fix it.