### PR TITLE
Fix Reload Workspace not working

### DIFF
--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -1073,7 +1073,6 @@ void ProjectPanel::popupMenuCmd(int cmdID)
 		case IDM_PROJECT_RELOADWS:
 		{
 			NativeLangSpeaker *pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
-			bool forceOpen = false;
 			if (_isDirty)
 			{
 				int res = pNativeSpeaker->messageBox("ProjectPanelReloadDirty",
@@ -1082,11 +1081,7 @@ void ProjectPanel::popupMenuCmd(int cmdID)
 					L"Reload Workspace",
 					MB_YESNO | MB_ICONQUESTION | MB_APPLMODAL);
 
-				if (res == IDYES)
-				{
-					forceOpen = true;
-				}
-				else if (res == IDNO)
+				if (res == IDNO)
 				{
 					return;
 				}
@@ -1094,7 +1089,7 @@ void ProjectPanel::popupMenuCmd(int cmdID)
 
 			if (doesFileExist(_workSpaceFilePath.c_str()))
 			{
-				openWorkSpace(_workSpaceFilePath.c_str(), forceOpen);
+				openWorkSpace(_workSpaceFilePath.c_str(), true);
 			}
 			else
 			{


### PR DESCRIPTION
fix #11551

In case of reloading, openWorkSpace() needs to be called forced=true always.