### PR TITLE
Update dpiAware.manifest to support per-monitor DPI awareness

### DIFF
--- a/PowerEditor/src/dpiAware.manifest
+++ b/PowerEditor/src/dpiAware.manifest
@@ -2,10 +2,10 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
     <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
         <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-            <dpiAware>true</dpiAware>
+            <dpiAware>true/pm</dpiAware>
         </asmv3:windowsSettings>
         <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-            <dpiAwareness>system, unaware</dpiAwareness>
+            <dpiAwareness>PerMonitor</dpiAwareness>
         </asmv3:windowsSettings>
         <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">
             <gdiScaling>false</gdiScaling>


### PR DESCRIPTION
After reading almost all of the issues related dpi awareness I found that for the current version of N++ setting `notepadd++.exe -> properties -> compatibility -> change high DPI settings -> Override...`  to `Application` works without any issue in my system configuration. No blurred window nor any moved buttons, see attached screenshots.
Also I found that setting `<dpiAware>` to `true/pw` was not tested often and this is a way to gain `Application`/`PerMonitor` setting, [see here](https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process).

I invite others to see if setting `notepad++.exe DPI settings` to `Application` and confirm that the app is ok in their multi-monior configurations.

```
Notepad++ v8.7.1   (32-bit)
Build time : Nov 21 2024 - 21:16:16
Path : D:\git\notepad-plus-plus\PowerEditor\visual.net\Debug\Notepad++.exe
Command Line : 
Admin mode : OFF
Local Conf mode : OFF
Cloud Config : OFF
Periodic Backup : ON
OS Name : Windows 10 Enterprise (64-bit)
OS Version : 22H2
OS Build : 19045.4780
Current ANSI codepage : 1250
Plugins : none
```
![obraz](https://github.com/user-attachments/assets/bbd68129-d12c-4a0d-8439-0576d5495b56)

Monitor 1:
![obraz](https://github.com/user-attachments/assets/1f689801-7428-4c66-90b7-4f2f4dd76101)

Monitor 2:
![obraz](https://github.com/user-attachments/assets/820b8bc1-1db2-4a1d-9642-2d9e29a2ea3c)

![obraz](https://github.com/user-attachments/assets/ee4bf29a-bc5b-4165-bc3b-ff662612a5c6)


