### PR TITLE
[BUG FIX] Double-clicking the tab view border still creates a new tab

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2997,7 +2997,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_LBUTTONDBLCLK:
 		{
-			::SendMessage(hwnd, WM_COMMAND, IDM_FILE_NEW, 0);
+			POINT pt;
+			::GetCursorPos(&pt);
+			if (!_mainDocTab.isPointInBorder(pt))	// no need to check for _subDocTab here
+				::SendMessage(hwnd, WM_COMMAND, IDM_FILE_NEW, 0);
+
 			return TRUE;
 		}
 

--- a/PowerEditor/src/ScintillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.cpp
@@ -267,3 +267,33 @@ void DocTabView::reSizeTo(RECT & rc)
 	SendMessage(_hParent, NPPM_INTERNAL_UPDATECLICKABLELINKS, reinterpret_cast<WPARAM>(_pView), 0);
 }
 
+// Check if a (clicked) point is within the border
+bool DocTabView::isPointInBorder(POINT pt) const
+{
+	RECT rcView;
+	::GetClientRect(_pView->getHSelf(), &rcView);
+	::ClientRectToScreenRect(_pView->getHSelf(), &rcView);
+
+	RECT rcViewWithBorder = rcView;
+	NppParameters& nppParam = NppParameters::getInstance();
+	NppGUI& nppGUI = nppParam.getNppGUI();
+	if (nppGUI._tabStatus & TAB_HIDE)
+	{
+		// if the tab bar is hidden, there will be no border
+		// which means no matter where the point is, it can't be within the border
+
+		return false;
+	}
+	else
+	{
+		int borderWidth = nppParam.getSVP()._borderWidth + borderWidthOffset;
+
+		rcViewWithBorder.left -= borderWidth;
+		rcViewWithBorder.right += borderWidth * 2;
+		rcViewWithBorder.top -= borderWidth;
+		rcViewWithBorder.bottom += (borderWidth * 2);
+	}
+
+	return (::PtInRect(&rcViewWithBorder, pt) && !::PtInRect(&rcView, pt));
+};
+

--- a/PowerEditor/src/ScintillaComponent/DocTabView.h
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.h
@@ -24,6 +24,7 @@ const int UNSAVED_IMG_INDEX = 1;
 const int REDONLY_IMG_INDEX = 2;
 const int MONITORING_IMG_INDEX = 3;
 
+const int borderWidthOffset = 2;
 
 class DocTabView : public TabBarPlus
 {
@@ -89,6 +90,7 @@ public :
 			index = 0;
 		return _pIconListVector[index]->getHandle();
 	};
+	bool isPointInBorder(POINT pt) const;
 
 private :
 	ScintillaEditView *_pView = nullptr;

--- a/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.h
+++ b/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.h
@@ -83,4 +83,5 @@ private :
 	static LRESULT CALLBACK staticWinProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
 	LRESULT runProc(UINT Message, WPARAM wParam, LPARAM lParam);
 	void rotateTo(DIRECTION direction);
+	bool isPointInBorder(POINT pt, Window* whichWnd = nullptr) const;
 };


### PR DESCRIPTION
## 🐞Description
The issue was reported in [#16561 (comment)](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/16561#issuecomment-2938756492)

## ✅ Test Plan
- Manual testing on Windows 10/11
- Tested in both Single-View and Double-View modes
- Tested in both Tab Bar visible and hidden cases

## 🔗 Related Issue
Merging this PR can reopen #16561 and #16552

## 📋 Checklist
- [x] Code compiles without errors
- [x] Manual testing completed
- [x] No regressions observed