### PR TITLE
Fix regression of keeping saving backup even w/o modification

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1223,6 +1223,8 @@ bool FileManager::backupCurrentBuffer()
 
 					buffer->setTabCreatedTimeStringFromBakFile();
 
+					buffer->setModifiedStatus(false);
+
 					result = true;	//all done
 				}
 			}

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1079,7 +1079,7 @@ For existing file (c:\tmp\foo.h)
 	- Editing
 	when a file starts being modified, a file will be created with name: FILENAME@CREATION_TIMESTAMP (backup\foo.h@198776)
 	the Buffer object will associate with this FILENAME@CREATION_TIMESTAMP file (backup\foo.h@198776).
-	1. sync: (each 3-5 second) backup file will be saved, if buffer is dirty, and modification is present (a bool on modified notificatin).
+	1. sync: (each N seconds) backup file will be saved, if buffer is dirty, and modification is present (a bool on modified notification).
 	2. sync: each save file, or close file, the backup file will be deleted (if buffer is not dirty).
 	3. before switch off to another tab (or close files on exit), check 1 & 2 (sync with backup).
 
@@ -1097,7 +1097,7 @@ For untitled document (new  4)
 	- Editing
 	when a untitled document starts being modified, a backup file will be created with name: UNTITLED_NAME@CREATION_TIMESTAMP (backup\new  4@198776)
 	the Buffer object will associate with this UNTITLED_NAME@CREATION_TIMESTAMP file (backup\new  4@198776).
-	1. sync: (each 3-5 second) backup file will be saved, if buffer is dirty, and modification is present (a bool on modified notificatin).
+	1. sync: (each N seconds) backup file will be saved, if buffer is dirty, and modification is present (a bool on modified notification).
 	2. sync: if untitled document is saved, or closed, the backup file will be deleted.
 	3. before switch off to another tab (or close documents on exit), check 1 & 2 (sync with backup).
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1079,7 +1079,7 @@ For existing file (c:\tmp\foo.h)
 	- Editing
 	when a file starts being modified, a file will be created with name: FILENAME@CREATION_TIMESTAMP (backup\foo.h@198776)
 	the Buffer object will associate with this FILENAME@CREATION_TIMESTAMP file (backup\foo.h@198776).
-	1. sync: (each N seconds) backup file will be saved, if buffer is dirty, and modification is present (a bool on modified notification).
+	1. sync: (every N seconds) the backup file will be saved if the buffer is dirty and modifications are present. A boolean flag is set to true upon modification notification, and it's set to false after the backup file is saved.
 	2. sync: each save file, or close file, the backup file will be deleted (if buffer is not dirty).
 	3. before switch off to another tab (or close files on exit), check 1 & 2 (sync with backup).
 
@@ -1088,22 +1088,22 @@ For existing file (c:\tmp\foo.h)
 	1. track FILENAME@CREATION_TIMESTAMP (backup\foo.h@198776) if exist (in session.xml).
 	2. track last modified timestamp of FILENAME (c:\tmp\foo.h) if FILENAME@CREATION_TIMESTAMP (backup\foo.h@198776) was tracked  (in session.xml).
 
-For untitled document (new  4)
+For untitled document (new 4)
 	- Open
 	In the next session, Notepad++
-	1. open file UNTITLED_NAME@CREATION_TIMESTAMP (backup\new  4@198776)
-	2. set label as UNTITLED_NAME (new  4) and disk icon as red.
+	1. open file UNTITLED_NAME@CREATION_TIMESTAMP (backup\new 4@198776)
+	2. set label as UNTITLED_NAME (new 4) and disk icon as red.
 
 	- Editing
-	when a untitled document starts being modified, a backup file will be created with name: UNTITLED_NAME@CREATION_TIMESTAMP (backup\new  4@198776)
-	the Buffer object will associate with this UNTITLED_NAME@CREATION_TIMESTAMP file (backup\new  4@198776).
-	1. sync: (each N seconds) backup file will be saved, if buffer is dirty, and modification is present (a bool on modified notification).
+	when a untitled document starts being modified, a backup file will be created with name: UNTITLED_NAME@CREATION_TIMESTAMP (backup\new 4@198776)
+	the Buffer object will associate with this UNTITLED_NAME@CREATION_TIMESTAMP file (backup\new 4@198776).
+	1. Sync: (every N seconds) the backup file will be saved if the buffer is dirty and modifications are present. A boolean flag is set to true upon modification notification, and it's set to false after the backup file is saved.
 	2. sync: if untitled document is saved, or closed, the backup file will be deleted.
 	3. before switch off to another tab (or close documents on exit), check 1 & 2 (sync with backup).
 
-	- CLOSE
+	- Close
 	In the current session, Notepad++
-	1. track UNTITLED_NAME@CREATION_TIMESTAMP (backup\new  4@198776) in session.xml.
+	1. track UNTITLED_NAME@CREATION_TIMESTAMP (backup\new 4@198776) in session.xml.
 */
 
 std::mutex backup_mutex;
@@ -1247,14 +1247,11 @@ bool FileManager::backupCurrentBuffer()
 			// Session changes, save it
 			hasModifForSession = true;
 		}
-		//printStr(L"backup deleted in backupCurrentBuffer"));
 		result = true; // no backup file to delete
 	}
-	//printStr(L"backup sync"));
 
 	if (result && hasModifForSession)
 	{
-		//printStr(buffer->getBackupFileName().c_str());
 		_pNotepadPlus->saveCurrentSession();
 	}
 	return result;


### PR DESCRIPTION
The regression was introduced by commit fc051a1231065731205ff5e315684ce3bfb19033
v8.7 is OK. The regression is from v8.7.1 to v8.7.7. 

Fix #16186