### PR TITLE
Fix an unresponsive issue due to hide lines

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -3880,6 +3880,9 @@ void Notepad_plus::setLanguage(LangType langType)
 	{
 		(_pEditView->getCurrentBuffer())->setLangType(langType);
 	}
+
+
+	_pEditView->restoreHiddenLines();
 }
 
 LangType Notepad_plus::menuID2LangType(int cmdID)

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -4266,17 +4266,31 @@ void ScintillaEditView::restoreHiddenLines()
 
 	while (line != -1)
 	{
-		line = static_cast<int>(execute(SCI_MARKERNEXT, line, 1 << MARK_HIDELINESBEGIN));
-		
-		if (line != -1)
-		{
-			int startHiding = line + 1;
-			line = static_cast<int>(execute(SCI_MARKERNEXT, line, 1 << MARK_HIDELINESEND));
+		int lineBegin = static_cast<int>(execute(SCI_MARKERNEXT, line, 1 << MARK_HIDELINESBEGIN));
+		int lineEnd = static_cast<int>(execute(SCI_MARKERNEXT, line, 1 << MARK_HIDELINESEND));
 
-			if (line != -1)
-			{
-				execute(SCI_HIDELINES, startHiding, line - 1);
-			}
+		if (lineBegin != -1 && lineEnd != -1 && lineBegin != lineEnd)
+		{
+			execute(SCI_HIDELINES, lineBegin + 1, lineEnd - 1);
+			
+			// Check if the end mark & the begin mark are on the same line
+			lineBegin = static_cast<int>(execute(SCI_MARKERNEXT, lineEnd, 1 << MARK_HIDELINESBEGIN));
+			lineEnd = static_cast<int>(execute(SCI_MARKERNEXT, lineEnd, 1 << MARK_HIDELINESEND));
+			
+			line = lineEnd + ((lineBegin == lineEnd) ? 0 : 1);
+		}
+		else if (lineBegin != -1 && lineEnd != -1 && lineBegin == lineEnd) // The end mark & the begin mark are on the same line
+		{
+			lineEnd = static_cast<int>(execute(SCI_MARKERNEXT, line + 1, 1 << MARK_HIDELINESEND));
+
+			if (lineEnd != -1)
+				execute(SCI_HIDELINES, lineBegin + 1, lineEnd - 1);
+
+			line = lineEnd;
+		}
+		else // one of (or both) lineBegin & lineEnd cannot be found - let's get out here
+		{
+			line = -1;
 		}
 	}
 }


### PR DESCRIPTION
Fix switching back to document which has processed hide lines makes Notepad++ unresponsive due to an infinite loop.
Fix also setting language makes hiding lines unhidden issue.

Fix #16316