### PR TITLE
Fix nfo file losing modification issue (regression)

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -1861,7 +1861,7 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 
 			Buffer* buf = MainFileManager.getBufferByID(_currentBufferID);
 
-			if (buf->getEncoding() == NPP_CP_DOS_437)
+			if (buf->getEncoding() == NPP_CP_DOS_437 && !buf->isDirty())
 			{
 				MainFileManager.reloadBuffer(buf);
 			}


### PR DESCRIPTION
The regression was introduced by:
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/dd0b557e145fc664e2c2c10bda2227b1b46e1921#diff-d88ddee57a027ab23daf332c4778ced0cee352edcb34efdda1b218e8a75c61b2R1864

Fix #15964