### PR TITLE
add NULL check in NPPM_GETNATIVELANGFILENAME

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3761,7 +3761,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_GETNATIVELANGFILENAME:
 		{
-			string fileName = _nativeLangSpeaker.getFileName();
+			const char * fileNameBuf = _nativeLangSpeaker.getFileName();
+			if (fileNameBuf == NULL)
+				return 0;
+			string fileName(fileNameBuf);
 			if (lParam != 0)
 			{
 				if (fileName.length() >= static_cast<size_t>(wParam))


### PR DESCRIPTION
Would fix #15627 

To test, follow the replication instructions [in this comment](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/15627#issue-2526729405). You may also wish to verify that the message still works normally when `nativeLang.xml` *does* exist by setting the UI language to `Español` and verify that the `CSharpPluginPack` plugin has been translated into spanish.