### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.7.2

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
-			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 21st (v8.7.1), Nov. 16th (v8.7.2)
+			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 21st (v8.7.1), Nov. 20th (v8.7.2)
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
 			  Nov. 15th (v8.5.9), Nov. 22nd (v8.6), Dec. 19th (v8.6.1), Dec. 29th (v8.6.1)
@@ -1581,6 +1581,7 @@ Appughjate nant’à u buttone Vai per apre a finestra di dialogu di ricerca o p
 			
 S’è vo avete bisognu di a funzione di ricerca RegEx à l’arritrosa, lighjite l’istruzzioni per attivalla in u manuale di l’utilizatore."/>
 			<PrintError title="0" message="Ùn si pò lancià u ducumentu di stampetta."/><!-- Use title="0" to use Windows OS default translated "Error" title. -->
+			<FileToLoadSizeCheckFailed title="Fiascu di u cuntrollu di dimensione di u schedariu à caricà" message="Ùn si pò ottene a dimensione di schedariu prima u caricamentu !"/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Cronolugia di u preme’papei"/>
@@ -1749,9 +1750,9 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
 			<finder-collapse-all value="Tuttu ripiegà"/>
 			<finder-uncollapse-all value="Tuttu spiegà"/>
 			<finder-copy value="Cupià a(e) linea(e) selezziunata(e)"/>
-			<finder-copy-paths value="Cupià i nomi di chjassu selezziunati"/>
+			<finder-copy-selected-paths value="Cupià i nomi di chjassu selezziunati"/>
 			<finder-clear-all value="Tuttu viutà"/>
-			<finder-open-all value="Apre i nomi di chjassu selezziunati"/>
+			<finder-open-selected-paths value="Apre i nomi di chjassu selezziunati"/>
 			<finder-purge-for-every-search value="Spurgulà per ogni ricerca"/>
 			<finder-wrap-long-lines value="Ritornu autumaticu à a linea per e linee longhe"/>
 			<common-ok value="Vai"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
-			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 21st (v8.7.1)
+			  June 13th (v8.6.9), Sept. 8th (v8.7), Oct. 21st (v8.7.1), Nov. 16th (v8.7.2)
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: Feb. 24th (v8.5), Mar. 12th (v8.5.1), Mar. 31st (v8.5.2),
 			  May 7th (v8.5.3), June 9th (v8.5.4), Aug. 1st (v8.5.5), Aug. 7th (v8.5.6), Oct. 7th (v8.5.8),
 			  Nov. 15th (v8.5.9), Nov. 22nd (v8.6), Dec. 19th (v8.6.1), Dec. 29th (v8.6.1)
@@ -34,7 +34,7 @@ Additionnal information about Corsican localization:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.7.1">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.7.2">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -666,7 +666,7 @@ Additionnal information about Corsican localization:
 					<Item id="2231" name="Sfurzà a grafia cursiva à tutti i stili"/>
 					<Item id="2232" name="Sfurzà a grafia sottulin. à tutti i stili"/>
 					<Item id="2234" name="Andà à i parametri"/>
-					<!-- Don't translate "&quot;Global override&quot; -->
+					<!-- Don't translate "Global override" -->
 					<Item id="2235" name="Cosa serà a « Global override » ?"/>
 				</SubDialog>
 			</StyleConfig>
@@ -985,6 +985,7 @@ Additionnal information about Corsican localization:
 					<Item id="6110" name="Barra culurita nant’à l’unghjetta attiva"/>
 					<Item id="6112" name="Buttonu di chjusura per ogni unghjetta"/>
 					<Item id="6113" name="Doppiu cliccu per chjode u ducumentu"/>
+					<Item id="6115" name="Attivà a funzione di fissazione di l’unghjetta"/>
 					<Item id="6118" name="Piattà"/>
 					<Item id="6119" name="Multilinea"/>
 					<Item id="6120" name="Verticale"/>
@@ -1343,6 +1344,7 @@ Additionnal information about Corsican localization:
 						<Element name="Nisuna azzione in"/>
 						<Element name="Impuculisce in"/>
 						<Element name="Chjode in"/>
+						<Element name="Impuculisce o chjode in"/>
 					</ComboBox>
 					<Item id="6308" name="u spaziu di nutificazione di u sistema"/>
 					<Item id="6312" name="Detezione autumatica di statu di schedariu"/>
@@ -1747,9 +1749,9 @@ Circà in tutti i schedarii ma esclude tutti i cartulari è sottucartulari log o
 			<finder-collapse-all value="Tuttu ripiegà"/>
 			<finder-uncollapse-all value="Tuttu spiegà"/>
 			<finder-copy value="Cupià a(e) linea(e) selezziunata(e)"/>
-			<finder-copy-paths value="Cupià u(i) nome(i) di chjassu"/>
+			<finder-copy-paths value="Cupià i nomi di chjassu selezziunati"/>
 			<finder-clear-all value="Tuttu viutà"/>
-			<finder-open-all value="Tuttu apre"/>
+			<finder-open-all value="Apre i nomi di chjassu selezziunati"/>
 			<finder-purge-for-every-search value="Spurgulà per ogni ricerca"/>
 			<finder-wrap-long-lines value="Ritornu autumaticu à a linea per e linee longhe"/>
 			<common-ok value="Vai"/>
@@ -1841,7 +1843,7 @@ Impiegà u buttone « ? » à diritta per apre u manuale di l’utilizatore na
 C, C++, Java, C#, Objective-C, PHP, JavaScript, JSP, CSS, Perl, Rust, PowerShell è JSON.
 
 S’è vo selezziunate u modu espertu ma ùn mudificate micca i schedarii in i linguaghji mintulati insù, l’indentazione sterà in modu basicu."/>
-			<!-- Don't translate "&quot;Global override&quot; and &quot;Default Style&quot; -->
+			<!-- Don't translate "Global override" and "Default Style" -->
 			<global-override-tip value="Attivà quì l’ozzione « Global override » supranerà sti parametri à tutti i stili di tutti i linguaghji di prugrammazione. Preferiscerete di sicuru impiegà piuttostu i parametri « Default Style »"/>
 		</MiscStrings>
 	</Native-Langue>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/ba3b4578b2e29c86a4fabb5b6b6dd75a44fcdb60 Notepad++ 8.7.1 release
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/ce58b424bdeec3616943f9ea8cd257f66700c3c0 Add Pin tab feature
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/b8224808bdb6f9eaf94c066219634715703828da Add ability to open/copy selected files from Search-results
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/eeb47530449cebabc9c94a8bccefc0f574a2491c Add "Minimize / Close to" option for System tray

Updated on November 20<sup>th</sup>:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/467182602a4331342015f5ad99a295e76b9da8bd Fix selected pathnames in search results localization issue
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/c021c861959765db9efa0a7d6b156538a0e6f4db Code enhancement for file checking

Cheers,
Patriccollu.