### PR TITLE
ShortcutMapper: fix active shortcut index

### DIFF
--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -553,6 +553,7 @@ intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPar
 
 			// while buiding the IDC_KEY_COMBO keys, update the map to which VirtualKey is used for each index
 			int iFound = -1;
+			oemVkUsedIDs.clear();	// the logic below (always pushing onto the vector) requires that it starts fresh every time, otherwise it will grow every time the dialog is launched
 			for (size_t i = 0 ; i < nbKeys ; ++i)
 			{
 				const char* nameStr = namedKeyArray[i].name;
@@ -571,7 +572,7 @@ intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPar
 				}
 
 				if (_keyCombo._key == namedKeyArray[i].id)
-					iFound = static_cast<int32_t>(oemVkUsedIDs.size());
+					iFound = static_cast<int32_t>(oemVkUsedIDs.size()-1);	// -1 because it's already been added, so the most recent index of oemVkUsedIDs is 1 less than the length
 			}
 
 			if (iFound != -1)
@@ -1243,6 +1244,7 @@ intptr_t CALLBACK ScintillaKeyMap::run_dlgProc(UINT Message, WPARAM wParam, LPAR
 
 			::SetDlgItemText(_hSelf, IDC_NAME_EDIT, string2wstring(_name, CP_UTF8).c_str());
 			_keyCombo = _keyCombos[0];
+			oemVkUsedIDs.clear();	// the logic below (always pushing onto the vector) requires that it starts fresh every time, otherwise it will grow every time the dialog is launched
 
 			for (size_t i = 0 ; i < nbKeys ; ++i)
 			{

--- a/PowerEditor/src/WinControls/shortcut/shortcut.cpp
+++ b/PowerEditor/src/WinControls/shortcut/shortcut.cpp
@@ -572,7 +572,7 @@ intptr_t CALLBACK Shortcut::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPar
 				}
 
 				if (_keyCombo._key == namedKeyArray[i].id)
-					iFound = static_cast<int32_t>(oemVkUsedIDs.size()-1);	// -1 because it's already been added, so the most recent index of oemVkUsedIDs is 1 less than the length
+					iFound = static_cast<int32_t>(oemVkUsedIDs.size())-1;	// -1 because it's already been added, so the most recent index of oemVkUsedIDs is 1 less than the length
 			}
 
 			if (iFound != -1)


### PR DESCRIPTION
- there was off-by-1 when building the oemVkUsedIDs vector, which was caused by using the index based on .size() instead of .size()-1 to get the most-recently-added

- also cleared the vector each launch of the dialog, because the .push_back() was causing the vector to grow without bounds, messing up the indexing on subsequent runs of the dialog, causing it to pick _none_ of the entries

fixes #16491 