### PR TITLE
Fix toggling "Read-only attribute in Windows" command wrong behaviour with invalid file attribute(s) or insufficient user rights

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -220,7 +220,7 @@ std::wstring getDateTimeStrFrom(const std::wstring& dateTimeFormat, const SYSTEM
 
 HFONT createFont(const wchar_t* fontName, int fontSize, bool isBold, HWND hDestParent);
 bool removeReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath);
-bool toggleReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath);
+bool toggleReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath, bool& isChangedToReadOnly);
 
 bool isWin32NamespacePrefixedFileName(const std::wstring& fileName);
 bool isWin32NamespacePrefixedFileName(const wchar_t* szFileName);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2107,9 +2107,10 @@ void Notepad_plus::command(int id)
 
 		case IDM_EDIT_TOGGLESYSTEMREADONLY:
 		{
-			Buffer * buf = _pEditView->getCurrentBuffer();
-			bool isSysReadOnly = toggleReadOnlyFlagFromFileAttributes(buf->getFullPathName());
-			buf->setFileReadOnly(isSysReadOnly);
+			Buffer* buf = _pEditView->getCurrentBuffer();
+			bool isSysReadOnly = false;
+			if (toggleReadOnlyFlagFromFileAttributes(buf->getFullPathName(), isSysReadOnly))
+				buf->setFileReadOnly(isSysReadOnly);
 		}
 		break;
 


### PR DESCRIPTION
Fix #16734

Before, the func could return incorrect Read-Only boolean file-state:
- when the  `if (dwFileAttribs == INVALID_FILE_ATTRIBUTES || (dwFileAttribs & FILE_ATTRIBUTE_DIRECTORY))` was true
- also when the  `SetFileAttributes` WINAPI failed (ERROR_ACCESS_DENIED)