### PR TITLE
Improve security for DLL loading

### DIFF
--- a/PowerEditor/visual.net/notepadPlus.Cpp.props
+++ b/PowerEditor/visual.net/notepadPlus.Cpp.props
@@ -50,6 +50,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>..\..\scintilla\bin;$(IntDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>..\src\dpiAware.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>


### PR DESCRIPTION
related #13964

Notepad++ plugins and other 3rd party apps can cause Notepad++ to try to load DLLs in its directory, this can be used by attacker to hijack DLL, for example using his own crafted `UxTheme.dll`.

By using [/DEPENDENTLOADFLAG:0x800](https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-170) we can at least forbid loading DLLs from Notepad++ directory, DLLs which Notepad++ use directly by importing static lib files such as `UxTheme.lib` for `UxTheme.dll`.

Tested with code from #12113.

