### PR TITLE
Optimize Scintilla notification code performance

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -71,7 +71,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 		case SCN_SAVEPOINTREACHED:
 		case SCN_SAVEPOINTLEFT:
 		{
-			if (!notifyView) return FALSE;
+			//if (!notifyView) return FALSE; // Could be _invisibleEditView or _fileEditView (see the following code)
 
 			Buffer * buf = 0;
 			if (isFromPrimary)


### PR DESCRIPTION
Treat only main & sub Scintilla views for (most of) all SCN_* notification.

1. Move all SCN_* together.
2. Add a `if (!notifyView) return FALSE;` in the begining of case for most of all SCN_* notification.

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/15981#issuecomment-2565003286