### PR TITLE
Fix invalid dot-char(s) handling in unsupported filenames checking

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1530,9 +1530,15 @@ bool isUnsupportedFileName(const wstring& fileName)
 
 			if (!invalidASCIIChar)
 			{
-				// strip input string to a filename without a possible path
-				wstring fileNameOnly = fileName;
-				size_t pos = fileNameOnly.find_last_of(L"\\");
+				// strip input string to a filename without a possible path and the last extension
+				wstring fileNameOnly;
+				size_t pos = fileName.rfind(L".");
+				if (pos != std::string::npos)
+					fileNameOnly = fileName.substr(0, pos);
+				else
+					fileNameOnly = fileName;
+
+				pos = fileNameOnly.find_last_of(L"\\");
 				if (pos == std::string::npos)
 					pos = fileNameOnly.find_last_of(L"/");
 				if (pos != std::string::npos)

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1530,15 +1530,9 @@ bool isUnsupportedFileName(const wstring& fileName)
 
 			if (!invalidASCIIChar)
 			{
-				// strip input string to a filename without a possible path and the last extension
-				wstring fileNameOnly;
-				size_t pos = fileName.rfind(L".");
-				if (pos != std::string::npos)
-					fileNameOnly = fileName.substr(0, pos);
-				else
-					fileNameOnly = fileName;
-
-				pos = fileNameOnly.find_last_of(L"\\");
+				// strip input string to a filename without a possible path
+				wstring fileNameOnly = fileName;
+				size_t pos = fileNameOnly.find_last_of(L"\\");
 				if (pos == std::string::npos)
 					pos = fileNameOnly.find_last_of(L"/");
 				if (pos != std::string::npos)

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1530,15 +1530,14 @@ bool isUnsupportedFileName(const wstring& fileName)
 
 			if (!invalidASCIIChar)
 			{
-				// strip input string to a filename without a possible path and the last extension
+				// strip input string to a filename without a possible path and/or ending dot-char
 				wstring fileNameOnly;
-				size_t pos = fileName.rfind(L".");
-				if (pos != std::string::npos)
-					fileNameOnly = fileName.substr(0, pos);
+				if (fileName.ends_with(L'.'))
+					fileNameOnly = fileName.substr(0, fileName.rfind(L"."));
 				else
 					fileNameOnly = fileName;
 
-				pos = fileNameOnly.find_last_of(L"\\");
+				size_t pos = fileNameOnly.find_last_of(L"\\");
 				if (pos == std::string::npos)
 					pos = fileNameOnly.find_last_of(L"/");
 				if (pos != std::string::npos)

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1530,9 +1530,9 @@ bool isUnsupportedFileName(const wstring& fileName)
 
 			if (!invalidASCIIChar)
 			{
-				// strip input string to a filename without a possible path and extension(s)
+				// strip input string to a filename without a possible path and the last extension
 				wstring fileNameOnly;
-				size_t pos = fileName.find_first_of(L".");
+				size_t pos = fileName.rfind(L".");
 				if (pos != std::string::npos)
 					fileNameOnly = fileName.substr(0, pos);
 				else


### PR DESCRIPTION
Fix #16328 .

Previously, not even the filenames like 'con.1.txt' was incorrectly flagged as unsupported (it was considered as the Win32 reserved name 'con' instead of the right 'con.1'), but when a fullfilename with path contained a folder with a dot-char(s) within, the remaining part of the path was stripped down during comparison instead of the file extension only.