### PR TITLE
Fix buffer overflow problem in plugin APIs

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1172,7 +1172,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				{
 					BufferID id = _mainDocTab.getBufferByIndex(i);
 					Buffer * buf = MainFileManager.getBufferByID(id);
-					lstrcpy(fileNames[j++], buf->getFullPathName());
+					LPWSTR res = lstrcpyW(fileNames[j++], buf->getFullPathName());
+					if (!res)
+					{
+						throw std::exception("Exception: NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESPRIMARY - The buffer you provide may not be large enough to contain the path you want to copy.");
+					}
 				}
 			}
 
@@ -1182,7 +1186,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				{
 					BufferID id = _subDocTab.getBufferByIndex(i);
 					Buffer * buf = MainFileManager.getBufferByID(id);
-					lstrcpy(fileNames[j++], buf->getFullPathName());
+					LPWSTR res = lstrcpyW(fileNames[j++], buf->getFullPathName());
+					if (!res)
+					{
+						throw std::exception("Exception: NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESSECOND - The buffer you provide may not be large enough to contain the path you want to copy.");
+					}
 				}
 			}
 			return j;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1175,7 +1175,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					LPWSTR res = lstrcpyW(fileNames[j++], buf->getFullPathName());
 					if (!res)
 					{
-						throw std::exception("Exception: NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESPRIMARY - The buffer you provide may not be large enough to contain the path you want to copy.");
+						struct lstrcpyException : std::exception
+						{
+							const char* what() const noexcept override { return "NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESPRIMARY - The buffer you provide may not be large enough to contain the path you want to copy."; }
+						};
+						throw lstrcpyException();
 					}
 				}
 			}
@@ -1189,7 +1193,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					LPWSTR res = lstrcpyW(fileNames[j++], buf->getFullPathName());
 					if (!res)
 					{
-						throw std::exception("Exception: NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESSECOND - The buffer you provide may not be large enough to contain the path you want to copy.");
+						struct lstrcpyException : std::exception
+						{
+							const char* what() const noexcept override { return "NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESSECOND - The buffer you provide may not be large enough to contain the path you want to copy."; }
+						};
+						throw lstrcpyException();
 					}
 				}
 			}
@@ -1300,17 +1308,30 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			Session session2Load;
 			if (nppParam.loadSession(session2Load, sessionFileName, true))
 			{
+				struct lstrcpyException : std::exception
+				{
+					const char* what() const noexcept override { return "NPPM_GETSESSIONFILES - The buffer you provide may not be large enough to contain the path you want to copy."; }
+				};
+
 				size_t i = 0;
 				for ( ; i < session2Load.nbMainFiles() ; )
 				{
 					const wchar_t *pFn = session2Load._mainViewFiles[i]._fileName.c_str();
-					lstrcpy(sessionFileArray[i++], pFn);
+					LPWSTR res = lstrcpyW(sessionFileArray[i++], pFn);
+					if (!res)
+					{
+						throw lstrcpyException();
+					}
 				}
 
 				for (size_t j = 0, len = session2Load.nbSubFiles(); j < len ; ++j)
 				{
 					const wchar_t *pFn = session2Load._subViewFiles[j]._fileName.c_str();
-					lstrcpy(sessionFileArray[i++], pFn);
+					LPWSTR res = lstrcpyW(sessionFileArray[i++], pFn);
+					if (!res)
+					{
+						throw lstrcpyException();
+					}
 				}
 				return TRUE;
 			}


### PR DESCRIPTION
Concerning message: NPPM_GETOPENFILENAMES, NPPM_GETOPENFILENAMESPRIMARY & NPPM_GETOPENFILENAMESECOND
Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/15997#issuecomment-2569862393

Fix #15997