### PR TITLE
Fix DisplayInfo maxAdapters searching limitation

### DIFF
--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -52,9 +52,10 @@ void AppendDisplayAdaptersInfo(wstring& strOut, const unsigned int maxAdaptersIn
 		nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 	if ((lStatus == ERROR_SUCCESS) && (dwSubkeysCount > 0))
 	{
+		DWORD dwAdapterSubkeysFound = 0;
 		for (DWORD i = 0; i < dwSubkeysCount; ++i)
 		{
-			if (i >= maxAdaptersIn)
+			if (dwAdapterSubkeysFound >= maxAdaptersIn)
 			{
 				strOut += L"\n    - warning, search has been limited to maximum number of adapter records: "
 					+ std::to_wstring(maxAdaptersIn);
@@ -77,6 +78,7 @@ void AppendDisplayAdaptersInfo(wstring& strOut, const unsigned int maxAdaptersIn
 				if (::RegQueryValueExW(hkAdapterSubKey, L"DriverDesc", nullptr, &dwType, (LPBYTE)wszKeyVal, &dwSize)
 					== ERROR_SUCCESS)
 				{
+					dwAdapterSubkeysFound++;
 					strOut += strAdapterNo + L": Description - ";
 					strOut += wszKeyVal;
 				}


### PR DESCRIPTION
Fixed incorrect misleading warning in unreleased-yet code for the next N++ version when a more complicated Display Class Registry record occurred:

```
Display Info : 
    primary monitor: 1920x1080, scaling 112%
    visible monitors count: 1
    installed Display Class adapters: 
        0001: Description - Intel(R) UHD Graphics 630
        0001: DriverVersion - 31.0.101.2111
        0002: Description - NVIDIA GeForce GTX 1050 Ti
        0002: DriverVersion - 32.0.15.7652
    - warning, search has been limited to maximum number of adapter records: 4
```

(reported in https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16588#issue-3086711102 )