### PR TITLE
Fix crash on closing a disconnected network file

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -323,7 +323,11 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				activateBuffer(bufferToClose, iView);
 			}
 
-			if (fileClose(bufferToClose, iView))
+			BufferID bufferToClose2ndCheck = notifyDocTab->getBufferByIndex(index);
+
+			if ((bufferToClose == bufferToClose2ndCheck) // Here we make sure the buffer is the same to prevent from the situation that the buffer to be close was already closed,
+			                                             // because the precedent call "activateBuffer(bufferToClose, iView)" could finally lead "doClose" call as well (in case of file non-existent).
+				&& fileClose(bufferToClose, iView))
 				checkDocState();
 
 			break;


### PR DESCRIPTION
Context: While the network file is disconnected, it's considered non-existent and might to be deleted.

The reason of crash: 
"doClose" on the same buffer happens twice while users clicks X button, then chooses "No" when they are asked whether if this file should be kept in editor.

Explanation:
When user clicks X button on the tab of the file in question to close it, "activateBuffer" is called, then "fileClose" is called.
* activateBuffer: Following "activeateBuffer" call in the depth, "checkFileState" is invoked - that leads the message "The file "xxxxxx" doesn't exist anymore. Keep this file in Editor?". If user clicks on No, "doClose" will close the tab and destroy the buffer.
* fileClose: in "fileClose" call, "doClose" will be invoked and try to close the already-destroyed buffer.

Solution:
Retrieve the buffer ID once again, after "activateBuffer" call, for comparing with old buffer ID. If the buffer was destroyed, the new retrieved buffer ID is not the same. 

Note: this commit fixes the crash, but it doesn't fix the misbehaviour: If user clicks on "Yes" to answer the message "The file "xxxxxx" doesn't exist anymore. Keep this file in Editor?", the tab will be still closed. I have so far no solution for it.

Fix #15684