### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.7.1

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
-			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 17th (v8.7.1)
+			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 21st (v8.7.1)
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
 			  Nov. 15th (v8.5.9), Nov. 22nd (v8.6), Dec. 19th (v8.6.1), Dec. 29th (v8.6.1)
@@ -666,7 +666,8 @@ Additionnal information about Corsican localization:
 					<Item id="2231" name="Sfurzà a grafia cursiva à tutti i stili"/>
 					<Item id="2232" name="Sfurzà a grafia sottulin. à tutti i stili"/>
 					<Item id="2234" name="Andà à i parametri"/>
-					<Item id="2235" name="Cosa serà a prevalenza glubale ?"/>
+					<!-- Don't translate "&quot;Global override&quot; -->
+					<Item id="2235" name="Cosa serà a « Global override » ?"/>
 				</SubDialog>
 			</StyleConfig>
 
@@ -1830,7 +1831,8 @@ U+200B : spaziu di larghezza nulla
 U+FEFF : spaziu nonspezzevule di larghezza nulla
 Per ottene a lista sana, fighjate u Manuale di l’utilizatore.
 Impiegà u buttone « ? » à diritta per apre u manuale di l’utilizatore nant’à u situ web."/>
-			<npcCustomColor-tip value="Accidite à u Cunfiguratore di stilu per persunalizà u culore predefinitu di i spazii bianchi selezziunati è di i caratteri nonstampevule (&quot;Non-printing characters custom color&quot;)."/><!-- Don't translate "(&quot;Non-printing characters custom color&quot;)" -->
+			<!-- Don't translate "(&quot;Non-printing characters custom color&quot;)" -->
+			<npcCustomColor-tip value="Accidite à u Cunfiguratore di stilu per persunalizà u culore predefinitu di i spazii bianchi selezziunati è di i caratteri nonstampevule (&quot;Non-printing characters custom color&quot;)."/>
 			<npcIncludeCcUniEol-tip value="Appiecate i parametri d’apparenza di caratteri nonstampevule à i caratteri di cuntrollu C0, C1 è quelli di fine di linea Unicode (linea seguente, separadore di linea è separadore di paragrafu)."/>
 			<searchingInSelThresh-tip value="Numeru di caratteri selezziunati in l’area di mudificazione per cuntrollà autumaticamente l’ozzione « In a selezzione » quandu u dialogu di ricerca hè attivatu. U valore massimu hè 1024. Definite u valore à 0 per disattivà a verificazione autumatica."/>
 			<verticalEdge-tip value="Aghjunghjite u vostru marcatore di culonna indichendu a so pusizione cù un numeru interu. Pudete definisce parechji marcatori di culonna impieghendu un spaziu per staccà ogni numeru."/>
@@ -1838,9 +1840,10 @@ Impiegà u buttone « ? » à diritta per apre u manuale di l’utilizatore na
 			<autoIndentBasic-tip value="Assicurassi chì l’indentazione di a linea currente (i.e. a linea nova creata da u tastu ENTRÉE) currisponde à l’indentazione di a linea precedente."/>
 			<autoIndentAdvanced-tip value="Attivà l’indentazione astuta per i linguaghji di tipu C è Python. I linguaghji di tipu C includenu :
 C, C++, Java, C#, Objective-C, PHP, JavaScript, JSP, CSS, Perl, Rust, PowerShell è JSON.
+
 S’è vo selezziunate u modu espertu ma ùn mudificate micca i schedarii in i linguaghji mintulati insù, l’indentazione sterà in modu basicu."/>
 			<!-- Don't translate "&quot;Global override&quot; and &quot;Default Style&quot; -->
-			<global-override-tip value="Permette quì a « Prevalenza glubale » supranerà sti parametri à tutti i stili di tutti i linguaghji di prugrammazione. Preferiscerete di sicuru impiegà piuttostu i parametri « Stilu predefinitu »"/>
+			<global-override-tip value="Attivà quì l’ozzione « Global override » supranerà sti parametri à tutti i stili di tutti i linguaghji di prugrammazione. Preferiscerete di sicuru impiegà piuttostu i parametri « Default Style »"/>
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
-			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 11th (v8.7.1)
+			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 17th (v8.7.1)
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
 			  Nov. 15th (v8.5.9), Nov. 22nd (v8.6), Dec. 19th (v8.6.1), Dec. 29th (v8.6.1)
@@ -658,14 +658,15 @@ Additionnal information about Corsican localization:
 					<Item id="2219" name="Parolle chjave predefinite"/>
 					<Item id="2221" name="Parolle chjave definite da l’utilizatore"/>
 					<Item id="2225" name="Linguaghju :"/>
-					<Item id="2226" name="Permette culore di primu pianu"/>
-					<Item id="2227" name="Permette culore di fondu"/>
-					<Item id="2228" name="Permette una grafia glubale"/>
-					<Item id="2229" name="Permette dimensione di grafia glubale"/>
-					<Item id="2230" name="Permette stilu di grafia glubale grassu"/>
-					<Item id="2231" name="Permette stilu di grafia glubale italicu"/>
-					<Item id="2232" name="Permette stilu di gra. glub. sottulineatu"/>
+					<Item id="2226" name="Sfurzà u primu pianu à tutti i stili"/>
+					<Item id="2227" name="Sfurzà u sfondulu à tutti i stili"/>
+					<Item id="2228" name="Sfurzà a grafia à tutti i stili"/>
+					<Item id="2229" name="Sfurzà a dimens. di grafia à tutti i stili"/>
+					<Item id="2230" name="Sfurzà a grafia grassa à tutti i stili"/>
+					<Item id="2231" name="Sfurzà a grafia cursiva à tutti i stili"/>
+					<Item id="2232" name="Sfurzà a grafia sottulin. à tutti i stili"/>
 					<Item id="2234" name="Andà à i parametri"/>
+					<Item id="2235" name="Cosa serà a prevalenza glubale ?"/>
 				</SubDialog>
 			</StyleConfig>
 
@@ -1340,7 +1341,7 @@ Additionnal information about Corsican localization:
 					</ComboBox>
 					<ComboBox id="6307">
 						<Element name="Nisuna azzione in"/>
-						<Element name="Impuculì in"/>
+						<Element name="Impuculisce in"/>
 						<Element name="Chjode in"/>
 					</ComboBox>
 					<Item id="6308" name="u spaziu di nutificazione di u sistema"/>
@@ -1713,8 +1714,8 @@ Circà in tutti i schedarii ma esclude i cartulari tests, bin è bin64 :
 Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o logs :
 *.* !+\log*"/><!-- HowToReproduce: Tip of mouse hovered on "Filters" label in "Find in Files" section of Find dialog. -->
 			<find-in-files-select-folder value="Selezziunà u cartulare per facci a ricerca"/><!-- HowToReproduce: Search > Find in Files > [...] -->
-			<find-status-top-reached value="Circà : Ultima occurrenza trova da a fine. U principiu di u ducumentu hè statu toccu."/>
-			<find-status-end-reached value="Circà : Ultima occurrenza trova da u principiu. A fine di u ducumentu hè stata tocca."/>
+			<find-status-top-reached value="Circà : U principiu di u ducumentu hè statu toccu, prima occurrenza trova da a fine."/>
+			<find-status-end-reached value="Circà : A fine di u ducumentu hè stata tocca, prima occurrenza trova da u principiu."/>
 			<find-status-replaceinfiles-1-replaced value="Rimpiazzà in schedarii : 1 occurrenza hè stata rimpiazzata"/>
 			<find-status-replaceinfiles-nb-replaced value="Rimpiazzà in schedarii : $INT_REPLACE$ occurrenze sò state rimpiazzate"/>
 			<find-status-replaceinopenedfiles-1-replaced value="Rimpiazzà in schedarii aperti : 1 occurrenza hè stata rimpiazzata"/>
@@ -1728,8 +1729,8 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
 			<find-status-replaceall-1-replaced value="Rimpiazzalle tutte : 1 occurrenza hè stata rimpiazzata"/>
 			<find-status-replaceall-nb-replaced value="Rimpiazzalle tutte : $INT_REPLACE$ occurrenze sò state rimpiazzate"/>
 			<find-status-replaceall-readonly value="Rimpiazzalle tutte : Ùn si pò rimpiazzà u testu. U ducumentu attuale pò solu si leghje"/>
-			<find-status-replace-end-reached value="Rimpiazzà : Ultima occurrenza rimpiazzata da u principiu. A fine di u ducumentu hè stata tocca"/>
-			<find-status-replace-top-reached value="Rimpiazzà : Ultima occurrenza rimpiazzata da a fine. U principiu di u ducumentu hè statu toccu"/>
+			<find-status-replace-end-reached value="Rimpiazzà : A fine di u ducumentu hè stata tocca, principiatu da l’altu."/>
+			<find-status-replace-top-reached value="Rimpiazzà : U principiu di u ducumentu hè statu toccu, principiatu da u bassu."/>
 			<find-status-replaced-next-found value="Rimpiazzà : 1 occurrenza hè stata rimpiazzata. A prossima occurrenza trova."/>
 			<find-status-replaced-without-continuing value="Rimpiazzà : 1 occurrenza hè stata rimpiazzata."/>
 			<find-status-replaced-next-not-found value="Rimpiazzà : 1 occurrenza hè stata rimpiazzata. Alcuna altra occurrenza trova."/>
@@ -1836,8 +1837,10 @@ Impiegà u buttone « ? » à diritta per apre u manuale di l’utilizatore na
 			<fileSaveAsCopySaveButton-tip value="Mantinite u tastu Maius quandu s’appoghja nant’à u buttone Arregistà per apre a copia dopu à l’arregistramentu."/>
 			<autoIndentBasic-tip value="Assicurassi chì l’indentazione di a linea currente (i.e. a linea nova creata da u tastu ENTRÉE) currisponde à l’indentazione di a linea precedente."/>
 			<autoIndentAdvanced-tip value="Attivà l’indentazione astuta per i linguaghji di tipu C è Python. I linguaghji di tipu C includenu :
-C, C++, Java, C#, Objective-C, PHP, JavaScript, JSP, CSS, Perl, Rust, PowerShell è JSON
+C, C++, Java, C#, Objective-C, PHP, JavaScript, JSP, CSS, Perl, Rust, PowerShell è JSON.
 S’è vo selezziunate u modu espertu ma ùn mudificate micca i schedarii in i linguaghji mintulati insù, l’indentazione sterà in modu basicu."/>
+			<!-- Don't translate "&quot;Global override&quot; and &quot;Default Style&quot; -->
+			<global-override-tip value="Permette quì a « Prevalenza glubale » supranerà sti parametri à tutti i stili di tutti i linguaghji di prugrammazione. Preferiscerete di sicuru impiegà piuttostu i parametri « Stilu predefinitu »"/>
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
-			  June 13th (v8.6.9), Sept. 8th (v8.7)
+			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 11th (v8.7.1)
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
 			  Nov. 15th (v8.5.9), Nov. 22nd (v8.6), Dec. 19th (v8.6.1), Dec. 29th (v8.6.1)
@@ -34,7 +34,7 @@ Additionnal information about Corsican localization:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.7">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.7.1">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -561,7 +561,7 @@ Additionnal information about Corsican localization:
 
 			<GoToLine title="Andà à…">
 				<Item id="2007" name="&amp;Linea"/>
-				<Item id="2008" name="&amp;Staccamentu"/>
+				<Item id="2008" name="&amp;Spustime"/>
 				<Item id="1" name="&amp;Andà"/>
 				<Item id="2" name="Ùn vocu inlocu"/>
 				<Item id="2004" name="Site quì :"/>
@@ -1338,6 +1338,12 @@ Additionnal information about Corsican localization:
 						<Element name="Attivà per tutti i schedarii aperti"/>
 						<Element name="Disattivà"/>
 					</ComboBox>
+					<ComboBox id="6307">
+						<Element name="Nisuna azzione in"/>
+						<Element name="Impuculì in"/>
+						<Element name="Chjode in"/>
+					</ComboBox>
+					<Item id="6308" name="u spaziu di nutificazione di u sistema"/>
 					<Item id="6312" name="Detezione autumatica di statu di schedariu"/>
 					<Item id="6313" name="Mudificazione senza avertimentu"/>
 					<Item id="6325" name="Andà à l’ultima linea dopu a mudificazione"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/035ef19b17ab6cedce7b68d3bc6a3b1108acaf56 Add "Close to system tray" in MISC preference
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/cd45afc0208f92c21afd286ce3f691f6f32d1989 Improve GUI for commands for the system tray in Preferences

Updated on October 17<sup>th</sup>:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/1890ea65f98f8d915ac2f4c437b2afd3b2535f8b Avoid user confusion between Global override & Default Styles
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/901014746c2cf432ac7f20cebb940529a1bd31f8 Fix Find dialog status bar wrong messaging
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/bfe835e8a4ad61619311ac2ba39fb7991d0e0637 Fix wrong messages for replacement status

Updated on October 21<sup>st</sup>:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/ba8cd8c46f1c44bb4cdf1b64156b3899e94f8583 Add one comment for localization file

Cheers,
Patriccollu.