### PR TITLE
Fix syntax hiliting err while switch lang on untitled doc regression

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -1721,7 +1721,7 @@ void ScintillaEditView::setLanguage(LangType langType)
 {
 	unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
 
-	if (_currentBuffer->getLastLangType() > 0)
+	if (_currentBuffer->getLastLangType() > 0 && !_currentBuffer->isUntitled())
 	{
 		saveCurrentPos();
 		Document prev = execute(SCI_GETDOCPOINTER);


### PR DESCRIPTION
The regression was introduced by commit b2152d983e3b20aed7f687ba1d9e916ae6065b24

Fix #16250