### PR TITLE
Fix the issue where the menu bar is toggled to reappear when right-clicking on the title bar

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -344,8 +344,6 @@ private:
 	WindowsMenu _windowsMenu;
 	HMENU _mainMenuHandle = NULL;
 
-	bool _sysMenuEntering = false;
-
 	// make sure we don't recursively call doClose when closing the last file with -quitOnEmpty
 	bool _isAttemptingCloseOnQuit = false;
 

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2983,13 +2983,16 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				return TRUE;
 			}
 
-			if (wParam == SC_KEYMENU && lParam == VK_SPACE)
+			if ((wParam == SC_KEYMENU && lParam != VK_SPACE))
 			{
-				_sysMenuEntering = true;
-			}
-			else if (wParam == 0xF093) //it should be SC_MOUSEMENU. A bug?
-			{
-				_sysMenuEntering = true;
+				const NppGUI & nppgui = nppParam.getNppGUI();
+				if (!nppgui._menuBarShow)
+				{
+					HMENU curMenuHandle = (!::GetMenu(hwnd)) ? _mainMenuHandle : NULL;
+					::SetMenu(hwnd, curMenuHandle);
+
+					return FALSE;	// must return here to prevent the system from activating the menu bar
+				}
 			}
 
 			return ::DefWindowProc(hwnd, message, wParam, lParam);
@@ -3778,24 +3781,6 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 		{
 			_windowsMenu.initPopupMenu(reinterpret_cast<HMENU>(wParam), _pDocTab);
 			return TRUE;
-		}
-
-		case WM_ENTERMENULOOP:
-		{
-			const NppGUI & nppgui = nppParam.getNppGUI();
-			if (!nppgui._menuBarShow && !wParam && !_sysMenuEntering)
-				::SetMenu(hwnd, _mainMenuHandle);
-
-			return TRUE;
-		}
-
-		case WM_EXITMENULOOP:
-		{
-			const NppGUI & nppgui = nppParam.getNppGUI();
-			if (!nppgui._menuBarShow && !wParam && !_sysMenuEntering)
-				::SetMenu(hwnd, NULL);
-			_sysMenuEntering = false;
-			return FALSE;
 		}
 
 		case WM_DPICHANGED:


### PR DESCRIPTION
## 🐞 Description
This PR fixes a UI bug where the menu bar temporarily reappears when right-clicking the title bar to open the system menu, even though it is set to be hidden via `Preferences > General > Menu`
Issue #16652

## ✅ Test Plan
- Manual testing on Windows 10/11
- Tested in cases pressing the Alt/F10 key when the system menu is displayed.

## 📋 Checklist
- [x] Code compiles without errors
- [x] Manual testing completed
- [x] No regressions observed