### PR TITLE
[Enhancement] Add an audible alert and window flash when the top/bottom of the search results is reached (issue #3445)

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4189,31 +4189,18 @@ void FindReplaceDlg::setStatusbarMessage(const wstring & msg, FindStatus status,
 
 	_statusbarTooltipMsg = tooltipMsg;
 
-	if (status == FSNotFound)
+	if (status == FSNotFound || status == FSTopReached || status == FSEndReached)
 	{
 		if (!NppParameters::getInstance().getNppGUI()._muteSounds)
 			::MessageBeep(0xFFFFFFFF);
 
 		FLASHWINFO flashInfo{};
 		flashInfo.cbSize = sizeof(FLASHWINFO);
-		flashInfo.hwnd = isVisible()?_hSelf:GetParent(_hSelf);
+		flashInfo.hwnd = isVisible() ? _hSelf : GetParent(_hSelf);
 		flashInfo.uCount = 3;
 		flashInfo.dwTimeout = 100;
 		flashInfo.dwFlags = FLASHW_ALL;
 		FlashWindowEx(&flashInfo);
-	}
-	else if (status == FSTopReached || status == FSEndReached)
-	{
-		if (!isVisible())
-		{
-			FLASHWINFO flashInfo{};
-			flashInfo.cbSize = sizeof(FLASHWINFO);
-			flashInfo.hwnd = GetParent(_hSelf);
-			flashInfo.uCount = 2;
-			flashInfo.dwTimeout = 100;
-			flashInfo.dwFlags = FLASHW_ALL;
-			FlashWindowEx(&flashInfo);
-		}
 	}
 
 	if (isVisible())


### PR DESCRIPTION
## 🐞Description of the Issue
>When the Find feature has reached the end of its searches, it blinks the window title bar and menu titles.

>When using the F3 button to repeat searching throughout a window, this can be very easy to miss and you end up going round and round the same collection.

>Please could you make it more obvious when you've reached the end of the loop? Perhaps blink the whole window in some way.

## ✨What's New in This Enhancement
I modified the Find dialog to make it behave the same as when not found anything
- Make an audible "ding" sound.
- Flash the Find dialog if visible.

## 🔗 Related Issue
Merging this PR will close the issue #3445 

## 📋 Checklist
 - [x] Code compiles without errors
 - [x] Manual testing completed
 - [x] No regressions observed