### PR TITLE
Fix network files hanging while the network disconnected (part 2)

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1764,6 +1764,9 @@ bool Version::isCompatibleTo(const Version& from, const Version& to) const
 	return false;
 }
 
+
+#define DEFAULT_MILLISEC 1000
+
 //----------------------------------------------------
 struct GetAttrParamResult {
 	std::wstring _filePath;
@@ -1779,7 +1782,7 @@ DWORD WINAPI getFileAttributesWorker(void* data)
 	return TRUE;
 };
 
-DWORD getFileAttrWaitSec(const wchar_t* filePath, DWORD milleSec2wait, bool* isNetWorkProblem)
+DWORD getFileAttrWaitSec(const wchar_t* filePath, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
 	GetAttrParamResult data;
 	data._fileAttr = INVALID_FILE_ATTRIBUTES;
@@ -1793,7 +1796,7 @@ DWORD getFileAttrWaitSec(const wchar_t* filePath, DWORD milleSec2wait, bool* isN
 	}
 
 	// wait for our worker thread to complete or terminate it when the required timeout has elapsed
-	DWORD dwWaitStatus = ::WaitForSingleObject(hThread, milleSec2wait == 0 ? 1000 : milleSec2wait);
+	DWORD dwWaitStatus = ::WaitForSingleObject(hThread, milliSec2wait == 0 ? DEFAULT_MILLISEC : milliSec2wait);
 	switch (dwWaitStatus)
 	{
 		case WAIT_OBJECT_0: // Ok, the state of our worker thread is signaled, so it finished itself in the timeout given		
@@ -1814,21 +1817,21 @@ DWORD getFileAttrWaitSec(const wchar_t* filePath, DWORD milleSec2wait, bool* isN
 	return data._fileAttr;
 };
 
-bool doesFileExist(const wchar_t* filePath, DWORD milleSec2wait, bool* isNetWorkProblem)
+bool doesFileExist(const wchar_t* filePath, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
-	DWORD attr = getFileAttrWaitSec(filePath, milleSec2wait, isNetWorkProblem);
+	DWORD attr = getFileAttrWaitSec(filePath, milliSec2wait, isNetWorkProblem);
 	return (attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY));
 }
 
-bool doesDirectoryExist(const wchar_t* dirPath, DWORD milleSec2wait, bool* isNetWorkProblem)
+bool doesDirectoryExist(const wchar_t* dirPath, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
-	DWORD attr = getFileAttrWaitSec(dirPath, milleSec2wait, isNetWorkProblem);
+	DWORD attr = getFileAttrWaitSec(dirPath, milliSec2wait, isNetWorkProblem);
 	return (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY));
 }
 
-bool doesPathExist(const wchar_t* path, DWORD milleSec2wait, bool* isNetWorkProblem)
+bool doesPathExist(const wchar_t* path, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
-	DWORD attr = getFileAttrWaitSec(path, milleSec2wait, isNetWorkProblem);
+	DWORD attr = getFileAttrWaitSec(path, milliSec2wait, isNetWorkProblem);
 	return (attr != INVALID_FILE_ATTRIBUTES);
 }
 
@@ -1850,7 +1853,7 @@ DWORD WINAPI getDiskFreeSpaceExWorker(void* data)
 	return TRUE;
 };
 
-DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milleSec2wait, bool* isNetWorkProblem)
+DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
 	GetDiskFreeSpaceParamResult data;
 	data._dirPath = dirPath;
@@ -1865,7 +1868,7 @@ DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesF
 	}
 
 	// wait for our worker thread to complete or terminate it when the required timeout has elapsed
-	DWORD dwWaitStatus = ::WaitForSingleObject(hThread, milleSec2wait == 0 ? 1000 : milleSec2wait);
+	DWORD dwWaitStatus = ::WaitForSingleObject(hThread, milliSec2wait == 0 ? DEFAULT_MILLISEC : milliSec2wait);
 	switch (dwWaitStatus)
 	{
 		case WAIT_OBJECT_0: // Ok, the state of our worker thread is signaled, so it finished itself in the timeout given		
@@ -1907,11 +1910,11 @@ DWORD WINAPI getFileAttributesExWorker(void* data)
 	return TRUE;
 };
 
-DWORD getFileAttributesExWaitSec(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milleSec2wait, bool* isNetWorkProblem)
+DWORD getFileAttributesExWaitSec(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
 	GetAttrExParamResult data;
 	data._filePath = filePath;
-	data._attributes = {};
+	data._attributes.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
 	data._result = FALSE;
 	data._isNetworkFailure = true;
 
@@ -1922,7 +1925,7 @@ DWORD getFileAttributesExWaitSec(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_D
 	}
 
 	// wait for our worker thread to complete or terminate it when the required timeout has elapsed
-	DWORD dwWaitStatus = ::WaitForSingleObject(hThread, milleSec2wait == 0 ? 1000 : milleSec2wait);
+	DWORD dwWaitStatus = ::WaitForSingleObject(hThread, milliSec2wait == 0 ? DEFAULT_MILLISEC : milliSec2wait);
 	switch (dwWaitStatus)
 	{
 		case WAIT_OBJECT_0: // Ok, the state of our worker thread is signaled, so it finished itself in the timeout given		

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1769,7 +1769,7 @@ bool Version::isCompatibleTo(const Version& from, const Version& to) const
 
 //----------------------------------------------------
 struct GetAttrParamResult {
-	std::wstring _filePath;
+	wstring _filePath;
 	DWORD _fileAttr = INVALID_FILE_ATTRIBUTES;
 	bool _isNetworkFailure = true;
 };
@@ -1779,15 +1779,12 @@ DWORD WINAPI getFileAttributesWorker(void* data)
 	GetAttrParamResult* inAndOut = static_cast<GetAttrParamResult*>(data);
 	inAndOut->_fileAttr = ::GetFileAttributesW(inAndOut->_filePath.c_str());
 	inAndOut->_isNetworkFailure = false;
-	return TRUE;
+	return ERROR_SUCCESS;
 };
 
 DWORD getFileAttrWaitSec(const wchar_t* filePath, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
-	GetAttrParamResult data;
-	data._fileAttr = INVALID_FILE_ATTRIBUTES;
-	data._filePath = filePath;
-	data._isNetworkFailure = true;
+	GetAttrParamResult data(filePath);
 
 	HANDLE hThread = ::CreateThread(NULL, 0, getFileAttributesWorker, &data, 0, NULL);
 	if (!hThread)
@@ -1843,6 +1840,7 @@ struct GetDiskFreeSpaceParamResult
 	ULARGE_INTEGER _freeBytesForUser {};
 	DWORD _result = FALSE;
 	bool _isNetworkFailure = true;
+	GetDiskFreeSpaceParamResult(wstring dirPath) : _dirPath(dirPath) {};
 };
 
 DWORD WINAPI getDiskFreeSpaceExWorker(void* data)
@@ -1850,16 +1848,12 @@ DWORD WINAPI getDiskFreeSpaceExWorker(void* data)
 	GetDiskFreeSpaceParamResult* inAndOut = static_cast<GetDiskFreeSpaceParamResult*>(data);
 	inAndOut->_result = ::GetDiskFreeSpaceExW(inAndOut->_dirPath.c_str(), &(inAndOut->_freeBytesForUser), nullptr, nullptr);
 	inAndOut->_isNetworkFailure = false;
-	return TRUE;
+	return ERROR_SUCCESS;
 };
 
 DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
-	GetDiskFreeSpaceParamResult data;
-	data._dirPath = dirPath;
-	data._freeBytesForUser = {};
-	data._result = FALSE;
-	data._isNetworkFailure = true;
+	GetDiskFreeSpaceParamResult data(dirPath);
 
 	HANDLE hThread = ::CreateThread(NULL, 0, getDiskFreeSpaceExWorker, &data, 0, NULL);
 	if (!hThread)
@@ -1896,10 +1890,13 @@ DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesF
 
 struct GetAttrExParamResult
 {
-	std::wstring _filePath;
+	wstring _filePath;
 	WIN32_FILE_ATTRIBUTE_DATA _attributes{};
 	DWORD _result = FALSE;
 	bool _isNetworkFailure = true;
+	GetAttrExParamResult(wstring filePath): _filePath(filePath) {
+		_attributes.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
+	}
 };
 
 DWORD WINAPI getFileAttributesExWorker(void* data)
@@ -1907,16 +1904,12 @@ DWORD WINAPI getFileAttributesExWorker(void* data)
 	GetAttrExParamResult* inAndOut = static_cast<GetAttrExParamResult*>(data);
 	inAndOut->_result = ::GetFileAttributesEx(inAndOut->_filePath.c_str(), GetFileExInfoStandard, &(inAndOut->_attributes));
 	inAndOut->_isNetworkFailure = false;
-	return TRUE;
+	return ERROR_SUCCESS;
 };
 
 DWORD getFileAttributesExWaitSec(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milliSec2wait, bool* isNetWorkProblem)
 {
-	GetAttrExParamResult data;
-	data._filePath = filePath;
-	data._attributes.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
-	data._result = FALSE;
-	data._isNetworkFailure = true;
+	GetAttrExParamResult data(filePath);
 
 	HANDLE hThread = ::CreateThread(NULL, 0, getFileAttributesExWorker, &data, 0, NULL);
 	if (!hThread)

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -281,9 +281,10 @@ private:
 	unsigned long _build = 0;
 };
 
-bool doesFileExist(const wchar_t* filePath, DWORD milleSec2wait = 0, bool* isNetWorkProblem = nullptr);
-bool doesDirectoryExist(const wchar_t* dirPath, DWORD milleSec2wait = 0, bool* isNetWorkProblem = nullptr);
-bool doesPathExist(const wchar_t* path, DWORD milleSec2wait = 0, bool* isNetWorkProblem = nullptr);
+DWORD getFileAttrWaitSec(const wchar_t* filePath, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
+bool doesFileExist(const wchar_t* filePath, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
+bool doesDirectoryExist(const wchar_t* dirPath, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
+bool doesPathExist(const wchar_t* path, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
 
-DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milleSec2wait = 0, bool* isNetWorkProblem = nullptr);
-DWORD getFileAttributesExWaitSec(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milleSec2wait = 0, bool* isNetWorkProblem = nullptr);
+DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
+DWORD getFileAttributesExWaitSec(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -8216,7 +8216,7 @@ DWORD WINAPI Notepad_plus::threadTextPlayer(void *params)
 
 			BufferID currentBufID = pCurrentView->getCurrentBufferID();
 			if (currentBufID != targetBufID)
-				return TRUE;
+				return ERROR_SUCCESS;
 
 			char charToShow[4] = { '\0' };
 			::WideCharToMultiByte(CP_UTF8, 0, quoter + i, 1, charToShow, sizeof(charToShow), NULL, NULL);
@@ -8227,7 +8227,7 @@ DWORD WINAPI Notepad_plus::threadTextPlayer(void *params)
 		}
 	}
 
-    return TRUE;
+    return ERROR_SUCCESS;
 }
 
 
@@ -8310,7 +8310,7 @@ DWORD WINAPI Notepad_plus::threadTextTroller(void *params)
 	}
 
 	ReleaseMutex(textTrollerParams->_mutex);
-	return TRUE;
+	return ERROR_SUCCESS;
 }
 
 
@@ -8643,7 +8643,7 @@ DWORD WINAPI Notepad_plus::backupDocument(void * /*param*/)
 
 		::SendMessage(Notepad_plus_Window::gNppHWND, NPPM_INTERNAL_SAVEBACKUP, 0, 0);
 	}
-	return TRUE;
+	return ERROR_SUCCESS;
 }
 
 

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -129,7 +129,7 @@ DWORD WINAPI Notepad_plus::monitorFileOnChange(void * params)
 	dirChanges.Terminate();
 	fileChanges.Terminate();
 	delete monitorInfo;
-	return EXIT_SUCCESS;
+	return ERROR_SUCCESS;
 }
 
 bool resolveLinkFile(std::wstring& linkFilePath)

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -261,7 +261,7 @@ BufferID Notepad_plus::doOpen(const wstring& fileName, bool isRecursive, bool is
 		}
 	}
 
-	bool isSnapshotMode = backupFileName != NULL && doesFileExist(backupFileName);
+	bool isSnapshotMode = (backupFileName != NULL) && doesFileExist(backupFileName);
 	bool longFileNameExists = doesFileExist(longFileName);
 	if (isSnapshotMode && !longFileNameExists) // UNTITLED
 	{
@@ -423,18 +423,14 @@ BufferID Notepad_plus::doOpen(const wstring& fileName, bool isRecursive, bool is
 
 		if (buffer != BUFFER_INVALID)
 		{
-			isSnapshotMode = (backupFileName != NULL && doesFileExist(backupFileName));
-			if (isSnapshotMode)
-			{
-				// To notify plugins that a snapshot dirty file is loaded on startup
-				SCNotification scnN2{};
-				scnN2.nmhdr.hwndFrom = 0;
-				scnN2.nmhdr.idFrom = (uptr_t)buffer;
-				scnN2.nmhdr.code = NPPN_SNAPSHOTDIRTYFILELOADED;
-				_pluginsManager.notify(&scnN2);
+			// To notify plugins that a snapshot dirty file is loaded on startup
+			SCNotification scnN2{};
+			scnN2.nmhdr.hwndFrom = 0;
+			scnN2.nmhdr.idFrom = (uptr_t)buffer;
+			scnN2.nmhdr.code = NPPN_SNAPSHOTDIRTYFILELOADED;
+			_pluginsManager.notify(&scnN2);
 
-				buffer->setLoadedDirty(true);
-			}
+			buffer->setLoadedDirty(true);
 		}
 	}
 	else

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -532,17 +532,6 @@ static wstring removeTrailingSlash(const wstring& path)
 		return path;
 }
 
-static bool isDirectory(const wstring& path)
-{
-	DWORD type = ::GetFileAttributes(path.c_str());
-	return type != INVALID_FILE_ATTRIBUTES && (type & FILE_ATTRIBUTE_DIRECTORY);
-}
-
-static bool isFile(const wstring& path)
-{
-	DWORD type = ::GetFileAttributes(path.c_str());
-	return type != INVALID_FILE_ATTRIBUTES && ! (type & FILE_ATTRIBUTE_DIRECTORY);
-}
 
 static bool isAllowedBeforeDriveLetter(wchar_t c)
 {
@@ -578,11 +567,11 @@ static bool getPathsForPathCompletion(const wstring& input, wstring &rawPath_out
 	{
 		return false;
 	}
-	else if (isFile(rawPath) || isFile(removeTrailingSlash(rawPath)))
+	else if (doesFileExist(removeTrailingSlash(rawPath).c_str()))
 	{
 		return false;
 	}
-	else if (isDirectory(rawPath))
+	else if (doesDirectoryExist(rawPath.c_str()))
 	{
 		rawPath_out = rawPath;
 		pathToMatch_out = rawPath;

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -1714,7 +1714,7 @@ DWORD WINAPI FolderUpdater::watching(void *params)
 	// call Terminate() automatically.
 	changes.Terminate();
 	//printStr(L"Quit watching thread");
-	return EXIT_SUCCESS;
+	return ERROR_SUCCESS;
 }
 
 void FolderUpdater::processChange(DWORD dwAction, std::vector<wstring> filesToChange, FolderUpdater* thisFolderUpdater)


### PR DESCRIPTION
Refactoring for reducing the I/O calls, fix typos.

Reduce the startup time (while the a dirty disconnected network file is in the session) from about 12-15 seconds to about 6 seconds (on my laptop).

Note that there are 2 cases are not improved by the commit:

* STR 1: Open a network file, modify it. Disconnect the network, then save the file.

There will be a huge hanging time (around 1 minute) to get the warning dialog.
I tried to remedy with thread for CreateFileW in the constructor of Win32_IO_File, however it leads crash due to the lock guard in the caller.

* STR 2:
1. Open a network file.
2. Close Notepad++ to have it in the session.
3. Disconnect the network, and launch Notepad++ immediately.
4. Around more than 1 minute's delay, then the "Error" dialog displayed.

The reason of hanging is that the network file was detected by "doesFileExist" as true, so Notepad++ was trying to open non-existent file (by _wfopen).
I believe that there's some kind of cache during the very short period for the IO function (here's our case GetFileAttributes), and such cache is not immediately synchronized (cleared) while network disconnected. As a result, when we launch Notepad++ after the disconnection of network, GetFileAttributes keeps its memory & responds "FileExists". However for _wfopen it doesn't see the resource of network anymore - that makes hanging.


Ref #15658
Improve #4306, #6178, #8055, #11388, #12553, #15540