### PR TITLE
Fix: CompanyName in .exe files should be equal to Publisher

### DIFF
--- a/PowerEditor/installer/nsisInclude/globalDef.nsh
+++ b/PowerEditor/installer/nsisInclude/globalDef.nsh
@@ -52,7 +52,7 @@
 ; ------------------------------------------------------------------------
 
 !define APPNAMEANDVERSION	"${APPNAME} v${APPVERSION}"
-!define CompanyName		"Don HO don.h@free.fr"
+!define CompanyName		"Notepad++ Team"
 !define Description		"Notepad++ : a free (GNU) source code editor"
 !define Version		"${nppVer_1}.${nppVer_2}.${nppVer_3}.${nppVer_4}"
 !define ProdVer		"${VERSION_MAJOR}.${VERSION_MINOR}"

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -42,7 +42,7 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE    "CompanyName",        "Don HO don.h@free.fr\0"
+            VALUE    "CompanyName",        "Notepad++ Team\0"
             VALUE    "FileDescription",    "Notepad++\0"
             VALUE    "FileVersion",        VERSION_PRODUCT_VALUE
             VALUE    "InternalName",       "notepad++.exe\0"


### PR DESCRIPTION
Reason example: It helps for analytics tools to match software processes to installed application