### PR TITLE
Mark modified files with succeeding "*" in Windows menu dropdown (for Feature request #16542)

### DIFF
--- a/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
+++ b/PowerEditor/src/WinControls/WindowsDlg/WindowsDlg.cpp
@@ -1170,6 +1170,11 @@ void WindowsMenu::initPopupMenu(HMENU hMenu, DocTabView* pTab)
 
 			wstring strBuffer(BuildMenuFileName(60, static_cast<int32_t>(pos), buf->getFileName(), !isDropListMenu));
 			std::vector<wchar_t> vBuffer(strBuffer.begin(), strBuffer.end());
+			if (buf->isDirty()) 
+			{
+				// add a '*' after the modified tab name (like Visual Studio)
+				vBuffer.push_back('*');
+			}
 			vBuffer.push_back('\0');
 			mii.dwTypeData = (&vBuffer[0]);
 


### PR DESCRIPTION
## Implement
Mark modified files with succeeding "*" in Windows menu dropdown
Original feature request: [Issue #16542](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16542)

### Image:
![image](https://github.com/user-attachments/assets/cfcf5383-ba9a-412f-a613-7b6729cded5f)
