### PR TITLE
Fix possible filesize check fail before loading

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1788,6 +1788,7 @@ struct GetDiskFreeSpaceParamResult
 DWORD WINAPI getDiskFreeSpaceExWorker(void* data)
 {
 	GetDiskFreeSpaceParamResult* inAndOut = static_cast<GetDiskFreeSpaceParamResult*>(data);
+	::SetLastError(NO_ERROR);
 	inAndOut->_result = ::GetDiskFreeSpaceExW(inAndOut->_dirPath.c_str(), &(inAndOut->_freeBytesForUser), nullptr, nullptr);
 	inAndOut->_error = ::GetLastError();
 	inAndOut->_isTimeoutReached = false;
@@ -1853,6 +1854,7 @@ struct GetAttrExParamResult
 DWORD WINAPI getFileAttributesExWorker(void* data)
 {
 	GetAttrExParamResult* inAndOut = static_cast<GetAttrExParamResult*>(data);
+	::SetLastError(NO_ERROR);
 	inAndOut->_result = ::GetFileAttributesExW(inAndOut->_filePath.c_str(), GetFileExInfoStandard, &(inAndOut->_attributes));
 	inAndOut->_error = ::GetLastError();
 	inAndOut->_isTimeoutReached = false;
@@ -1908,7 +1910,8 @@ BOOL getFileAttributesExWithTimeout(const wchar_t* filePath, WIN32_FILE_ATTRIBUT
 	//if (wantMsgIfError && (data._error != NO_ERROR))
 	if (wantMsgIfError)
 	{
-		wstring strErr = L"Failure code " + to_wstring(data._error) + L" - " + GetLastErrorAsString(data._error);
+		wstring strErr = L"Failure code " + to_wstring(data._error) + L" - ";
+		strErr += (data._error != NO_ERROR) ? GetLastErrorAsString(data._error) : L"The operation completed successfully.";
 		strErr += L"\n\ndata._filePath: " + data._filePath + L"\n\ndata._attributes.dwFileAttributes: " + to_wstring(data._attributes.dwFileAttributes) + L"\n\ndata._result: " + to_wstring(data._result) + L"\n\ndata._isTimeoutReached: " + to_wstring(data._isTimeoutReached);
 		::MessageBoxW(NULL, strErr.c_str(), L"Notepad++ - getFileAttributesExWithTimeout", MB_OK | MB_APPLMODAL);
 	}

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1905,9 +1905,11 @@ BOOL getFileAttributesExWithTimeout(const wchar_t* filePath, WIN32_FILE_ATTRIBUT
 	if (pdwError != nullptr)
 		*pdwError = data._error;
 
-	if (wantMsgIfError && !(data._result) && (data._error != NO_ERROR))
+	//if (wantMsgIfError && (data._error != NO_ERROR))
+	if (wantMsgIfError)
 	{
 		wstring strErr = L"Failure code " + to_wstring(data._error) + L" - " + GetLastErrorAsString(data._error);
+		strErr += L"\n\ndata._filePath: " + data._filePath + L"\n\ndata._attributes.dwFileAttributes: " + to_wstring(data._attributes.dwFileAttributes) + L"\n\ndata._result: " + to_wstring(data._result) + L"\n\ndata._isTimeoutReached: " + to_wstring(data._isTimeoutReached);
 		::MessageBoxW(NULL, strErr.c_str(), L"Notepad++ - getFileAttributesExWithTimeout", MB_OK | MB_APPLMODAL);
 	}
 

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -283,9 +283,14 @@ private:
 };
 
 
-DWORD getDiskFreeSpaceWithTimeout(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
-DWORD getFileAttributesExWithTimeout(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
+BOOL getDiskFreeSpaceWithTimeout(const wchar_t* dirPath, ULARGE_INTEGER* freeBytesForUser,
+	DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
+BOOL getFileAttributesExWithTimeout(const wchar_t* filePath, WIN32_FILE_ATTRIBUTE_DATA* fileAttr,
+	DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr, DWORD* pdwError = nullptr, bool wantMsgIfError = false);
 
-bool doesFileExist(const wchar_t* filePath, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
-bool doesDirectoryExist(const wchar_t* dirPath, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
-bool doesPathExist(const wchar_t* path, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
+bool doesFileExist(const wchar_t* filePath, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr,
+	DWORD* pdwError = nullptr, bool wantMsgIfError = false);
+bool doesDirectoryExist(const wchar_t* dirPath, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr,
+	DWORD* pdwError = nullptr, bool wantMsgIfError = false);
+bool doesPathExist(const wchar_t* path, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr,
+	DWORD* pdwError = nullptr, bool wantMsgIfError = false);

--- a/PowerEditor/src/MISC/Common/FileInterface.cpp
+++ b/PowerEditor/src/MISC/Common/FileInterface.cpp
@@ -31,6 +31,7 @@ Win32_IO_File::Win32_IO_File(const wchar_t *fname)
 		_path = converter.to_bytes(fn);
 
 		WIN32_FILE_ATTRIBUTE_DATA attributes_original{};
+		attributes_original.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
 		DWORD dispParam = CREATE_ALWAYS;
 		bool fileExists = false;
 		bool isTimeoutReached = false;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -707,10 +707,13 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 	DWORD dwError = NO_ERROR;
 	if (!doesFileExist(pPath, 0, nullptr, &dwError, true))
 	{
-		if ((dwError == ERROR_FILE_NOT_FOUND) || (dwError == ERROR_PATH_NOT_FOUND))
-		{
-			pPath = backupFileName;
-		}
+		// DEBUG:
+		wstring strMsg = L"Filesize check, !doesFileExist -> pPath = backupFileName\n\n pPath: ";
+		strMsg += pPath;
+		strMsg += L"\n\nbackupFileName: ";
+		strMsg += backupFileName;
+		::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), strMsg.c_str(), L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
+		pPath = backupFileName;
 	}
 
 	if (pPath)
@@ -724,6 +727,10 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 			size.HighPart = attributes.nFileSizeHigh;
 
 			fileSize = size.QuadPart;
+
+			// DEBUG:
+			wstring strMsg = L"Filesize check, getFileAttributesExWithTimeout way, reported in bytes: " + to_wstring(fileSize);
+			::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), strMsg.c_str(), L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 		}
 		else
 		{
@@ -736,28 +743,33 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 				if (_fseeki64(fp, 0, SEEK_END) != 0)
 				{
 					// DEBUG:
-					::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), L"_fseeki64 failed", L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
+					::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), L"Filesize check, _fseeki64 failed!", L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 				}
 				else
 				{
 					fileSize = _ftelli64(fp);
+					
 					// DEBUG:
 					if (fileSize == -1)
 					{
 						errno_t err = 0;
 						_get_errno(&err);
-						wstring strErr = L"_ftelli64 failed with errno: " + to_wstring(err);
+						wstring strErr = L"Filesize check, _ftelli64 failed with errno: " + to_wstring(err);
 						::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), strErr.c_str(), L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 					}
 				}
 				fclose(fp);
+
+				// DEBUG:
+				wstring strMsg = L"Filesize check, POSIX way, reported in bytes: " + to_wstring(fileSize);
+				::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), strMsg.c_str(), L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 			}
 			else
 			{
 				// DEBUG:
 				errno_t err = 0;
 				_get_errno(&err);
-				wstring strErr = L"_wfopen failed with errno: " + to_wstring(err);
+				wstring strErr = L"Filesize check, _wfopen failed with errno: " + to_wstring(err);
 				::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), strErr.c_str(), L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 			}
 		}

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -900,6 +900,7 @@ bool FileManager::reloadBuffer(BufferID id)
 	//Get file size
 	int64_t fileSize = 0;
 	WIN32_FILE_ATTRIBUTE_DATA attributes{};
+	attributes.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
 	getFileAttributesExWithTimeout(buf->getFullPathName(), &attributes);
 	if (attributes.dwFileAttributes == INVALID_FILE_ATTRIBUTES)
 	{
@@ -1264,6 +1265,7 @@ SavingStatus FileManager::saveBuffer(BufferID id, const wchar_t* filename, bool 
 	}
 
 	WIN32_FILE_ATTRIBUTE_DATA attributes{};
+	attributes.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
 	getFileAttributesExWithTimeout(fullpath, &attributes);
 	if (attributes.dwFileAttributes != INVALID_FILE_ATTRIBUTES && !(attributes.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
 	{

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -705,6 +705,10 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 	if (!doesFileExist(pPath))
 	{
 		pPath = backupFileName;
+
+		// TEMP: DEBUG:
+		::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), L"!doesFileExist, pPath = backupFileName", L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
+		::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), pPath, L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 	}
 
 	if (pPath)
@@ -718,6 +722,10 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 			size.HighPart = attributes.nFileSizeHigh;
 
 			fileSize = size.QuadPart;
+
+			// TEMP: DEBUG:
+			if (fileSize == -1)
+				::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), L"getFileAttributesExWithTimeout succeeded, filesize still -1", L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 		}
 		else
 		{
@@ -727,9 +735,34 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 			FILE* fp = _wfopen(pPath, L"rb");
 			if (fp)
 			{
-				_fseeki64(fp, 0, SEEK_END);
-				fileSize = _ftelli64(fp);
+				if (_fseeki64(fp, 0, SEEK_END) != 0)
+				{
+					// TEMP: DEBUG:
+					::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), L"getFileAttributesExWithTimeout failed, _wfopen succeeded, _fseeki64 failed", L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
+				}
+				else
+				{
+					fileSize = _ftelli64(fp);
+					// TEMP: DEBUG:
+					if (fileSize == -1)
+					{
+						errno_t err = 0;
+						_get_errno(&err);
+						wstring strErr = to_wstring(err);
+						::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), L"getFileAttributesExWithTimeout failed, _wfopen succeeded, _ftelli64 failed", L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
+						::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), strErr.c_str(), L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
+					}
+				}
 				fclose(fp);
+			}
+			else
+			{
+				// TEMP: DEBUG:
+				errno_t err = 0;
+				_get_errno(&err);
+				wstring strErr = to_wstring(err);
+				::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), L"getFileAttributesExWithTimeout failed, _wfopen failed", L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
+				::MessageBoxW(_pNotepadPlus->_pEditView->getHSelf(), strErr.c_str(), L"DEBUG: FileManager::loadFile", MB_OK | MB_APPLMODAL);
 			}
 		}
 	}

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -707,7 +707,7 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 	DWORD dwError = NO_ERROR;
 	if (!doesFileExist(pPath, 0, nullptr, &dwError, true))
 	{
-		if (dwError == NO_ERROR)
+		if ((dwError == ERROR_FILE_NOT_FOUND) || (dwError == ERROR_PATH_NOT_FOUND))
 		{
 			pPath = backupFileName;
 		}

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -392,6 +392,15 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 		TheFirstOne = false;
 
 	std::wstring cmdLineString = pCmdLine ? pCmdLine : L"";
+
+	// DEBUG:
+	if (!cmdLineString.empty())
+	{
+		std::wstring strMsg = L"Passed pCmdLine param: \n\n";
+		strMsg += pCmdLine;
+		::MessageBoxW(NULL, strMsg.c_str(), L"DEBUG: Notepad++ wWinMain", MB_OK | MB_APPLMODAL);
+	}
+
 	ParamVector params;
 	parseCommandLine(pCmdLine, params);
 
@@ -451,6 +460,13 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 	NppParameters& nppParameters = NppParameters::getInstance();
 
 	nppParameters.setCmdLineString(cmdLineString);
+
+	// DEBUG:
+	if (!cmdLineString.empty())
+	{
+		std::wstring strMsg = L"_cmdLineString pCmdLine param copy: \n\n" + nppParameters.getCmdLineString();
+		::MessageBoxW(NULL, strMsg.c_str(), L"DEBUG: Notepad++ wWinMain", MB_OK | MB_APPLMODAL);
+	}
 
 	std::wstring path;
 	if (getParamValFromString(FLAG_SETTINGS_DIR, params, path))
@@ -543,6 +559,14 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 	for (size_t i = 0; i < nbFilesToOpen; ++i)
 	{
 		const wchar_t * currentFile = params.at(i).c_str();
+
+		// DEBUG:
+		if (!cmdLineString.empty())
+		{
+			std::wstring strMsg = L"Parsed ParamVector params.at(" + std::to_wstring(i) + L").c_str(): \n\n" + currentFile;
+			::MessageBoxW(NULL, strMsg.c_str(), L"DEBUG: Notepad++ wWinMain", MB_OK | MB_APPLMODAL);
+		}
+
 		if (currentFile[0])
 		{
 			//check if relative or full path. Relative paths dont have a colon for driveletter
@@ -551,6 +575,13 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 			quotFileName += relativeFilePathToFullFilePath(currentFile);
 			quotFileName += L"\" ";
 		}
+	}
+
+	// DEBUG:
+	if (!cmdLineString.empty())
+	{
+		std::wstring strMsg = L"Resulted quotFileName string: \n\n" + quotFileName;
+		::MessageBoxW(NULL, strMsg.c_str(), L"DEBUG: Notepad++ wWinMain", MB_OK | MB_APPLMODAL);
 	}
 
 	//Only after loading all the file paths set the working directory


### PR DESCRIPTION
Fix #15776

There is a possibility that the WIN32API GetFileAttributesEx method used may fail for some types of network storage (these probably do not have an IO class implementation for the 'GetFileExInfoStandard' needed), so adding back the previous POSIX way as a backup.