### PR TITLE
When advancing after a regex match, only advance by whole characters.

### DIFF
--- a/boostregex/BoostRegExSearch.cxx
+++ b/boostregex/BoostRegExSearch.cxx
@@ -434,7 +434,7 @@ Sci::Position BoostRegexSearch::SearchParameters::nextCharacter(Sci::Position po
 	if (_skip_windows_line_end_as_one_character && _document->CharAt(position) == '\r' && _document->CharAt(position+1) == '\n')
 		return position + 2;
 	else
-		return position + 1;
+		return _document->NextPosition(position, 1);
 }
 
 bool BoostRegexSearch::SearchParameters::isLineStart(Sci::Position position)


### PR DESCRIPTION
I believe this resolves #16207 without risking any unwanted change in behavior.