### PR TITLE
remove pointless "File to load size-check failed" message

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -729,7 +729,7 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 	if (fileSize == -1)
 	{
 		// we cannot continue (or Scintilla will throw SC_STATUS_FAILURE in the loadFileData later)
-		::MessageBox(_pNotepadPlus->_pEditView->getHSelf(), L"Cannot obtain the file size before loading!", L"File to load size-check failed", MB_OK | MB_APPLMODAL);
+		// - no error message here as this can be also a dir with files to open or globbing attempt
 		return BUFFER_INVALID;
 	}
 


### PR DESCRIPTION
Fix #15869 .

Only returning BUFFER_INVALID in FileManager::loadFile immediately if the file size check == -1. This is a must here because of the following code does not expect such -1 in fileSize.

But an error msg is not appropriate here, as it could also be a legal attempt to open a dir (with files inside) or an attempt to use the N++ globbing feature.

This early return also speeds up the loading stage a bit.