### PR TITLE
Fix monitoring large file with frequent writes freezes UI

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -98,7 +98,7 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 							{
 								::PostMessage(h, NPPM_INTERNAL_RELOADSCROLLTOEND, reinterpret_cast<WPARAM>(buf), 0);
 								bDoneOnce = true;
-								Sleep(250);
+								Sleep(250);	// Limit refresh rate
 							}
 						}
 						else if ((dwAction == FILE_ACTION_REMOVED) || (dwAction == FILE_ACTION_RENAMED_OLD_NAME))

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -79,6 +79,7 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 			case WAIT_OBJECT_0 + 1:
 			// We've received a notification in the queue.
 			{
+				bool bDoneOnce = false;
 				DWORD dwAction = 0;
 				wstring fn;
 				// Process all available changes, ignore User actions
@@ -93,7 +94,12 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 					{
 						if (dwAction == FILE_ACTION_MODIFIED)
 						{
-							::PostMessage(h, NPPM_INTERNAL_RELOADSCROLLTOEND, reinterpret_cast<WPARAM>(buf), 0);
+							if (!bDoneOnce)
+							{
+								::PostMessage(h, NPPM_INTERNAL_RELOADSCROLLTOEND, reinterpret_cast<WPARAM>(buf), 0);
+								bDoneOnce = true;
+								Sleep(250);
+							}
 						}
 						else if ((dwAction == FILE_ACTION_REMOVED) || (dwAction == FILE_ACTION_RENAMED_OLD_NAME))
 						{


### PR DESCRIPTION
Fix for annoying issue I commonly encounter when viewing actively written log files with monitoring enabled; as reported by others in #9661

Fix #9661