### PR TITLE
Fix Find dialog status text too left visual glitch

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4152,7 +4152,7 @@ void FindReplaceDlg::saveInMacro(size_t cmd, int cmdType)
 	::SendMessage(_hParent, WM_FRSAVE_INT, IDC_FRCOMMAND_EXEC, cmd);
 }
 
-void FindReplaceDlg::setStatusbarMessage(const wstring & msg, FindStatus staus, const wstring& tooltipMsg)
+void FindReplaceDlg::setStatusbarMessage(const wstring & msg, FindStatus status, const wstring& tooltipMsg)
 {
 	if (_statusbarTooltipWnd)
 	{
@@ -4162,7 +4162,7 @@ void FindReplaceDlg::setStatusbarMessage(const wstring & msg, FindStatus staus, 
 
 	_statusbarTooltipMsg = tooltipMsg;
 
-	if (staus == FSNotFound)
+	if (status == FSNotFound)
 	{
 		if (!NppParameters::getInstance().getNppGUI()._muteSounds)
 			::MessageBeep(0xFFFFFFFF);
@@ -4175,7 +4175,7 @@ void FindReplaceDlg::setStatusbarMessage(const wstring & msg, FindStatus staus, 
 		flashInfo.dwFlags = FLASHW_ALL;
 		FlashWindowEx(&flashInfo);
 	}
-	else if (staus == FSTopReached || staus == FSEndReached)
+	else if (status == FSTopReached || status == FSEndReached)
 	{
 		if (!isVisible())
 		{
@@ -4191,8 +4191,17 @@ void FindReplaceDlg::setStatusbarMessage(const wstring & msg, FindStatus staus, 
 
 	if (isVisible())
 	{
-		_statusbarFindStatus = staus;
-		_statusBar.setOwnerDrawText(msg.c_str());
+		_statusbarFindStatus = status;
+		if ((msg.length() > 0) && (msg.at(0) != L' '))
+		{
+			// fix visual glitch (text is visible, but positioned too far to the left)
+			wstring msgSpaceIndented = L' ' + msg;
+			_statusBar.setOwnerDrawText(msgSpaceIndented.c_str());
+		}
+		else
+		{
+			_statusBar.setOwnerDrawText(msg.c_str());
+		}
 	}
 }
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -405,7 +405,7 @@ public :
 
 	void execSavedCommand(int cmd, uptr_t intValue, const std::wstring& stringValue);
 	void clearMarks(const FindOption& opt);
-	void setStatusbarMessage(const std::wstring & msg, FindStatus staus, const std::wstring& tooltipMsg = L"");
+	void setStatusbarMessage(const std::wstring & msg, FindStatus status, const std::wstring& tooltipMsg = L"");
 	void setStatusbarMessageWithRegExprErr(ScintillaEditView* pEditView);
 	std::wstring getScopeInfoForStatusBar(FindOption const *pFindOpt) const;
 	Finder * createFinder();


### PR DESCRIPTION
Fix #16359 .

Text was visible but positioned too left. This visual glitch was accented in Windows 11 due to its rounding-wnd-corners effect.
STR and glitch/fix screenshots in the issue.