### PR TITLE
Use a common abbreviation of a specific control code

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -166,7 +166,7 @@ const std::vector<std::vector<const char*>> g_ccUniEolChars =
 	{"\xC2\x87", "ESA", "U+0087"},           // U+0087 : End of Selected Area
 	{"\xC2\x88", "HTS", "U+0088"},           // U+0088 : Character (Horizontal) Tabulation Set
 	{"\xC2\x89", "HTJ", "U+0089"},           // U+0089 : Character (Horizontal) Tabulation With Justification
-	{"\xC2\x8A", "LTS", "U+008A"},           // U+008A : Line (Vertical) Tabulation Set
+	{"\xC2\x8A", "VTS", "U+008A"},           // U+008A : Vertical (Line) Tabulation Set
 	{"\xC2\x8B", "PLD", "U+008B"},           // U+008B : Partial Line Forward (Down)
 	{"\xC2\x8C", "PLU", "U+008C"},           // U+008C : Partial Line Backward (Up)
 	{"\xC2\x8D", "RI", "U+008D"},            // U+008D : Reverse Line Feed (Index)


### PR DESCRIPTION
Use VTS instead of LTS.

Fix #16107