### PR TITLE
 Issue: #16432 - Added regex flavor display using tooltip

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -514,6 +514,7 @@ Translation note:
 					<Item id="1727" name="⤵ Copy from Find to Replace"/>
 					<Item id="1728" name="⤴ Copy from Replace to Find"/>
 				</Menu>
+				<Item id="regex-flavor-tip" name="Regex flavor: Boost.Regex (Perl syntax)&#x0a;See Notepad++ documentation for details."/>
 			</Find>
 
 			<IncrementalFind title="">

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -1593,7 +1593,11 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 
 			 wstring findInFilesFilterTip = pNativeSpeaker->getLocalizedStrFromID("find-in-files-filter-tip", L"Find in cpp, cxx, h, hxx && hpp:\r*.cpp *.cxx *.h *.hxx *.hpp\r\rFind in all files except exe, obj && log:\r*.* !*.exe !*.obj !*.log\r\rFind in all files but exclude folders tests, bin && bin64:\r*.* !\\tests !\\bin*\r\rFind in all files but exclude all folders log or logs recursively:\r*.* !+\\log*");
 			 _filterTip = CreateToolTip(IDD_FINDINFILES_FILTERS_STATIC, _hSelf, _hInst, const_cast<PTSTR>(findInFilesFilterTip.c_str()), _isRTL);
-
+			 // Added tooltip to display the regex flavor used in the Find dialog.
+			 std::wstring regexTip = pNativeSpeaker->getLocalizedStrFromID("regex-flavor-tip", L"Regex flavor: Boost.Regex (Perl syntax)\nSee Notepad++ documentation for details.");
+			 std::vector<wchar_t> regexTipBuffer(regexTip.begin(), regexTip.end());
+			 regexTipBuffer.push_back(L'\0');
+			 CreateToolTip(IDREGEXP, _hSelf, _hInst, const_cast<LPWSTR>(regexTip.c_str()), _isRTL);
 			 wstring dirFromActiveDocTip = pNativeSpeaker->getLocalizedStrFromID("find-in-files-dir-from-active-doc-tip", L"Fill directory field based on active document");
 			 _dirFromActiveDocTip = CreateToolTip(IDD_FINDINFILES_SETDIRFROMDOC_BUTTON, _hSelf, _hInst, const_cast<PTSTR>(dirFromActiveDocTip.c_str()), _isRTL);
 


### PR DESCRIPTION
Issue Description #16432

**Problem:**
Users of the Find dialog in Notepad++ may not know which regular expression (regex) engine or syntax is used when the "Regular expression" search mode is selected. This can cause confusion, as different editors use different regex flavors.
---
**Solution**
What was done:
A tooltip was added to the "Regular expression" option in the Find dialog, clarifying the regex flavor (Boost.Regex, Perl syntax) and referencing the Notepad++ documentation. The tooltip text is localized.
---
Code Changes
Files Modified:
•	src/ScintillaComponent/FindReplaceDlg.cpp
•	localization/english.xml
Key changes:
1.	FindReplaceDlg.cpp
      •	During Find dialog initialization, a tooltip is created for the "Regular expression" radio button.
      •	The tooltip text is retrieved using the localization system with the key "regex-flavor-tip", and a default message is provided.
      •	The tooltip is attached to the IDREGEXP control.
2.	english.xml
    •	Added a new entry for the tooltip string.
        This enables localization and ensures the tooltip can be translated in other language files.
-
Testing:
•	The changes were built and tested locally on my development environment.
•	I verified that the new tooltip for the regex flavor appears as expected in the Find dialog.
•	All existing Find/Replace dialog functionality continues to work as before.
•	No crashes or regressions were observed.
__
**Summary**
•	Issue: Lack of clarity about the regex engine in the Find dialog.
•	Fix: Added a localized tooltip to the regex option, clarifying the regex flavor.
•	Files changed: FindReplaceDlg.cpp, english.xml (localization).
________


