### PR TITLE
Fix floating panels position resetting in multi-monitor extended mode

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1905,6 +1905,11 @@ bool doesPathExist(const wchar_t* path, DWORD milliSec2wait, bool* isTimeoutReac
 	return (attributes.dwFileAttributes != INVALID_FILE_ATTRIBUTES);
 }
 
+#if defined(__GNUC__)
+#define LAMBDA_STDCALL __attribute__((__stdcall__))
+#else
+#define LAMBDA_STDCALL 
+#endif
 
 // check if the window rectangle intersects with any currently active monitor's working area
 // (this func handles also possible extended monitors mode aka the MS Virtual Screen)
@@ -1917,7 +1922,7 @@ bool isWindowVisibleOnAnyMonitor(const RECT& rectWndIn)
 	};
 
 	// callback func to check for intersection with each existing monitor
-	auto callback = []([[maybe_unused]] HMONITOR hMon, [[maybe_unused]] HDC hdc, LPRECT lprcMon, LPARAM lpInOut) -> BOOL
+	auto callback = []([[maybe_unused]] HMONITOR hMon, [[maybe_unused]] HDC hdc, LPRECT lprcMon, LPARAM lpInOut) -> BOOL LAMBDA_STDCALL
 	{
 		Param4InOut* paramInOut = reinterpret_cast<Param4InOut*>(lpInOut);
 		RECT rectIntersection{};

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#include <windows.h>
 #include <algorithm>
 #include <stdexcept>
 #include <shlwapi.h>
@@ -1902,4 +1903,52 @@ bool doesPathExist(const wchar_t* path, DWORD milliSec2wait, bool* isTimeoutReac
 	attributes.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
 	getFileAttributesExWithTimeout(path, &attributes, milliSec2wait, isTimeoutReached);
 	return (attributes.dwFileAttributes != INVALID_FILE_ATTRIBUTES);
+}
+
+
+// check if the window rectangle intersects with any currently active monitor's working area
+// (this func handles also possible extended monitors mode aka the MS Virtual Screen)
+bool isWindowVisibleOnAnyMonitor(const RECT& rectWndIn)
+{
+	struct Param4InOut
+	{
+		const RECT& rectWndIn;
+		bool isWndVisibleOut = false;
+	};
+
+	// callback func to check for intersection with each existing monitor
+	auto callback = []([[maybe_unused]] HMONITOR hMon, [[maybe_unused]] HDC hdc, LPRECT lprcMon, LPARAM lpInOut) -> BOOL
+	{
+		Param4InOut* paramInOut = reinterpret_cast<Param4InOut*>(lpInOut);
+		RECT rectIntersection{};
+		if (::IntersectRect(&rectIntersection, &(paramInOut->rectWndIn), lprcMon))
+		{
+			paramInOut->isWndVisibleOut = true; // the window is at least partially visible on this monitor
+			return FALSE; // ok, stop the enumeration
+		}
+		return TRUE; // continue enumeration as no intersection yet
+	};
+
+	// get scaled Virtual Screen size (scaled coordinates are saved by the Notepad++ into config.xml)
+	// - for unscaled, one has to 1st set the SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) & then use GetSystemMetricsForDpi with 96
+	// - for getting the VS RECT, we cannot use here the SystemParametersInfo with SPI_GETWORKAREA!
+	//   (while the SPI_SETWORKAREA is working with the VS coordinates the SPI_GETWORKAREA not...)
+	RECT rectVirtualScreen{ ::GetSystemMetrics(SM_XVIRTUALSCREEN), ::GetSystemMetrics(SM_YVIRTUALSCREEN),
+		::GetSystemMetrics(SM_CXVIRTUALSCREEN), ::GetSystemMetrics(SM_CYVIRTUALSCREEN) }; 
+
+	// 1) Before checking for intersections with individual monitors, we verify if the window's rectangle
+	//    is within the MS Virtual Screen area. If it is outside, this func exits with false early,
+	//    as the window in question cannot be visible on any individual monitor present.
+	RECT rectIntersection{};
+	if (!::IntersectRect(&rectIntersection, &rectWndIn, &rectVirtualScreen))
+	{
+		// the window in question is completely outside the overall Virtual Screen bounds
+		return false;
+	}
+
+	// 2) Using the EnumDisplayMonitors WINAPI to check each present monitor's visible area, we ensure that we are only looking
+	//    at monitors that are part of the Virtual Screen but not at Virtual Space coordinates where is NOT a monitor present.
+	Param4InOut param4InOut{ rectWndIn, false };
+	::EnumDisplayMonitors(NULL, &rectVirtualScreen, callback, reinterpret_cast<LPARAM>(&param4InOut));
+	return param4InOut.isWndVisibleOut;
 }

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -288,3 +288,7 @@ BOOL getFileAttributesExWithTimeout(const wchar_t* filePath, WIN32_FILE_ATTRIBUT
 bool doesFileExist(const wchar_t* filePath, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
 bool doesDirectoryExist(const wchar_t* dirPath, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
 bool doesPathExist(const wchar_t* path, DWORD milliSec2wait = 0, bool* isTimeoutReached = nullptr);
+
+
+// check if the window rectangle intersects with any currently active monitor's working area
+bool isWindowVisibleOnAnyMonitor(const RECT& rectWndIn);

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -6910,40 +6910,32 @@ void NppParameters::feedDockingManager(TiXmlNode *node)
 			int w = FWI_PANEL_WH_DEFAULT;
 			int h = FWI_PANEL_WH_DEFAULT;
 
+			bool bInputDataOk = false;
 			if (floatElement->Attribute(L"x", &x))
 			{
-				if ((x > (maxMonitorSize.cx - 1)) || (x < 0))
-					x = 0; // invalid, reset
+				if (floatElement->Attribute(L"y", &y))
+				{
+					if (floatElement->Attribute(L"width", &w))
+					{
+						if (floatElement->Attribute(L"height", &h))
+						{
+							RECT rect{ x,y,w,h };
+							bInputDataOk = isWindowVisibleOnAnyMonitor(rect);
+						}
+					}
+				}
 			}
-			if (floatElement->Attribute(L"y", &y))
+
+			if (!bInputDataOk)
 			{
-				if ((y > (maxMonitorSize.cy - 1)) || (y < 0))
-					y = 0; // invalid, reset
+				// reset to adjusted factory defaults
+				// (and the panel will automatically be on the current primary monitor due to the x,y == 0,0)
+				x = 0;
+				y = 0;
+				w = _nppGUI._dockingData._minFloatingPanelSize.cx;
+				h = _nppGUI._dockingData._minFloatingPanelSize.cy + FWI_PANEL_WH_DEFAULT;
 			}
-			if (floatElement->Attribute(L"width", &w))
-			{
-				if (w > maxMonitorSize.cx)
-				{
-					w = maxMonitorSize.cx; // invalid, reset
-				}
-				else
-				{
-					if (w < _nppGUI._dockingData._minFloatingPanelSize.cx)
-						w = _nppGUI._dockingData._minFloatingPanelSize.cx; // invalid, reset
-				}
-			}
-			if (floatElement->Attribute(L"height", &h))
-			{
-				if (h > maxMonitorSize.cy)
-				{
-					h = maxMonitorSize.cy; // invalid, reset
-				}
-				else
-				{
-					if (h < _nppGUI._dockingData._minFloatingPanelSize.cy)
-						h = _nppGUI._dockingData._minFloatingPanelSize.cy; // invalid, reset
-				}
-			}
+
 			_nppGUI._dockingData._floatingWindowInfo.push_back(FloatingWindowInfo(cont, x, y, w, h));
 		}
 	}


### PR DESCRIPTION
Fix #15498 , fix #16077 (partially, there are two different issues reported in it)

This fixes a regression caused by the PR #15236 (Fix for the "lost" panels problem).

Since the Virtual Screen in extended multi-monitor mode can start not only at 0,0 (like the primary monitor) but also at negative coordinates, we have to deal with this.

The MS Virtual Screen concept ref:   https://learn.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen

New `isWindowVisibleOnAnyMonitor` func will ensure that only those saved coordinates of the floating panels from the config.xml file, which will correspond to the current detected "green area" in the image below, will be considered correct. Others will be reset to some default size and moved to the current primary monitor.
![VirtualScreen-MultiMonitor-upr2](https://github.com/user-attachments/assets/7b437880-6319-4da0-8b59-0d6d7068197f)

The `isWindowVisibleOnAnyMonitor` can be also used in the future when resolving issues like # 15769 (on-the-fly disconnecting of the monitor where the main N++ window is). It will be enough to add the the [WM_DISPLAYCHANGE](https://learn.microsoft.com/en-us/windows/win32/gdi/wm-displaychange) message handler to the "NppBigSwitch.cpp" and call there this new func (& possibly react in the same way as here by repositioning the N++ app window to the current primary monitor). Similar stuff is already in use [here](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/1cf112a342cb30b8e3ce2017e6be2702c68c6bd9/PowerEditor/src/WinControls/StaticDialog/StaticDialog.cpp#L130-L152).
