### PR TITLE
Remove extraneous space in find status message.

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -39,7 +39,7 @@ enum DIALOG_TYPE {FIND_DLG, REPLACE_DLG, FINDINFILES_DLG, FINDINPROJECTS_DLG, MA
 #define DIR_UP false
 
 #define FIND_STATUS_END_REACHED_TEXT L"Find: Reached document end, first occurrence from the top found."
-#define FIND_STATUS_TOP_REACHED_TEXT L"Find:  Reached document beginning, first occurrence from the bottom found."
+#define FIND_STATUS_TOP_REACHED_TEXT L"Find: Reached document beginning, first occurrence from the bottom found."
 #define FIND_STATUS_REPLACE_END_REACHED_TEXT L"Replace: Reached document end, started from top."
 #define FIND_STATUS_REPLACE_TOP_REACHED_TEXT L"Replace: Reached document beginning, started from bottom."
 


### PR DESCRIPTION
FIND_STATUS_TOP_REACHED_TEXT has two spaces after "Find:" instead of one space like all other status messages do. This commit fixes that inconsistency.