### PR TITLE
[NPP-16603] [Feature] Add a way to persist read-only mode in the underlying file-system itself (not just the editor)

### DIFF
--- a/PowerEditor/Test/FunctionList/cpp/unitTest
+++ b/PowerEditor/Test/FunctionList/cpp/unitTest
@@ -164,6 +164,7 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{ VK_NULL,    IDM_EDIT_CHAR_PANEL,                          false, false, false, nullptr },
 	{ VK_NULL,    IDM_EDIT_CLIPBOARDHISTORY_PANEL,              false, false, false, nullptr },
 	{ VK_NULL,    IDM_EDIT_SETREADONLY,                         false, false, false, nullptr },
+    { VK_NULL,    IDM_EDIT_SETREADONLY_SYS,                     false, false, false, nullptr },
 	{ VK_NULL,    IDM_EDIT_CLEARREADONLY,                       false, false, false, nullptr },
 	{ VK_F,       IDM_SEARCH_FIND,                              true,  false, false, nullptr },
 	{ VK_F,       IDM_SEARCH_FINDINFILES,                       true,  false, true,  nullptr },

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1517,6 +1517,17 @@ bool removeReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath)
 	return (::SetFileAttributes(fileFullPath, dwFileAttribs) != FALSE);
 }
 
+bool setReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath)
+{
+	DWORD dwFileAttribs = ::GetFileAttributes(fileFullPath);
+
+	if (dwFileAttribs == INVALID_FILE_ATTRIBUTES || (dwFileAttribs & FILE_ATTRIBUTE_DIRECTORY))
+		return false;
+
+	dwFileAttribs |= FILE_ATTRIBUTE_READONLY;
+	return (::SetFileAttributes(fileFullPath, dwFileAttribs) != FALSE);
+}
+
 // "For file I/O, the "\\?\" prefix to a path string tells the Windows APIs to disable all string parsing
 // and to send the string that follows it straight to the file system..."
 // Ref: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -219,6 +219,7 @@ int nbDigitsFromNbLines(size_t nbLines);
 std::wstring getDateTimeStrFrom(const std::wstring& dateTimeFormat, const SYSTEMTIME& st);
 
 HFONT createFont(const wchar_t* fontName, int fontSize, bool isBold, HWND hDestParent);
+bool setReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath);
 bool removeReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath);
 
 bool isWin32NamespacePrefixedFileName(const std::wstring& fileName);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2591,9 +2591,11 @@ void Notepad_plus::checkDocState()
 
 	bool doEnable = !(curBuf->isMonitoringOn() || isSysReadOnly);
 	enableCommand(IDM_EDIT_SETREADONLY, doEnable, MENU);
+	enableCommand(IDM_EDIT_SETREADONLY_SYS, doEnable, MENU);
 
 	bool isUserReadOnly = curBuf->getUserReadOnly();
 	::CheckMenuItem(_mainMenuHandle, IDM_EDIT_SETREADONLY, MF_BYCOMMAND | (isUserReadOnly ? MF_CHECKED : MF_UNCHECKED));
+	::CheckMenuItem(_mainMenuHandle, IDM_EDIT_SETREADONLY_SYS, MF_BYCOMMAND | (isUserReadOnly ? MF_CHECKED : MF_UNCHECKED));
 
 	enableCommand(IDM_FILE_DELETE, isFileExisting, MENU);
 	enableCommand(IDM_FILE_OPEN_CMD, isFileExisting, MENU);

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -628,7 +628,8 @@ BEGIN
         MENUITEM "Character &Panel",         IDM_EDIT_CHAR_PANEL
         MENUITEM "Clipboard &History",       IDM_EDIT_CLIPBOARDHISTORY_PANEL
         MENUITEM SEPARATOR
-        MENUITEM "&Set Read-Only",           IDM_EDIT_SETREADONLY
+        MENUITEM "&Set Read-Only (Editor)",  IDM_EDIT_SETREADONLY
+        MENUITEM "S&et Read-Only (System)",  IDM_EDIT_SETREADONLY_SYS
         MENUITEM "Clear Read-Only Flag",     IDM_EDIT_CLEARREADONLY
     END
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2105,10 +2105,18 @@ void Notepad_plus::command(int id)
 		}
 		break;
 
+		case IDM_EDIT_SETREADONLY_SYS:
+		{
+			Buffer * buf = _pEditView->getCurrentBuffer();
+			(void)setReadOnlyFlagFromFileAttributes(buf->getFullPathName());
+			buf->setFileReadOnly(true);
+		}
+		break;
+
 		case IDM_EDIT_CLEARREADONLY:
 		{
 			Buffer * buf = _pEditView->getCurrentBuffer();
-			removeReadOnlyFlagFromFileAttributes(buf->getFullPathName());
+			(void)removeReadOnlyFlagFromFileAttributes(buf->getFullPathName());
 			buf->setFileReadOnly(false);
 		}
 		break;
@@ -4162,6 +4170,7 @@ void Notepad_plus::command(int id)
 			case IDM_EDIT_SW2TAB_ALL:
 			case IDM_EDIT_SW2TAB_LEADING:
 			case IDM_EDIT_SETREADONLY :
+			case IDM_EDIT_SETREADONLY_SYS :
 			case IDM_EDIT_FULLPATHTOCLIP :
 			case IDM_EDIT_FILENAMETOCLIP :
 			case IDM_EDIT_CURRENTDIRTOCLIP :

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -1036,7 +1036,8 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					itemUnitArray.push_back(MenuItemUnit(IDM_FILE_RELOAD, L"Reload"));
 					itemUnitArray.push_back(MenuItemUnit(IDM_FILE_PRINT, L"Print"));
 					itemUnitArray.push_back(MenuItemUnit(0, NULL));
-					itemUnitArray.push_back(MenuItemUnit(IDM_EDIT_SETREADONLY, L"Read-Only"));
+					itemUnitArray.push_back(MenuItemUnit(IDM_EDIT_SETREADONLY, L"Read-Only (Editor)"));
+					itemUnitArray.push_back(MenuItemUnit(IDM_EDIT_SETREADONLY_SYS, L"Read-Only (System)"));
 					itemUnitArray.push_back(MenuItemUnit(IDM_EDIT_CLEARREADONLY, L"Clear Read-Only Flag"));
 					itemUnitArray.push_back(MenuItemUnit(0, NULL));
 					itemUnitArray.push_back(MenuItemUnit(IDM_EDIT_FULLPATHTOCLIP, L"Copy Full File Path", L"Copy to Clipboard"));
@@ -1076,13 +1077,14 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			Buffer* buf = _pEditView->getCurrentBuffer();
 			bool isUserReadOnly = buf->getUserReadOnly();
 			_tabPopupMenu.checkItem(IDM_EDIT_SETREADONLY, isUserReadOnly);
+			_tabPopupMenu.checkItem(IDM_EDIT_SETREADONLY_SYS, isUserReadOnly);
 
 			bool isSysReadOnly = buf->getFileReadOnly();
 			bool isInaccessible = buf->isInaccessible();
 			_tabPopupMenu.enableItem(IDM_EDIT_SETREADONLY, !isSysReadOnly && !buf->isMonitoringOn());
-			_tabPopupMenu.enableItem(IDM_EDIT_CLEARREADONLY, isSysReadOnly);
-			if (isInaccessible)
-				_tabPopupMenu.enableItem(IDM_EDIT_CLEARREADONLY, false);
+			_tabPopupMenu.enableItem(IDM_EDIT_SETREADONLY_SYS, !isSysReadOnly && !buf->isMonitoringOn());
+
+			_tabPopupMenu.enableItem(IDM_EDIT_CLEARREADONLY, !isInaccessible && isSysReadOnly);
 
 			bool isFileExisting = doesFileExist(buf->getFullPathName());
 			_tabPopupMenu.enableItem(IDM_FILE_DELETE, isFileExisting);

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -190,6 +190,7 @@ static const WinMenuKeyDefinition winKeyDefs[] =
 	{ VK_NULL,    IDM_EDIT_CHAR_PANEL,                          false, false, false, L"Toggle Character Panel" },
 	{ VK_NULL,    IDM_EDIT_CLIPBOARDHISTORY_PANEL,              false, false, false, L"Toggle Clipboard History" },
 	{ VK_NULL,    IDM_EDIT_SETREADONLY,                         false, false, false, nullptr },
+	{ VK_NULL,    IDM_EDIT_SETREADONLY_SYS,                     false, false, false, nullptr },
 	{ VK_NULL,    IDM_EDIT_CLEARREADONLY,                       false, false, false, nullptr },
 	{ VK_F,       IDM_SEARCH_FIND,                              true,  false, false, nullptr },
 	{ VK_F,       IDM_SEARCH_FINDINFILES,                       true,  false, true,  nullptr },

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -184,6 +184,7 @@
     #define    IDM_EDIT_MULTISELECTSSKIP                        (IDM_EDIT + 99)
     #define    IDM_EDIT_SORTLINES_LOCALE_ASCENDING              (IDM_EDIT + 100)
     #define    IDM_EDIT_SORTLINES_LOCALE_DESCENDING             (IDM_EDIT + 101)
+    #define    IDM_EDIT_SETREADONLY_SYS                         (IDM_EDIT + 102)
 
     #define    IDM_EDIT_AUTOCOMPLETE                            (50000 + 0)
     #define    IDM_EDIT_AUTOCOMPLETE_CURRENTFILE                (50000 + 1)


### PR DESCRIPTION
Tackling:

https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16603

