### PR TITLE
Fixes issue 16651 Tooltips on Document List gets stuck

### DIFF
--- a/PowerEditor/src/WinControls/TaskList/TaskList.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskList.h
@@ -24,6 +24,7 @@
 #ifndef WM_MOUSEWHEEL
 #define WM_MOUSEWHEEL 0x020A
 #endif //WM_MOUSEWHEEL
+struct TaskListInfo;
 
 class TaskList : public Window
 {
@@ -50,6 +51,10 @@ public:
 	HFONT GetFontSelected() {return _hFontSelected;}
 
 protected:
+
+	HWND _hToolTip = nullptr;
+	int _lastToolTipIndex = -1;
+	TaskListInfo* _taskListInfo = nullptr;
 
 	WNDPROC _defaultProc = nullptr;
 	LRESULT runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);

--- a/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
+++ b/PowerEditor/src/WinControls/TaskList/TaskListDlg.h
@@ -57,6 +57,7 @@ public :
 
 protected :
 	intptr_t CALLBACK run_dlgProc(UINT Message, WPARAM wParam, LPARAM lParam) override;
+	int _lastToolTipIndex = -1;
 
 private :
 	TaskList _taskList;


### PR DESCRIPTION
### Description
This PR fixes an issue [16651](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16651) where tooltips in the Document List do not refresh properly when moving the mouse from top to bottom over open documents. The tooltip would often get stuck and not show the correct file path, especially when moving slowly.

### Root Cause
The tooltip was not being refreshed consistently on mouse movement due to missing or incorrect handling of WM_MOUSEMOVE events in the document list window. This caused the tooltip to remain stuck on a previously hovered item, especially when hovering slowly downward.

### Fix
The tooltip is now correctly updated when the mouse moves over a different document in the list, no matter the direction.

**Screenshots of the output:**
![Screenshot 2025-06-18 211448](https://github.com/user-attachments/assets/537dd561-4340-47de-b1c5-757498835fd7)
![Screenshot 2025-06-18 211500](https://github.com/user-attachments/assets/0cd0b588-3929-42b7-aebe-97a7453df98b)