### PR TITLE
[xml] fix wrong toolbar-accent-tip in German

### DIFF
--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -1883,7 +1883,7 @@ Wenn diese 'Intelligente Einrückung' gewählt wird, aber keine Dateien in den o
 			<statusbar-Pos value="Pos: "/>
 			<statusbar-Sel value="Gew: "/>
 			<statusbar-Sel-number value="Gew"/>
-			<toolbar-accent-tip value="Mit dieser Option werden die Symbolleistensymbole der Akzentfarbe des Windows-Systems angepasst. Die Akzentfarbe ist die Farbe, mit der Schaltflächen, Rahmen und Startmenükacheln in Windows hervorgehoben werden. Um sie zu ändern, gehen Sie zu Einstellungen &gt; Optionen &gt; Farben und wählen Sie dann Ihre bevorzugte Akzentfarbe."/>
+			<toolbar-accent-tip value="Mit dieser Option werden die Symbolleistensymbole der Akzentfarbe des Windows-Systems angepasst. Die Akzentfarbe ist die Farbe, mit der Schaltflächen, Rahmen und Startmenükacheln in Windows hervorgehoben werden. Um sie zu ändern, gehen Sie zu Einstellungen &gt; Personalisierung &gt; Farben und wählen Sie dann Ihre bevorzugte Akzentfarbe."/>
 		</MiscStrings>
 	</Native-Langue>
 </NotepadPlus>


### PR DESCRIPTION
The Windows settings in German are named "Einstellungen > Personalisierung > Farben", not "Einstellungen > Optionen > Farben". Probably @schnurlos thought the Notepad++ settings were meant in the tooltip.
![grafik](https://github.com/user-attachments/assets/19a575e2-f09f-4e1f-bd15-b706ce7e6265)