### PR TITLE
Fix regressionn while disabling clickable link

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3440,6 +3440,24 @@ bool isUrl(wchar_t * text, int textLen, int start, int* segmentLen)
 	return false;
 }
 
+void Notepad_plus::removeAllHotSpot()
+{
+	DocTabView* twoDocView[] { &_mainDocTab, &_subDocTab };
+	for (DocTabView* pDocView : twoDocView)
+	{
+		for (size_t i = 0; i < pDocView->nbItem(); ++i)
+		{
+			BufferID id = pDocView->getBufferByIndex(i);
+			Buffer* buf = MainFileManager.getBufferByID(id);
+
+			if (buf->allowClickableLink()) // if it's not allowed clickabled link in the buffer, there's nothing to be cleared
+			{
+				MainFileManager.removeHotSpot(buf);
+			}
+		}
+	}
+}
+
 void Notepad_plus::addHotSpot(ScintillaEditView* view)
 {
 	if (_isAttemptingCloseOnQuit)

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -514,6 +514,7 @@ private:
 	void maintainIndentation(wchar_t ch);
 
 	void addHotSpot(ScintillaEditView* view = nullptr);
+	void removeAllHotSpot();
 
     void bookmarkAdd(intptr_t lineno) const {
 		if (lineno == -1)

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3699,6 +3699,12 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_INTERNAL_UPDATECLICKABLELINKS:
 		{
+			if (wParam == 1)
+			{
+				removeAllHotSpot();
+				return TRUE;
+			}
+
 			ScintillaEditView* pView = reinterpret_cast<ScintillaEditView*>(wParam);
 
 			int urlAction = nppParam.getNppGUI()._styleURL;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -2007,3 +2007,16 @@ size_t FileManager::docLength(Buffer* buffer) const
 	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, curDoc);
 	return docLen;
 }
+
+
+void FileManager::removeHotSpot(Buffer* buffer) const
+{
+	Document curDoc = _pscratchTilla->execute(SCI_GETDOCPOINTER);
+	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, buffer->_doc);
+
+	_pscratchTilla->execute(SCI_SETINDICATORCURRENT, URL_INDIC);
+	size_t docLen = _pscratchTilla->getCurrentDocLen();
+	_pscratchTilla->execute(SCI_INDICATORCLEARRANGE, 0, docLen);
+
+	_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, curDoc);
+}

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -113,6 +113,7 @@ public:
 	};
 	int getFileNameFromBuffer(BufferID id, wchar_t * fn2copy);
 	size_t docLength(Buffer * buffer) const;
+	void removeHotSpot(Buffer * buffer) const;
 	size_t nextUntitledNewNumber() const;
 
 private:

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -5799,7 +5799,7 @@ intptr_t CALLBACK CloudAndLinkSubDlg::run_dlgProc(UINT message, WPARAM wParam, L
 
 					nppGUI._styleURL = isChecked ? urlUnderLineFg : urlDisable;
 					HWND grandParent = ::GetParent(_hParent);
-					::SendMessage(grandParent, NPPM_INTERNAL_UPDATECLICKABLELINKS, 0, 0);
+					::SendMessage(grandParent, NPPM_INTERNAL_UPDATECLICKABLELINKS, isChecked ? 0 : 1, 0);
 				}
 				return TRUE;
 


### PR DESCRIPTION
The regression was introduced by commit 71be434a334d300487c5d23114dc4afd084b94aa

Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/pull/15926#issuecomment-2572268207