### PR TITLE
Improve folding/unfolding performance for large files

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2227,7 +2227,7 @@ void Notepad_plus::command(int id)
 		case IDM_VIEW_FOLD_7:
 		case IDM_VIEW_FOLD_8:
 			_isFolding = true; // So we can ignore events while folding is taking place
- 			_pEditView->collapse(id - IDM_VIEW_FOLD - 1, fold_collapse);
+ 			_pEditView->foldLevel(id - IDM_VIEW_FOLD - 1, fold_collapse);
 			_isFolding = false;
 			break;
 
@@ -2240,7 +2240,7 @@ void Notepad_plus::command(int id)
 		case IDM_VIEW_UNFOLD_7:
 		case IDM_VIEW_UNFOLD_8:
 			_isFolding = true; // So we can ignore events while folding is taking place
- 			_pEditView->collapse(id - IDM_VIEW_UNFOLD - 1, fold_expand);
+ 			_pEditView->foldLevel(id - IDM_VIEW_UNFOLD - 1, fold_expand);
 			_isFolding = false;
 			break;
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -180,28 +180,6 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			break;
 		}
 
-		case SCN_FOLDINGSTATECHANGED:
-		{
-			if ((notification->nmhdr.hwndFrom == _mainEditView.getHSelf()) || (notification->nmhdr.hwndFrom == _subEditView.getHSelf()))
-			{
-				size_t lineClicked = notification->line;
-
-				if (!_isFolding)
-				{
-					int urlAction = (NppParameters::getInstance()).getNppGUI()._styleURL;
-					Buffer* currentBuf = _pEditView->getCurrentBuffer();
-					if (urlAction != urlDisable && currentBuf->allowClickableLink())
-					{
-						addHotSpot();
-					}
-				}
-
-				if (_pDocMap)
-					_pDocMap->fold(lineClicked, _pEditView->isFolded(lineClicked));
-			}
-			return TRUE;
-		}
-
 		case SCN_CHARADDED:
 		{
 			if (!notifyView) return FALSE;
@@ -582,6 +560,30 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 		// ======= End of SCN_*
 		//
 
+		case SCN_FOLDINGSTATECHANGED: // Notification not part of Scintilla, but Notepad++ added
+		{
+			if ((notification->nmhdr.hwndFrom == _mainEditView.getHSelf()) || (notification->nmhdr.hwndFrom == _subEditView.getHSelf()))
+			{
+				size_t lineClicked = notification->line;
+
+				/*
+				if (!_isFolding)
+				{
+					int urlAction = (NppParameters::getInstance()).getNppGUI()._styleURL;
+					Buffer* currentBuf = _pEditView->getCurrentBuffer();
+					if (urlAction != urlDisable && currentBuf->allowClickableLink())
+					{
+						addHotSpot();
+					}
+				}
+				*/
+
+				if (_pDocMap)
+					_pDocMap->fold(lineClicked, _pEditView->isFolded(lineClicked));
+			}
+
+			return TRUE;
+		}
 
 		case TCN_MOUSEHOVERING:
 		case TCN_MOUSEHOVERSWITCHING:

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -147,7 +147,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			}
 			else if ((notification->margin == ScintillaEditView::_SC_MARGE_SYMBOL) && !notification->modifiers)
 			{
-				if (!_pEditView->markerMarginClick(lineClick))
+				if (!_pEditView->hidelineMarkerClicked(lineClick))
 					bookmarkToggle(lineClick);
 			}
 			break;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -649,13 +649,13 @@ void Buffer::setHideLineChanged(bool isHide, size_t location)
 {
 	//First run through all docs without removing markers
 	for (int i = 0; i < _references; ++i)
-		_referees.at(i)->notifyMarkers(this, isHide, location, false); // (i == _references-1));
+		_referees.at(i)->notifyHideMarkers(this, isHide, location, false); // (i == _references-1));
 
 	if (!isHide) // no deleting if hiding lines
 	{
 		//Then all docs to remove markers.
 		for (int i = 0; i < _references; ++i)
-			_referees.at(i)->notifyMarkers(this, isHide, location, true);
+			_referees.at(i)->notifyHideMarkers(this, isHide, location, true);
 	}
 }
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -649,13 +649,13 @@ void Buffer::setHideLineChanged(bool isHide, size_t location)
 {
 	//First run through all docs without removing markers
 	for (int i = 0; i < _references; ++i)
-		_referees.at(i)->notifyHideMarkers(this, isHide, location, false); // (i == _references-1));
+		_referees.at(i)->notifyHidelineMarkers(this, isHide, location, false); // (i == _references-1));
 
 	if (!isHide) // no deleting if hiding lines
 	{
 		//Then all docs to remove markers.
 		for (int i = 0; i < _references; ++i)
-			_referees.at(i)->notifyHideMarkers(this, isHide, location, true);
+			_referees.at(i)->notifyHidelineMarkers(this, isHide, location, true);
 	}
 }
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -5581,7 +5581,7 @@ void Finder::beginNewFilesSearch()
 	_nbFoundFiles = 0;
 
 	// fold all old searches (1st level only)
-	_scintView.collapse(searchHeaderLevel - SC_FOLDLEVELBASE, fold_collapse);
+	_scintView.foldLevel(searchHeaderLevel - SC_FOLDLEVELBASE, fold_collapse);
 }
 
 void Finder::finishFilesSearch(int count, int searchedCount, bool searchedEntireNotSelection, const FindOption* pFindOpt)

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2663,15 +2663,7 @@ void ScintillaEditView::fold(size_t line, bool mode)
 
 void ScintillaEditView::foldAll(bool mode)
 {
-	auto maxLine = execute(SCI_GETLINECOUNT);
-
-	for (int line = 0; line < maxLine; ++line)
-	{
-		auto level = execute(SCI_GETFOLDLEVEL, line);
-		if (level & SC_FOLDLEVELHEADERFLAG)
-			if (isFolded(line) != mode)
-				fold(line, mode);
-	}
+	execute(SCI_FOLDALL, (mode ? SC_FOLDACTION_EXPAND : SC_FOLDACTION_CONTRACT) | SC_FOLDACTION_CONTRACT_EVERY_LEVEL, 0);
 }
 
 void ScintillaEditView::getText(char *dest, size_t start, size_t end) const

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -4130,7 +4130,7 @@ void ScintillaEditView::hideLines()
 	_currentBuffer->setHideLineChanged(true, startMarker);
 }
 
-bool ScintillaEditView::markerMarginClick(intptr_t lineNumber)
+bool ScintillaEditView::hidelineMarkerClicked(intptr_t lineNumber)
 {
 	auto state = execute(SCI_MARKERGET, lineNumber);
 	bool openPresent = (state & (1 << MARK_HIDELINESBEGIN)) != 0;
@@ -4169,7 +4169,7 @@ bool ScintillaEditView::markerMarginClick(intptr_t lineNumber)
 	return true;
 }
 
-void ScintillaEditView::notifyHideMarkers(Buffer * buf, bool isHide, size_t location, bool del)
+void ScintillaEditView::notifyHidelineMarkers(Buffer * buf, bool isHide, size_t location, bool del)
 {
 	if (buf != _currentBuffer)	//if not visible buffer dont do a thing
 		return;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2460,7 +2460,7 @@ void ScintillaEditView::syncFoldStateWith(const std::vector<size_t> & lineStateV
 		if (nbLineState > MAX_FOLD_LINES_MORE_THAN)
 		{
 			::SendMessage(_hSelf, WM_SETREDRAW, TRUE, 0);
-			scrollToCaret();
+			execute(SCI_SCROLLCARET);
 			::InvalidateRect(_hSelf, nullptr, TRUE);
 		}
 	}
@@ -2514,15 +2514,6 @@ void ScintillaEditView::bufferUpdated(Buffer * buffer, int mask)
             execute(SCI_SETCODEPAGE, enc);
 		}
 	}
-}
-
-void ScintillaEditView::scrollToCaret() const noexcept
-{
-	execute(SCI_SETXCARETPOLICY, CARET_SLOP | CARET_STRICT | CARET_EVEN, 50);
-	execute(SCI_SETYCARETPOLICY, CARET_SLOP | CARET_STRICT | CARET_EVEN, 5);
-	execute(SCI_SCROLLCARET, 0, 0);
-	execute(SCI_SETXCARETPOLICY, CARET_SLOP | CARET_EVEN, 50);
-	execute(SCI_SETYCARETPOLICY, CARET_EVEN, 0);
 }
 
 bool ScintillaEditView::isFoldIndentationBased() const
@@ -2594,7 +2585,7 @@ void ScintillaEditView::foldIndentationBasedLevel(int level2Collapse, bool mode)
 	if (maxLine > MAX_FOLD_LINES_MORE_THAN)
 	{
 		::SendMessage(_hSelf, WM_SETREDRAW, TRUE, 0);
-		scrollToCaret();
+		execute(SCI_SCROLLCARET);
 		::InvalidateRect(_hSelf, nullptr, TRUE);
 	}
 
@@ -2636,7 +2627,7 @@ void ScintillaEditView::foldLevel(int level2Collapse, bool mode)
 	if (maxLine > MAX_FOLD_LINES_MORE_THAN)
 	{
 		::SendMessage(_hSelf, WM_SETREDRAW, TRUE, 0);
-		scrollToCaret();
+		execute(SCI_SCROLLCARET);
 		::InvalidateRect(_hSelf, nullptr, TRUE);
 	}
 
@@ -2706,7 +2697,10 @@ void ScintillaEditView::foldAll(bool mode)
 	execute(SCI_FOLDALL, (mode == fold_expand ? SC_FOLDACTION_EXPAND : SC_FOLDACTION_CONTRACT) | SC_FOLDACTION_CONTRACT_EVERY_LEVEL, 0);
 
 	if (mode == fold_expand)
+	{
 		hideMarkedLines(0, true);
+		execute(SCI_SCROLLCARET);
+	}
 }
 
 void ScintillaEditView::getText(char *dest, size_t start, size_t end) const

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -774,7 +774,6 @@ public:
 			::MessageBox(_hSelf, L"This function needs a newer OS version.", L"Change Case Error", MB_OK | MB_ICONHAND);
 	};
 
-	void scrollToCaret() const noexcept;
 	void getCurrentFoldStates(std::vector<size_t> & lineStateVector);
 	void syncFoldStateWith(const std::vector<size_t> & lineStateVectorNew);
 	bool isFoldIndentationBased() const;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -741,8 +741,6 @@ public:
 	void updateLineNumberWidth();
 	void performGlobalStyles();
 
-	void expand(size_t& line, bool doExpand, bool force = false, intptr_t visLevels = 0, intptr_t level = -1);
-
 	std::pair<size_t, size_t> getSelectionLinesRange(intptr_t selectionNumber = -1) const;
     void currentLinesUp() const;
     void currentLinesDown() const;
@@ -787,6 +785,7 @@ public:
 	bool isFolded(size_t line) const {
 		return (execute(SCI_GETFOLDEXPANDED, line) != 0);
 	};
+	void expand(size_t& line, bool doExpand, bool force = false, intptr_t visLevels = 0, intptr_t level = -1);
 
 	bool isCurrentLineFolded() const;
 	void foldCurrentPos(bool mode);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -815,34 +815,13 @@ public:
 	void styleChange();
 
 	void hideLines();
-
-	bool markerMarginClick(intptr_t lineNumber);	//true if it did something
-	void notifyHideMarkers(Buffer * buf, bool isHide, size_t location, bool del);
+	bool hidelineMarkerClicked(intptr_t lineNumber);	//true if it did something
+	void notifyHidelineMarkers(Buffer * buf, bool isHide, size_t location, bool del);
 	void hideMarkedLines(size_t searchStart, bool endOfDoc);
 	void showHiddenLines(size_t searchStart, bool endOfDoc, bool doDelete);
 	void restoreHiddenLines();
 
 	bool hasSelection() const { return !execute(SCI_GETSELECTIONEMPTY); };
-
-	bool isSelecting() const {
-		static Sci_CharacterRangeFull previousSelRange = getSelection();
-		Sci_CharacterRangeFull currentSelRange = getSelection();
-
-		if (currentSelRange.cpMin == currentSelRange.cpMax)
-		{
-			previousSelRange = currentSelRange;
-			return false;
-		}
-
-		if ((previousSelRange.cpMin == currentSelRange.cpMin) || (previousSelRange.cpMax == currentSelRange.cpMax))
-		{
-			previousSelRange = currentSelRange;
-			return true;
-		}
-
-		previousSelRange = currentSelRange;
-		return false;
-	};
 
 	bool isPythonStyleIndentation(LangType typeDoc) const{
 		return (typeDoc == L_PYTHON || typeDoc == L_COFFEESCRIPT || typeDoc == L_HASKELL ||\

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -817,8 +817,9 @@ public:
 	void hideLines();
 
 	bool markerMarginClick(intptr_t lineNumber);	//true if it did something
-	void notifyMarkers(Buffer * buf, bool isHide, size_t location, bool del);
-	void runMarkers(bool doHide, size_t searchStart, bool endOfDoc, bool doDelete);
+	void notifyHideMarkers(Buffer * buf, bool isHide, size_t location, bool del);
+	void hideMarkedLines(size_t searchStart, bool endOfDoc);
+	void showHiddenLines(size_t searchStart, bool endOfDoc, bool doDelete);
 	void restoreHiddenLines();
 
 	bool hasSelection() const { return !execute(SCI_GETSELECTIONEMPTY); };

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -68,8 +68,6 @@ typedef void * SCINTILLA_PTR;
 #define WM_FINDINPROJECTS           (SCINTILLA_USER + 15)
 #define WM_REPLACEINPROJECTS        (SCINTILLA_USER + 16)
 
-const int NB_FOLDER_STATE = 7;
-
 // Codepage
 const int CP_CHINESE_TRADITIONAL = 950;
 const int CP_CHINESE_SIMPLIFIED = 936;
@@ -89,9 +87,13 @@ const int CP_GREEK = 1253;
 #define LIST_7 128
 #define LIST_8 256
 
+
 const bool fold_expand = true;
 const bool fold_collapse = false;
+
+const int NB_FOLDER_STATE = 7;
 #define MAX_FOLD_COLLAPSE_LEVEL	8
+#define MAX_FOLD_LINES_MORE_THAN 99
 
 #define MODEVENTMASK_OFF 0
 
@@ -454,8 +456,7 @@ public:
 
 	void activateBuffer(BufferID buffer, bool force);
 
-	void getCurrentFoldStates(std::vector<size_t> & lineStateVector);
-	void syncFoldStateWith(const std::vector<size_t> & lineStateVectorNew);
+
 
 	void getText(char *dest, size_t start, size_t end) const;
 	void getGenericText(wchar_t *dest, size_t destlen, size_t start, size_t end) const;
@@ -775,14 +776,18 @@ public:
 			::MessageBox(_hSelf, L"This function needs a newer OS version.", L"Change Case Error", MB_OK | MB_ICONHAND);
 	};
 
+	void scrollToCaret() const noexcept;
+	void getCurrentFoldStates(std::vector<size_t> & lineStateVector);
+	void syncFoldStateWith(const std::vector<size_t> & lineStateVectorNew);
 	bool isFoldIndentationBased() const;
-	void collapseFoldIndentationBased(int level2Collapse, bool mode);
-	void collapse(int level2Collapse, bool mode);
+	void foldIndentationBasedLevel(int level, bool mode);
+	void foldLevel(int level, bool mode);
 	void foldAll(bool mode);
-	void fold(size_t line, bool mode);
+	void fold(size_t line, bool mode, bool shouldBeNotified = true);
 	bool isFolded(size_t line) const {
 		return (execute(SCI_GETFOLDEXPANDED, line) != 0);
 	};
+
 	bool isCurrentLineFolded() const;
 	void foldCurrentPos(bool mode);
 	int getCodepage() const {return _codepage;};

--- a/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
+++ b/PowerEditor/src/WinControls/DocumentMap/documentMap.cpp
@@ -293,7 +293,7 @@ void DocumentMap::doMove()
 
 void DocumentMap::fold(size_t line, bool foldOrNot)
 {
-	_pMapView->fold(line, foldOrNot);
+	_pMapView->fold(line, foldOrNot, false);
 }
 
 void DocumentMap::foldAll(bool mode)


### PR DESCRIPTION
* Use the Scintilla dedicated command SCI_FOLDALL to replace the inefficient loop for "Fold All" command.
* Fix "Fold level" & switching back to large files folding performance.
* Refactoring the hide/show lines functions.

Note that there might be a regression of URL link:
https://github.com/notepad-plus-plus/notepad-plus-plus/pull/16200/files#r1961937279

Fix #16064