### PR TITLE
Fix: Block Uncomment functionality removes comment tags even with quotes

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -8726,6 +8726,8 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 
 	_pEditView->execute(SCI_BEGINUNDOACTION);
 
+	LangType lang = buf->getLangType();
+
 	// do as long as stream-comments are within selection
 	do
 	{
@@ -8756,9 +8758,17 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		//-- When searching upwards the start-position for searching must be moved one after the current position
 		//   to find a search-string just starting before the current position!
 		//-- Direction DIR_UP ---
-		posStartCommentBefore[iSelStart] = _pEditView->searchInTarget(start_comment.c_str(), start_comment_length, selectionStart, 0);
+		if (lang == L_HTML)
+		{
+			posStartCommentBefore[iSelStart] = _pEditView->searchInHtml(start_comment.c_str(), 0, selectionStart, true);
+			posEndCommentBefore[iSelStart] = _pEditView->searchInHtml(end_comment.c_str(), 0, selectionStart, true);
+		}
+		else 
+		{
+			posStartCommentBefore[iSelStart] = _pEditView->searchInTarget(start_comment.c_str(), start_comment_length, selectionStart, 0);
+			posEndCommentBefore[iSelStart] = _pEditView->searchInTarget(end_comment.c_str(), end_comment_length, selectionStart, 0);
+		}
 		(posStartCommentBefore[iSelStart] == -1 ? blnStartCommentBefore[iSelStart] = false : blnStartCommentBefore[iSelStart] = true);
-		posEndCommentBefore[iSelStart] = _pEditView->searchInTarget(end_comment.c_str(), end_comment_length, selectionStart, 0);
 		(posEndCommentBefore[iSelStart] == -1 ? blnEndCommentBefore[iSelStart] = false : blnEndCommentBefore[iSelStart] = true);
 		//-- Direction DIR_DOWN ---
 		posStartCommentAfter[iSelStart] = _pEditView->searchInTarget(start_comment.c_str(), start_comment_length, selectionStart, docLength);
@@ -8781,10 +8791,19 @@ bool Notepad_plus::undoStreamComment(bool tryBlockComment)
 		{
 			//-- Find all start- and end-comments before and after the selectionEnd position.
 			//-- Direction DIR_UP ---
-			posStartCommentBefore[iSelEnd] = _pEditView->searchInTarget(start_comment.c_str(), start_comment_length, selectionEnd, 0);
+			if (lang == L_HTML)
+			{
+				posStartCommentBefore[iSelEnd] = _pEditView->searchInHtml(start_comment.c_str(), 0, selectionEnd, true);
+				posEndCommentBefore[iSelEnd] = _pEditView->searchInHtml(end_comment.c_str(), 0, selectionEnd, true);
+			}
+			else
+			{
+				posStartCommentBefore[iSelEnd] = _pEditView->searchInTarget(start_comment.c_str(), start_comment_length, selectionEnd, 0);
+				posEndCommentBefore[iSelEnd] = _pEditView->searchInTarget(end_comment.c_str(), end_comment_length, selectionEnd, 0);
+			}
 			(posStartCommentBefore[iSelEnd] == -1 ? blnStartCommentBefore[iSelEnd] = false : blnStartCommentBefore[iSelEnd] = true);
-			posEndCommentBefore[iSelEnd] = _pEditView->searchInTarget(end_comment.c_str(), end_comment_length, selectionEnd, 0);
 			(posEndCommentBefore[iSelEnd] == -1 ? blnEndCommentBefore[iSelEnd] = false : blnEndCommentBefore[iSelEnd] = true);
+
 			//-- Direction DIR_DOWN ---
 			posStartCommentAfter[iSelEnd] = _pEditView->searchInTarget(start_comment.c_str(), start_comment_length, selectionEnd, docLength);
 			(posStartCommentAfter[iSelEnd] == -1 ? blnStartCommentAfter[iSelEnd] = false : blnStartCommentAfter[iSelEnd] = true);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2774,7 +2774,6 @@ wchar_t * ScintillaEditView::getGenericSelectedText(wchar_t * txt, int size, boo
 intptr_t ScintillaEditView::searchInTarget(const wchar_t * text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const
 {
 	execute(SCI_SETTARGETRANGE, fromPos, toPos);
-
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	size_t cp = execute(SCI_GETCODEPAGE);
 	const char *text2FindA = wmc.wchar2char(text2Find, cp);
@@ -2782,6 +2781,48 @@ intptr_t ScintillaEditView::searchInTarget(const wchar_t * text2Find, size_t len
    	size_t len = (lenOfText2Find > text2FindALen) ? lenOfText2Find : text2FindALen;
 	return execute(SCI_SEARCHINTARGET, len, reinterpret_cast<LPARAM>(text2FindA));
 }
+
+intptr_t ScintillaEditView::searchInHtml(const wchar_t* text2Find,size_t fromPos,size_t toPos,bool reverse) const
+{
+	// Convert types for efficient runtime
+	std::wstring wstr = text2Find;
+	int size_needed = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
+	std::string utf8Str(size_needed, 0);
+	WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &utf8Str[0], size_needed, nullptr, nullptr);
+	if (!utf8Str.c_str())
+	{
+		return -1;
+	}
+	// Do a search for the pattern
+	Sci_TextToFind ttf;
+	ttf.chrg.cpMin = static_cast<Sci_PositionCR>(fromPos);
+	ttf.chrg.cpMax = static_cast<Sci_PositionCR>(toPos);
+	ttf.lpstrText = const_cast<char*>(utf8Str.c_str()); 
+	intptr_t result = -1;
+	if (!reverse) {
+		result = execute(SCI_FINDTEXT, 0, reinterpret_cast<LPARAM>(&ttf));
+	}
+	else {
+		intptr_t lastMatch = -1;
+		size_t curEnd = toPos;
+		while (curEnd > fromPos)
+		{
+			ttf.chrg.cpMin = static_cast<Sci_PositionCR>(fromPos);
+			ttf.chrg.cpMax = static_cast<Sci_PositionCR>(curEnd);
+			intptr_t foundPos = execute(SCI_FINDTEXT, 0, reinterpret_cast<LPARAM>(&ttf));
+			intptr_t curr = curEnd;
+			if (foundPos == -1 || foundPos >= curr)
+			{
+				break;
+			}
+			lastMatch = foundPos;
+			fromPos = lastMatch+1;
+		}
+		result = lastMatch;
+	}
+	return result;
+}
+
 
 void ScintillaEditView::appandGenericText(const wchar_t * text2Append) const
 {

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -471,7 +471,8 @@ public:
     char * getWordOnCaretPos(char * txt, size_t size);
     wchar_t * getGenericWordOnCaretPos(wchar_t * txt, int size);
 	wchar_t * getGenericSelectedText(wchar_t * txt, int size, bool expand = true);
-	intptr_t searchInTarget(const wchar_t * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
+	intptr_t searchInTarget(const wchar_t * text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;
+	intptr_t searchInHtml(const wchar_t* text2Find, size_t fromPos, size_t toPos, bool reverse) const;
 	void appandGenericText(const wchar_t * text2Append) const;
 	void addGenericText(const wchar_t * text2Append) const;
 	void addGenericText(const wchar_t * text2Append, intptr_t* mstart, intptr_t* mend) const;


### PR DESCRIPTION
Bug #15914 
Fixing block uncomment functionality for HTML tags, adding in a method and some new conditional checks.