### PR TITLE
[Bug fix] Re-add the tray icon when the taskbar is re-created

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -41,6 +41,7 @@ using namespace std;
 #endif
 
 std::atomic<bool> g_bNppExitFlag{ false };
+const UINT WM_TASKBARCREATED = ::RegisterWindowMessage(L"TaskbarCreated");
 
 
 struct SortTaskListPred final
@@ -4350,6 +4351,16 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 						break;
 					}
 				}
+				return TRUE;
+			}
+
+			else if (message == WM_TASKBARCREATED)
+			{
+				if (!_pTrayIco)
+					return TRUE;
+
+				// re-add tray icon
+				_pTrayIco->reAddTrayIcon();
 				return TRUE;
 			}
 

--- a/PowerEditor/src/WinControls/TrayIcon/trayIconControler.cpp
+++ b/PowerEditor/src/WinControls/TrayIcon/trayIconControler.cpp
@@ -27,7 +27,6 @@ trayIconControler::trayIconControler(HWND hwnd, UINT uID, UINT uCBMsg, HICON hic
   _nid.hIcon = hicon;
   wcscpy_s(_nid.szTip, tip);
   
-  ::RegisterWindowMessage(L"TaskbarCreated");
   _isIconShown = false;
 }
 
@@ -43,4 +42,19 @@ int trayIconControler::doTrayIcon(DWORD op)
   _isIconShown = !_isIconShown;
 
   return 0;
+}
+
+int trayIconControler::reAddTrayIcon()
+{
+    if (!_isIconShown)
+        return -1;
+
+    // we only re-add the tray icon when it has been lost and no longer exists,
+    // but we still delete it first to ensure it's not duplicated 
+    // due to an incorrect call or something
+    ::Shell_NotifyIcon(NIM_DELETE, &_nid);
+
+    // reset state and re-add tray icon
+    _isIconShown = false;
+    return doTrayIcon(ADD);
 }

--- a/PowerEditor/src/WinControls/TrayIcon/trayIconControler.h
+++ b/PowerEditor/src/WinControls/TrayIcon/trayIconControler.h
@@ -32,6 +32,7 @@ public:
   trayIconControler(HWND hwnd, UINT uID, UINT uCBMsg, HICON hicon, const wchar_t *tip);
   int doTrayIcon(DWORD op);
   bool isInTray() const {return _isIconShown;};
+  int reAddTrayIcon();
 
 private:
   NOTIFYICONDATA _nid;


### PR DESCRIPTION
## 🐞Description
This PR resolves the issue described in #16588 

## ✅ Test Plan
- Manual testing on Windows 10/11
- Tested in cases where the tray icon wasn't shown before the taskbar was recreated

## 📋 Checklist
- [x] Code compiles without errors
- [x] Manual testing completed
- [x] No regressions observed