### PR TITLE
Optimize Scintilla notification code performance (part 2)

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -224,6 +224,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_subEditView.init(_pPublicInterface->getHinst(), hwnd);
 
 	_fileEditView.init(_pPublicInterface->getHinst(), hwnd);
+	_fileEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF); // Turn off the modification event
 	MainFileManager.init(this, &_fileEditView); //get it up and running asap.
 
 	nppParam.setFontList(hwnd);
@@ -280,6 +281,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_invisibleEditView.init(_pPublicInterface->getHinst(), hwnd);
 	_invisibleEditView.execute(SCI_SETUNDOCOLLECTION);
 	_invisibleEditView.execute(SCI_EMPTYUNDOBUFFER);
+	_invisibleEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF); // Turn off the modification event
 	_invisibleEditView.wrap(false); // Make sure no slow down
 
 	// Configuration of 2 scintilla views
@@ -629,8 +631,8 @@ LRESULT Notepad_plus::init(HWND hwnd)
 
 	if (nppParam.hasCustomContextMenu())
 	{
-		_mainEditView.execute(SCI_USEPOPUP, FALSE);
-		_subEditView.execute(SCI_USEPOPUP, FALSE);
+		_mainEditView.execute(SCI_USEPOPUP, SC_POPUP_NEVER);
+		_subEditView.execute(SCI_USEPOPUP, SC_POPUP_NEVER);
 	}
 
 	_nativeLangSpeaker.changeMenuLang(_mainMenuHandle);

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -3595,7 +3595,8 @@ void FindReplaceDlg::findAllIn(InWhat op)
 
 		_pFinder->setFinderReadOnly(true);
 		_pFinder->_scintView.execute(SCI_SETCODEPAGE, SC_CP_UTF8);
-		_pFinder->_scintView.execute(SCI_USEPOPUP, FALSE);
+		_pFinder->_scintView.execute(SCI_USEPOPUP, SC_POPUP_NEVER);
+		_pFinder->_scintView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF); // Turn off the modification event
 		_pFinder->_scintView.execute(SCI_SETUNDOCOLLECTION, false);	//dont store any undo information
 		_pFinder->_scintView.execute(SCI_SETCARETWIDTH, 1);
 		_pFinder->_scintView.showMargin(ScintillaEditView::_SC_MARGE_FOLDER, true);
@@ -3693,11 +3694,11 @@ void FindReplaceDlg::findAllIn(InWhat op)
 		::SendMessage(_hSelf, WM_NEXTDLGCTL, reinterpret_cast<WPARAM>(::GetDlgItem(_hSelf, IDD_FINDINFILES_DIR_COMBO)), TRUE);
 }
 
-Finder * FindReplaceDlg::createFinder()
+Finder* FindReplaceDlg::createFinder()
 {
 	NppParameters& nppParam = NppParameters::getInstance();
 
-	Finder *pFinder = new Finder();
+	Finder* pFinder = new Finder();
 	pFinder->init(_hInst, (*_ppEditView)->getHParent(), _ppEditView);
 
 	tTbData	data{};
@@ -3743,7 +3744,8 @@ Finder * FindReplaceDlg::createFinder()
 
 	pFinder->setFinderReadOnly(true);
 	pFinder->_scintView.execute(SCI_SETCODEPAGE, SC_CP_UTF8);
-	pFinder->_scintView.execute(SCI_USEPOPUP, FALSE);
+	pFinder->_scintView.execute(SCI_USEPOPUP, SC_POPUP_NEVER);
+	pFinder->_scintView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF); // Turn off the modification event
 	pFinder->_scintView.execute(SCI_SETUNDOCOLLECTION, false);	//dont store any undo information
 	pFinder->_scintView.execute(SCI_SETCARETWIDTH, 1);
 	pFinder->_scintView.showMargin(ScintillaEditView::_SC_MARGE_FOLDER, true);

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -329,6 +329,7 @@ intptr_t CALLBACK DocumentMap::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			_pMapView->execute(SCI_SETZOOM, static_cast<WPARAM>(-10), 0);
 			_pMapView->execute(SCI_SETVSCROLLBAR, FALSE, 0);
 			_pMapView->execute(SCI_SETHSCROLLBAR, FALSE, 0);
+			_pMapView->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF); // Turn off the modification event
 
 			_pMapView->showIndentGuideLine(false);
 			_pMapView->display();

--- a/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentSnapshot.cpp
@@ -29,6 +29,7 @@ intptr_t CALLBACK DocumentPeeker::run_dlgProc(UINT message, WPARAM /*wParam*/, L
 			_pPeekerView->execute(SCI_SETZOOM, static_cast<WPARAM>(-10), 0);
 			_pPeekerView->execute(SCI_SETVSCROLLBAR, FALSE, 0);
 			_pPeekerView->execute(SCI_SETHSCROLLBAR, FALSE, 0);
+			_pPeekerView->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF); // Turn off the modification event
 
 			_pPeekerView->showIndentGuideLine(false);
 


### PR DESCRIPTION
Turn off modification events for some Scintilla controls.

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/15981#issuecomment-2565003286

