### PR TITLE
Add release-notifier workflow

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -1,0 +1,69 @@
+name: Plugin Files Release Notifier
+
+on:
+  push:
+    branches: 'main'
+
+  workflow_dispatch:
+
+jobs:
+  release-notifier:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+         fetch-depth: 0
+      - name: Get changes
+        run: |
+          $any_changed = $false
+          $watch_files = @(
+            "scintilla/include/Scintilla.h",
+            "scintilla/include/Sci_Position.h",
+            "PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h",
+            "PowerEditor/src/MISC/PluginsManager/PluginInterface.h",
+            "PowerEditor/src/menuCmdID.h",
+            "PowerEditor/src/WinControls/DockingWnd/Docking.h",
+            "PowerEditor/src/WinControls/DockingWnd/dockingResource.h"
+          )
+          if("${{ github.event_name }}" -eq "workflow_dispatch") {
+            #Write-Output "non-push: use HEAD~1..HEAD, which isn't as specific, but better than nothing"
+            $changed_files = @( git diff --name-only HEAD~1..HEAD )
+          } else {
+            #Write-Output "for-push: use before/after"
+            $changed_files = @( git diff --name-only ${{ github.event.before }} ${{ github.event.after }} )
+          }
+          foreach ($this_file in $changed_files) {
+            #Write-Output "the following is different: $this_file"
+            if( $this_file -in $watch_files ) {
+              Write-Output "+ Saw changes in: $this_file"
+              $any_changed = $true
+            }
+          }
+          if($any_changed) {
+            $map = @(
+              @( "${{ secrets.PAT_NOTIFY_NPPPLUGINS }}", "npp-plugins/plugintemplate", "CI_update_remote.yml" ),
+              @( "${{ secrets.PAT_NOTIFY_NPPPLUGINS }}", "npp-plugins/plugindemo", "CI_update_remote.yml" )
+            )
+
+            foreach ($target in $map) {
+              $pat = $target[0]
+              $ref = $target[1]
+              $yml = $target[2]
+              # Write-Output "DEBUG: len(pat)='$($pat.Length)' ref='$ref' len(ref)=$($ref.Length) yml='$yml' len(yml)=$($yml.Length): 'https://api.github.com/repos/$ref/actions/workflows/$yml/dispatches'"
+              Write-Output "Notifying '$ref' workflow '$yml' using curl 'https://api.github.com/repos/$ref/actions/workflows/$yml/dispatches'."
+              curl -s -L `
+                -X POST `
+                -H "Accept: application/vnd.github+json" `
+                -H "Authorization: Bearer $pat" `
+                -H "X-GitHub-Api-Version: 2022-11-28" `
+                https://api.github.com/repos/$ref/actions/workflows/$yml/dispatches `
+                -d "{`"ref`": `"${{ github.ref_name }}`", `"inputs`": {}}"   
+              # NOTE: if there is a problem with the curl call, there will be a message in the workflow output,
+              # but the workflow will not fail, so that the Notepad++ build will not fail; we do our best to notify,
+              # but we don't want a problem with another repo holding up a N++ fix.
+            }
+          } else {
+            Write-Output "No watched-files changed, so not sending notification to plugin templates this time."
+          }


### PR DESCRIPTION
notify the plugintemplate & plugindemo repos anytime that a push to Notepad++'s master branch includes changes to the 7 plugin-related source-files

(see https://github.com/npp-plugins/plugintemplate/issues/13#issuecomment-2867953737 and related discussion)