### PR TITLE
Update CMakeLists.txt to make the cmake build runnable again

### DIFF
--- a/PowerEditor/src/CMakeLists.txt
+++ b/PowerEditor/src/CMakeLists.txt
@@ -7,7 +7,7 @@
 #   not optimal.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 PROJECT(Notepad++)
 

--- a/PowerEditor/src/CMakeLists.txt
+++ b/PowerEditor/src/CMakeLists.txt
@@ -7,7 +7,7 @@
 #   not optimal.
 #
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 PROJECT(Notepad++)
 


### PR DESCRIPTION
Update CMakeLists.txt to cmake_minimum_required(VERSION 3.10) to make the cmake build runnable again. For reference see pull request #16354 of @ozone10.

CMake build is broken since build environment was updated to CMake version 4.0.0 which removed compatibility for CMake versions below 3.5.

Set minimum required version to 3.10 since CMake from version 3.31 onwards issues already a warning for versions below 3.10. With 3.10 we also avoid this warning. Further reference: [CMake Documentation for cmake_minimum_required](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)
`cmake_minimum_required(VERSION 3.10)`

See details in [#16354 (comment)](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/16354#issuecomment-2771584139)
