### PR TITLE
Installer - always allow to use the "Show details" functionality

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -283,6 +283,11 @@ FunctionEnd
 
 
 Section -"Notepad++" mainSection
+	${If} $showDetailsChecked == ${BST_CHECKED}
+		SetDetailsView show
+		SetAutoClose false
+	${endIf}
+
 	${If} $diffArchDir2Remove != ""
 		!insertmacro uninstallRegKey
 		!insertmacro uninstallDir $diffArchDir2Remove 

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -85,7 +85,7 @@ page Custom ExtraOptions
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW "CheckIfRunning"
 !insertmacro MUI_PAGE_INSTFILES
 
-!define MUI_FINISHPAGE_NOAUTOCLOSE
+
 !define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_RUN_FUNCTION "LaunchNpp"
 !insertmacro MUI_PAGE_FINISH

--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -85,7 +85,7 @@ page Custom ExtraOptions
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW "CheckIfRunning"
 !insertmacro MUI_PAGE_INSTFILES
 
-
+!define MUI_FINISHPAGE_NOAUTOCLOSE
 !define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_RUN_FUNCTION "LaunchNpp"
 !insertmacro MUI_PAGE_FINISH

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -72,9 +72,11 @@ FunctionEnd
 Var Dialog
 Var NoUserDataCheckboxHandle
 Var ShortcutCheckboxHandle
+Var ShowDetailsCheckboxHandle
 Var WinVer
 Var noUserDataChecked
 Var createShortcutChecked
+Var showDetailsChecked
 
 ; The definition of "OnChange" event for checkbox
 Function OnChange_NoUserDataCheckBox
@@ -83,6 +85,10 @@ FunctionEnd
 
 Function OnChange_ShortcutCheckBox
 	${NSD_GetState} $ShortcutCheckboxHandle $createShortcutChecked
+FunctionEnd
+
+Function OnChange_ShowDetailsCheckbox
+	${NSD_GetState} $ShowDetailsCheckboxHandle $showDetailsChecked
 FunctionEnd
 
 Function ExtraOptions
@@ -98,8 +104,8 @@ Function ExtraOptions
 	StrCmp $WinVer "8" 0 +2
 	${NSD_Check} $ShortcutCheckboxHandle
 	${NSD_OnClick} $ShortcutCheckboxHandle OnChange_ShortcutCheckBox
-	
-	${NSD_CreateCheckbox} 0 120 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."
+
+	${NSD_CreateCheckbox} 0 80 100% 30u "Don't use %APPDATA%$\nEnable this option to make Notepad++ load/write the configuration files from/to its install directory. Check it if you use Notepad++ in a USB device."
 	Pop $NoUserDataCheckboxHandle
 	IfFileExists $INSTDIR\doLocalConf.xml doLocalConfExists doLocalConfDoesNotExists
 	doLocalConfExists:
@@ -108,7 +114,11 @@ Function ExtraOptions
 		StrCpy $noUserDataChecked ${BST_CHECKED}
 	doLocalConfDoesNotExists:
 	${NSD_OnClick} $NoUserDataCheckboxHandle OnChange_NoUserDataCheckBox
-	
+
+	${NSD_CreateCheckbox} 0 160 100% 30u "Show installation details"
+	Pop $ShowDetailsCheckboxHandle
+	${NSD_OnClick} $ShowDetailsCheckboxHandle OnChange_ShowDetailsCheckbox
+
 	StrLen $0 $PROGRAMFILES
 	StrCpy $1 $InstDir $0
 


### PR DESCRIPTION
Fix #15718 

By using the NSIS MUI_FINISHPAGE_NOAUTOCLOSE, the installer will always wait for the user Next-click confirmation before it goes to the last Finish-page.

Otherwise, sometimes even during the installation phase, the details of the installation activities cannot be displayed (probably some problem with the focus of the NSIS installer prevents the "Show details" button from being successfully clicked).

![npp-installer-ShowDetailsBtn-fix](https://github.com/user-attachments/assets/fb76fc87-bd7b-4300-bb95-35b9c747d2a7)
