### PR TITLE
Fix default installation setting for preventing control characters input

### DIFF
--- a/PowerEditor/src/config.4zipPackage.xml
+++ b/PowerEditor/src/config.4zipPackage.xml
@@ -39,7 +39,7 @@
         <GUIConfig name="MISC" fileSwitcherWithoutExtColumn="no" backSlashIsEscapeCharacterForSql="yes" newStyleSaveDlg="yes" isFolderDroppedOpenFiles="no" docPeekOnTab="no" docPeekOnMap="no" />
         <GUIConfig name="searchEngine" searchEngineChoice="2" searchEngineCustom="" />
         <GUIConfig name="SmartHighLight" matchCase="no" wholeWordOnly="yes" useFindSettings="no" onAnotherView="no">yes</GUIConfig>
-        <GUIConfig name="ScintillaPrimaryView" lineNumberMargin="show" bookMarkMargin="show" indentGuideLine="show" folderMarkStyle="box" lineWrapMethod="aligned" currentLineHilitingShow="show" scrollBeyondLastLine="no" disableAdvancedScrolling="no" wrapSymbolShow="hide" Wrap="no" borderEdge="yes" edge="no" edgeNbColumn="80" zoom="0" zoom2="0" whiteSpaceShow="hide" eolShow="hide" borderWidth="2" smoothFont="no" />
+        <GUIConfig name="ScintillaPrimaryView" lineNumberMargin="show" bookMarkMargin="show" indentGuideLine="show" folderMarkStyle="box" lineWrapMethod="aligned" currentLineHilitingShow="show" scrollBeyondLastLine="no" disableAdvancedScrolling="no" wrapSymbolShow="hide" Wrap="no" borderEdge="yes" edge="no" edgeNbColumn="80" zoom="0" zoom2="0" whiteSpaceShow="hide" eolShow="hide" npcNoInputC0="yes" borderWidth="2" smoothFont="no" />
         <GUIConfig name="DockingManager" leftWidth="200" rightWidth="200" topHeight="200" bottomHeight="200">
             <ActiveTabs cont="0" activeTab="-1" />
             <ActiveTabs cont="1" activeTab="-1" />


### PR DESCRIPTION
Fix #16326 , Fix #15839 , Fix #15729
(fix for commit https://github.com/notepad-plus-plus/notepad-plus-plus/commit/35deb8a303cbe6f2d4902c0aed1ab0ed17c749e7#diff-d2f976c2d1c54b02bc8170fb05a99a96e30c9554abbdb4de60fe39d57b437406R970 )

Before, a missing `npcNoInputC0` config.xml entry caused the feature to incorrectly reset to `false/no` (the default for any missing config.xml boolean setting) during the first launch of the Notepad++. This caused that the intended default ON for the Preferences > Editing 2 > 'Prevent control character (C0 code) typing into document' checkbox has been reset.