### PR TITLE
Fix a significant error (causes a hang) in PR 16208.

### DIFF
--- a/boostregex/BoostRegExSearch.cxx
+++ b/boostregex/BoostRegExSearch.cxx
@@ -437,7 +437,7 @@ Sci::Position BoostRegexSearch::SearchParameters::nextCharacter(Sci::Position po
 	if (_skip_windows_line_end_as_one_character && _document->CharAt(position) == '\r' && _document->CharAt(position+1) == '\n')
 		return position + 2;
 	else
-		return _document->NextPosition(position, 1);
+		return std::max(_document->NextPosition(position, 1), position + 1);
 }
 
 bool BoostRegexSearch::SearchParameters::isLineStart(Sci::Position position) const


### PR DESCRIPTION
The fix applied in PR #16208 to avoid a hang when using certain regular expressions with certain data resolved that issue but created a new one. Prior to PR #16208, when called (after a zero-length match at the end of the document) with the length of the document as argument, BoostRegexSearch::SearchParameters::nextCharacter returned one greater than the length of the document. PR #16208 did not account for that, and it fails to advance the match position after a zero-length match at the end of the document, thus causing an infinite loop. This change fixes that by assuring that when BoostRegexSearch::SearchParameters::nextCharacter is called, the return is always at least one greater than the argument. This will avoid the end-of-document failure while preserving the correct behavior in the cases PR #16208 fixed.