### PR TITLE
Feature: Ability to hide selected toolbar buttons via xml config

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -709,7 +709,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 
 	// Setup config for toolbar buttons visibility before toolbar initialization
 	int toolbarIconsArrayCount = sizeof(toolBarIcons) / sizeof(ToolBarButtonUnit);
-	ToolbarButtonConfig toolbarButtonConfig = _toolBar.initToolbarButtonVisibilityConfig(toolBarIcons, toolbarIconsArrayCount);
+	ToolbarButtonConfig toolbarButtonConfig = _toolBar.initToolbarButtonVisibilityConfig(toolBarIcons, nppParam._toolbarVisibilityXmlResult, toolbarIconsArrayCount);
 
 	_toolBar.init(_pPublicInterface->getHinst(), hwnd, tbStatus, toolBarIcons, toolbarIconsArrayCount, toolbarButtonConfig);
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -707,7 +707,11 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	scnN.nmhdr.idFrom = 0;
 	_pluginsManager.notify(&scnN);
 
-	_toolBar.init(_pPublicInterface->getHinst(), hwnd, tbStatus, toolBarIcons, sizeof(toolBarIcons) / sizeof(ToolBarButtonUnit));
+	// Setup config for toolbar buttons visibility before toolbar initialization
+	int toolbarIconsArrayCount = sizeof(toolBarIcons) / sizeof(ToolBarButtonUnit);
+	ToolbarButtonConfig toolbarButtonConfig = _toolBar.initToolbarButtonVisibilityConfig(toolBarIcons, toolbarIconsArrayCount);
+
+	_toolBar.init(_pPublicInterface->getHinst(), hwnd, tbStatus, toolBarIcons, toolbarIconsArrayCount, toolbarButtonConfig);
 
 	_rebarTop.init(_pPublicInterface->getHinst(), hwnd);
 	_rebarBottom.init(_pPublicInterface->getHinst(), hwnd);

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -25,6 +25,7 @@
 #include "UserDefineDialog.h"
 #include "WindowsDlgRc.h"
 #include "Notepad_plus_Window.h"
+#include "Toolbar.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996) // for GetVersionEx()
@@ -1495,6 +1496,13 @@ bool NppParameters::load()
 		_pXmlToolIconsDoc = nullptr;
 		isAllLoaded = false;
 	}
+
+	//------------------------------//
+	// toolbarButtonVisibility.xml : for per user //
+	//------------------------------//
+	std::wstring toolbarVisibilityXmlPath(_userPath);
+	pathAppend(toolbarVisibilityXmlPath, L"toolbarButtonVisibility.xml");
+	_toolbarVisibilityXmlResult = ToolBar::loadToolbarVisibilityXML(toolbarVisibilityXmlPath);
 
 	//------------------------------//
 	// shortcuts.xml : for per user //

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1851,6 +1851,7 @@ public:
 	bool isStylerDocLoaded() const { return _pXmlUserStylerDoc != nullptr; };
 
 	ColumnEditorParam _columnEditParam;
+	ToolbarButtonConfigLoadResult _toolbarVisibilityXmlResult{};
 
 private:
 	NppParameters();

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
@@ -26,6 +26,8 @@ using namespace std;
 
 constexpr DWORD WS_TOOLBARSTYLE = WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | TBSTYLE_TOOLTIPS | TBSTYLE_FLAT | CCS_TOP | CCS_NOPARENTALIGN | CCS_NORESIZE | CCS_NODIVIDER;
 
+const std::wstring TOOLBAR_CONFIG_FILE = L"toolbarButtonVisibility.xml";
+
 struct ToolbarIconIdUnit
 {
 	wstring _id;
@@ -122,7 +124,375 @@ void ToolBar::initTheme(TiXmlDocument *toolIconsDocRoot)
 	}
 }
 
-bool ToolBar::init( HINSTANCE hInst, HWND hPere, toolBarStatusType type, ToolBarButtonUnit *buttonUnitArray, int arraySize)
+ToolbarButtonConfig ToolBar::initToolbarButtonVisibilityConfig(ToolBarButtonUnit standardCommandToolbarIcons[], int toolbarIconsArrayCount)
+{
+	vector<CommandInfo> commandInfos{};
+	std::vector<DynamicCmdIcoBmp> registedPluginButtonCommands = this->_vDynBtnReg;
+	std::vector<ToolBarButtonUnit> vStandardCommandToolbarIcons{};
+	std::vector<wstring> hiddenPlugins{};
+	ToolbarButtonConfig toolbarButtonsConfig{};
+	bool xmlFileNeedsUpdate = false;
+
+	// -----------------------------------------------------------------------------------------------
+	// Prepare initial toolbar configuration before loading XML file
+	// -----------------------------------------------------------------------------------------------
+
+	// Get info about all plugin commands
+	std::vector<PluginCmdShortcut>& pluginCommands = NppParameters::getInstance().getPluginCommandList();
+	for (size_t i = 0, len = pluginCommands.size(); i < len; ++i)
+	{
+		auto pluginName = pluginCommands[i].getModuleName();
+		wstring pluginNameW = string2wstring(pluginName, CP_UTF8);
+
+		const int cmdID = pluginCommands[i].getID();
+		const std::wstring commandName = pluginCommands[i].getShortcutName();
+		commandInfos.push_back({ cmdID, commandName, pluginNameW });
+	}
+
+	// Loop through the plugin commands that were registered as toolbar buttons and flag them as buttons in commandInfos
+	for (CommandInfo& pluginCommand : commandInfos)
+	{
+		int messageID = pluginCommand._cmdID;
+
+		for (DynamicCmdIcoBmp& registedPluginButtonCommand : registedPluginButtonCommands)
+		{
+			if (static_cast<unsigned int>(messageID) == registedPluginButtonCommand._message)
+			{
+				pluginCommand._hasToolbarButton = true;
+				break;
+			}
+		}
+	}
+
+	// Convert array of built-in toolbar icon infos to vector for easier manipulation. They contain command ID and icon info for built-in buttons, but not the command names
+	for (int i = 0; i < toolbarIconsArrayCount; ++i)
+	{
+		vStandardCommandToolbarIcons.push_back(standardCommandToolbarIcons[i]);
+	}
+
+	// Add the built-in toolbar commands to the list of all commands
+	for (ToolBarButtonUnit& standardCommand : vStandardCommandToolbarIcons)
+	{
+		// Don't bother with separators, they aren't included in the config anyway
+		if (standardCommand._cmdID == SEPARATOR_CMD_ID)
+		{
+			continue;
+		}
+
+		CommandInfo standardCommandInfo{};
+
+		std::wstring commandName{};
+		getNameStrFromCmd(standardCommand._cmdID, commandName);
+
+		// Set applicable fields for the standard command, the rest will use struct defaults for now unless updated from XML config
+		standardCommandInfo._cmdID = standardCommand._cmdID;
+		standardCommandInfo._commandName = commandName;
+		standardCommandInfo._pluginName = TBConfigConsts::_builtInName;
+		standardCommandInfo._hasToolbarButton = true;
+
+		commandInfos.push_back(standardCommandInfo);
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	// Load and apply toolbar button config XML file, to update command infos with user settings
+	// -----------------------------------------------------------------------------------------------
+
+	// Get folder path for Notepad++ AppData directory, then load the XML config file if it's there
+	TiXmlDocument xmlDoc{};
+	bool loadFileSucceeded = false;
+	wstring nppPath = NppParameters::getInstance().getAppDataNppDir();
+	if (!nppPath.empty())
+	{
+		nppPath = pathAppend(nppPath, TOOLBAR_CONFIG_FILE);
+		loadFileSucceeded = xmlDoc.LoadFile(nppPath.c_str());
+	}
+
+	// Make list of plugins found in the config to compare against loaded plugins in memory later, to know if config xml needs updating
+	std::vector<std::wstring> pluginNamesInConfig{};
+	std::vector<std::wstring> pluginNamesInMemory{};
+
+	// Make the list of loaded plugins that have toolbar buttons
+	for (CommandInfo& cmd : commandInfos)
+	{
+		// Don't count commands that aren't toolbar buttons. Some plugins don't have toolbar buttons, so they won't be in the XML config
+		if (!cmd._hasToolbarButton)
+		{
+			continue;
+		}
+		// Ensure no duplicates in the list
+		if (std::find(pluginNamesInMemory.begin(), pluginNamesInMemory.end(), cmd._pluginName) == pluginNamesInMemory.end())
+		{
+			pluginNamesInMemory.push_back(cmd._pluginName);
+		}
+	}
+
+	// Temporary vector of CommandInfos to hold data from the XML file before updating the main vector
+	std::vector<CommandInfo> commandInfos_fromConfig;
+
+	// Parse the loaded file if applicable, and update the commandInfos vector with the user's settings
+	if (loadFileSucceeded != true)
+	{
+		xmlFileNeedsUpdate = true;
+	} 
+	else
+	{
+		// Root element, nothing special at this level
+		TiXmlElement* rootPtr = xmlDoc.RootElement();
+		if (!rootPtr)
+		{
+			writeToolbarButtonsConfig(toolbarButtonsConfig);
+			return toolbarButtonsConfig;
+		}
+		// Convert pointer to a reference for cleaner usage
+		TiXmlElement& root = *rootPtr;
+
+		// ToolbarButtons level - Contains Plugin element children
+		TiXmlElement* toolbarButtonsPtr = root.FirstChildElement(TBConfigConsts::_toolbarButtons);
+		if (!toolbarButtonsPtr)
+		{
+			writeToolbarButtonsConfig(toolbarButtonsConfig);
+			return toolbarButtonsConfig;
+		}
+		TiXmlElement& toolbarButtons = *toolbarButtonsPtr;
+
+		// Plugin level logic - Gather the plugin name and hideAll attribute
+		// Contains Button element children (processed in inner loop)
+		for (TiXmlElement* pluginPtr = toolbarButtons.FirstChildElement(TBConfigConsts::_plugin);
+			pluginPtr != nullptr;
+			pluginPtr = pluginPtr->NextSiblingElement(TBConfigConsts::_plugin))
+		{
+			// Convert plugin pointer to reference
+			TiXmlElement& plugin = *pluginPtr;
+
+			const wchar_t* pluginName_fromConfig = plugin.Attribute(TBConfigConsts::_name);
+			const wchar_t* hideAll = plugin.Attribute(TBConfigConsts::_hideAll);
+			bool hideAllBool = (hideAll && !lstrcmpi(hideAll, TBConfigConsts::_trueStr));
+
+			if (!pluginName_fromConfig)
+			{
+				continue;
+			}
+
+			pluginNamesInConfig.push_back(pluginName_fromConfig);
+
+			if (hideAllBool)
+			{
+				hiddenPlugins.emplace_back(pluginName_fromConfig);
+			}
+
+			// Inner loop for each button command. Find the matching command info in memory and update it with user's settings from the XML
+			for (TiXmlElement* buttonPtr = plugin.FirstChildElement(TBConfigConsts::_button);
+				buttonPtr != nullptr;
+				buttonPtr = buttonPtr->NextSiblingElement(TBConfigConsts::_button))
+			{
+				// Convert button pointer to reference
+				TiXmlElement& button = *buttonPtr;
+
+				const wchar_t* name_fromConfig = button.Attribute(TBConfigConsts::_name);
+				const wchar_t* hideFromToolbar_fromConfig = button.Attribute(TBConfigConsts::_hide);
+
+				// If name or showOnToolbar is null, skip this button because something is wrong
+				if (!name_fromConfig || !hideFromToolbar_fromConfig)
+				{
+					xmlFileNeedsUpdate = true;
+					continue;
+				}
+
+				// If showOnToolbar is invalid (not "true" or "false"), skip to the next button setting
+				if (!lstrcmpi(hideFromToolbar_fromConfig, TBConfigConsts::_trueStr) && !lstrcmpi(hideFromToolbar_fromConfig, TBConfigConsts::_falseStr))
+				{
+					xmlFileNeedsUpdate = true;
+					continue;
+				}
+
+				// Parse the showOnToolbar string to a bool, case insensitive. Will store this in the CommandInfo struct later
+				bool hideFromToolbarBool = !lstrcmpi(hideFromToolbar_fromConfig, TBConfigConsts::_trueStr);
+
+				// Store command info from XML into temporary vector to match with those in memory after parsing
+				CommandInfo currentCommandInfo{};
+				currentCommandInfo._commandName = std::wstring(name_fromConfig);
+				currentCommandInfo._pluginName = std::wstring(pluginName_fromConfig);
+				currentCommandInfo._hideToolbarButton = hideFromToolbarBool;
+				currentCommandInfo._isFromHiddenPlugin = hideAllBool;
+
+				commandInfos_fromConfig.push_back(currentCommandInfo);
+
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------------------
+	// With XML Data loaded, match the command infos from memory and apply the settings from the XML file
+	// ---------------------------------------------------------------------------------------------------------
+
+	for (CommandInfo& cmd : commandInfos)
+	{
+		// Don't bother with commands that aren't toolbar buttons
+		if (!cmd._hasToolbarButton)
+		{
+			continue;
+		}
+
+		// Find the matching command info from the XML file by command name and plugin name
+		std::vector< CommandInfo>::iterator iter = std::find_if(commandInfos_fromConfig.begin(), commandInfos_fromConfig.end(), [&cmd](const CommandInfo& cmdFromConfig)
+		{
+			return cmd._commandName == cmdFromConfig._commandName && cmd._pluginName == cmdFromConfig._pluginName;
+		});
+
+		// If it was found in the XML file, apply those settings
+		if (iter != commandInfos_fromConfig.end())
+		{
+			cmd._hideToolbarButton = iter->_hideToolbarButton;
+			cmd._isFromHiddenPlugin = iter->_isFromHiddenPlugin;
+		}
+		else // If the command wasn't found in the XML file, the plugin might be new, or the command was removed from the XML file, so mark the xml for update
+		{
+			xmlFileNeedsUpdate = true;
+			// At least still apply the _isFromHiddenPlugin setting if the plugin is in the hidden list
+			if (std::find(hiddenPlugins.begin(), hiddenPlugins.end(), cmd._pluginName) != hiddenPlugins.end())
+			{
+				cmd._isFromHiddenPlugin = true;
+			}
+		}
+	}
+
+	// Check the reverse - If there were any XML settings that aren't in memory, like removed plugins, and mark the XML file for update
+	if (!xmlFileNeedsUpdate)
+	{
+		for (const CommandInfo& cmdFromConfig : commandInfos_fromConfig)
+		{
+			bool foundInMemory = false;
+			for (const CommandInfo& cmd : commandInfos)
+			{
+				if (cmdFromConfig._commandName == cmd._commandName && cmdFromConfig._pluginName == cmd._pluginName)
+				{
+					foundInMemory = true;
+					break;
+				}
+			}
+
+			if (!foundInMemory)
+			{
+				xmlFileNeedsUpdate = true;
+				break;
+			}
+		}
+	}
+	
+
+	// ------------------------------------------------------------------------------------------------
+	// Final processing and assignment of the toolbar button configuration
+	// ------------------------------------------------------------------------------------------------
+
+	// Ensure all commands for hidden plugins are hidden, even those not in the XML config for some reason
+	for (CommandInfo& cmd : commandInfos)
+	{
+		if (std::find(hiddenPlugins.begin(), hiddenPlugins.end(), cmd._pluginName) != hiddenPlugins.end())
+		{
+			cmd._isFromHiddenPlugin = true;
+		}
+	}
+
+	// Assign the final configuration to the struct before writing it to the XML file and returning
+	toolbarButtonsConfig._commandInfos = commandInfos;
+	toolbarButtonsConfig._hiddenPlugins = hiddenPlugins;
+
+	// Finally update the XML file if needed. Existing valid settings will be retained in the updated version.
+	if (xmlFileNeedsUpdate)
+	{
+		writeToolbarButtonsConfig(toolbarButtonsConfig);
+	}
+
+	return toolbarButtonsConfig;
+}
+
+void ToolBar::writeToolbarButtonsConfig(const ToolbarButtonConfig& config)
+{
+	TiXmlDocument doc{};
+
+	NppParameters& nppParams = NppParameters::getInstance();
+	std::wstring configPath = nppParams.getAppDataNppDir();
+	configPath = pathAppend(configPath, TOOLBAR_CONFIG_FILE);
+
+	// Create XML declaration
+	TiXmlDeclaration decl(L"1.0", L"UTF-8", L"");
+	doc.InsertEndChild(decl);
+
+	// Create root element
+	TiXmlElement rootElem(TBConfigConsts::_notepadPlus);
+	doc.InsertEndChild(rootElem);
+
+	TiXmlElement* root = doc.FirstChildElement(TBConfigConsts::_notepadPlus);
+	if (!root)
+	{
+		return;
+	}
+
+	// Create ToolbarButtons element
+	TiXmlElement toolbarButtonsElem(TBConfigConsts::_toolbarButtons);
+	root->InsertEndChild(toolbarButtonsElem);
+
+	TiXmlElement* toolbarButtons = root->FirstChildElement(TBConfigConsts::_toolbarButtons);
+	if (!toolbarButtons)
+	{
+		return; // Abort
+	}
+
+	// Group commands by plugin name. Only include in the file if the command is used on a toolbar button
+	std::map<std::wstring, std::vector<CommandInfo>> pluginGroups{};
+	for (const CommandInfo& cmd : config._commandInfos)
+	{
+		if (cmd._hasToolbarButton == true)
+		{
+			pluginGroups[cmd._pluginName].push_back(cmd);
+		}
+	}
+
+	// Create Plugin elements
+	for (const auto& [pluginName, commands] : pluginGroups)
+	{
+		// Create plugin element on the stack
+		TiXmlElement pluginElem(TBConfigConsts::_plugin);
+		pluginElem.SetAttribute(TBConfigConsts::_name, pluginName.c_str());
+
+		// Check if this plugin is in the hidden plugins list
+		bool hideAll = (std::find(config._hiddenPlugins.begin(),
+			config._hiddenPlugins.end(),
+			pluginName) != config._hiddenPlugins.end());
+		pluginElem.SetAttribute(TBConfigConsts::_hideAll, hideAll ? TBConfigConsts::_trueStr : TBConfigConsts::_falseStr);
+
+		// Insert the plugin element under <toolbarButtons>
+		TiXmlElement* plugin = dynamic_cast<TiXmlElement*>(toolbarButtons->InsertEndChild(pluginElem));
+		if (!plugin)
+		{
+			continue; // Skip on fail
+		}
+
+		// Create Button elements for each command
+		for (const auto& cmd : commands)
+		{
+			// Skip empty command names and IDs of separators. Assume anything else positive is valid
+			if (cmd._cmdID == SEPARATOR_CMD_ID || cmd._cmdID < 0 || cmd._commandName.empty())
+			{
+				continue;
+			}
+
+			// Create button element on the stack
+			TiXmlElement buttonElem(TBConfigConsts::_button);
+
+			buttonElem.SetAttribute(TBConfigConsts::_hide, cmd._hideToolbarButton ? TBConfigConsts::_trueStr : TBConfigConsts::_falseStr);
+			buttonElem.SetAttribute(TBConfigConsts::_name, cmd._commandName.c_str());
+
+			// Insert the <button> element under <plugin>
+			plugin->InsertEndChild(buttonElem);
+		}
+	}
+
+	// Save the file
+	doc.SaveFile(configPath.c_str());
+}
+
+bool ToolBar::init( HINSTANCE hInst, HWND hPere, toolBarStatusType type, ToolBarButtonUnit *buttonUnitArray, int arraySize, const ToolbarButtonConfig& toolbarButtonConfig)
 {
 	Window::init(hInst, hPere);
 	
@@ -141,22 +511,53 @@ bool ToolBar::init( HINSTANCE hInst, HWND hPere, toolBarStatusType type, ToolBar
 	InitCommonControlsEx(&icex);
 
 	//Create the list of buttons
-	_nbButtons    = arraySize;
-	_nbDynButtons = _vDynBtnReg.size();
+	_nbButtons    = arraySize; // Built-in buttons
+	_nbDynButtons = _vDynBtnReg.size(); // Plugin buttons
 	_nbTotalButtons = _nbButtons + (_nbDynButtons ? _nbDynButtons + 1 : 0);
 	_pTBB = new TBBUTTON[_nbTotalButtons];	//add one for the extra separator
 
-	int cmd = 0;
+	bool isAllBuiltInButtonsHidden = std::ranges::find(toolbarButtonConfig._hiddenPlugins, TBConfigConsts::_builtInName) != toolbarButtonConfig._hiddenPlugins.end();
+	int visibleIconsSinceLastSeparator = 0;
+
+	int cmd;
 	int bmpIndex = -1;
 	BYTE style = 0;
 	size_t i = 0;
-	for (; i < _nbButtons && i < _nbTotalButtons; ++i)
+	for (; i < _nbButtons && i < _nbTotalButtons; ++i) // Add the built-in toolbar buttons
 	{
 		cmd = buttonUnitArray[i]._cmdID;
+		BYTE buttonState = TBSTATE_ENABLED; // Default to showing the button
+
+		// Check the toolbar button config to see if the button should be shown
+		for (const CommandInfo& command : toolbarButtonConfig._commandInfos)
+		{
+			if ((command._cmdID == cmd && (command._isFromHiddenPlugin || command._hideToolbarButton)) // Check via matching command ID number
+				|| (cmd == SEPARATOR_CMD_ID && isAllBuiltInButtonsHidden)) // Hide separators if all built-in buttons set to hidden
+			{
+				buttonState |= TBSTATE_HIDDEN;
+				break;
+			}
+		}
+
+		// Count the number of visible icons since the last separator so we can hide the separator if there are no visible icons before it
+		if (cmd != 0 && !(buttonState & TBSTATE_HIDDEN))
+		{
+			++visibleIconsSinceLastSeparator;
+		}
+		
 		switch (cmd)
 		{
-			case 0:
+			case SEPARATOR_CMD_ID:
 			{
+				if (visibleIconsSinceLastSeparator == 0)
+				{
+					buttonState |= TBSTATE_HIDDEN;
+				}
+				else
+				{
+					visibleIconsSinceLastSeparator = 0;
+				}
+
 				style = BTNS_SEP;
 				break;
 			}
@@ -176,34 +577,50 @@ bool ToolBar::init( HINSTANCE hInst, HWND hPere, toolBarStatusType type, ToolBar
 			}
 		}
 
-		_pTBB[i].iBitmap = (cmd != 0 ? bmpIndex : 0);
+		_pTBB[i].iBitmap = (cmd != SEPARATOR_CMD_ID ? bmpIndex : 0);
 		_pTBB[i].idCommand = cmd;
-		_pTBB[i].fsState = TBSTATE_ENABLED;
+		_pTBB[i].fsState = buttonState;
 		_pTBB[i].fsStyle = style;
 		_pTBB[i].dwData = 0; 
 		_pTBB[i].iString = 0;
 	}
 
+	// If any plugin buttons are registered, add them to the toolbar after a separator
 	if (_nbDynButtons > 0 && i < _nbTotalButtons)
 	{
-		//add separator
+		// Don't show the separator after built-in buttons if all built-in buttons are hidden
+		BYTE frontSeparatorState = isAllBuiltInButtonsHidden ? (TBSTATE_HIDDEN | TBSTATE_ENABLED) : TBSTATE_ENABLED;
+
+		// Add separator
 		_pTBB[i].iBitmap = 0;
-		_pTBB[i].idCommand = 0;
-		_pTBB[i].fsState = TBSTATE_ENABLED;
+		_pTBB[i].idCommand = SEPARATOR_CMD_ID;
+		_pTBB[i].fsState = frontSeparatorState;
 		_pTBB[i].fsStyle = BTNS_SEP;
 		_pTBB[i].dwData = 0; 
 		_pTBB[i].iString = 0;
 		++i;
 
-		//add plugin buttons
+		// Add plugin buttons
 		for (size_t j = 0; j < _nbDynButtons && i < _nbTotalButtons; ++j, ++i)
 		{
 			cmd = _vDynBtnReg[j]._message;
 			++bmpIndex;
 
+			BYTE buttonState = TBSTATE_ENABLED; // Default to showing the button
+
+			// Check the toolbar button config to see if the button should be shown
+			for (auto& command : toolbarButtonConfig._commandInfos)
+			{
+				if (command._hasToolbarButton && command._cmdID == cmd && (command._isFromHiddenPlugin || command._hideToolbarButton))
+				{
+					buttonState |= TBSTATE_HIDDEN;
+					break;
+				}
+			}
+
 			_pTBB[i].iBitmap = bmpIndex;
 			_pTBB[i].idCommand = cmd;
-			_pTBB[i].fsState = TBSTATE_ENABLED;
+			_pTBB[i].fsState = buttonState;
 			_pTBB[i].fsStyle = BTNS_BUTTON; 
 			_pTBB[i].dwData = 0; 
 			_pTBB[i].iString = 0;

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.h
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.h
@@ -56,6 +56,12 @@ struct CommandInfo {
 struct ToolbarButtonConfig {
 	std::vector<CommandInfo> _commandInfos;
 	std::vector<std::wstring> _hiddenPlugins;
+	bool _useAllDefaults = true; // Allow us to skip checking button visibility altogether
+};
+
+struct ToolbarButtonConfigLoadResult {
+	bool _success = false;
+	ToolbarButtonConfig _config;
 };
 
 struct TBConfigConsts
@@ -133,8 +139,9 @@ public :
 
 	void resizeIconsDpi(UINT dpi);
 
-	ToolbarButtonConfig initToolbarButtonVisibilityConfig(ToolBarButtonUnit standardCommandToolbarIcons[], int toolbarIconsArrayCount);
-	void writeToolbarButtonsConfig(const ToolbarButtonConfig& config);
+	ToolbarButtonConfig initToolbarButtonVisibilityConfig(ToolBarButtonUnit standardCommandToolbarIcons[], ToolbarButtonConfigLoadResult toolbarButtonXmlResult, int toolbarIconsArrayCount);
+	static ToolbarButtonConfigLoadResult loadToolbarVisibilityXML(std::wstring xmlFilePath);
+	static void writeToolbarButtonsExampleConfig(std::wstring exampleXmlPath, const ToolbarButtonConfig& config);
 
 private :
 	TBBUTTON *_pTBB = nullptr;

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.h
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.h
@@ -33,6 +33,7 @@
 
 enum toolBarStatusType {TB_SMALL, TB_LARGE, TB_SMALL2, TB_LARGE2, TB_STANDARD};
 
+constexpr int SEPARATOR_CMD_ID = 0;
 
 struct iconLocator {
 	size_t _listIndex = 0;
@@ -41,6 +42,34 @@ struct iconLocator {
 
 	iconLocator(size_t iList, size_t iIcon, const std::wstring& iconLoc)
 		: _listIndex(iList), _iconIndex(iIcon), _iconLocation(iconLoc){};
+};
+
+struct CommandInfo {
+	int _cmdID = -1;
+	std::wstring _commandName;
+	std::wstring _pluginName;
+	bool _hasToolbarButton = false;
+	bool _hideToolbarButton = false;
+	bool _isFromHiddenPlugin = false;
+};
+
+struct ToolbarButtonConfig {
+	std::vector<CommandInfo> _commandInfos;
+	std::vector<std::wstring> _hiddenPlugins;
+};
+
+struct TBConfigConsts
+{
+	inline static const std::wstring _notepadPlus = L"NotepadPlus";
+	inline static const std::wstring _toolbarButtons = L"ToolbarButtons";
+	inline static const std::wstring _plugin = L"Plugin";
+	inline static const std::wstring _button = L"Button";
+	inline static const std::wstring _name = L"Name";
+	inline static const std::wstring _hide = L"Hide";
+	inline static const std::wstring _hideAll = L"HideAll";
+	inline static const std::wstring _builtInName = L"Built-In";
+	inline static const wchar_t _trueStr[] = L"yes";
+	inline static const wchar_t _falseStr[] = L"no";
 };
 
 class ReBar;
@@ -55,7 +84,7 @@ public :
 
     void initTheme(TiXmlDocument *toolIconsDocRoot);
 	virtual bool init(HINSTANCE hInst, HWND hPere, toolBarStatusType type, 
-		ToolBarButtonUnit *buttonUnitArray, int arraySize);
+		ToolBarButtonUnit *buttonUnitArray, int arraySize, const ToolbarButtonConfig& toolbarButtonConfig);
 
 	virtual void destroy();
 	void enable(int cmdID, bool doEnable) const {
@@ -103,6 +132,9 @@ public :
 	void addToRebar(ReBar * rebar);
 
 	void resizeIconsDpi(UINT dpi);
+
+	ToolbarButtonConfig initToolbarButtonVisibilityConfig(ToolBarButtonUnit standardCommandToolbarIcons[], int toolbarIconsArrayCount);
+	void writeToolbarButtonsConfig(const ToolbarButtonConfig& config);
 
 private :
 	TBBUTTON *_pTBB = nullptr;


### PR DESCRIPTION
I ended up taking a crack at an issue that has been bothering me for a while, which is the overwhelming amount of toolbar buttons, especially as more plugins get installed.

Basically this addition creates a new xml config file in the AppData folder which lists all the button commands for each plugin, as well as the built in buttons, and a 'hide' attribute you can set to hide that button. You can also hide all buttons and override the individual hide settings for a particular plugin by setting the respective `hideAll` attributes to yes.

Corresponding feature request:
resolves #16000 

It could partly address #15106 (though that person seems to want more advanced features like combining plugin buttons. Apparently the Customize Toolbar plugin has compatibility issues with recent versions of Notepad++ as discussed in #15440, so this feature could be a replacement for those who simply want to hide / show certain buttons.

### Example - Before (Default everything showing):

<img width="480" alt="image" src="https://github.com/user-attachments/assets/f18146ad-7ae0-48f9-8e27-afe1020713fa" />


### Example - After: First several built in buttons hidden:

<img width="480" alt="image" src="https://github.com/user-attachments/assets/abfc9602-3087-4243-a7e0-81a6e9accaf3" />


### Details

Ultimately the way it hides buttons is within `ToolBar::init` inside `Toolbar.cpp`, where it checks if the button about to be processed/added is one that should be hidden, and if so it adds the `TBSTATE_HIDDEN` flag to the `_pTBB[i].fsState` value that gets set. 

Importantly this means behind the scenes the button is still there, just invisible, so it shouldn't mess up other references to that button or something.

The actual bulk of the logic is in a single function in `Toolbar.cpp` called `initToolbarButtonVisibilityConfig`. It uses two new structs, `CommandInfo` and `ToolbarButtonConfig` which I used to collect all the necessary info about each button in one place. 

<img width=50% alt="image" src="https://github.com/user-attachments/assets/e9e5cb07-6641-4dad-adfa-d51004c3599d" />

There's also a struct that's just basically serves as a sort of enum for string values mostly used with the XML file since hardcoding strings in the logic can be a pain I think

<img width="431" alt="image" src="https://github.com/user-attachments/assets/eb45eec3-d285-4cb4-ac34-baa46b1accc9" />

------

`initToolbarButtonVisibilityConfig` is a big function but its very linear so figured it was better to keep it all together. The basics of the logic are:
1.  Get the info about all the built-in commands and plugin commands, and determine which are for buttons
2. Load the XML config file (if there is one)
3. Match up the user setting for each button using the name of the command, and apply it to the `ToolbarButtonConfig` object.
4. Using dedicated function `writeToolbarButtonsConfig`, write an updated or entirely new version of the XML file if list of commands between the xml file and the initially obtained button command list is different. It will still match up whichever command settings it can even if others are missing or new, and retain those settings when updating the xml file.

`initToolbarButtonVisibilityConfig`  gets called within `Notepad_plus.cpp` right before the `init` function. Then in there is some basic logic for checking if the command ID matches one that's hidden in the config object. Plus a bit extra logic to prevent consecutive separators if many of the built-in functions are hidden.

------


### Stuff I wasn't sure about
- I just put the name of the file as a constant at the top of Toolbar.cpp, but I figure there might be a better place for it like with other config files, but couldn't really find it
- I couldn't find an existing constant defined anywhere for the separator command ID that seems to be 0, so I just made one `SEPARATOR_CMD_ID` in `ToolBar.h` since the guidelines mention avoiding using 'magic numbers', and that command ID of 0 for separators appeared in several places even though I guess it's a placeholder anyway.

Overall this is a pretty basic implementation of the feature, though it does work, and I am not aware of any issues (it's highly possible I missed something though). I'm not familiar with C++ at all so you might want to double check the parts dealing with reading/writing the XML files since apparently TinyXML requires the usage of pointers as far as I can tell, so I'm not sure if I handled all that correctly.

Anyway even if you decide not to add it as-is, maybe some of it can be used as scaffolding in the future or something.