### PR TITLE
Fix disabled Paste command with no previous text-data in clipboard

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -379,6 +379,7 @@ void Notepad_plus::command(int id)
 			{
 				::SendMessage(focusedHwnd, WM_CUT, 0, 0);
 			}
+			checkClipboard(); // for enabling possible Paste command
 			break;
 		}
 
@@ -404,9 +405,7 @@ void Notepad_plus::command(int id)
 				else
 					::SendMessage(focusedHwnd, WM_COPY, 0, 0);
 			}
-
-			checkClipboard(); // for enabling possible Paste command (otherwise a Notepad++ editor activity or focus switching was needed)
-
+			checkClipboard(); // for enabling possible Paste command
 			break;
 		}
 
@@ -500,6 +499,8 @@ void Notepad_plus::command(int id)
 
 			if (id == IDM_EDIT_CUT_BINARY)
 				_pEditView->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
+
+			checkClipboard(); // for enabling possible Paste command
 		}
 		break;
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -395,7 +395,6 @@ void Notepad_plus::command(int id)
 				{
 					_pEditView->execute(SCI_COPYALLOWLINE); // Copy without selected text, it will copy the whole line with EOL, for pasting before any line where the caret is.
 				}
-
 			}
 			else
 			{
@@ -405,6 +404,8 @@ void Notepad_plus::command(int id)
 				else
 					::SendMessage(focusedHwnd, WM_COPY, 0, 0);
 			}
+
+			checkClipboard(); // for enabling possible Paste command (otherwise a Notepad++ editor activity or focus switching was needed)
 
 			break;
 		}


### PR DESCRIPTION
Fix #16456

Previously, a Notepad++ editor user activity or focus switching was needed to allow for eventual Pasting of data from the clipboard after a previous successful Copy command (when the clipboard did not contain any previous text-data).

STR: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16456#issuecomment-2821646963