### PR TITLE
Add ability to open/copy selected files from Search-results, not always ALL files

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1719,9 +1719,9 @@ Find in all files but exclude all folders log or logs recursively:
 			<finder-collapse-all value="Fold all"/>
 			<finder-uncollapse-all value="Unfold all"/>
 			<finder-copy value="Copy Selected Line(s)"/>
-			<finder-copy-paths value="Copy Pathname(s)"/>
+			<finder-copy-paths value="Copy Selected Pathname(s)"/>
 			<finder-clear-all value="Clear all"/>
-			<finder-open-all value="Open all"/>
+			<finder-open-all value="Open Selected Pathname(s)"/>
 			<finder-purge-for-every-search value="Purge for every search"/>
 			<finder-wrap-long-lines value="Word wrap long lines"/>
 			<common-ok value="OK"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1718,9 +1718,9 @@ Find in all files but exclude all folders log or logs recursively:
 			<finder-collapse-all value="Fold all"/>
 			<finder-uncollapse-all value="Unfold all"/>
 			<finder-copy value="Copy Selected Line(s)"/>
-			<finder-copy-paths value="Copy Pathname(s)"/>
+			<finder-copy-paths value="Copy Selected Pathname(s)"/>
 			<finder-clear-all value="Clear all"/>
-			<finder-open-all value="Open all"/>
+			<finder-open-all value="Open Selected Pathname(s)"/>
 			<finder-purge-for-every-search value="Purge for every search"/>
 			<finder-wrap-long-lines value="Word wrap long lines"/>
 			<common-ok value="OK"/>

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2049,7 +2049,7 @@ bool Notepad_plus::findInFinderFiles(FindersInfo *findInFolderInfo)
 	_pEditView = &_invisibleEditView;
 	Document oldDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER);
 
-	vector<wstring> fileNames = findInFolderInfo->_pSourceFinder->getResultFilePaths();
+	vector<wstring> fileNames = findInFolderInfo->_pSourceFinder->getResultFilePaths(false);
 
 	findInFolderInfo->_pDestFinder->beginNewFilesSearch();
 	findInFolderInfo->_pDestFinder->addSearchLine(findInFolderInfo->_findOption._str2Search.c_str());

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -143,7 +143,7 @@ public:
 	void gotoNextFoundResult(int direction);
 	std::pair<intptr_t, intptr_t> gotoFoundLine(size_t nOccurrence = 0); // value 0 means this argument is not used
 	void deleteResult();
-	std::vector<std::wstring> getResultFilePaths() const;
+	std::vector<std::wstring> getResultFilePaths(bool onlyInSelectedText = false) const;
 	bool canFind(const wchar_t *fileName, size_t lineNumber, size_t* indexToStartFrom) const;
 	void setVolatiled(bool val) { _canBeVolatiled = val; };
 	std::wstring getHitsString(int count) const;

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -143,7 +143,7 @@ public:
 	void gotoNextFoundResult(int direction);
 	std::pair<intptr_t, intptr_t> gotoFoundLine(size_t nOccurrence = 0); // value 0 means this argument is not used
 	void deleteResult();
-	std::vector<std::wstring> getResultFilePaths(bool onlyInSelectedText = false) const;
+	std::vector<std::wstring> getResultFilePaths(bool onlyInSelectedText) const;
 	bool canFind(const wchar_t *fileName, size_t lineNumber, size_t* indexToStartFrom) const;
 	void setVolatiled(bool val) { _canBeVolatiled = val; };
 	std::wstring getHitsString(int count) const;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2801,7 +2801,7 @@ void ScintillaEditView::showCallTip(size_t startPos, const wchar_t * def)
 	execute(SCI_CALLTIPSHOW, startPos, reinterpret_cast<LPARAM>(defA));
 }
 
-wstring ScintillaEditView::getLine(size_t lineNumber)
+wstring ScintillaEditView::getLine(size_t lineNumber) const
 {
 	size_t lineLen = execute(SCI_LINELENGTH, lineNumber);
 	const size_t bufSize = lineLen + 1;
@@ -2810,7 +2810,7 @@ wstring ScintillaEditView::getLine(size_t lineNumber)
 	return buf.get();
 }
 
-void ScintillaEditView::getLine(size_t lineNumber, wchar_t * line, size_t lineBufferLen)
+void ScintillaEditView::getLine(size_t lineNumber, wchar_t * line, size_t lineBufferLen) const
 {
 	// make sure the buffer length is enough to get the whole line
 	size_t lineLen = execute(SCI_LINELENGTH, lineNumber);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -476,8 +476,8 @@ public:
 	intptr_t replaceTargetRegExMode(const wchar_t * re, intptr_t fromTargetPos = -1, intptr_t toTargetPos = -1) const;
 	void showAutoComletion(size_t lenEntered, const wchar_t * list);
 	void showCallTip(size_t startPos, const wchar_t * def);
-	std::wstring getLine(size_t lineNumber);
-	void getLine(size_t lineNumber, wchar_t * line, size_t lineBufferLen);
+	std::wstring getLine(size_t lineNumber) const;
+	void getLine(size_t lineNumber, wchar_t * line, size_t lineBufferLen) const;
 	void addText(size_t length, const char *buf);
 
 	void insertNewLineAboveCurrentLine();


### PR DESCRIPTION
Fix #15741

@donho You didn't get back to replying to the issue to say if you liked the idea or not, but there was not a lot of code to this so I just went ahead with it.

Note that changes to `ScintillaEditView.*` are simply to change two `getLine` functions into `const` functions (which they should have been even without this issue).  Note that the `const` is required for the code changes of this PR to build without error.