### PR TITLE
Themes: get rid of fontSize overrides

### DIFF
--- a/PowerEditor/installer/themes/Bespin.xml
+++ b/PowerEditor/installer/themes/Bespin.xml
@@ -43,135 +43,135 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="go" desc="Go" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="FFAAFF" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RAW" styleID="20" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="FFAAFF" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
@@ -219,68 +219,68 @@ Credits:
             <WordsStyle name="ANSI COLOR WHITE" styleID="55" fgColor="FFFFFF" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="" fontSize="" />
@@ -298,91 +298,91 @@ Credits:
             <WordsStyle name="STATEMENT" styleID="15" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="USER1" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="USER1" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="80FF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF0000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="FF82B0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="80FF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF0000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="FF82B0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER-DEFINED" styleID="16" fgColor="FF5555" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">the_ID the_post have_posts wp_link_pages the_content</WordsStyle>
-            <WordsStyle name="STRING" styleID="119" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1">$_POST $_GET $_SESSION</WordsStyle>
-            <WordsStyle name="NUMBER" styleID="122" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="BDAF9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREDEFINED" styleID="213" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6"></WordsStyle>
-            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7"></WordsStyle>
-            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8"></WordsStyle>
-            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1"></WordsStyle>
-            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2"></WordsStyle>
-            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3"></WordsStyle>
-            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4"></WordsStyle>
-            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5"></WordsStyle>
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER-DEFINED" styleID="16" fgColor="FF5555" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1">the_ID the_post have_posts wp_link_pages the_content</WordsStyle>
+            <WordsStyle name="STRING" styleID="119" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="121" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1">$_POST $_GET $_SESSION</WordsStyle>
+            <WordsStyle name="NUMBER" styleID="122" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="BDAF9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6"></WordsStyle>
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7"></WordsStyle>
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4"></WordsStyle>
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5"></WordsStyle>
         </LexerType>
         <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="BDAF9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1">alert appendChild arguments array blur checked childNodes className confirm dialogArguments event focus getElementById getElementsByTagName innerHTML keyCode length location null number parentNode push RegExp replace selectNodes selectSingleNode setAttribute split src srcElement test undefined value window</WordsStyle>
-            <WordsStyle name="USER-DEFINED" styleID="16" fgColor="FF5555" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">XmlUtil loadXmlString TopologyXmlTree NotificationArea loadXmlFile debug</WordsStyle>
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="BDAF9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="46" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1">alert appendChild arguments array blur checked childNodes className confirm dialogArguments event focus getElementById getElementsByTagName innerHTML keyCode length location null number parentNode push RegExp replace selectNodes selectSingleNode setAttribute split src srcElement test undefined value window</WordsStyle>
+            <WordsStyle name="USER-DEFINED" styleID="16" fgColor="FF5555" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1">XmlUtil loadXmlString TopologyXmlTree NotificationArea loadXmlFile debug</WordsStyle>
             <WordsStyle name="STRINGRAW" styleID="20" fgColor="00FF40" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="00FF40" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="80FF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="00FF40" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="00FF40" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10">param @projectDescription projectDescription @param</WordsStyle>
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="00FF40" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="80FF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="00FF40" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="00FF40" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="">param @projectDescription projectDescription @param</WordsStyle>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
@@ -401,143 +401,143 @@ Credits:
             <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1">import</WordsStyle>
-            <WordsStyle name="STRING" styleID="85" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10">import</WordsStyle>
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="84" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1">import</WordsStyle>
+            <WordsStyle name="STRING" styleID="85" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="">import</WordsStyle>
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="XMLEND" styleID="13" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="80FF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="80FF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF0000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="666666" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="80FF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="80FF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="37A8ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF0000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="8080FF" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="00FF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="8080FF" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="FF8080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="00FF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F8" bgColor="2A211C" fontSize="" fontStyle="0" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="FF5555" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FF5555" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="9DF39F" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="3" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATE" styleID="8" fgColor="9DF39F" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="2" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ID" styleID="10" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="7" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="13" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASM" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASM" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="HASH" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="STRING Q" styleID="26" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING QQ" styleID="27" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QX" styleID="28" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QR" styleID="29" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QW" styleID="30" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="TRANSLATION" styleID="44" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="2" fontSize="" />
@@ -554,10 +554,10 @@ Credits:
             <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="FORMAT BODY" styleID="42" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DATA SECTION" styleID="21" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="21" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="POD VERBATIM" styleID="31" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="10" fontSize="" />
         </LexerType>
         <LexerType name="raku" desc="Raku" ext="">
             <WordsStyle name="DEFAULT"                      styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
@@ -592,71 +592,71 @@ Credits:
             <WordsStyle name="CLASS"                        styleID="28" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type6" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
@@ -676,360 +676,360 @@ Credits:
             <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="2A211C" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10">endfunction endif</WordsStyle>
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="LABEL" styleID="7" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="SECTION" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="">endfunction endif</WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="BDAF9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2">ContentScroller</WordsStyle>
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">onMotionChanged onMotionFinished Tween ImagesStrip ContentScroller mx transitions easing Sprite Point MouseEvent Event BitmapData Timer TimerEvent addEventListener event x y height width</WordsStyle>
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="80FF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="7E7E7E" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="7E7E7E" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7E7E7E" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="FF0000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="BDAF9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2">ContentScroller</WordsStyle>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="37A3ED" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1">onMotionChanged onMotionFinished Tween ImagesStrip ContentScroller mx transitions easing Sprite Point MouseEvent Event BitmapData Timer TimerEvent addEventListener event x y height width</WordsStyle>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="80FF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="7E7E7E" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFF00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="7E7E7E" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7E7E7E" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="FFFF80" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="FF0080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="FF0000" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING Q" styleID="24" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Name" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10">True False</WordsStyle>
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="">True False</WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="1" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="1" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SELF" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NIL" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">if else for while</WordsStyle>
-            <WordsStyle name="LINENUM" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10">bool long int char</WordsStyle>
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="8" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="11" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1">if else for while</WordsStyle>
+            <WordsStyle name="LINENUM" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="">bool long int char</WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="11" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER" styleID="19" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="2A211C" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="2A211C" fontName="" fontStyle="" fontSize="" />
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="2" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VAR" styleID="5" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SENT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="6" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SECTION" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="EFE900" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING R" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="FB9A4B" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
@@ -1043,9 +1043,9 @@ Credits:
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="BDAE9D" bgColor="2A211C" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="2A211C" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="E5C138" bgColor="2A211C" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="4B3C34" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="83675A" fgColor="C00000" />

--- a/PowerEditor/installer/themes/Black board.xml
+++ b/PowerEditor/installer/themes/Black board.xml
@@ -45,135 +45,135 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="go" desc="Go" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="FBDEFB" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RAW" styleID="20" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="FBDEFB" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
@@ -221,68 +221,68 @@ Credits:
             <WordsStyle name="ANSI COLOR WHITE" styleID="55" fgColor="FFFFFF" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="" fontSize="" />
@@ -300,87 +300,87 @@ Credits:
             <WordsStyle name="STATEMENT" styleID="15" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="USER1" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="USER1" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="119" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="122" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREDEFINED" styleID="213" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="119" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="121" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
         </LexerType>
         <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRINGRAW" styleID="20" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRINGRAW" styleID="20" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
@@ -399,143 +399,143 @@ Credits:
             <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="85" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="84" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="7F90AA" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="XMLEND" styleID="13" fgColor="7F90AA" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="7F90AA" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="7F90AA" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F8" bgColor="0C1021" fontSize="" fontStyle="0" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="7F90AA" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="FF8080" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="7F90AA" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FF8080" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATE" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ID" styleID="10" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="7" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="13" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASM" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASM" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="HASH" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="STRING Q" styleID="26" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING QQ" styleID="27" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QX" styleID="28" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QR" styleID="29" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QW" styleID="30" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="TRANSLATION" styleID="44" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="2" fontSize="" />
@@ -552,10 +552,10 @@ Credits:
             <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="FORMAT BODY" styleID="42" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DATA SECTION" styleID="21" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="21" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="POD VERBATIM" styleID="31" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="10" fontSize="" />
         </LexerType>
         <LexerType name="raku" desc="Raku" ext="">
             <WordsStyle name="DEFAULT"                      styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
@@ -590,63 +590,63 @@ Credits:
             <WordsStyle name="CLASS"                        styleID="28" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="BECDE6" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="BECDE6" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type6" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
@@ -666,360 +666,360 @@ Credits:
             <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10">endfunction endif</WordsStyle>
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="LABEL" styleID="7" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="SECTION" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="">endfunction endif</WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING Q" styleID="24" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Name" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10">True False</WordsStyle>
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="">True False</WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="1" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="1" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SELF" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NIL" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="8" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="11" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="11" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER" styleID="19" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="0C1021" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="0C1021" fontName="" fontStyle="" fontSize="" />
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="2" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VAR" styleID="5" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SENT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="6" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SECTION" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="FF6400" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING R" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="8DA6CE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
@@ -1033,9 +1033,9 @@ Credits:
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="F8F8F8" bgColor="0C1021" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="0C1021" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="0C1021" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="121830" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="253B76" fgColor="8000FF" />

--- a/PowerEditor/installer/themes/Choco.xml
+++ b/PowerEditor/installer/themes/Choco.xml
@@ -45,135 +45,135 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="go" desc="Go" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="B393B3" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RAW" styleID="20" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="B393B3" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
@@ -221,68 +221,68 @@ Credits:
             <WordsStyle name="ANSI COLOR WHITE" styleID="55" fgColor="FFFFFF" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="" fontSize="" />
@@ -300,87 +300,87 @@ Credits:
             <WordsStyle name="STATEMENT" styleID="15" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="USER1" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10">ooooo</WordsStyle>
-            <WordsStyle name="STRING2" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10">ooooo</WordsStyle>
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="USER1" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="">ooooo</WordsStyle>
+            <WordsStyle name="STRING2" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="">ooooo</WordsStyle>
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="119" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="122" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREDEFINED" styleID="213" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="119" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="121" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
         </LexerType>
         <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="46" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
             <WordsStyle name="STRINGRAW" styleID="20" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
@@ -399,143 +399,143 @@ Credits:
             <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="85" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="84" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="494949" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="XMLEND" styleID="13" fgColor="494949" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="494949" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="494949" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="C3BE98" bgColor="1A0F0B" fontSize="" fontStyle="0" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="FF8080" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FF8080" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="A8799C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="3" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATE" styleID="8" fgColor="A8799C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ID" styleID="10" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="7" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="13" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASM" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASM" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="HASH" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="STRING Q" styleID="26" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING QQ" styleID="27" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QX" styleID="28" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QR" styleID="29" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QW" styleID="30" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="TRANSLATION" styleID="44" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="2" fontSize="" />
@@ -552,10 +552,10 @@ Credits:
             <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="FORMAT BODY" styleID="42" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DATA SECTION" styleID="21" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="21" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="POD VERBATIM" styleID="31" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="10" fontSize="" />
         </LexerType>
         <LexerType name="raku" desc="Raku" ext="">
             <WordsStyle name="DEFAULT"                      styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
@@ -590,63 +590,63 @@ Credits:
             <WordsStyle name="CLASS"                        styleID="28" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type6" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
@@ -666,360 +666,360 @@ Credits:
             <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10">endfunction endif</WordsStyle>
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="LABEL" styleID="7" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="SECTION" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="">endfunction endif</WordsStyle>
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING Q" styleID="24" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Name" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10">True False</WordsStyle>
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="">True False</WordsStyle>
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="1" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="1" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SELF" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NIL" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1">if else for while</WordsStyle>
-            <WordsStyle name="LINENUM" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10">bool long int char</WordsStyle>
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="8" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="11" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1">if else for while</WordsStyle>
+            <WordsStyle name="LINENUM" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="">bool long int char</WordsStyle>
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="11" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER" styleID="19" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="1A0F0B" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="1A0F0B" fontName="" fontStyle="" fontSize="" />
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="2" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VAR" styleID="5" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="C29863" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SENT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="6" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SECTION" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="6D4C2F" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING R" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="D77261" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="7989A6" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
@@ -1033,9 +1033,9 @@ Credits:
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="C3BE98" bgColor="1A0F0B" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="281711" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="372017" fgColor="8000FF" />

--- a/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
+++ b/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
@@ -860,7 +860,7 @@ Installation : Copy this file to "%APPDATA%\Notepad++\themes" and in a portable 
             <WordsStyle name="OPERATOR" styleID="10" fgColor="8F8F8F" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
         </LexerType>
         <LexerType name="r" desc="R" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
@@ -1152,9 +1152,9 @@ Installation : Copy this file to "%APPDATA%\Notepad++\themes" and in a portable 
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="C7C7C7" bgColor="2E2E2E" fontName="Source Code Pro" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="4D4D4D" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="9865A8" bgColor="A88AB6" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="A88AB6" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="4D4D4D" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="9865A8" bgColor="A88AB6" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="A88AB6" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="363636" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="4D4D4D" fgColor="C0C0C0" />

--- a/PowerEditor/installer/themes/Deep Black.xml
+++ b/PowerEditor/installer/themes/Deep Black.xml
@@ -215,8 +215,8 @@ https://notepad-plus-plus.org/donate/
             <!-- TYPEDEF styling applies to type1..type4 lists from langs.xml, but only associated with type1 in stylers/themes -->
             <WordsStyle name="TYPEDEF"                      styleID="22" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
             <WordsStyle name="MU"                           styleID="23" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="POSITIONAL"                   styleID="24" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="9" />
-            <WordsStyle name="ASSOCIATIVE"                  styleID="25" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="9" />
+            <WordsStyle name="POSITIONAL"                   styleID="24" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSOCIATIVE"                  styleID="25" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CALLABLE"                     styleID="26" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="GRAMMAR"                      styleID="27" fgColor="C0C0C0" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CLASS"                        styleID="28" fgColor="C0C0C0" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -581,7 +581,7 @@ https://notepad-plus-plus.org/donate/
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F STRING" styleID="16" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Hello Kitty.xml
+++ b/PowerEditor/installer/themes/Hello Kitty.xml
@@ -274,7 +274,7 @@ so your enhanced file can be included in Notepad++ future release.
             <WordsStyle name="ADDED" styleID="6" fgColor="0080FF" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
-            <WordsStyle name="DEFAULT" styleID="32" fgColor="C0C0C0" bgColor="000000" fontSize="10" fontStyle="0" />
+            <WordsStyle name="DEFAULT" styleID="32" fgColor="C0C0C0" bgColor="000000" fontSize="" fontStyle="0" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
@@ -744,7 +744,7 @@ so your enhanced file can be included in Notepad++ future release.
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="008000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFF00" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="808080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="808080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="FF8000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
@@ -1012,7 +1012,7 @@ so your enhanced file can be included in Notepad++ future release.
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="000000" bgColor="FFB0FF" fontName="Courier New" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="C0C0C0" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FF0000" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="12" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FF0000" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="800000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="FF80C0" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->

--- a/PowerEditor/installer/themes/HotFudgeSundae.xml
+++ b/PowerEditor/installer/themes/HotFudgeSundae.xml
@@ -865,7 +865,7 @@ Installation:
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CFBA28" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="B7975D" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="B7975D" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="BCBB80" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="BCBB80" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="BCBB80" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Mono Industrial.xml
+++ b/PowerEditor/installer/themes/Mono Industrial.xml
@@ -45,135 +45,135 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="go" desc="Go" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="A39EA3" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RAW" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="A39EA3" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
@@ -253,68 +253,68 @@ Credits:
             <WordsStyle name="CLASS"                        styleID="28" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="" fontSize="" />
@@ -332,87 +332,87 @@ Credits:
             <WordsStyle name="STATEMENT" styleID="15" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="USER1" styleID="16" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="KEYWORD2" styleID="19" fgColor="C0C0C0" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="USER1" styleID="16" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="C0C0C0" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="119" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="122" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREDEFINED" styleID="213" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="119" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="121" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
         </LexerType>
         <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="46" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
             <WordsStyle name="STRINGRAW" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
@@ -431,143 +431,143 @@ Credits:
             <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="85" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="84" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="XMLEND" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="FFFFFF" bgColor="222C28" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="3" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATE" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="2" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ID" styleID="10" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="7" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="13" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASM" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASM" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="10" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="HASH" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="STRING Q" styleID="26" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING QQ" styleID="27" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QX" styleID="28" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QR" styleID="29" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QW" styleID="30" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="TRANSLATION" styleID="44" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="2" fontSize="" />
@@ -584,74 +584,74 @@ Credits:
             <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="FORMAT BODY" styleID="42" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DATA SECTION" styleID="21" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="21" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="POD VERBATIM" styleID="31" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="10" fontSize="" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="F STRING" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F CHARACTER" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLE" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="F STRING" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F CHARACTER" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type6" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
@@ -671,360 +671,360 @@ Credits:
             <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="222C28" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="LABEL" styleID="7" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="SECTION" styleID="9" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING Q" styleID="24" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Name" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="1" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SELF" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NIL" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="8" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="A65EFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER" styleID="19" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="222C28" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="222C28" fontName="" fontStyle="" fontSize="" />
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VAR" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="588E60" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SENT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="9" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="6" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SECTION" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="909993" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING R" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="C87500" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="648BD2" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
@@ -1038,9 +1038,9 @@ Credits:
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="FFFFFF" bgColor="222C28" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="222C28" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="222C28" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="222C28" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="2C3833" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="919994" fgColor="000000" />

--- a/PowerEditor/installer/themes/Monokai.xml
+++ b/PowerEditor/installer/themes/Monokai.xml
@@ -45,135 +45,135 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="go" desc="Go" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="F926F9" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING RAW" styleID="20" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="F926F9" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
@@ -253,68 +253,68 @@ Credits:
             <WordsStyle name="CLASS"                        styleID="28" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
@@ -332,87 +332,87 @@ Credits:
             <WordsStyle name="STATEMENT" styleID="15" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="USER1" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="USER1" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="119" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="122" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PREDEFINED" styleID="213" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="119" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="WORD" styleID="121" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
         </LexerType>
         <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
             <WordsStyle name="STRINGRAW" styleID="20" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
@@ -431,143 +431,143 @@ Credits:
             <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="85" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="WORD" styleID="84" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="XMLEND" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F2" bgColor="272822" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="WORD" styleID="3" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DATE" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="2" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ID" styleID="10" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="7" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="13" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ASM" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ASM" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="10" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="10" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="STRING Q" styleID="26" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING QQ" styleID="27" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QX" styleID="28" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QR" styleID="29" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QW" styleID="30" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="TRANSLATION" styleID="44" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="2" fontSize="" />
@@ -584,74 +584,74 @@ Credits:
             <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="FORMAT BODY" styleID="42" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DATA SECTION" styleID="21" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="21" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="POD VERBATIM" styleID="31" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="10" fontSize="" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="FF8080" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="F STRING" styleID="16" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="F CHARACTER" styleID="17" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="F TRIPLE" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="FF8080" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="FD971F" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="F STRING" styleID="16" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="F CHARACTER" styleID="17" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type6" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
@@ -671,360 +671,360 @@ Credits:
             <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="272822" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="LABEL" styleID="7" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="SECTION" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING Q" styleID="24" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="Name" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="1" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="1" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="8" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="11" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="11" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER" styleID="19" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="6" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SECTION" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="A6E22E" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING R" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
@@ -1035,28 +1035,28 @@ Credits:
             <WordsStyle name="Current line background colour" styleID="6" bgColor="E8E8FF" fgColor="0080FF" fontSize="" fontStyle="0">bool long int char</WordsStyle>
         </LexerType>
         <LexerType name="powershell" desc="PowerShell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="CMDLET" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ALIAS" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="COMMENT STREAM" styleID="13" fgColor="75715E" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE STRING" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE CHARACTER" styleID="15" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" fgColor="75715E" bgColor="272822" fontName="" fontStyle="1" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="2" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="3" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="5" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="CMDLET" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="ALIAS" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="COMMENT STREAM" styleID="13" fgColor="75715E" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE STRING" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE CHARACTER" styleID="15" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="16" fgColor="75715E" bgColor="272822" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
         </LexerType>
     </LexerStyles>
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="F8F8F2" bgColor="272822" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="272822" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="272822" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="272822" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="3E3D32" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="49483E" fgColor="000000" />

--- a/PowerEditor/installer/themes/MossyLawn.xml
+++ b/PowerEditor/installer/themes/MossyLawn.xml
@@ -865,7 +865,7 @@ Installation:
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="efc53d" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="2a390e" bgColor="58693D" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="162504" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="f2c476" bgColor="58693D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="f2c476" bgColor="58693D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="ffdc87" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="ffdc87" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="ffdc87" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Navajo.xml
+++ b/PowerEditor/installer/themes/Navajo.xml
@@ -862,7 +862,7 @@ Installation:
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="106060" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="000000" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="000000" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Obsidian.xml
+++ b/PowerEditor/installer/themes/Obsidian.xml
@@ -745,7 +745,7 @@ Notepad++ Custom Style
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="66747B" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="FF8409" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="66747B" bgColor="293134" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Plastic Code Wrap.xml
+++ b/PowerEditor/installer/themes/Plastic Code Wrap.xml
@@ -45,135 +45,135 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="go" desc="Go" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="FFAAFF" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RAW" styleID="20" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="FFAAFF" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
@@ -253,68 +253,68 @@ Credits:
             <WordsStyle name="CLASS"                        styleID="28" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="" fontSize="" />
@@ -332,87 +332,87 @@ Credits:
             <WordsStyle name="STATEMENT" styleID="15" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="USER1" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="USER1" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="119" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="122" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREDEFINED" styleID="213" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="119" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="121" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
         </LexerType>
         <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
             <WordsStyle name="STRINGRAW" styleID="20" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
@@ -431,143 +431,143 @@ Credits:
             <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="85" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="84" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="9EFFFF" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="XMLEND" styleID="13" fgColor="9EFFFF" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="9EFFFF" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="XMLEND" styleID="13" fgColor="9EFFFF" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F8" bgColor="0B161D" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="9DF39F" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="3" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATE" styleID="8" fgColor="9DF39F" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ID" styleID="10" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="7" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="13" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASM" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASM" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="STRING Q" styleID="26" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING QQ" styleID="27" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QX" styleID="28" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QR" styleID="29" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QW" styleID="30" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="TRANSLATION" styleID="44" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="2" fontSize="" />
@@ -584,10 +584,10 @@ Credits:
             <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="FORMAT BODY" styleID="42" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DATA SECTION" styleID="21" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="21" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="POD VERBATIM" styleID="31" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="10" fontSize="" />
         </LexerType>
         <LexerType name="powershell" desc="PowerShell" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
@@ -602,68 +602,68 @@ Credits:
             <WordsStyle name="ALIAS" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="F STRING" styleID="16" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F CHARACTER" styleID="17" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLE" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="F STRING" styleID="16" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F CHARACTER" styleID="17" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type6" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
@@ -683,360 +683,360 @@ Credits:
             <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="LABEL" styleID="7" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="SECTION" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="LABEL" styleID="7" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="SECTION" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="13" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING Q" styleID="24" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING Q" styleID="24" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEXT" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Name" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEXT" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="1" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="1" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="8" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="11" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="8" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="11" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER" styleID="19" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="0B161D" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="0B161D" fontName="" fontStyle="" fontSize="" />
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="2" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="2" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LABEL" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LABEL" styleID="9" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS" styleID="6" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS" styleID="6" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SECTION" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="SECTION" styleID="4" fgColor="EFE900" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING R" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING R" styleID="4" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="EB939A" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="FB9A4B" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="14" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
@@ -1050,9 +1050,9 @@ Credits:
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="F8F8F8" bgColor="0B161D" fontName="DejaVu Sans Mono" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="0B161D" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="0B161D" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="11222D" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="162E3D" fgColor="000000" />

--- a/PowerEditor/installer/themes/Ruby Blue.xml
+++ b/PowerEditor/installer/themes/Ruby Blue.xml
@@ -599,7 +599,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Solarized-light.xml
+++ b/PowerEditor/installer/themes/Solarized-light.xml
@@ -873,7 +873,7 @@ Installation:
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="B58900" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="657B83" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="657B83" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="2AA198" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="2AA198" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="2AA198" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Solarized.xml
+++ b/PowerEditor/installer/themes/Solarized.xml
@@ -1176,7 +1176,7 @@ Installation:
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="B58900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="839496" bgColor="002B36" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="839496" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="2AA198" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="2AA198" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="2AA198" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Twilight.xml
+++ b/PowerEditor/installer/themes/Twilight.xml
@@ -46,135 +46,135 @@ Credits:
 <NotepadPlus>
     <LexerStyles>
         <LexerType name="c" desc="C" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cpp" desc="C++" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="go" desc="Go" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="CDA8CD" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RAW" styleID="20" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="PREDECLARED IDENTIFIERS" styleID="19" fgColor="CDA8CD" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RAW" styleID="20" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="java" desc="Java" ext="">
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="cs" desc="C#" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="errorlist" desc="ErrorList" ext="">
             <WordsStyle name="DEFAULT STYLE" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
@@ -254,68 +254,68 @@ Credits:
             <WordsStyle name="CLASS"                        styleID="28" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="rc" desc="RC" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="" fontSize="" />
@@ -333,87 +333,87 @@ Credits:
             <WordsStyle name="STATEMENT" styleID="15" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="" fontSize="" keywordClass="type2" />
         </LexerType>
         <LexerType name="sql" desc="SQL" ext="">
-            <WordsStyle name="KEYWORD" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="USER1" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="KEYWORD" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="USER1" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="KEYWORD2" styleID="19" fgColor="FF8080" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="Q OPERATOR" styleID="24" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="19" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="19" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER TAGS 1" styleID="192" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER TAGS 2" styleID="193" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER TAGS 3" styleID="194" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER TAGS 4" styleID="195" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="196" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="197" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="198" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="199" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="php" desc="php" ext="">
-            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="119" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="121" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="122" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="123" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="127" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREDEFINED" styleID="213" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
+            <WordsStyle name="QUESTION MARK" styleID="18" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="118" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="119" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING VARIABLE" styleID="126" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SIMPLESTRING" styleID="120" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="121" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="122" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="123" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="127" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREDEFINED" styleID="213" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="FUNCS AND METHODS 2" styleID="215" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="208" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="209" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="210" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="211" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="212" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
         </LexerType>
         <LexerType name="javascript" desc="JavaScript (embedded)" ext="">
-            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="45" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="47" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="DEFAULT" styleID="41" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="45" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="46" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="47" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
             <WordsStyle name="STRINGRAW" styleID="20" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="51" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="52" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="42" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DOUBLESTRING" styleID="48" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="49" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (CLIENT)" styleID="53" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TEMPLATE LIT. (SERVER)" styleID="68" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOLS" styleID="50" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="51" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="52" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="42" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="43" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTDOC" styleID="44" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="200" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="201" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="202" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="203" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="204" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="205" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="206" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="207" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="json" desc="JSON" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
@@ -432,143 +432,143 @@ Credits:
             <WordsStyle name="ERROR" styleID="13" fgColor="FFFF80" bgColor="FF0000" fontName="" fontStyle="0" fontSize="" />
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
-            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="83" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="84" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="85" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="87" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="81" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="83" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="84" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="85" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="87" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="86" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASPSYMBOL" styleID="15" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SCRIPTTYPE" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="USER KEYWORDS 1" styleID="216" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="217" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="218" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="219" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="220" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="221" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="222" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="223" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="xml" desc="XML" ext="wpl">
-            <WordsStyle name="XMLSTART" styleID="12" fgColor="494949" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="XMLEND" styleID="13" fgColor="494949" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="9" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAG" styleID="1" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGEND" styleID="11" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CDATA" styleID="17" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ENTITY" styleID="10" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="XMLSTART" styleID="12" fgColor="494949" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="XMLEND" styleID="13" fgColor="494949" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="9" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SINGLESTRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAG" styleID="1" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGEND" styleID="11" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TAGUNKNOWN" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTE" styleID="3" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ATTRIBUTEUNKNOWN" styleID="4" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SGMLDEFAULT" styleID="21" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CDATA" styleID="17" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ENTITY" styleID="10" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER ATTRIBUTES 1" styleID="192" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER ATTRIBUTES 2" styleID="193" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER ATTRIBUTES 3" styleID="194" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER ATTRIBUTES 4" styleID="195" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER ATTRIBUTES 5" styleID="196" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER ATTRIBUTES 6" styleID="197" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER ATTRIBUTES 7" styleID="198" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER ATTRIBUTES 8" styleID="199" fgColor="CCCCCC" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SECTION" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SECTION" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFVAL" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFVAL" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="diff" desc="DIFF" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="2" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="2" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="E8DD8E" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="2" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="CD6749" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="8FC6E8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="E8DD8E" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="CD6749" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="8FC6E8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="F8F8F8" bgColor="141414" />
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="E8DD8E" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="E8DD8E" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="E8DD8E" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="E8DD8E" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
-            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="WORD" styleID="3" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DATE" styleID="8" fgColor="9B859D" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD" styleID="3" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DATE" styleID="8" fgColor="9B859D" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="css" desc="CSS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="TAG" styleID="1" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CLASS" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VALUE" styleID="8" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ID" styleID="10" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IMPORTANT" styleID="11" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="TAG" styleID="1" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CLASS" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="PSEUDOCLASS" styleID="3" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="UNKNOWN_PSEUDOCLASS" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VALUE" styleID="8" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ID" styleID="10" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IMPORTANT" styleID="11" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DIRECTIVE" styleID="12" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="pascal" desc="Pascal" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="13" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="ASM" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="9" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="13" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="ASM" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="10" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="10" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="SCALAR" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="ARRAY" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="HASH" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="STRING Q" styleID="26" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING QQ" styleID="27" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QX" styleID="28" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QR" styleID="29" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING QW" styleID="30" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="REGEX MATCH" styleID="17" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="REGEX SUBSTITUTION" styleID="18" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="TRANSLATION" styleID="44" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="HEREDOC DELIMITER" styleID="22" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HEREDOC SINGLEQUOTE" styleID="23" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="2" fontSize="" />
@@ -585,74 +585,74 @@ Credits:
             <WordsStyle name="VAR IN STRING QR" styleID="66" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="FORMAT IDENTIFIER" styleID="41" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="FORMAT BODY" styleID="42" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DATA SECTION" styleID="21" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="21" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
+            <WordsStyle name="POD" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
             <WordsStyle name="POD VERBATIM" styleID="31" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="10" fontSize="" />
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="F STRING" styleID="16" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F CHARACTER" styleID="17" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLE" styleID="18" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="F STRING" styleID="16" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F CHARACTER" styleID="17" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F TRIPLE" styleID="18" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="F TRIPLEDOUBLE" styleID="19" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORDS" styleID="2" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LABEL" styleID="3" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORDS" styleID="2" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="LABEL" styleID="3" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="AFTER LABEL" styleID="8" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type3"/>
-            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type4"/>
-            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type5"/>
-            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type6"/>
-            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="LITERALSTRING" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="FUNC1" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="FUNC2" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="FUNC3" styleID="15" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="USER KEYWORD 1" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type3"/>
+            <WordsStyle name="USER KEYWORD 2" styleID="17" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type4"/>
+            <WordsStyle name="USER KEYWORD 3" styleID="18" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type5"/>
+            <WordsStyle name="USER KEYWORD 4" styleID="19" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type6"/>
+            <WordsStyle name="USER KEYWORDS 5" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMAND" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="TEXT" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="GROUP" styleID="2" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SYMBOL" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMAND" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="TEXT" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FF0000" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
@@ -672,360 +672,360 @@ Credits:
             <WordsStyle name="DATETIME" styleID="14" fgColor="A0FAC7" bgColor="141414" fontName="" fontStyle="1" fontSize="" />
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="FUNCTION" styleID="5" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="VARIABLE" styleID="6" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="LABEL" styleID="7" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="SECTION" styleID="9" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="8A97A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="MACRO" styleID="12" fgColor="8A97A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING VAR" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="14" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="FUNCTION" styleID="5" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="VARIABLE" styleID="6" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="LABEL" styleID="7" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="SECTION" styleID="9" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="8A97A8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="MACRO" styleID="12" fgColor="8A97A8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING VAR" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="14" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <!--
-            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="" fontSize="10" keywordClass="instre2"/>
+            <WordsStyle name="DIRECTIVE" styleID="19" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="" fontSize="" keywordClass="instre2"/>
             -->
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="FUNCTION" styleID="20" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="FUNCTION" styleID="20" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER KEYWORDS 5" styleID="132" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER KEYWORDS 6" styleID="133" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER KEYWORDS 7" styleID="134" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER KEYWORDS 8" styleID="135" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="bash" desc="bash" ext="po">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="ERROR" styleID="1" fgColor="FF6464" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CHARACTER" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SCALAR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="BACKTICKS" styleID="11" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle1" />
-            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle2" />
-            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle3" />
-            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle4" />
-            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle5" />
-            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle6" />
-            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle7" />
-            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="substyle8" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="ERROR" styleID="1" fgColor="FF6464" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CHARACTER" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="8" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SCALAR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BACKTICKS" styleID="11" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle1" />
+            <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle2" />
+            <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle3" />
+            <WordsStyle name="USER KEYWORDS 4" styleID="131" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle4" />
+            <WordsStyle name="USER SCALAR 1" styleID="132" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle5" />
+            <WordsStyle name="USER SCALAR 2" styleID="133" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle6" />
+            <WordsStyle name="USER SCALAR 3" styleID="134" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle7" />
+            <WordsStyle name="USER SCALAR 4" styleID="135" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="substyle8" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="LABEL" styleID="13" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="LABEL" styleID="13" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING2" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRINGEOL" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="LABEL" styleID="13" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING2" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRINGEOL" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="LABEL" styleID="13" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRINGEOL" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="12" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="SYMBOL" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRINGEOL" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IDENTIFIER" styleID="9" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="12" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR" styleID="4" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type3"/>
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRINGEOL" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type4"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR" styleID="4" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IDENTIFIER" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="REGISTER" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="DIRECTIVE" styleID="9" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type3"/>
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRINGEOL" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type4"/>
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="POD" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1">raise</WordsStyle>
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="CLASS NAME" styleID="8" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DEF NAME" styleID="9" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="REGEX" styleID="12" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="GLOBAL" styleID="13" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="BACKTICKS" styleID="18" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING Q" styleID="24" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="ERROR" styleID="1" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="POD" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1">raise</WordsStyle>
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="CLASS NAME" styleID="8" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEF NAME" styleID="9" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="REGEX" styleID="12" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="GLOBAL" styleID="13" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SYMBOL" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="BACKTICKS" styleID="18" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING Q" styleID="24" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="Name" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="TEXT" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="HEX STRING" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="Name" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="LITERAL" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="TEXT" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="HEX STRING" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="BASE85 STRING" styleID="14" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="BAD STRING CHAR" styleID="15" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING EOL" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type3"/>
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type4"/>
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type5"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="5" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="6" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING EOL" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION" styleID="8" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type3"/>
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type4"/>
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type5"/>
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING" styleID="1" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="GLOBAL" styleID="10" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER" styleID="15" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING" styleID="1" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SYMBOL" styleID="4" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="BINARY" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="BOOL" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SELF" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SUPER" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NIL" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="GLOBAL" styleID="10" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="RETURN" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="KWS END" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER" styleID="15" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="TAGNAME" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="8" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER" styleID="9" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING" styleID="11" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="TAGNAME" styleID="2" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="TYPE" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="LINENUM" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="8" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER" styleID="9" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING" styleID="11" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="KEYWORD" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING EOL" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="USER" styleID="19" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="11" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="KEYWORD" styleID="7" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING EOL" styleID="12" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="USER" styleID="19" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="141414" fontName="" fontStyle="" fontSize="10"/>
+            <WordsStyle name="" styleID="0" fgColor="" bgColor="141414" fontName="" fontStyle="" fontSize=""/>
         -->
-            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING" styleID="2" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING2" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="FUNCTION" styleID="8" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="OPERATOR" styleID="9" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="31" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING" styleID="2" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING2" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="VAR" styleID="5" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="FUNCTION" styleID="8" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="OPERATOR" styleID="9" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="FUNCTION" styleID="4" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="STRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR" styleID="8" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="VARIABLE" styleID="9" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type3"/>
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type4"/>
-            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type5"/>
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="FUNCTION" styleID="4" fgColor="DAD085" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="MACRO" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="STRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR" styleID="8" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="VARIABLE" styleID="9" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="SENT" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type3"/>
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type4"/>
+            <WordsStyle name="EXPAND" styleID="13" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type5"/>
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING EOL" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="LABEL" styleID="9" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="IDENTIFIER" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING EOL" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="LABEL" styleID="9" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMAND" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STRING" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMAND" styleID="2" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="STRING" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DOUBLE QUOTE STRING" styleID="8" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="haskell" desc="Haskell" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CHARACTER" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CLASS" styleID="6" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="OPERATOR" styleID="11" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="1" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CHARACTER" styleID="5" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CLASS" styleID="6" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="MODULE" styleID="7" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="DATA" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IMPORT" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="OPERATOR" styleID="11" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENTLINE" styleID="13" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENTBLOCK3" styleID="16" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="KEYWORD" styleID="2" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2"/>
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="SECTION" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type2"/>
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type3"/>
-            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type4"/>
-            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="KEYWORD" styleID="2" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2"/>
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="SECTION" styleID="4" fgColor="9B703F" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2"/>
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type3"/>
+            <WordsStyle name="KEYWORD USER" styleID="9" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type4"/>
+            <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING SINGLE" styleID="11" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="12" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING D" styleID="2" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-            <WordsStyle name="STRING L" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING R" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="COMMAND" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="instre1"/>
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="VARIABLE" styleID="7" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10" keywordClass="type1"/>
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
-            <WordsStyle name="NUMBER" styleID="14" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="10"/>
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING D" styleID="2" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="STRING L" styleID="3" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING R" styleID="4" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="COMMAND" styleID="5" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1"/>
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="VARIABLE" styleID="7" fgColor="7587A6" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1"/>
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="IFDEF" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
+            <WordsStyle name="NUMBER" styleID="14" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
         </LexerType>
         <LexerType name="searchResult" desc="Search result" ext="">
             <WordsStyle name="Search Header" styleID="1" fgColor="000080" bgColor="BBBBFF" fontName="" fontStyle="1" fontSize="" />
@@ -1039,9 +1039,9 @@ Credits:
     <GlobalStyles>
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="F8F8F8" bgColor="141414" fontName="Consolas" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="141414" fontName="" fontStyle="1" fontSize="10" />
-        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="141414" fontName="" fontStyle="0" fontSize="10" />
+        <WidgetStyle name="Indent guideline style" styleID="37" fgColor="888A85" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="FCE94F" bgColor="141414" fontName="" fontStyle="1" fontSize="" />
+        <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="292929" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->
         <WidgetStyle name="Selected text colour" styleID="0" bgColor="3E3E3E" fgColor="000000" />

--- a/PowerEditor/installer/themes/Vibrant Ink.xml
+++ b/PowerEditor/installer/themes/Vibrant Ink.xml
@@ -31,12 +31,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1" />
             <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2" />
             <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3" />
@@ -57,12 +57,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1" />
             <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2" />
             <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3" />
@@ -85,12 +85,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1" />
             <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2" />
             <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3" />
@@ -110,12 +110,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1" />
             <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2" />
             <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3" />
@@ -136,12 +136,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1" />
             <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2" />
             <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3" />
@@ -199,8 +199,8 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <LexerType name="raku" desc="Raku" ext="">
             <WordsStyle name="DEFAULT"                      styleID="0" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="ERROR"                        styleID="1" fgColor="FF80C0" bgColor="000000" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="COMMENT LINE"                 styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="8" fontSize="8" />
-            <WordsStyle name="COMMENT EMBED"                styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="8" fontSize="8" />
+            <WordsStyle name="COMMENT LINE"                 styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="8" fontSize="" />
+            <WordsStyle name="COMMENT EMBED"                styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="8" fontSize="" />
             <WordsStyle name="POD"                          styleID="4" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="CHARACTER"                    styleID="5" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="HEREDOC Q"                    styleID="6" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
@@ -239,12 +239,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1" />
             <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2" />
             <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3" />
@@ -265,12 +265,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A001D6" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
@@ -285,12 +285,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="sas" desc="SAS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="" fontSize="" />
@@ -315,14 +315,14 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="STRING" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING2" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="Q OPERATOR" styleID="24" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="html" desc="HTML" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="5" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="SINGLESTRING" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -353,8 +353,8 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="WORD" styleID="121" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="122" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="VARIABLE" styleID="123" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="124" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="124" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENTLINE" styleID="125" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="127" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="PREDEFINED" styleID="213" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle6" />
             <WordsStyle name="FUNCS AND METHODS 1" styleID="214" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle7" />
@@ -408,7 +408,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
 		</LexerType>
         <LexerType name="asp" desc="asp" ext="asp">
             <WordsStyle name="DEFAULT" styleID="81" fgColor="66FF00" bgColor="C4F9FD" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="9933CC" bgColor="C4F9FD" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENTLINE" styleID="82" fgColor="9933CC" bgColor="C4F9FD" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="83" fgColor="99CC99" bgColor="C4F9FD" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="WORD" styleID="84" fgColor="FFCC00" bgColor="C4F9FD" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="85" fgColor="66FF00" bgColor="C4F9FD" fontName="" fontStyle="0" fontSize="" />
@@ -429,7 +429,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="XMLSTART" styleID="12" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="XMLEND" styleID="13" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="5" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="DOUBLESTRING" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="SINGLESTRING" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -452,14 +452,14 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="ini" desc="ini file" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SECTION" styleID="2" fgColor="66FF00" bgColor="070707" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="DEFVAL" styleID="4" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="props" desc="Properties file" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="ASSIGNMENT" styleID="3" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="DEFVAL" styleID="4" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
@@ -477,7 +477,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="makefile" desc="Makefile" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="FFFF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -486,7 +486,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="WORD" styleID="3" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="4" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -504,7 +504,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="999966" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
             <WordsStyle name="UNKNOWN_IDENTIFIER" styleID="7" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="VALUE" styleID="8" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="9" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="9" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="ID" styleID="10" fgColor="339999" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IMPORTANT" styleID="11" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="DIRECTIVE" styleID="12" fgColor="339999" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -518,9 +518,9 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="CHARACTER" styleID="12" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="13" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="ASM" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="707070" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="4" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="707070" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="perl" desc="Perl" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="" fontSize="" />
@@ -533,7 +533,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="HASH" styleID="14" fgColor="999966" bgColor="000000" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="PROTOTYPE" styleID="40" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="8" fontSize="8" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="8" fontSize="" />
             <WordsStyle name="STRING SINGLEQUOTE" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="STRING DOUBLEQUOTE" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="STRING BACKTICKS" styleID="20" fgColor="FFFF00" bgColor="000000" fontName="" fontStyle="" fontSize="" />
@@ -567,7 +567,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="python" desc="Python" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="3" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -578,8 +578,8 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="DEFNAME" styleID="9" fgColor="FF00FF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -587,7 +587,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="batch" desc="Batch" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="KEYWORDS" styleID="2" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
             <WordsStyle name="LABEL" styleID="3" fgColor="99CC99" bgColor="FFFF80" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HIDE SYMBOL" styleID="4" fgColor="FF00FF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -598,9 +598,9 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="lua" desc="Lua" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="LITERALSTRING" styleID="8" fgColor="95004A" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
@@ -625,7 +625,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="SPECIAL" styleID="1" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
             <WordsStyle name="GROUP" styleID="2" fgColor="FF00FF" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="800000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMAND" styleID="4" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
+            <WordsStyle name="COMMAND" styleID="4" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="TEXT" styleID="5" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="4" fontSize="" />
         </LexerType>
         <LexerType name="toml" desc="TOML" ext="">
@@ -647,7 +647,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="nsis" desc="NSIS" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING DOUBLE QUOTE" styleID="2" fgColor="66FF00" bgColor="EEEEEE" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING LEFT QUOTE" styleID="3" fgColor="FFFF80" bgColor="C0C0C0" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING RIGHT QUOTE" styleID="4" fgColor="FFFFFF" bgColor="C0C0C0" fontName="" fontStyle="0" fontSize="" />
@@ -677,12 +677,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="8" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="USER KEYWORDS 1" styleID="128" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle1" />
             <WordsStyle name="USER KEYWORDS 2" styleID="129" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle2" />
             <WordsStyle name="USER KEYWORDS 3" styleID="130" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="substyle3" />
@@ -702,7 +702,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="OPERATOR" styleID="7" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SCALAR" styleID="9" fgColor="FF8040" bgColor="FFFFD9" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="PARAM" styleID="10" fgColor="9933CC" bgColor="00FFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="BACKTICKS" styleID="11" fgColor="804040" bgColor="E1FFF3" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="HERE DELIM" styleID="12" fgColor="FF6600" bgColor="FF0000" fontName="" fontStyle="1" fontSize="" />
@@ -718,7 +718,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="3" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING2" styleID="4" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -735,7 +735,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="fortran77" desc="Fortran (fixed form)" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="3" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING2" styleID="4" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -752,7 +752,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENTLINE" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -765,7 +765,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="3" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -775,7 +775,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="REGISTER" styleID="8" fgColor="8080FF" bgColor="FFFFCC" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="339999" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
             <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="type3" />
-            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="808000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
@@ -783,7 +783,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="ERROR" styleID="1" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENTLINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="POD" styleID="3" fgColor="004000" bgColor="C0FFC0" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
@@ -805,8 +805,8 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="DSC VALUE" styleID="3" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="Name" styleID="5" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -823,8 +823,8 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="vhdl" desc="VHDL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LIne" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="4" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="5" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
@@ -842,7 +842,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="1" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="408080" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="BINARY" styleID="5" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="BOOL" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -853,7 +853,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="RETURN" styleID="11" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="SPECIAL" styleID="12" fgColor="808000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="KWS END" styleID="13" fgColor="339999" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="FF80C0" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
@@ -869,10 +869,10 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="NUMBER" styleID="8" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="11" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="12" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="12" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="13" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT DOC" styleID="14" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="verilog" desc="Verilog" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -883,9 +883,9 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="66FF00" bgColor="F2F4FF" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="USER" styleID="19" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
@@ -894,7 +894,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
 		-->
             <WordsStyle name="DEFAULT" styleID="31" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="2" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING2" styleID="3" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -906,8 +906,8 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="autoit" desc="autoIt" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
-            <WordsStyle name="COMMENT" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT LINE" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
@@ -932,12 +932,12 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="STRING" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="LABEL" styleID="9" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT LINE" styleID="10" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="ILLEGAL" styleID="11" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMAND" styleID="2" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
@@ -967,13 +967,13 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="inno" desc="InnoSetup" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
             <WordsStyle name="PARAMETER" styleID="3" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="800000" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="0080C0" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="8080FF" bgColor="FFFFCC" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
             <WordsStyle name="STRING DOUBLE" styleID="10" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
@@ -982,7 +982,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         </LexerType>
         <LexerType name="cmake" desc="CMakeFile" ext="cmake">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="8" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING D" styleID="2" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING L" styleID="3" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRING R" styleID="4" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="4" fontSize="" />
@@ -1010,7 +1010,7 @@ http://sourceforge.net/donate/index.php?group_id=95717
         <!-- Attention : Don't modify the name of styleID="0" -->
         <WidgetStyle name="Default Style" styleID="32" fgColor="FFFFFF" bgColor="000000" fontName="Monaco" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Indent guideline style" styleID="37" fgColor="C0C0C0" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="1" fontSize="12" />
+        <WidgetStyle name="Brace highlight style" styleID="34" fgColor="99CC99" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="CCFF33" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="333333" />
         <!-- In below rule 'fgColor' attribute for 'Selected text colour' can be unlocked with a enableSelectFgColor.xml file -->

--- a/PowerEditor/installer/themes/khaki.xml
+++ b/PowerEditor/installer/themes/khaki.xml
@@ -862,7 +862,7 @@ Installation:
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="000087" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="5f5f00" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="5f5f00" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
             <WordsStyle name="F STRING" styleID="16" fgColor="005f5f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F CHARACTER" styleID="17" fgColor="005f5f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="F TRIPLE" styleID="18" fgColor="005f5f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/vim Dark Blue.xml
+++ b/PowerEditor/installer/themes/vim Dark Blue.xml
@@ -738,7 +738,7 @@
             <WordsStyle name="OPERATOR" styleID="10" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="C0C0C0" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="BUILTINS" styleID="14" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
         </LexerType>
         <LexerType name="raku" desc="Raku" ext="">
             <WordsStyle name="DEFAULT"                      styleID="0" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="" fontSize="" />


### PR DESCRIPTION
themes should not mess up monospacing by changing font size for only certain languages/styles: they should all inherit their font-size from the Default Style in that theme

resolves #16667