### PR TITLE
fix SaveAs dlg Append extension checked functionality

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -505,7 +505,7 @@ private:
 		expandEnv(fileName);
 		bool nameChanged = transformPath(fileName);
 		// Update the controls.
-		if (doesDirectoryExist(getAbsPath(fileName).c_str()))
+		if (!doesDirectoryExist(getAbsPath(fileName).c_str()))
 		{
 			// Name is a file path.
 			// Add file extension if missing.


### PR DESCRIPTION
Fix [Community report](https://community.notepad-plus-plus.org/post/97385) v8.7.1rc regression.

Added missing "not" operator in commit:

https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f884a39dd422cda908b36e9439fb00c340c4d85e