### PR TITLE
Avoid usage of non FULL scintilla interfaces

### DIFF
--- a/scintilla/include/Scintilla.h
+++ b/scintilla/include/Scintilla.h
@@ -62,7 +62,9 @@ typedef sptr_t (*SciFnDirectStatus)(sptr_t ptr, unsigned int iMessage, uptr_t wP
 #define SCI_SETUNDOCOLLECTION 2012
 #define SCI_SELECTALL 2013
 #define SCI_SETSAVEPOINT 2014
-#define SCI_GETSTYLEDTEXT 2015
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL,SCI_GETSTYLEDTEXTFULL and SCI_FORMATRANGEFULL and corresponding defines/structs
+//#define SCI_GETSTYLEDTEXT 2015
 #define SCI_GETSTYLEDTEXTFULL 2778
 #define SCI_CANREDO 2016
 #define SCI_MARKERLINEFROMHANDLE 2017
@@ -523,9 +525,13 @@ typedef sptr_t (*SciFnDirectStatus)(sptr_t ptr, unsigned int iMessage, uptr_t wP
 #define SCFIND_REGEXP 0x00200000
 #define SCFIND_POSIX 0x00400000
 #define SCFIND_CXX11REGEX 0x00800000
-#define SCI_FINDTEXT 2150
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL,SCI_GETSTYLEDTEXTFULL and SCI_FORMATRANGEFULL and corresponding defines/structs
+//#define SCI_FINDTEXT 2150
 #define SCI_FINDTEXTFULL 2196
-#define SCI_FORMATRANGE 2151
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL,SCI_GETSTYLEDTEXTFULL and SCI_FORMATRANGEFULL and corresponding defines/structs
+//#define SCI_FORMATRANGE 2151
 #define SCI_FORMATRANGEFULL 2777
 #define SC_CHANGE_HISTORY_DISABLED 0
 #define SC_CHANGE_HISTORY_ENABLED 1
@@ -550,7 +556,9 @@ typedef sptr_t (*SciFnDirectStatus)(sptr_t ptr, unsigned int iMessage, uptr_t wP
 #define SCI_GETMODIFY 2159
 #define SCI_SETSEL 2160
 #define SCI_GETSELTEXT 2161
-#define SCI_GETTEXTRANGE 2162
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL,SCI_GETSTYLEDTEXTFULL and SCI_FORMATRANGEFULL and corresponding defines/structs
+//#define SCI_GETTEXTRANGE 2162
 #define SCI_GETTEXTRANGEFULL 2039
 #define SCI_HIDESELECTION 2163
 #define SCI_GETSELECTIONHIDDEN 2088
@@ -1344,31 +1352,37 @@ typedef sptr_t (*SciFnDirectStatus)(sptr_t ptr, unsigned int iMessage, uptr_t wP
  * CHARRANGE, TEXTRANGE, FINDTEXTEX, FORMATRANGE, and NMHDR structs.
  * So older code that treats Scintilla as a RichEdit will work. */
 
-struct Sci_CharacterRange {
-	Sci_PositionCR cpMin;
-	Sci_PositionCR cpMax;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_CharacterRange {
+//	Sci_PositionCR cpMin;
+//	Sci_PositionCR cpMax;
+//};
 
 struct Sci_CharacterRangeFull {
 	Sci_Position cpMin;
 	Sci_Position cpMax;
 };
 
-struct Sci_TextRange {
-	struct Sci_CharacterRange chrg;
-	char *lpstrText;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_TextRange {
+//	struct Sci_CharacterRange chrg;
+//	char *lpstrText;
+//};
 
 struct Sci_TextRangeFull {
 	struct Sci_CharacterRangeFull chrg;
 	char *lpstrText;
 };
 
-struct Sci_TextToFind {
-	struct Sci_CharacterRange chrg;
-	const char *lpstrText;
-	struct Sci_CharacterRange chrgText;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_TextToFind {
+//	struct Sci_CharacterRange chrg;
+//	const char *lpstrText;
+//	struct Sci_CharacterRange chrgText;
+//};
 
 struct Sci_TextToFindFull {
 	struct Sci_CharacterRangeFull chrg;
@@ -1388,13 +1402,15 @@ struct Sci_Rectangle {
 /* This structure is used in printing and requires some of the graphics types
  * from Platform.h.  Not needed by most client code. */
 
-struct Sci_RangeToFormat {
-	Sci_SurfaceID hdc;
-	Sci_SurfaceID hdcTarget;
-	struct Sci_Rectangle rc;
-	struct Sci_Rectangle rcPage;
-	struct Sci_CharacterRange chrg;
-};
+//deprecated by N++ 2GB+ support via new scintilla interfaces from 5.2.3 (see https://www.scintilla.org/ScintillaHistory.html), 
+//please use SCI_GETTEXTRANGEFULL, SCI_FINDTEXTFULL, and SCI_FORMATRANGEFULL and corresponding defines/structs
+//struct Sci_RangeToFormat {
+//	Sci_SurfaceID hdc;
+//	Sci_SurfaceID hdcTarget;
+//	struct Sci_Rectangle rc;
+//	struct Sci_Rectangle rcPage;
+//	struct Sci_CharacterRange chrg;
+//};
 
 struct Sci_RangeToFormatFull {
 	Sci_SurfaceID hdc;


### PR DESCRIPTION
- see discussion at https://github.com/notepad-plus-plus/notepad-plus-plus/pull/16467
- disabled versions with usage of Sci_PositionCR restricted to 2GB files on windows to avoid usage within N++ and to enforce usage of new functions within plugins
- didn't adapt ScintillaStructures.h to avoid disabling/patching of functions for SCI_GETTEXTRANGE, SCI_FINDTEXT, SCI_GETSTYLEDTEXTFULL and SCI_FORMATRANGE within scintilla code