### PR TITLE
Add new plugin command & notification while native lang being changed

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -980,6 +980,15 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// lParam[in]: newName - the desired new name of the tab
 	// Return TRUE upon success; FALSE upon failure
 
+	#define NPPM_GETNATIVELANGFILENAME (NPPMSG + 116)
+	// int NPPM_GETNATIVELANGFILENAME(size_t strLen, char* nativeLangFileName)
+	// Get the Current native language file name string.
+	// Users should call it with nativeLangFileName as NULL to get the required number of char (not including the terminating nul character),
+	// allocate commandLineStr buffer with the return value + 1, then call it again to get the current native language file name string.
+	// wParam[in]: strLen is "commandLineStr" buffer length
+	// lParam[out]: commandLineStr recieves all copied native language file name string
+	// Return the number of char copied/to copy
+
 	// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0
 	#define FULL_CURRENT_PATH 1
@@ -1195,4 +1204,11 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
                                                    // This notification is implemented in Notepad++ v8.6.5.
 	//scnNotification->nmhdr.code = NPPN_GLOBALMODIFIED;
 	//scnNotification->nmhdr.hwndFrom = BufferID;
+	//scnNotification->nmhdr.idFrom = 0; // preserved for the future use, must be zero
+
+	#define NPPN_NATIVELANGCHANGED (NPPN_FIRST + 31)  // To notify plugins that the current native language is just changed to another one.
+                                                      // Use NPPM_GETNATIVELANGFILENAME to get current native language file name.
+                                                      // Use NPPM_GETMENUHANDLE(NPPPLUGINMENU, 0) to get submenu "Plugins" handle (HMENU)
+	//scnNotification->nmhdr.code = NPPN_NATIVELANGCHANGED;
+	//scnNotification->nmhdr.hwndFrom = hwndNpp
 	//scnNotification->nmhdr.idFrom = 0; // preserved for the future use, must be zero

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -982,7 +982,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 
 	#define NPPM_GETNATIVELANGFILENAME (NPPMSG + 116)
 	// int NPPM_GETNATIVELANGFILENAME(size_t strLen, char* nativeLangFileName)
-	// Get the Current native language file name string.
+	// Get the Current native language file name string. Use it after getting NPPN_READY notification to find out which native language is used.
 	// Users should call it with nativeLangFileName as NULL to get the required number of char (not including the terminating nul character),
 	// allocate commandLineStr buffer with the return value + 1, then call it again to get the current native language file name string.
 	// wParam[in]: strLen is "commandLineStr" buffer length
@@ -1041,7 +1041,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 
 // Notification code
 #define NPPN_FIRST 1000
-	#define NPPN_READY (NPPN_FIRST + 1) // To notify plugins that all the procedures of launchment of notepad++ are done.
+	#define NPPN_READY (NPPN_FIRST + 1) // To notify plugins that all the initialization for launching Notepad++ is complete.
 	//scnNotification->nmhdr.code = NPPN_READY;
 	//scnNotification->nmhdr.hwndFrom = hwndNpp;
 	//scnNotification->nmhdr.idFrom = 0;

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7248,13 +7248,6 @@ bool Notepad_plus::reloadLang()
 	}
 
 	_lastRecentFileList.setLangEncoding(_nativeLangSpeaker.getLangEncoding());
-
-	SCNotification scnN{};
-	scnN.nmhdr.code = NPPN_NATIVELANGCHANGED;
-	scnN.nmhdr.hwndFrom = _pPublicInterface->getHSelf();
-	scnN.nmhdr.idFrom = 0;
-	_pluginsManager.notify(&scnN);
-
 	return true;
 }
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -7248,6 +7248,13 @@ bool Notepad_plus::reloadLang()
 	}
 
 	_lastRecentFileList.setLangEncoding(_nativeLangSpeaker.getLangEncoding());
+
+	SCNotification scnN{};
+	scnN.nmhdr.code = NPPN_NATIVELANGCHANGED;
+	scnN.nmhdr.hwndFrom = _pPublicInterface->getHSelf();
+	scnN.nmhdr.idFrom = 0;
+	_pluginsManager.notify(&scnN);
+
 	return true;
 }
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -913,6 +913,16 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_INTERNAL_RELOADNATIVELANG:
 		{
 			reloadLang();
+
+			bool doNotif = wParam;
+			if (doNotif)
+			{
+				SCNotification scnN{};
+				scnN.nmhdr.code = NPPN_NATIVELANGCHANGED;
+				scnN.nmhdr.hwndFrom = _pPublicInterface->getHSelf();
+				scnN.nmhdr.idFrom = 0;
+				_pluginsManager.notify(&scnN);
+			}
 			return TRUE;
 		}
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3747,6 +3747,20 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return TRUE;
 		}
 
+		case NPPM_GETNATIVELANGFILENAME:
+		{
+			string fileName = _nativeLangSpeaker.getFileName();
+			if (lParam != 0)
+			{
+				if (fileName.length() >= static_cast<size_t>(wParam))
+				{
+					return 0;
+				}
+				strcpy(reinterpret_cast<char*>(lParam), fileName.c_str());
+			}
+			return fileName.length();
+		}
+
 		default:
 		{
 			if (message == WDN_NOTIFY)

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -812,15 +812,16 @@ intptr_t CALLBACK GeneralSubDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM
 									::SendDlgItemMessage(_hSelf, IDC_COMBO_LOCALIZATION, CB_GETLBTEXT, index, reinterpret_cast<LPARAM>(langName));
 									if (langName[0])
 									{
-										// Make English as basic language
-										if (localizationSwitcher.switchToLang(L"English"))
+										// Make English as basic language, but if we switch from another language to English, we can skip it
+										if ((lstrcmpW(langName, L"English") != 0) && localizationSwitcher.switchToLang(L"English"))
 										{
-											::SendMessage(::GetParent(_hParent), NPPM_INTERNAL_RELOADNATIVELANG, 0, 0);
+											::SendMessage(::GetParent(_hParent), NPPM_INTERNAL_RELOADNATIVELANG, FALSE, 0);
 										}
+
 										// Change the language 
 										if (localizationSwitcher.switchToLang(langName))
 										{
-											::SendMessage(::GetParent(_hParent), NPPM_INTERNAL_RELOADNATIVELANG, 0, 0);
+											::SendMessage(::GetParent(_hParent), NPPM_INTERNAL_RELOADNATIVELANG, TRUE, 0);
 											::InvalidateRect(_hParent, NULL, TRUE);
 										}
 									}


### PR DESCRIPTION
Add new plugin notification `NPPN_NATIVELANGCHANGED` when the native language has been changed, and add new plugin message `NPPM_GETNATIVELANGFILENAME` for plugins calling after getting `NPPN_NATIVELANGCHANGED` notification.

Usage of the command:
```cpp
	#define NPPM_GETNATIVELANGFILENAME (NPPMSG + 116)
	// int NPPM_GETNATIVELANGFILENAME(size_t strLen, char* nativeLangFileName)
	// Get the Current native language file name string.
	// Users should call it with nativeLangFileName as NULL to get the required number of char (not including the terminating nul character),
	// allocate commandLineStr buffer with the return value + 1, then call it again to get the current native language file name string.
	// wParam[in]: strLen is "commandLineStr" buffer length
	// lParam[out]: commandLineStr recieves all copied native language file name string
	// Return the number of char copied/to copy
```
Usage of the notification:
```cpp
	#define NPPN_NATIVELANGCHANGED (NPPN_FIRST + 31)  // To notify plugins that the current native language is just changed to another one.
                                                      // Use NPPM_GETNATIVELANGFILENAME to get current native language file name.
                                                      // Use NPPM_GETMENUHANDLE(NPPPLUGINMENU, 0) to get submenu "Plugins" handle (HMENU)
	//scnNotification->nmhdr.code = NPPN_NATIVELANGCHANGED;
	//scnNotification->nmhdr.hwndFrom = hwndNpp
	//scnNotification->nmhdr.idFrom = 0; // preserved for the future use, must be zero
```

Fix #15513