### PR TITLE
Update portuguese.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/portuguese.xml
+++ b/PowerEditor/installer/nativeLang/portuguese.xml
@@ -957,7 +957,7 @@ Translation note:
 					<Item id="6108" name="Bloquear (sem arrastar e largar)"/>
 					<Item id="6109" name="Escurecer separadores inativos"/>
 					<Item id="6110" name="Barra colorida no separador ativo"/>
-					<Item id="6111" name="Mostrar botões nos separadores inactivos"/>
+					<Item id="6111" name="Mostrar botões nos separadores inativos"/>
 					<Item id="6112" name="Mostrar o botão de fechar"/>
 					<Item id="6113" name="Clique duplo para fechar documento"/>
 					<Item id="6115" name="Ativar a funcionalidade de fixar separador"/>
@@ -1015,7 +1015,7 @@ Translation note:
 					<Item id="6255" name="Ponto de código"/>
 					<Item id="6256" name="Cor personalizada"/>
 					<Item id="6258" name="Aplicar definições de Aspeto a carateres C0, C1 &amp;e Fim de linha do Unicode"/>
-					<Item id="6259" name="Impedir a introdução de caracteres de controlo (código C0) no documento"/>
+					<Item id="6259" name="Impedir a introdução de carateres de controlo (código C0) no documento"/>
 				</Scintillas2>
 
 				<DarkMode title="Modo Escuro">
@@ -1324,7 +1324,7 @@ Translation note:
 					</ComboBox>
 					<ComboBox id="6362">
 						<Element name="GDI (mais compatível)"/>
-						<Element name="DirectWrite (padrão)"/>
+						<Element name="DirectWrite (predefinição)"/>
 						<Element name="DirectWrite (mantém estrutura)"/>
 						<Element name="DirectWrite (estender a GDI DC)"/>
 						<Element name="DirectWrite (DirectX 11)"/>
@@ -1867,7 +1867,7 @@ Hugo Carvalho <hugokarvalho@hotmail.com>
 Filipe Mota <blackspirits@gmail.com>
 27/03/2023 (version 8.5.1, 8.6.3, 8.7)
 
-Last modified: 24 March 2025 by Hugo Carvalho
+Last modified: 10 May 2025 by Hugo Carvalho and Filipe Mota (BlackSpirits)
 
 TRADUÇÃO DE ACORDO COM O NOVO ACORDO ORTOGRÁFICO
 POR FAVOR, NÃO ALTEREM A ORDEM PORQUE TORNA-SE MAIS DIFÍCIL A COMPARAÇÃO ENTRE OS FICHEIROS PT E EN


### PR DESCRIPTION
@hugok79, you translated
DirectWrite (retain frames)
DirectWrite (draw to GDI DC)
to
DirectWrite (mantém estrutura)
DirectWrite (estender a GDI DC)

but I think it would look better
DirectWrite (manter frames) or DirectWrite (manter fotogramas)
DirectWrite (desenhar para DC GDI)

what do you think? why "estrutura" and "estender"?
I could be wrong, but I don't think it makes sense.

Do you use Discord? That way we could talk and help each other with questions and on various projects.