### PR TITLE
Dark mode enhancement for tab control

### DIFF
--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -1013,7 +1013,6 @@ intptr_t CALLBACK UserDefineDialog::run_dlgProc(UINT message, WPARAM wParam, LPA
             _pUserLang = _pCurrentUserLang;
 
             _ctrlTab.init(_hInst, _hSelf);
-            NppDarkMode::subclassTabControl(_ctrlTab.getHSelf());
 
             _folderStyleDlg.init(_hInst, _hSelf);
             _folderStyleDlg.create(IDD_FOLDER_STYLE_DLG);

--- a/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
+++ b/PowerEditor/src/WinControls/Grid/ShortcutMapper.cpp
@@ -24,7 +24,6 @@ using namespace std;
 void ShortcutMapper::initTabs()
 {
 	_hTabCtrl = ::GetDlgItem(_hSelf, IDC_BABYGRID_TABBAR);
-	NppDarkMode::subclassTabControl(_hTabCtrl);
 	TCITEM tie{};
 	tie.mask = TCIF_TEXT;
 

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -130,7 +130,6 @@ void PluginsAdminDlg::create(int dialogID, bool isRTL, bool msgDestParent)
 	RECT rect{};
 	getClientRect(rect);
 	_tab.init(_hInst, _hSelf, false, true);
-	NppDarkMode::subclassTabControl(_tab.getHSelf());
 
 	const wchar_t *available = L"Available";
 	const wchar_t *updates = L"Updates";


### PR DESCRIPTION
- enable to use in generic dark mode subclass for plugins
- handle more styles (button style, usage of icons)
- double buffer to avoid flicker
- focus rect when keyboard is used for navigation

fix #16668