### PR TITLE
let NPPM_DARKMODESUBCLASSANDTHEME also subclass TabControls

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1,4 +1,4 @@
-﻿// This file is part of Notepad++ project
+// This file is part of Notepad++ project
 // Copyright (C)2021 adzm / Adam D. Walling
 
 // This program is free software: you can redistribute it and/or modify
@@ -2847,6 +2847,13 @@ namespace NppDarkMode
 			if (wcscmp(className, WC_LINK) == 0)
 			{
 				NppDarkMode::setUrlLinkControlColor(hwnd, p);
+				return TRUE;
+			}
+
+			// For plugins
+			if (wcscmp(className, WC_TABCONTROL) == 0)
+			{
+				NppDarkMode::subclassTabControl(hwnd);
 				return TRUE;
 			}
 


### PR DESCRIPTION
I believe this fixes #16668 

However, as I said in the issue, I am not an expert in Dark Mode coding, and my PR doesn't pass the `NppDarkModeParams p` as a parameter (because the existing `subclassTabControl()` doesn't currently take that argument): it appears to work correctly (as the second screenshot from the issue was taken using the code from this PR):

![](https://private-user-images.githubusercontent.com/17455758/454140787-356bdad9-d9b9-43a6-a664-d131886c1844.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDk2ODM2OTUsIm5iZiI6MTc0OTY4MzM5NSwicGF0aCI6Ii8xNzQ1NTc1OC80NTQxNDA3ODctMzU2YmRhZDktZDliOS00M2E2LWE2NjQtZDEzMTg4NmMxODQ0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA2MTElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNjExVDIzMDk1NVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTZhOGEwZWFmMWQwODcwMjk0YmJlNWJmMzM0MzE4M2QzZDRiNWQ4ODQ2ODM1ZDBmM2RiMDNmMjQwYzc3ZGJjYzUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.DH685o6saAknERhWswArx66dXRY4oOGHi1c7VSYusp8)

So if that call is not sufficient (for example, if a new copy of that function needs to be made, which does accept the parameter), I will probably need someone else to either provide guidance, or make edits to this PR, or reject this PR and have an expert provide a separate implementation.