### PR TITLE
Add NPPM_ADDSCINTILLANOTIFS to fix regression for Plugins

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -990,6 +990,13 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// lParam[out]: language file name string receives all copied native language file name string
 	// Return the number of char copied/to copy
 
+	#define NPPM_ADDSCINTILLANOTIFS (NPPMSG + 117)
+	// int NPPM_ADDSCINTILLANOTIFS(0, unsigned long mask2Add)
+
+	// wParam: 0 (not used)
+	// lParam[out]: language file name string receives all copied native language file name string
+	// Return TRUE
+
 	// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0
 	#define FULL_CURRENT_PATH 1

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -991,11 +991,31 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// Return the number of char copied/to copy
 
 	#define NPPM_ADDSCINTILLANOTIFS (NPPMSG + 117)
-	// int NPPM_ADDSCINTILLANOTIFS(0, unsigned long mask2Add)
-
+	// BOOL NPPM_ADDSCINTILLANOTIFS(0, unsigned long scintillaNotifs2Add)
+	// Add needed Scintilla notifications so your plugin will recieve these notifications for your specific treatments. 
+	// By default, Notepad++ forwards only the following 5 notification SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR to plugins.
+	// If your plugin need to process other Scintilla notifications, you should add the notification you need by sending this message to Notepad++, just after recieving NPPN_READY.
 	// wParam: 0 (not used)
-	// lParam[out]: language file name string receives all copied native language file name string
+	// lParam[in]: scintillaNotifs2Add - Scintilla notifications to add. 
 	// Return TRUE
+	//
+	// Example:
+	//
+	//  extern "C" __declspec(dllexport) void beNotified(SCNotification* notifyCode)
+	//  {
+	//  	switch (notifyCode->nmhdr.code)
+	//  	{
+	//  		case NPPN_READY:
+	//  		{
+	//  			// Add SC_MOD_DELETETEXT and SC_MOD_INSERTTEXT notifications
+	//  			::SendMessage(nppData._nppHandle, NPPM_ADDSCINTILLANOTIFS, 0, SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT); 
+	//  		}
+	//  		break;
+	//  		...
+	//  	}
+	//  	...
+	//  }
+
 
 	// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0

--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -990,13 +990,13 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// lParam[out]: language file name string receives all copied native language file name string
 	// Return the number of char copied/to copy
 
-	#define NPPM_ADDSCINTILLANOTIFS (NPPMSG + 117)
-	// BOOL NPPM_ADDSCINTILLANOTIFS(0, unsigned long scintillaNotifs2Add)
-	// Add needed Scintilla notifications so your plugin will recieve these notifications for your specific treatments. 
-	// By default, Notepad++ forwards only the following 5 notification SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR to plugins.
-	// If your plugin need to process other Scintilla notifications, you should add the notification you need by sending this message to Notepad++, just after recieving NPPN_READY.
+	#define NPPM_ADDSCNMODIFIEDFLAGS (NPPMSG + 117)
+	// BOOL NPPM_ADDSCNMODIFIEDFLAGS(0, unsigned long scnMotifiedFlags2Add)
+	// Add needed SCN_MODIFIED flags so your plugin will recieve the notification SCN_MODIFIED of these events for your specific treatments.
+	// By default, Notepad++ only forwards SCN_MODIFIED with the following 5 flags/events SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR to plugins.
+	// If your plugin need to process other events of SCN_MODIFIED, you should add the flags you need by sending this message to Notepad++, just after recieving NPPN_READY.
 	// wParam: 0 (not used)
-	// lParam[in]: scintillaNotifs2Add - Scintilla notifications to add. 
+	// lParam[in]: scnMotifiedFlags2Add - Scintilla SCN_MODIFIED flags to add. 
 	// Return TRUE
 	//
 	// Example:
@@ -1008,7 +1008,7 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//  		case NPPN_READY:
 	//  		{
 	//  			// Add SC_MOD_DELETETEXT and SC_MOD_INSERTTEXT notifications
-	//  			::SendMessage(nppData._nppHandle, NPPM_ADDSCINTILLANOTIFS, 0, SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT); 
+	//  			::SendMessage(nppData._nppHandle, NPPM_ADDSCNMODIFIEDFLAGS, 0, SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT); 
 	//  		}
 	//  		break;
 	//  		...

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3876,6 +3876,7 @@ void Notepad_plus::setLanguage(LangType langType)
 	//If so, release one document
 	bool reset = false;
 	Document prev = 0;
+	unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
 	if (bothActive())
 	{
 		if (_mainEditView.getCurrentBufferID() == _subEditView.getCurrentBufferID())
@@ -3885,7 +3886,7 @@ void Notepad_plus::setLanguage(LangType langType)
 			prev = _subEditView.execute(SCI_GETDOCPOINTER);
 			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_subEditView.execute(SCI_SETDOCPOINTER, 0, 0);
-			_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 		}
 	}
 	
@@ -3902,7 +3903,7 @@ void Notepad_plus::setLanguage(LangType langType)
 	{
 		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_subEditView.execute(SCI_SETDOCPOINTER, 0, prev);
-		_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 		_subEditView.restoreCurrentPosPreStep();
 	}
 }

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3885,7 +3885,7 @@ void Notepad_plus::setLanguage(LangType langType)
 			prev = _subEditView.execute(SCI_GETDOCPOINTER);
 			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_subEditView.execute(SCI_SETDOCPOINTER, 0, 0);
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 		}
 	}
 	
@@ -3902,7 +3902,7 @@ void Notepad_plus::setLanguage(LangType langType)
 	{
 		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_subEditView.execute(SCI_SETDOCPOINTER, 0, prev);
-		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 		_subEditView.restoreCurrentPosPreStep();
 	}
 }

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3792,6 +3792,12 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return fileName.length();
 		}
 
+		case NPPM_ADDSCINTILLANOTIFS:
+		{
+			nppParam.addModeEventMask(static_cast<unsigned long>(wParam));
+			return TRUE;
+		}
+
 		case NPPM_INTERNAL_HILITECURRENTLINE:
 		{
 			const ScintillaViewParams& svp = nppParam.getSVP();

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3792,7 +3792,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return fileName.length();
 		}
 
-		case NPPM_ADDSCINTILLANOTIFS:
+		case NPPM_ADDSCNMODIFIEDFLAGS:
 		{
 			nppParam.addScintillaModEventMask(static_cast<unsigned long>(lParam));
 			return TRUE;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3794,7 +3794,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_ADDSCINTILLANOTIFS:
 		{
-			nppParam.addModeEventMask(static_cast<unsigned long>(wParam));
+			nppParam.addModeEventMask(static_cast<unsigned long>(lParam));
 			return TRUE;
 		}
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3794,7 +3794,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case NPPM_ADDSCINTILLANOTIFS:
 		{
-			nppParam.addModeEventMask(static_cast<unsigned long>(lParam));
+			nppParam.addScintillaModEventMask(static_cast<unsigned long>(lParam));
 			return TRUE;
 		}
 

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -571,12 +571,13 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	//an empty Document is inserted during reload if needed.
 	bool mainVisisble = (_mainEditView.getCurrentBufferID() == id);
 	bool subVisisble = (_subEditView.getCurrentBufferID() == id);
+	unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
 	if (mainVisisble)
 	{
 		_mainEditView.saveCurrentPos();
 		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_mainEditView.execute(SCI_SETDOCPOINTER, 0, 0);
-		_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 	}
 
 	if (subVisisble)
@@ -584,7 +585,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 		_subEditView.saveCurrentPos();
 		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_subEditView.execute(SCI_SETDOCPOINTER, 0, 0);
-		_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 	}
 
 	if (!mainVisisble && !subVisisble)
@@ -598,7 +599,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	{
 		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_mainEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-		_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 		_mainEditView.restoreCurrentPosPreStep();
 	}
 
@@ -606,7 +607,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	{
 		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_subEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-		_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 		_subEditView.restoreCurrentPosPreStep();
 	}
 
@@ -2482,16 +2483,17 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			//Force in the document so we can add the markers
 			//Don't use default methods because of performance
 			Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
+			unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
 			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			for (size_t j = 0, len = session._mainViewFiles[i]._marks.size(); j < len ; ++j)
 			{
 				_mainEditView.execute(SCI_MARKERADD, session._mainViewFiles[i]._marks[j], MARK_BOOKMARK);
 			}
 			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			++i;
 		}
 		else
@@ -2617,16 +2619,17 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			//Force in the document so we can add the markers
 			//Don't use default methods because of performance
 			Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
+			unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
 			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			for (size_t j = 0, len = session._subViewFiles[k]._marks.size(); j < len ; ++j)
 			{
 				_subEditView.execute(SCI_MARKERADD, session._subViewFiles[k]._marks[j], MARK_BOOKMARK);
 			}
 			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 
 			++k;
 		}

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -576,7 +576,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 		_mainEditView.saveCurrentPos();
 		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_mainEditView.execute(SCI_SETDOCPOINTER, 0, 0);
-		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 	}
 
 	if (subVisisble)
@@ -584,7 +584,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 		_subEditView.saveCurrentPos();
 		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_subEditView.execute(SCI_SETDOCPOINTER, 0, 0);
-		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 	}
 
 	if (!mainVisisble && !subVisisble)
@@ -598,7 +598,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	{
 		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_mainEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-		_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 		_mainEditView.restoreCurrentPosPreStep();
 	}
 
@@ -606,7 +606,7 @@ bool Notepad_plus::doReload(BufferID id, bool alert)
 	{
 		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		_subEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
-		_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 		_subEditView.restoreCurrentPosPreStep();
 	}
 
@@ -2484,14 +2484,14 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
 			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 			for (size_t j = 0, len = session._mainViewFiles[i]._marks.size(); j < len ; ++j)
 			{
 				_mainEditView.execute(SCI_MARKERADD, session._mainViewFiles[i]._marks[j], MARK_BOOKMARK);
 			}
 			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			_mainEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 			++i;
 		}
 		else
@@ -2619,14 +2619,14 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
 			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 			for (size_t j = 0, len = session._subViewFiles[k]._marks.size(); j < len ; ++j)
 			{
 				_subEditView.execute(SCI_MARKERADD, session._subViewFiles[k]._marks[j], MARK_BOOKMARK);
 			}
 			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			_subEditView.execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 
 			++k;
 		}

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1852,6 +1852,8 @@ public:
 	bool isStylerDocLoaded() const { return _pXmlUserStylerDoc != nullptr; };
 
 	ColumnEditorParam _columnEditParam;
+	unsigned long getModeEventMask() const { return _modeEventMask; };
+	void addModeEventMask(unsigned long mask2Add) { _modeEventMask |= mask2Add; };
 
 private:
 	NppParameters();
@@ -2100,5 +2102,5 @@ private:
 	int getCmdIdFromMenuEntryItemName(HMENU mainMenuHadle, const std::wstring& menuEntryName, const std::wstring& menuItemName); // return -1 if not found
 	int getPluginCmdIdFromMenuEntryItemName(HMENU pluginsMenu, const std::wstring& pluginName, const std::wstring& pluginCmdName); // return -1 if not found
 	winVer getWindowsVersion();
-
+	unsigned long _modeEventMask = SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR;
 };

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1852,8 +1852,8 @@ public:
 	bool isStylerDocLoaded() const { return _pXmlUserStylerDoc != nullptr; };
 
 	ColumnEditorParam _columnEditParam;
-	unsigned long getModeEventMask() const { return _modeEventMask; };
-	void addModeEventMask(unsigned long mask2Add) { _modeEventMask |= mask2Add; };
+	unsigned long getScintillaModEventMask() const { return _sintillaModEventMask; };
+	void addScintillaModEventMask(unsigned long mask2Add) { _sintillaModEventMask |= mask2Add; };
 
 private:
 	NppParameters();
@@ -2102,5 +2102,5 @@ private:
 	int getCmdIdFromMenuEntryItemName(HMENU mainMenuHadle, const std::wstring& menuEntryName, const std::wstring& menuItemName); // return -1 if not found
 	int getPluginCmdIdFromMenuEntryItemName(HMENU pluginsMenu, const std::wstring& pluginName, const std::wstring& pluginCmdName); // return -1 if not found
 	winVer getWindowsVersion();
-	unsigned long _modeEventMask = SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR;
+	unsigned long _sintillaModEventMask = SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR;
 };

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1393,7 +1393,7 @@ SavingStatus FileManager::saveBuffer(BufferID id, const wchar_t* filename, bool 
 		{
 			_pscratchTilla->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, _scratchDocDefault);
-			_pscratchTilla->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			_pscratchTilla->execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 			return SavingStatus::SaveOK;	//all done - we don't change the current buffer's path to "fullpath", since it's "Save a Copy As..." action.
 		}
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1391,9 +1391,10 @@ SavingStatus FileManager::saveBuffer(BufferID id, const wchar_t* filename, bool 
 
 		if (isCopy) // "Save a Copy As..." command
 		{
+			unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
 			_pscratchTilla->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 			_pscratchTilla->execute(SCI_SETDOCPOINTER, 0, _scratchDocDefault);
-			_pscratchTilla->execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+			_pscratchTilla->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			return SavingStatus::SaveOK;	//all done - we don't change the current buffer's path to "fullpath", since it's "Save a Copy As..." action.
 		}
 

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
@@ -112,7 +112,8 @@ intptr_t CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 							(*_ppEditView)->execute(SCI_GOTOPOS, posToGoto);
 						}
 					}
-					(*_ppEditView)->execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+					unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
+					(*_ppEditView)->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 
 					SCNotification notification{};
 					notification.nmhdr.code = SCN_PAINTED;

--- a/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/GoToLineDlg.cpp
@@ -112,7 +112,7 @@ intptr_t CALLBACK GoToLineDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 							(*_ppEditView)->execute(SCI_GOTOPOS, posToGoto);
 						}
 					}
-					(*_ppEditView)->execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+					(*_ppEditView)->execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 
 					SCNotification notification{};
 					notification.nmhdr.code = SCN_PAINTED;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -347,7 +347,7 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 			delete[] defaultCharList;
 		}
 	}
-	execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+	execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 	//Get the startup document and make a buffer for it so it can be accessed like a file
 	attachDefaultDoc();
 }
@@ -2308,7 +2308,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 		// Note that the actual reference in the Buffer itself is NOT decreased, Notepad_plus does that if neccessary
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
-		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 
 		// Due to execute(SCI_CLEARDOCUMENTSTYLE); in defineDocType() function
 		// defineDocType() function should be called here, but not be after the fold info loop
@@ -2319,7 +2319,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 		// No need to call defineDocType() since it's the same language type
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
-		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 
 		if (force)
 			defineDocType(_currentBuffer->getLangType());
@@ -2330,13 +2330,13 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 		// a blank document is used for accelerate defineDocType() call.
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, getBlankDocument());
-		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 
 		defineDocType(_currentBuffer->getLangType());
 
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
-		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
 	}
 
 	_currentBuffer->setLastLangType(currentLangInt);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -252,8 +252,9 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 	const COLORREF hiddenLinesGreen = RGB(0x77, 0xCC, 0x77);
 	long hiddenLinesGreenWithAlpha = hiddenLinesGreen | 0xFF000000;
 	setElementColour(SC_ELEMENT_HIDDEN_LINE, hiddenLinesGreenWithAlpha);
-
-	if (NppParameters::getInstance()._dpiManager.scaleX(100) >= 150)
+	
+	NppParameters& nppParams = NppParameters::getInstance();
+	if (nppParams._dpiManager.scaleX(100) >= 150)
 	{
 		execute(SCI_RGBAIMAGESETWIDTH, 18);
 		execute(SCI_RGBAIMAGESETHEIGHT, 18);
@@ -311,7 +312,7 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT4, true);
 	execute(SCI_INDICSETUNDER, SCE_UNIVERSAL_FOUND_STYLE_EXT5, true);
 
-	NppGUI& nppGui = (NppParameters::getInstance()).getNppGUI();
+	NppGUI& nppGui = nppParams.getNppGUI();
 
 	HMODULE hNtdllModule = ::GetModuleHandle(L"ntdll.dll");
 	FARPROC isWINE = nullptr;
@@ -347,7 +348,8 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 			delete[] defaultCharList;
 		}
 	}
-	execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+	unsigned long MODEVENTMASK_ON = nppParams.getScintillaModEventMask();
+	execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 	//Get the startup document and make a buffer for it so it can be accessed like a file
 	attachDefaultDoc();
 }
@@ -382,6 +384,7 @@ LRESULT CALLBACK ScintillaEditView::scintillaStatic_Proc(HWND hwnd, UINT Message
 		return ::DefWindowProc(hwnd, Message, wParam, lParam);
 
 }
+
 LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
 	switch (Message)
@@ -2301,6 +2304,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 	const int currentLangInt = static_cast<int>(_currentBuffer->getLangType());
 	const bool isFirstActiveBuffer = (_currentBuffer->getLastLangType() != currentLangInt);
 
+	unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
 	if (isFirstActiveBuffer)  // Entering the tab for the 1st time
 	{
 		// change the doc, this operation will decrease
@@ -2308,7 +2312,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 		// Note that the actual reference in the Buffer itself is NOT decreased, Notepad_plus does that if neccessary
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
-		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 
 		// Due to execute(SCI_CLEARDOCUMENTSTYLE); in defineDocType() function
 		// defineDocType() function should be called here, but not be after the fold info loop
@@ -2319,7 +2323,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 		// No need to call defineDocType() since it's the same language type
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
-		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 
 		if (force)
 			defineDocType(_currentBuffer->getLangType());
@@ -2330,13 +2334,13 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 		// a blank document is used for accelerate defineDocType() call.
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, getBlankDocument());
-		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 
 		defineDocType(_currentBuffer->getLangType());
 
 		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 		execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
-		execute(SCI_SETMODEVENTMASK, NppParameters::getInstance().getModeEventMask());
+		execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 	}
 
 	_currentBuffer->setLastLangType(currentLangInt);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -93,8 +93,7 @@ const bool fold_uncollapse = true;
 const bool fold_collapse = false;
 #define MAX_FOLD_COLLAPSE_LEVEL	8
 
-#define MODEVENTMASK_OFF         0
-#define MODEVENTMASK_ON          SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR
+#define MODEVENTMASK_OFF 0
 
 enum TextCase : UCHAR
 {


### PR DESCRIPTION
Add **NPPM_ADDSCNMODIFIEDFLAGS** message for plugins which need the SCN_MODIFIED notification of other events.


**API:**
`BOOL NPPM_ADDSCNMODIFIEDFLAGS(0, unsigned long scnMotifiedFlags2Add)`

**Description:**
Add needed SCN_MODIFIED flags so your plugin will recieve the notification SCN_MODIFIED of these events for your specific treatments.
By default, Notepad++ only forwards SCN_MODIFIED with the following 5 flags/events SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT | SC_PERFORMED_UNDO | SC_PERFORMED_REDO | SC_MOD_CHANGEINDICATOR to plugins.
If your plugin need to process other events of SCN_MODIFIED, you should add the flags you need by sending this message to Notepad++, just after recieving NPPN_READY.

* wParam: 0 (not used)
* lParam[in]: scnMotifiedFlags2Add- Scintilla SCN_MODIFIED flags to add. 
* Return TRUE

	
**Example:**
```cpp
extern "C" __declspec(dllexport) void beNotified(SCNotification* notifyCode)
{
	switch (notifyCode->nmhdr.code)
	{
		case NPPN_READY:
		{
			// Add SC_MOD_DELETETEXT and SC_MOD_INSERTTEXT notifications
			::SendMessage(nppData._nppHandle, NPPM_ADDSCNMODIFIEDFLAGS, 0, SC_MOD_DELETETEXT | SC_MOD_INSERTTEXT); 
		}
		break;
		...
	}
	...
}
```
Fix #16121