### PR TITLE
#15604 open files from FolderAsWorkspace as read-only with switches -openFoldersAsWorkspace -ro

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -8863,13 +8863,19 @@ void Notepad_plus::monitoringStartOrStopAndUpdateUI(Buffer* pBuf, bool isStartin
 	if (pBuf)
 	{
 		if (isStarting)
+		{
 			pBuf->startMonitoring();
+			pBuf->saveReadOnlyState();
+			pBuf->setUserReadOnly(true);
+		}
 		else
+		{
 			pBuf->stopMonitoring();
+			pBuf->setUserReadOnly(pBuf->restoreReadOnlyState());
+		}
 
 		checkMenuItem(IDM_VIEW_MONITORING, isStarting);
 		_toolBar.setCheck(IDM_VIEW_MONITORING, isStarting);
-		pBuf->setUserReadOnly(isStarting);
 	}
 }
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -8864,9 +8864,10 @@ void Notepad_plus::monitoringStartOrStopAndUpdateUI(Buffer* pBuf, bool isStartin
 	{
 		if (isStarting)
 		{
+			pBuf->reload();
 			pBuf->startMonitoring();
 			pBuf->saveReadOnlyState();
-			pBuf->setUserReadOnly(true);
+			pBuf->setUserReadOnly(true);		
 		}
 		else
 		{

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -547,7 +547,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		case NPPM_DOOPEN:
 		case WM_DOOPEN:
 		{
-			BufferID id = doOpen(reinterpret_cast<const wchar_t *>(lParam));
+			auto& cmdLine = nppParam.getCmdLineString();
+			bool bReadOnly = cmdLine.find(_T("-ro ")) != -1 && cmdLine.find(_T("-openFoldersAsWorkspace ")) != -1;
+
+			BufferID id = doOpen(reinterpret_cast<const wchar_t*>(lParam), false, bReadOnly);
 			if (id != BUFFER_INVALID)
 				return switchToFile(id);
 			break;

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -203,6 +203,13 @@ public:
 		doNotify(BufferChangeReadonly);
 	}
 
+	void saveReadOnlyState() { _wasReadOnly = _isUserReadOnly; };
+
+	bool restoreReadOnlyState() {
+		_isUserReadOnly = _wasReadOnly; 
+		return _isUserReadOnly;
+	};
+
 	EolType getEolFormat() const { return _eolFormat; }
 
 	void setEolFormat(EolType format) {
@@ -374,6 +381,7 @@ private:
 	UniMode _unicodeMode = uniUTF8;
 	int _encoding = -1;
 	bool _isUserReadOnly = false;
+	bool _wasReadOnly = false;
 	bool _needLexer = false; // new buffers do not need lexing, Scintilla takes care of that
 	//these properties have to be duplicated because of multiple references
 


### PR DESCRIPTION
(LogViewer use-case)
- When using -openFoldersAsWorkspace -ro  switches, I would prefer if the editor operates in read-only mode, unless I explicity unset the option for a file, for the session. 
- When I turn on monitoring, if file is stale, I expect file to be reloaded and scrolled to end.
- When I turn off monitoring, the read-only UI state should be restored to prior status, not cleared.

note: nppParam.getCmdLineParams not synced with nppParam.getCmdLineString from launch, so used latter

fix #15604  #15660 #13181 