### PR TITLE
Fix all deprecated function usages of stricmp & wcsicmp by converting them to _stricmp & _wcsicmp, respectively

### DIFF
--- a/PowerEditor/src/EncodingMapper.cpp
+++ b/PowerEditor/src/EncodingMapper.cpp
@@ -89,7 +89,7 @@ bool isInListA(const char *token, const char *list)
 				word[j] = '\0';
 				j = 0;
 				
-				if (!stricmp(token, word))
+				if (!_stricmp(token, word))
 					return true;
 			}
 		}

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -282,7 +282,7 @@ bool isInList(const wchar_t *token, const wchar_t *list)
 				word[j] = '\0';
 				j = 0;
 
-				if (!wcsicmp(token, word))
+				if (!_wcsicmp(token, word))
 					return true;
 			}
 		}

--- a/PowerEditor/src/MISC/Common/Sorters.h
+++ b/PowerEditor/src/MISC/Common/Sorters.h
@@ -128,11 +128,11 @@ public:
 				{
 					if (isDescending())
 					{
-						return wcsicmp(getSortKey(a).c_str(), getSortKey(b).c_str()) > 0;
+						return _wcsicmp(getSortKey(a).c_str(), getSortKey(b).c_str()) > 0;
 					}
 					else
 					{
-						return wcsicmp(getSortKey(a).c_str(), getSortKey(b).c_str()) < 0;
+						return _wcsicmp(getSortKey(a).c_str(), getSortKey(b).c_str()) < 0;
 					}
 				});
 		}
@@ -142,11 +142,11 @@ public:
 				{
 					if (isDescending())
 					{
-						return wcsicmp(a.c_str(), b.c_str()) > 0;
+						return _wcsicmp(a.c_str(), b.c_str()) > 0;
 					}
 					else
 					{
-						return wcsicmp(a.c_str(), b.c_str()) < 0;
+						return _wcsicmp(a.c_str(), b.c_str()) < 0;
 					}
 				});
 		}

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -337,7 +337,7 @@ bool PluginsManager::loadPlugins(const wchar_t* dir, const PluginViewList* plugi
 		const wchar_t* incompatibleWarningWithSolution = L"%s's version %s is not compatible to this version of Notepad++ (v%s).\r\nAs a result the plugin cannot be loaded.\r\n\r\nGo to Updates section and update your plugin to %s for solving the compatibility issue.";
 
 		wstring foundFileName = foundData.cFileName;
-		if (foundFileName != L"." && foundFileName != L".." && wcsicmp(foundFileName.c_str(), L"Config") != 0)
+		if (foundFileName != L"." && foundFileName != L".." && _wcsicmp(foundFileName.c_str(), L"Config") != 0)
 		{
 			wstring pluginsFullPathFilter = pluginsFolder;
 			pathAppend(pluginsFullPathFilter, foundFileName);
@@ -409,7 +409,7 @@ bool PluginsManager::loadPlugins(const wchar_t* dir, const PluginViewList* plugi
 		while (::FindNextFile(hFindFolder, &foundData))
 		{
 			wstring foundFileName2 = foundData.cFileName;
-			if (foundFileName2 != L"." && foundFileName2 != L".." && wcsicmp(foundFileName2.c_str(), L"Config") != 0)
+			if (foundFileName2 != L"." && foundFileName2 != L".." && _wcsicmp(foundFileName2.c_str(), L"Config") != 0)
 			{
 				wstring pluginsFullPathFilter2 = pluginsFolder;
 				pathAppend(pluginsFullPathFilter2, foundFileName2);
@@ -652,7 +652,7 @@ void PluginsManager::runPluginCommand(const wchar_t *pluginName, int commandID)
 {
 	for (size_t i = 0, len = _pluginsCommands.size() ; i < len ; ++i)
 	{
-		if (!wcsicmp(_pluginsCommands[i]._pluginName.c_str(), pluginName))
+		if (!_wcsicmp(_pluginsCommands[i]._pluginName.c_str(), pluginName))
 		{
 			if (_pluginsCommands[i]._funcID == commandID)
 			{

--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.h
@@ -152,7 +152,7 @@ private:
 
 	bool isInLoadedDlls(const wchar_t *fn) const {
 		for (size_t i = 0; i < _loadedDlls.size(); ++i)
-			if (wcsicmp(fn, _loadedDlls[i]._fileName.c_str()) == 0)
+			if (_wcsicmp(fn, _loadedDlls[i]._fileName.c_str()) == 0)
 				return true;
 		return false;
 	}

--- a/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
+++ b/PowerEditor/src/MISC/RegExt/regExtDlg.cpp
@@ -216,7 +216,7 @@ intptr_t CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPa
 					{
 						for (int i = 1 ; i < nbExtMax ; ++i)
 						{
-							if (!wcsicmp(ext2Sup, defExtArray[langIndex][i]))
+							if (!_wcsicmp(ext2Sup, defExtArray[langIndex][i]))
 							{
 								::SendDlgItemMessage(_hSelf, IDC_REGEXT_LANGEXT_LIST, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(ext2Sup));
 								return TRUE;
@@ -264,7 +264,7 @@ intptr_t CALLBACK RegExtDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM lPa
 
 						::SendDlgItemMessage(_hSelf, LOWORD(wParam), LB_GETTEXT, i, reinterpret_cast<LPARAM>(itemName));
 
-						if (!wcsicmp(defExtArray[nbSupportedLang-1][0], itemName))
+						if (!_wcsicmp(defExtArray[nbSupportedLang-1][0], itemName))
 						{
 							::ShowWindow(::GetDlgItem(_hSelf, IDC_REGEXT_LANGEXT_LIST), SW_HIDE);
 							::ShowWindow(::GetDlgItem(_hSelf, IDC_CUSTOMEXT_EDIT), SW_SHOW);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6289,7 +6289,7 @@ bool Notepad_plus::getIntegralDockingData(tTbData & dockData, int & iCont, bool 
 	{
 		const PluginDlgDockingInfo & pddi = dockingData._pluginDockInfo[i];
 
-		if (!wcsicmp(pddi._name.c_str(), dockData.pszModuleName) && (pddi._internalID == dockData.dlgID))
+		if (!_wcsicmp(pddi._name.c_str(), dockData.pszModuleName) && (pddi._internalID == dockData.dlgID))
 		{
 			iCont				= pddi._currContainer;
 			isVisible			= pddi._isVisible;
@@ -8332,11 +8332,11 @@ int Notepad_plus::getQuoteIndexFrom(const wchar_t* quoter) const
 	if (!quoter)
 		return -1;
 
-	if (wcsicmp(quoter, L"Get them all!!!") == 0)
+	if (_wcsicmp(quoter, L"Get them all!!!") == 0)
 		return -2;
 
 	int nbQuote = sizeof(quotes) / sizeof(QuoteParams);
-	if (wcsicmp(quoter, L"random") == 0)
+	if (_wcsicmp(quoter, L"random") == 0)
 	{
 		srand(static_cast<UINT>(time(NULL)));
 		return getRandomNumber(nbQuote);
@@ -8344,7 +8344,7 @@ int Notepad_plus::getQuoteIndexFrom(const wchar_t* quoter) const
 
 	for (int i = 0; i < nbQuote; ++i)
 	{
-		if (wcsicmp(quotes[i]._quoter, quoter) == 0)
+		if (_wcsicmp(quotes[i]._quoter, quoter) == 0)
 			return i;
 	}
 	return -1;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3095,12 +3095,12 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				std::vector<tTbData *> tbData = dockContainer[i]->getDataOfAllTb();
 				for (size_t j = 0, len2 = tbData.size() ; j < len2 ; ++j)
 				{
-					if (wcsicmp(moduleName, tbData[j]->pszModuleName) == 0)
+					if (_wcsicmp(moduleName, tbData[j]->pszModuleName) == 0)
 					{
 						if (!windowName)
 							return (LRESULT)tbData[j]->hClient;
 
-						if (wcsicmp(windowName, tbData[j]->pszName) == 0)
+						if (_wcsicmp(windowName, tbData[j]->pszName) == 0)
 							return (LRESULT)tbData[j]->hClient;
 					}
 				}

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2388,7 +2388,7 @@ bool Notepad_plus::isFileSession(const wchar_t * filename)
 		}
 		usrSessionExt += definedSessionExt;
 
-		if (!wcsicmp(pExt, usrSessionExt.c_str()))
+		if (!_wcsicmp(pExt, usrSessionExt.c_str()))
 		{
 			return true;
 		}
@@ -2412,7 +2412,7 @@ bool Notepad_plus::isFileWorkspace(const wchar_t * filename)
 		}
 		usrWorkspaceExt += definedWorkspaceExt;
 
-		if (!wcsicmp(pExt, usrWorkspaceExt.c_str()))
+		if (!_wcsicmp(pExt, usrWorkspaceExt.c_str()))
 		{
 			return true;
 		}

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -705,7 +705,7 @@ std::wstring LocalizationSwitcher::getLangFromXmlFileName(const wchar_t *fn) con
 	size_t nbItem = sizeof(localizationDefs)/sizeof(LocalizationSwitcher::LocalizationDefinition);
 	for (size_t i = 0 ; i < nbItem ; ++i)
 	{
-		if (0 == wcsicmp(fn, localizationDefs[i]._xmlFileName))
+		if (0 == _wcsicmp(fn, localizationDefs[i]._xmlFileName))
 			return localizationDefs[i]._langName;
 	}
 	return std::wstring();
@@ -716,7 +716,7 @@ std::wstring LocalizationSwitcher::getXmlFilePathFromLangName(const wchar_t *lan
 {
 	for (size_t i = 0, len = _localizationList.size(); i < len ; ++i)
 	{
-		if (0 == wcsicmp(langName, _localizationList[i].first.c_str()))
+		if (0 == _wcsicmp(langName, _localizationList[i].first.c_str()))
 			return _localizationList[i].second;
 	}
 	return std::wstring();
@@ -1781,7 +1781,7 @@ const wchar_t* NppParameters::getUserDefinedLangNameFromExt(wchar_t *ext, wchar_
 		// Force to use dark mode UDL in dark mode or to use  light mode UDL in light mode
 		for (size_t j = 0, len = extVect.size(); j < len; ++j)
 		{
-			if (!wcsicmp(extVect[j].c_str(), ext) || (wcschr(fullName, '.') && !wcsicmp(extVect[j].c_str(), fullName)))
+			if (!_wcsicmp(extVect[j].c_str(), ext) || (wcschr(fullName, '.') && !_wcsicmp(extVect[j].c_str(), fullName)))
 			{
 				// preserve ext matched UDL
 				iMatched = i;
@@ -2114,7 +2114,7 @@ int NppParameters::getCmdIdFromMenuEntryItemName(HMENU mainMenuHandle, const std
 	{
 		wchar_t menuEntryString[menuItemStrLenMax];
 		::GetMenuString(mainMenuHandle, i, menuEntryString, menuItemStrLenMax, MF_BYPOSITION);
-		if (wcsicmp(menuEntryName.c_str(), purgeMenuItemString(menuEntryString).c_str()) == 0)
+		if (_wcsicmp(menuEntryName.c_str(), purgeMenuItemString(menuEntryString).c_str()) == 0)
 		{
 			vector< pair<HMENU, int> > parentMenuPos;
 			HMENU topMenu = ::GetSubMenu(mainMenuHandle, i);
@@ -2139,7 +2139,7 @@ int NppParameters::getCmdIdFromMenuEntryItemName(HMENU mainMenuHandle, const std
 					//  Check current menu position.
 					wchar_t cmdStr[menuItemStrLenMax];
 					::GetMenuString(currMenu, currMenuPos, cmdStr, menuItemStrLenMax, MF_BYPOSITION);
-					if (wcsicmp(menuItemName.c_str(), purgeMenuItemString(cmdStr).c_str()) == 0)
+					if (_wcsicmp(menuItemName.c_str(), purgeMenuItemString(cmdStr).c_str()) == 0)
 					{
 						return ::GetMenuItemID(currMenu, currMenuPos);
 					}
@@ -2174,7 +2174,7 @@ int NppParameters::getPluginCmdIdFromMenuEntryItemName(HMENU pluginsMenu, const 
 	{
 		wchar_t menuItemString[menuItemStrLenMax];
 		::GetMenuString(pluginsMenu, i, menuItemString, menuItemStrLenMax, MF_BYPOSITION);
-		if (wcsicmp(pluginName.c_str(), purgeMenuItemString(menuItemString).c_str()) == 0)
+		if (_wcsicmp(pluginName.c_str(), purgeMenuItemString(menuItemString).c_str()) == 0)
 		{
 			HMENU pluginMenu = ::GetSubMenu(pluginsMenu, i);
 			int nbPluginCmd = ::GetMenuItemCount(pluginMenu);
@@ -2182,7 +2182,7 @@ int NppParameters::getPluginCmdIdFromMenuEntryItemName(HMENU pluginsMenu, const 
 			{
 				wchar_t pluginCmdStr[menuItemStrLenMax];
 				::GetMenuString(pluginMenu, j, pluginCmdStr, menuItemStrLenMax, MF_BYPOSITION);
-				if (wcsicmp(pluginCmdName.c_str(), purgeMenuItemString(pluginCmdStr).c_str()) == 0)
+				if (_wcsicmp(pluginCmdName.c_str(), purgeMenuItemString(pluginCmdStr).c_str()) == 0)
 				{
 					return ::GetMenuItemID(pluginMenu, j);
 				}

--- a/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
+++ b/PowerEditor/src/ScintillaComponent/AutoCompletion.cpp
@@ -350,7 +350,7 @@ bool AutoCompletion::showAutoComplete(AutocompleteType autocType, bool autoInser
 				if (_ignoreCase)
 				{
 					wstring kwSufix = _keyWordArray[i].substr(0, len);
-					compareResult = wcsicmp(beginChars, kwSufix.c_str());
+					compareResult = _wcsicmp(beginChars, kwSufix.c_str());
 				}
 				else
 				{

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -277,15 +277,15 @@ void Buffer::setFileName(const wchar_t *fn)
 
 	if (determinedLang == L_TEXT)	// language can probably be refined
 	{
-		if ((wcsicmp(_fileName, L"makefile") == 0) || (wcsicmp(_fileName, L"GNUmakefile") == 0))
+		if ((_wcsicmp(_fileName, L"makefile") == 0) || (_wcsicmp(_fileName, L"GNUmakefile") == 0))
 			determinedLang = L_MAKEFILE;
-		else if (wcsicmp(_fileName, L"CmakeLists.txt") == 0)
+		else if (_wcsicmp(_fileName, L"CmakeLists.txt") == 0)
 			determinedLang = L_CMAKE;
-		else if ((wcsicmp(_fileName, L"SConstruct") == 0) || (wcsicmp(_fileName, L"SConscript") == 0) || (wcsicmp(_fileName, L"wscript") == 0))
+		else if ((_wcsicmp(_fileName, L"SConstruct") == 0) || (_wcsicmp(_fileName, L"SConscript") == 0) || (_wcsicmp(_fileName, L"wscript") == 0))
 			determinedLang = L_PYTHON;
-		else if ((wcsicmp(_fileName, L"Rakefile") == 0) || (wcsicmp(_fileName, L"Vagrantfile") == 0))
+		else if ((_wcsicmp(_fileName, L"Rakefile") == 0) || (_wcsicmp(_fileName, L"Vagrantfile") == 0))
 			determinedLang = L_RUBY;
-		else if ((wcsicmp(_fileName, L"crontab") == 0) || (wcsicmp(_fileName, L"PKGBUILD") == 0) || (wcsicmp(_fileName, L"APKBUILD") == 0))
+		else if ((_wcsicmp(_fileName, L"crontab") == 0) || (_wcsicmp(_fileName, L"PKGBUILD") == 0) || (_wcsicmp(_fileName, L"APKBUILD") == 0))
 			determinedLang = L_BASH;
 	}
 
@@ -1627,7 +1627,7 @@ int FileManager::detectCodepage(char* buf, size_t len)
 	uchardet_handle_data(ud, buf, len);
 	uchardet_data_end(ud);
 	const char* cs = uchardet_get_charset(ud);
-	if (stricmp(cs, "TIS-620") != 0) // TIS-620 detection is disabled here because uchardet detects usually wrongly UTF-8 as TIS-620
+	if (_stricmp(cs, "TIS-620") != 0) // TIS-620 detection is disabled here because uchardet detects usually wrongly UTF-8 as TIS-620
 		codepage = EncodingMapper::getInstance().getEncodingFromString(cs);
 	uchardet_delete(ud);
 	return codepage;
@@ -1997,7 +1997,7 @@ BufferID FileManager::getBufferFromName(const wchar_t* name)
 {
 	for (auto buf : _buffers)
 	{
-		if (wcsicmp(name, buf->getFullPathName()) == 0)
+		if (_wcsicmp(name, buf->getFullPathName()) == 0)
 		{
 			if (!(buf->_referees.empty()) && buf->_referees[0]->isVisible())
 			{

--- a/PowerEditor/src/ScintillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.cpp
@@ -130,7 +130,7 @@ BufferID DocTabView::findBufferByName(const wchar_t * fullfilename) //-1 if not 
 		::SendMessage(_hSelf, TCM_GETITEM, i, reinterpret_cast<LPARAM>(&tie));
 		BufferID id = reinterpret_cast<BufferID>(tie.lParam);
 		const Buffer* buf = MainFileManager.getBufferByID(id);
-		if (wcsicmp(fullfilename, buf->getFullPathName()) == 0)
+		if (_wcsicmp(fullfilename, buf->getFullPathName()) == 0)
 		{
 			return id;
 		}

--- a/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/xmlMatchedTagsHighlighter.cpp
@@ -572,7 +572,7 @@ XmlMatchedTagsHighlighter::FindResult XmlMatchedTagsHighlighter::findText(const 
 	search.chrg.cpMax = static_cast<Sci_Position>(end);
 
 	LangType lang = (_pEditView->getCurrentBuffer())->getLangType();
-	if (lang == L_XML || (lang == L_HTML && wcsicmp(PathFindExtension((_pEditView->getCurrentBuffer())->getFileName()), L".xhtml") == 0))
+	if (lang == L_XML || (lang == L_HTML && _wcsicmp(PathFindExtension((_pEditView->getCurrentBuffer())->getFileName()), L".xhtml") == 0))
 		flags = flags | SCFIND_MATCHCASE;
 
 	intptr_t result = _pEditView->execute(SCI_FINDTEXTFULL, flags, reinterpret_cast<LPARAM>(&search));

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -161,7 +161,7 @@ void NativeLangSpeaker::init(TiXmlDocumentA *nativeLangDocRootA, bool loadIfEngl
 				// get original file name (defined by Notpad++) from the attribute
                 _fileName = element->Attribute("filename");
 
-				if (!loadIfEnglish && _fileName && stricmp("english.xml", _fileName) == 0)
+				if (!loadIfEnglish && _fileName && _stricmp("english.xml", _fileName) == 0)
                 {
 					_nativeLangA = NULL;
 					return;


### PR DESCRIPTION
Issue: #16645
---
Microsoft has deprecated function names of stricmp and wcsicmp. Please see this [article](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stricmp-wcsicmp?view=msvc-170).

**From that article:**
> The Microsoft-specific function names stricmp and wcsicmp are deprecated aliases for the [_stricmp and _wcsicmp](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stricmp-wcsicmp-mbsicmp-stricmp-l-wcsicmp-l-mbsicmp-l?view=msvc-170) functions. By default, they generate [Compiler warning (level 3) C4996](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-170). The names are deprecated because they don't follow the Standard C rules for implementation-specific names. However, the functions are still supported.
> 
> We recommend you use [_stricmp or _wcsicmp](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stricmp-wcsicmp-mbsicmp-stricmp-l-wcsicmp-l-mbsicmp-l?view=msvc-170) instead. Or, you can continue to use these function names, and disable the warning.