### PR TITLE
allow '?' in URL fragment

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3302,7 +3302,7 @@ void scanToUrlEnd(const wchar_t *text, int textLen, int start, int* distance)
 				break;
 
 			case sFragment:
-				if (!isUrlTextChar(text [p]))
+				if (text [p] != '?' && !isUrlTextChar(text [p]))
 				{
 					*distance = p - start;
 					return;


### PR DESCRIPTION
Fixes #13583 by simply allowing '?' to appear in the URL fragment.
