### PR TITLE
Implement Plugin Communication Message: NPPM_GETTOOLBARICONSETMODE

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -1017,6 +1017,13 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	//  	...
 	//  }
 
+	#define NPPM_GETTOOLBARICONSETMODE (NPPMSG + 118)
+	// BOOL NPPM_GETTOOLBARICONSETMODE(0, 0)
+	// Get Notepad++ Toobar Icon Set mode (ENUM Range: 0 to 4).
+	// wParam: 0 (not used)
+	// lParam: 0 (not used)
+	// Return Toolbar Icon Set mode as an integer value [ENUM range: 0 (TB_SMALL - Fluent UI: small) to 4 (TB_STANDARD - Standard icons: small)].
+
 
 	// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3107,6 +3107,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return TRUE;
 		}
 
+		case NPPM_GETTOOLBARICONSETMODE:
+		{
+			return _toolBar.getState();
+		}
+
 		case NPPM_SETMENUITEMCHECK:
 		{
 			::CheckMenuItem(_mainMenuHandle, static_cast<UINT>(wParam), MF_BYCOMMAND | (static_cast<BOOL>(lParam) ? MF_CHECKED : MF_UNCHECKED));


### PR DESCRIPTION
Fix #16547 [New API message: NPPM_GETTOOLBARICONSETMODE for Plugin Dock Panels with Fluent or Standard icon based on Notepad++ Preference setting]