### PR TITLE
[BUG FIX] Double clicking on border creates a new tab (new solution)

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3006,7 +3006,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 		case WM_LBUTTONDBLCLK:
 		{
-			::SendMessage(hwnd, WM_COMMAND, IDM_FILE_NEW, 0);
+			DocTabView* curTabView = (currentView() == MAIN_VIEW) ? &_mainDocTab : &_subDocTab;
+			if (curTabView)
+				::SendMessage(curTabView->getHSelf(), WM_LBUTTONDBLCLK, wParam, lParam);
+
 			return TRUE;
 		}
 

--- a/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.cpp
+++ b/PowerEditor/src/WinControls/SplitterContainer/SplitterContainer.cpp
@@ -316,7 +316,7 @@ LRESULT SplitterContainer::runProc(UINT message, WPARAM wParam, LPARAM lParam)
 				: (pt.y < 0 ? _pWin0 : _pWin1);
 
 			::SendMessage(parent, NPPM_INTERNAL_SWITCHVIEWFROMHWND, 0, reinterpret_cast<LPARAM>(targetWindow->getHSelf()));
-			::SendMessage(parent, WM_COMMAND, IDM_FILE_NEW, 0);
+			::SendMessage(parent, WM_LBUTTONDBLCLK, wParam, lParam);
 			return TRUE;
 		}
 


### PR DESCRIPTION
## 🐞Description
The issue was reported in [#16561 (comment)](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/16561#issuecomment-2938756492)
This PR implements another solution than #16662

## ✅ Test Plan
- [x] Manual testing on Windows 10/11
- [x] Testing with both Single-View and Double-View modes
- [x] Testing the tab bar in both vertical and horizontal (normal) orientations
- [x] Testing the tab bar in both single-line and multi-line modes
- [x] Testing with the tab bar both visible and hidden
- [x] Testing with `Double click to close document` option both enabled and disabled

## 📋 Checklist
- [x] Code compiles without errors
- [x] Manual testing completed
- [x] No regressions observed