### PR TITLE
Fix hidden document-view after deleting files in both views from outside.

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4607,9 +4607,9 @@ void Notepad_plus::hideView(int whichOne)
 	// resize the main window
 	::SendMessage(_pPublicInterface->getHSelf(), WM_SIZE, 0, 0);
 
-	switchEditViewTo(otherFromView(whichOne));
 	auto viewToDisable = static_cast<UCHAR>(whichOne == SUB_VIEW ? WindowSubActive : WindowMainActive);
 	_mainWindowStatus &= static_cast<UCHAR>(~viewToDisable);
+	switchEditViewTo(otherFromView(whichOne));
 }
 
 bool Notepad_plus::loadStyles()


### PR DESCRIPTION
Fix #15922 .

Update `_mainWindowStatus` before calling the `switchEditViewTo`.