### PR TITLE
When changing localization resize checkbox radio buttons for Style Configurator window

### DIFF
--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -696,6 +696,7 @@ void NativeLangSpeaker::changeConfigLang(HWND hDlg)
 			{
 				const wchar_t *nameW = wmc.char2wchar(name, _nativeLangEncoding);
 				::SetWindowText(hItem, nameW);
+				resizeCheckboxRadioBtn(hItem);
 			}
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16549.

Invoking `resizeCheckboxRadioBtn` solves my problem.

![image](https://github.com/user-attachments/assets/89721aa4-1cff-48bd-8635-d10fd3ad0b57)
