### PR TITLE
Fix network files hanging while the network disconnected (part 3.5)

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -282,11 +282,10 @@ private:
 	unsigned long _build = 0;
 };
 
-DWORD getFileAttrWaitSec(const wchar_t* filePath, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
+
+DWORD getDiskFreeSpaceWithTimeout(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
+DWORD getFileAttributesExWithTimeout(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
+
 bool doesFileExist(const wchar_t* filePath, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
 bool doesDirectoryExist(const wchar_t* dirPath, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
 bool doesPathExist(const wchar_t* path, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
-
-DWORD getDiskFreeSpaceWaitSec(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
-DWORD getFileAttributesExWaitSec(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);
-HANDLE createFileWaitSec(const wchar_t* filePath, DWORD accessParam, DWORD shareParam, DWORD dispParam, DWORD attribParam, DWORD milliSec2wait = 0, bool* isNetWorkProblem = nullptr);

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -845,7 +845,7 @@ bool FileManager::reloadBuffer(BufferID id)
 	//Get file size
 	int64_t fileSize = 0;
 	WIN32_FILE_ATTRIBUTE_DATA attributes{};
-	getFileAttributesExWaitSec(buf->getFullPathName(), &attributes);
+	getFileAttributesExWithTimeout(buf->getFullPathName(), &attributes);
 	if (attributes.dwFileAttributes == INVALID_FILE_ATTRIBUTES)
 	{
 		return false;


### PR DESCRIPTION
This PR prevent hanging when user: Open a network file, modify it. Disconnect the network, then save the file.
It also prevents the zombie process due to blocked CreateFile left behind.

Remove the timeout thread for CreateFile to prevent the zombie process. Use another way for the detection:
If the result of network file existent detection is false, and the network problem found (timeout reached), we just stop and don't call CreateFile routine.


Ref: 1445487bb76b92a3a30cf71d8175b8b416b4c0c9

Improve #4306, #6178, #8055, #11388, #12553, #15540