### PR TITLE
Synchronize FunctionList panel with the current tab/buffer syntax set

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6737,7 +6737,7 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 		else if (_subEditView.getCurrentBuffer() == buffer)
 			_autoCompleteSub.setLanguage(buffer->getLangType());
 
-		if (_pFuncList)
+		if (_pFuncList && (!_pFuncList->isClosed()) && _pFuncList->isVisible())
 			_pFuncList->reload(); // sync FL with the current buffer lang
 
 		SCNotification scnN{};

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6737,6 +6737,9 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 		else if (_subEditView.getCurrentBuffer() == buffer)
 			_autoCompleteSub.setLanguage(buffer->getLangType());
 
+		if (_pFuncList)
+			_pFuncList->reload(); // sync FL with the current buffer lang
+
 		SCNotification scnN{};
 		scnN.nmhdr.code = NPPN_LANGCHANGED;
 		scnN.nmhdr.hwndFrom = _pPublicInterface->getHSelf();


### PR DESCRIPTION
Fix #16221    (issue needs a renaming because the fixed shortcoming was not specific to the UDL only...)

Ensures automatic FunctionList panel switching to the currently used tab/buffer lang.

Before, the FL remained populated according to the previously used lang, even if the user switched to a different one (standard or UDL, it does not matter). In such a case a manual FL-reload/re-init was needed (STR: Load e.g. a cpp-file, show the FL and then switch lang to something else - the FL will incorrectly keep the previous cpp-stuff, only clicking on the FL reload-button then helps...)