### PR TITLE
Simplify customizable tab color feature

### DIFF
--- a/PowerEditor/installer/themes/Bespin.xml
+++ b/PowerEditor/installer/themes/Bespin.xml
@@ -1023,6 +1023,11 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="BDAE9D" bgColor="2A211C" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Black board.xml
+++ b/PowerEditor/installer/themes/Black board.xml
@@ -1021,6 +1021,11 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="BDAE9D" />
         <WidgetStyle name="Document map" styleID="0" fgColor="F8F8F8" bgColor="0C1021" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Choco.xml
+++ b/PowerEditor/installer/themes/Choco.xml
@@ -1013,6 +1013,11 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
+++ b/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
@@ -1132,6 +1132,11 @@ Installation : Copy this file to "%APPDATA%\Notepad++\themes" and in a portable 
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="C792EA" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="C7C7C7" bgColor="2E2E2E" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/DarkModeDefault.xml
+++ b/PowerEditor/installer/themes/DarkModeDefault.xml
@@ -1745,6 +1745,11 @@ License:             GPL2
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="3FBA89" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="101010" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="A3DCA3" />
         <WidgetStyle name="Document map" styleID="0" fgColor="000000" bgColor="FFFFFF" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Deep Black.xml
+++ b/PowerEditor/installer/themes/Deep Black.xml
@@ -1018,6 +1018,11 @@ https://notepad-plus-plus.org/donate/
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FF8000" bgColor="FFFFFF" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Hello Kitty.xml
+++ b/PowerEditor/installer/themes/Hello Kitty.xml
@@ -990,6 +990,11 @@ so your enhanced file can be included in Notepad++ future release.
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="000000" bgColor="FFB0FF" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/HotFudgeSundae.xml
+++ b/PowerEditor/installer/themes/HotFudgeSundae.xml
@@ -1147,6 +1147,11 @@ Installation:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="2B0F01" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="43250B" bgColor="D5BC93" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="B7975D" bgColor="2B0F01" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Mono Industrial.xml
+++ b/PowerEditor/installer/themes/Mono Industrial.xml
@@ -1017,6 +1017,11 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FFFFFF" bgColor="222C28" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Monokai.xml
+++ b/PowerEditor/installer/themes/Monokai.xml
@@ -1033,6 +1033,11 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="F8F8F2" bgColor="272822" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/MossyLawn.xml
+++ b/PowerEditor/installer/themes/MossyLawn.xml
@@ -1147,6 +1147,11 @@ Installation:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="58693D" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="012001" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="162504" bgColor="BBCF60" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="F2C476" bgColor="58693D" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Navajo.xml
+++ b/PowerEditor/installer/themes/Navajo.xml
@@ -1144,6 +1144,11 @@ Installation:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="BA9C80" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="181880" bgColor="BA9C80" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="000000" bgColor="BA9C80" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Obsidian.xml
+++ b/PowerEditor/installer/themes/Obsidian.xml
@@ -1021,6 +1021,11 @@ Notepad++ Custom Style
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="E0E2E4" bgColor="293134" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Plastic Code Wrap.xml
+++ b/PowerEditor/installer/themes/Plastic Code Wrap.xml
@@ -1029,6 +1029,11 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="F8F8F8" bgColor="0B161D" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Ruby Blue.xml
+++ b/PowerEditor/installer/themes/Ruby Blue.xml
@@ -867,6 +867,11 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FFFFFF" bgColor="112435" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Solarized-light.xml
+++ b/PowerEditor/installer/themes/Solarized-light.xml
@@ -1155,6 +1155,11 @@ Installation:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FDF6E3" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="073642" bgColor="93A1A1" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="808040" />
         <WidgetStyle name="Document map" styleID="0" fgColor="657B83" bgColor="FDF6E3" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Solarized.xml
+++ b/PowerEditor/installer/themes/Solarized.xml
@@ -1545,6 +1545,11 @@ Installation:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="002B36" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="EEE8D5" bgColor="586E75" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="839496" bgColor="002B36" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Twilight.xml
+++ b/PowerEditor/installer/themes/Twilight.xml
@@ -1018,6 +1018,11 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="F8F8F8" bgColor="141414" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Vibrant Ink.xml
+++ b/PowerEditor/installer/themes/Vibrant Ink.xml
@@ -989,6 +989,11 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FFFFFF" bgColor="000000" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/Zenburn.xml
+++ b/PowerEditor/installer/themes/Zenburn.xml
@@ -1713,6 +1713,11 @@ License:             GPL2
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="3FBA89" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="101010" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="808080" bgColor="C0C0C0" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="A3DCA3" />
         <WidgetStyle name="Document map" styleID="0" fgColor="000000" bgColor="FFFFFF" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/khaki.xml
+++ b/PowerEditor/installer/themes/khaki.xml
@@ -1144,6 +1144,11 @@ Installation:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="D7D7AF" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="5F5F00" bgColor="D7D7AF" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="808040" />
         <WidgetStyle name="Document map" styleID="0" fgColor="5F5F00" bgColor="D7D7AF" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/installer/themes/vim Dark Blue.xml
+++ b/PowerEditor/installer/themes/vim Dark Blue.xml
@@ -981,6 +981,11 @@
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="FFCAB0" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="000000" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="8080C0" bgColor="CECECE" />
+        <WidgetStyle name="Tab color 1" styleID="0" bgColor="F3F0CB" />
+        <WidgetStyle name="Tab color 2" styleID="0" bgColor="DBF3CB" />
+        <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
+        <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
+        <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="FFFFFF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FFFFBF" bgColor="000040" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="808080" />

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -8862,49 +8862,13 @@ void NppParameters::initTabCustomColors()
 	{
 		individualTabHues[4].loadFromRGB(pStyle->_bgColor);
 	}
-
-
-	pStyle = stylers.findByName(TABBAR_INDIVIDUALCOLOR_DM_1);
-	if (pStyle)
-	{
-		individualTabHuesFor_Dark[0].loadFromRGB(pStyle->_bgColor);
-	}
-
-	pStyle = stylers.findByName(TABBAR_INDIVIDUALCOLOR_DM_2);
-	if (pStyle)
-	{
-		individualTabHuesFor_Dark[1].loadFromRGB(pStyle->_bgColor);
-	}
-
-	pStyle = stylers.findByName(TABBAR_INDIVIDUALCOLOR_DM_3);
-	if (pStyle)
-	{
-		individualTabHuesFor_Dark[2].loadFromRGB(pStyle->_bgColor);
-	}
-
-	pStyle = stylers.findByName(TABBAR_INDIVIDUALCOLOR_DM_4);
-	if (pStyle)
-	{
-		individualTabHuesFor_Dark[3].loadFromRGB(pStyle->_bgColor);
-	}
-
-	pStyle = stylers.findByName(TABBAR_INDIVIDUALCOLOR_DM_5);
-	if (pStyle)
-	{
-		individualTabHuesFor_Dark[4].loadFromRGB(pStyle->_bgColor);
-	}
 }
 
 
-void NppParameters::setIndividualTabColor(COLORREF colour2Set, int colourIndex, bool isDarkMode)
+void NppParameters::setIndividualTabColor(COLORREF colour2Set, int colourIndex)
 {
 	if (colourIndex < 0 || colourIndex > 4) return;
-
-	if (isDarkMode)
-		individualTabHuesFor_Dark[colourIndex].loadFromRGB(colour2Set);
-	else
-		individualTabHues[colourIndex].loadFromRGB(colour2Set);
-
+	individualTabHues[colourIndex].loadFromRGB(colour2Set);
 	return;
 }
 
@@ -8912,10 +8876,11 @@ COLORREF NppParameters::getIndividualTabColor(int colourIndex, bool isDarkMode, 
 {
 	if (colourIndex < 0 || colourIndex > 4) return {};
 
-	HLSColour result;
+	HLSColour result = individualTabHues[colourIndex];
+
 	if (isDarkMode)
 	{
-		result = individualTabHuesFor_Dark[colourIndex];
+		result = result.toRGB4DarkModWithTuning(-150, 65);
 
 		if (saturated)
 		{
@@ -8925,8 +8890,6 @@ COLORREF NppParameters::getIndividualTabColor(int colourIndex, bool isDarkMode, 
 	}
 	else
 	{
-		result = individualTabHues[colourIndex];
-
 		if (saturated)
 		{
 			result._lightness = 140U;

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1927,9 +1927,7 @@ private:
 
 	std::wstring _loadedSessionFullFilePath;
 
-	std::array<HLSColour, 5> individualTabHuesFor_Dark{ { HLSColour{37, 60, 60}, HLSColour{70, 60, 60}, HLSColour{144, 70, 60}, HLSColour{255, 60, 60}, HLSColour{195, 60, 60} } };
 	std::array<HLSColour, 5> individualTabHues{ { HLSColour{37, 210, 150}, HLSColour{70, 210, 150}, HLSColour{144, 210, 150}, HLSColour{255, 210, 150}, HLSColour{195, 210, 150}} };
-
 	std::array<COLORREF, 3> findDlgStatusMessageColor{ red, blue, darkGreen};
 
 public:
@@ -2040,7 +2038,7 @@ public:
 
 
 	void initTabCustomColors();
-	void setIndividualTabColor(COLORREF colour2Set, int colourIndex, bool isDarkMode);
+	void setIndividualTabColor(COLORREF colour2Set, int colourIndex);
 	COLORREF getIndividualTabColor(int colourIndex, bool isDarkMode, bool saturated);
 
 	void initFindDlgStatusMsgCustomColors();

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -578,11 +578,8 @@ intptr_t CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM 
 
 										if (colourIndex != -1)
 										{
-											if (colourIndex >= TabBarPlus::individualTabColourId::id5)
-												colourIndex -= TabBarPlus::individualTabColourId::id5;
-
 											NppParameters& nppParamInst = NppParameters::getInstance();
-											nppParamInst.setIndividualTabColor(_pBgColour->getColour(), colourIndex, NppDarkMode::isEnabled());
+											nppParamInst.setIndividualTabColor(_pBgColour->getColour(), colourIndex);
 										}
 									}
 
@@ -689,12 +686,7 @@ int WordStyleDlg::getApplicationInfo() const
 		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_2) == 0) ||
 		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_3) == 0) ||
 		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_4) == 0) ||
-		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_5) == 0) ||
-		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_1) == 0) ||
-		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_2) == 0) ||
-		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_3) == 0) ||
-		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_4) == 0) ||
-		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_5) == 0))
+		(lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_5) == 0))
 	{
 		return (GENERAL_CHANGE | COLOR_CHANGE_4_MENU);
 	}
@@ -750,23 +742,6 @@ int WordStyleDlg::whichIndividualTabColourId()
 
 	if (lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_5) == 0)
 		return TabBarPlus::individualTabColourId::id4;
-
-
-	if (lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_1) == 0)
-		return TabBarPlus::individualTabColourId::id5;
-
-	if (lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_2) == 0)
-		return TabBarPlus::individualTabColourId::id6;
-
-	if (lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_3) == 0)
-		return TabBarPlus::individualTabColourId::id7;
-
-	if (lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_4) == 0)
-		return TabBarPlus::individualTabColourId::id8;
-
-	if (lstrcmp(styleName, TABBAR_INDIVIDUALCOLOR_DM_5) == 0)
-		return TabBarPlus::individualTabColourId::id9;
-
 
 	return -1;
 }

--- a/PowerEditor/src/WinControls/TabBar/TabBar.h
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.h
@@ -53,12 +53,6 @@ const wchar_t TABBAR_INDIVIDUALCOLOR_3[64] = L"Tab color 3";
 const wchar_t TABBAR_INDIVIDUALCOLOR_4[64] = L"Tab color 4";
 const wchar_t TABBAR_INDIVIDUALCOLOR_5[64] = L"Tab color 5";
 
-const wchar_t TABBAR_INDIVIDUALCOLOR_DM_1[64] = L"Tab color dark mode 1";
-const wchar_t TABBAR_INDIVIDUALCOLOR_DM_2[64] = L"Tab color dark mode 2";
-const wchar_t TABBAR_INDIVIDUALCOLOR_DM_3[64] = L"Tab color dark mode 3";
-const wchar_t TABBAR_INDIVIDUALCOLOR_DM_4[64] = L"Tab color dark mode 4";
-const wchar_t TABBAR_INDIVIDUALCOLOR_DM_5[64] = L"Tab color dark mode 5";
-
 constexpr int g_TabIconSize = 16;
 constexpr int g_TabHeight = 22;
 constexpr int g_TabHeightLarge = 25;
@@ -170,7 +164,7 @@ public :
 	};
 
 	enum individualTabColourId {
-		id0, id1, id2, id3, id4, id5, id6, id7, id8, id9
+		id0, id1, id2, id3, id4
 	};
 
 	static void doDragNDrop(bool justDoIt) {

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -1753,11 +1753,6 @@
         <WidgetStyle name="Tab color 3" styleID="0" bgColor="CBDBF3" />
         <WidgetStyle name="Tab color 4" styleID="0" bgColor="F3DBCB" />
         <WidgetStyle name="Tab color 5" styleID="0" bgColor="F3CBEE" />
-        <WidgetStyle name="Tab color dark mode 1" styleID="0" bgColor="807848" />
-        <WidgetStyle name="Tab color dark mode 2" styleID="0" bgColor="568048" />
-        <WidgetStyle name="Tab color dark mode 3" styleID="0" bgColor="507094" />
-        <WidgetStyle name="Tab color dark mode 4" styleID="0" bgColor="804849" />
-        <WidgetStyle name="Tab color dark mode 5" styleID="0" bgColor="754880" />
         <WidgetStyle name="URL hovered" styleID="0" fgColor="0000FF" />
         <WidgetStyle name="Document map" styleID="0" fgColor="FF8000" bgColor="FFFFFF" />
         <WidgetStyle name="EOL custom color" styleID="0" fgColor="DADADA" />


### PR DESCRIPTION
In commit a16261caaa173689da468d5be66e32866681e152, customizable tab color feature was added. However the entries were needed for both "Tab color #" & "Tab color dark mode #". This commit keeps only 5 entries of "Tab color #" and removes 5 entries of "Tab color dark mode #" from Style Configurator, and uses tab light mode color for generating tab dark mode color on the fly.