### PR TITLE
[Feature/Enhancement] Make auto-completion popup list cyclable

### DIFF
--- a/scintilla/src/AutoComplete.cxx
+++ b/scintilla/src/AutoComplete.cxx
@@ -238,10 +238,14 @@ void AutoComplete::Move(int delta) {
 	const int count = lb->Length();
 	int current = lb->GetSelection();
 	current += delta;
-	if (current >= count)
-		current = count - 1;
-	if (current < 0)
+	if (current >= count) {
+		// back to the first selection
 		current = 0;
+	}
+	if (current < 0) {
+		// go to the last one
+		current = count - 1;
+	}
 	lb->Select(current);
 }
 


### PR DESCRIPTION
I enhanced the Scintilla Auto-completion popup list, making the selection cyclable.
Feature request: [Issue #16564](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16564)