### PR TITLE
Update MVS to v17.14 (MS Visual Studio Community 2022)

### DIFF
--- a/PowerEditor/visual.net/notepadPlus.sln
+++ b/PowerEditor/visual.net/notepadPlus.sln
@@ -1,17 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32002.261
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36109.1 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Notepad++", "notepadPlus.vcxproj", "{FCF60E65-1B78-4D1D-AB59-4FC00AC8C248}"
 	ProjectSection(ProjectDependencies) = postProject
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD} = {C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD} = {19CCA8B8-46B9-4609-B7CE-198DA19F07BD}
 		{E541C9BE-13BC-4CE6-A0A4-31145F51A2C1} = {E541C9BE-13BC-4CE6-A0A4-31145F51A2C1}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Lexilla", "..\..\lexilla\src\Lexilla.vcxproj", "{E541C9BE-13BC-4CE6-A0A4-31145F51A2C1}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Scintilla", "..\..\scintilla\win32\Scintilla.vcxproj", "{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Scintilla", "..\..\scintilla\win32\Scintilla.vcxproj", "{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,18 +47,18 @@ Global
 		{E541C9BE-13BC-4CE6-A0A4-31145F51A2C1}.Release|Win32.Build.0 = Release|Win32
 		{E541C9BE-13BC-4CE6-A0A4-31145F51A2C1}.Release|x64.ActiveCfg = Release|x64
 		{E541C9BE-13BC-4CE6-A0A4-31145F51A2C1}.Release|x64.Build.0 = Release|x64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Debug|ARM64.ActiveCfg = Debug|ARM64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Debug|ARM64.Build.0 = Debug|ARM64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Debug|Win32.ActiveCfg = Debug|Win32
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Debug|Win32.Build.0 = Debug|Win32
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Debug|x64.ActiveCfg = Debug|x64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Debug|x64.Build.0 = Debug|x64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Release|ARM64.ActiveCfg = Release|ARM64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Release|ARM64.Build.0 = Release|ARM64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Release|Win32.ActiveCfg = Release|Win32
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Release|Win32.Build.0 = Release|Win32
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Release|x64.ActiveCfg = Release|x64
-		{C5FBF9A9-FBEF-487B-A5ED-4542E6F03FCD}.Release|x64.Build.0 = Release|x64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Debug|ARM64.Build.0 = Debug|ARM64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Debug|Win32.ActiveCfg = Debug|Win32
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Debug|Win32.Build.0 = Debug|Win32
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Debug|x64.ActiveCfg = Debug|x64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Debug|x64.Build.0 = Debug|x64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Release|ARM64.ActiveCfg = Release|ARM64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Release|ARM64.Build.0 = Release|ARM64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Release|Win32.ActiveCfg = Release|Win32
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Release|Win32.Build.0 = Release|Win32
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Release|x64.ActiveCfg = Release|x64
+		{19CCA8B8-46B9-4609-B7CE-198DA19F07BD}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION


```
Microsoft Visual Studio Community 2022
Version 17.14.0
VisualStudio.17.Release/17.14.0+36109.1
Microsoft .NET Framework
Version 4.8.09032

Installed Version: Community

Visual C++ 2022   00482-90000-00000-AA924
Microsoft Visual C++ 2022
...
```