### PR TITLE
Fix regression of folding state not being remembered through sessions

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2521,6 +2521,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			allSessionFilesLoaded = false;
 		}
 	}
+
 	if (mainIndex2Update != -1)
 	{
 		_isFolding = true;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2592,6 +2592,27 @@ bool ScintillaEditView::isCurrentLineFolded() const
 
 void ScintillaEditView::fold(size_t line, bool mode, bool shouldBeNotified/* = true*/)
 {
+	auto endStyled = execute(SCI_GETENDSTYLED);
+	auto len = execute(SCI_GETTEXTLENGTH);
+
+	if (endStyled < len)
+		execute(SCI_COLOURISE, 0, -1);
+/*
+The method ScintillaEditView::fold() is called not only on manual folding by the users, but also on:
+
+1. startup's loading session to restore the folding state programmatically.
+2. after startup, switching among the documents to restore the folding state programmatically.
+
+The above lines are important for the case 1.
+
+However, these lines are necessary only on the first load of each file after the startup of Notepad++.
+"execute(SCI_COLOURISE, 0, -1);" needs to be run for once (the case 1), not twice or more (the case 2).
+
+So if there's a way to detect if a document has been run "execute(SCI_COLOURISE, 0, -1);" once (in the case 1),
+and don't run it again (the case 2), it will save the time to switch among the document.
+*/
+
+
 	intptr_t headerLine;
 	auto level = execute(SCI_GETFOLDLEVEL, line);
 


### PR DESCRIPTION
The regression is introduced by:
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/83755ca15584bddf8e83cffcc8a5c71ce1f594e2#diff-d88ddee57a027ab23daf332c4778ced0cee352edcb34efdda1b218e8a75c61b2L2636

The culprit of this regression is the deletion of following 4 lines in the commit above:
```
void ScintillaEditView::fold(size_t line, bool mode, bool shouldBeNotified/* = true*/)
{
	auto endStyled = execute(SCI_GETENDSTYLED);
	auto len = execute(SCI_GETTEXTLENGTH);

	if (endStyled < len)
		execute(SCI_COLOURISE, 0, -1);
```
The method "ScintillaEditView::fold()" is called not only on manual folding by the users, but also on:

1. startup's loading session to restore the folding state programmatically.
2. after startup, switching among the documents to restore the folding state programmatically.

The above lines are important for the case 1.

However, these lines are necessary only on the first load of each file after the startup of Notepad++. "execute(SCI_COLOURISE, 0, -1);" needs to be run for once (the case 1), not twice or more (the case 2).

So if there's a way to detect if a document has been run "execute(SCI_COLOURISE, 0, -1);" once (in the case 1), and don't run it again (the case 2), it will save the time to switch among the document.

Fix #16597