### PR TITLE
Fix the bug where the dark mode setting causes external lexers to be duplicated in the 'Indentation Settings' list.

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1074,6 +1074,11 @@ bool NppParameters::reloadStylers(const wchar_t* stylePath)
 	_lexerStylerVect.clear();
 	_widgetStyleArray.clear();
 
+	for (int index = 0; index < _nbLang; ++index)
+		delete _langList[index];
+	_nbLang = 0;
+
+	getLangKeywordsFromXmlTree();
 	getUserStylersFromXmlTree();
 
 	//  Reload plugin styles.


### PR DESCRIPTION
## 🐞Description of the Issue
The issue was reported in #16462

## 🔍 Cause and Solution
1. When Notepad++ starts, it loads language and lexer settings (including default, user-defined, and external languages/lexers).
2. If dark mode is enabled, the `NppParameters::reloadStylers(const wchar_t* stylePath)` function is called. This function reloads the language and lexer settings (excluding the default languages), but it does not reset the language list, which leads to the duplication of external languages in the list.
3. Each time `NppParameters::reloadStylers(const wchar_t* stylePath)` is called (when switching between Light and Dark modes), the external language list will be doubled.
4. The "Indentation Settings" list in the `Preferences > Indentation` tab displays this language list. However, since it only updates once (during WM_INITDIALOG), the external lexers appear twice. (If it updates every time the styler is reloaded, they may appear more than twice)
5. To resolve this issue, I modified the `NppParameters::reloadStylers(const wchar_t* stylePath)` function to reset the language list and reload the default languages/lexers.

## ✅ Test Plan
- Manual testing on Windows 10/11

## 🔗 Related Issue
Merging this PR will close the issue #16462

## 📋 Checklist
- [x] Code compiles without errors
- [x] Manual testing completed
- [x] No regressions observed