### PR TITLE
[TEST] Use FILE_SHARE_DELETE mode for the Notepad++ write-ops

### DIFF
--- a/PowerEditor/src/MISC/Common/FileInterface.h
+++ b/PowerEditor/src/MISC/Common/FileInterface.h
@@ -55,6 +55,6 @@ private:
 	std::string _path;
 
 	const DWORD _accessParam  { GENERIC_READ | GENERIC_WRITE };
-	const DWORD _shareParam   { FILE_SHARE_READ | FILE_SHARE_WRITE };
+	const DWORD _shareParam   { FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE};
 	const DWORD _attribParam  { FILE_ATTRIBUTE_NORMAL };
 };


### PR DESCRIPTION
Test to solve some issues when using Roaming profiles.