### PR TITLE
avoid linux mingw build issue

### DIFF
--- a/PowerEditor/src/WinControls/DoubleBuffer/DoubleBuffer.cpp
+++ b/PowerEditor/src/WinControls/DoubleBuffer/DoubleBuffer.cpp
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "DoubleBuffer.h"
-#include <CommCtrl.h>
+#include <commctrl.h>
 #include <cassert>
 #include <memory>
 


### PR DESCRIPTION
- avoid linux mingw build issue
../src/WinControls/DoubleBuffer/DoubleBuffer.cpp:18:10: fatal error: CommCtrl.h: No such file or directory
   18 | #include <CommCtrl.h>
      |          ^~~~~~~~~~~~