### PR TITLE
Fix uninstaller security issue (CVE-2025-49144)

### DIFF
--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -55,12 +55,12 @@ FunctionEnd
 
 
 Section un.explorerContextMenu
-	ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_01.dll"'
-	ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_02.dll"'
-	ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_03.dll"'
-	ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_04.dll"'
-	ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_05.dll"'
-	ExecWait 'regsvr32 /u /s "$INSTDIR\NppShell_06.dll"'
+	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\NppShell_01.dll"'
+	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\NppShell_02.dll"'
+	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\NppShell_03.dll"'
+	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\NppShell_04.dll"'
+	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\NppShell_05.dll"'
+	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\NppShell_06.dll"'
 	Delete "$INSTDIR\NppShell_01.dll"
 	Delete "$INSTDIR\NppShell_02.dll"
 	Delete "$INSTDIR\NppShell_03.dll"
@@ -68,7 +68,7 @@ Section un.explorerContextMenu
 	Delete "$INSTDIR\NppShell_05.dll"
 	Delete "$INSTDIR\NppShell_06.dll"
 	
-	ExecWait 'regsvr32 /u /s "$INSTDIR\contextmenu\NppShell.dll"'
+	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\contextmenu\NppShell.dll"'
 SectionEnd
 
 Section un.UnregisterFileExt
@@ -295,7 +295,7 @@ Section Uninstall
 	; In order to not delete context menu binary before we unregistered it,
 	; we delete them at the end, using the CleanupDll function, since it can be locked by explorer.
 	IfFileExists "$INSTDIR\contextmenu\NppShell.dll" 0 +2
-		ExecWait 'rundll32.exe "$INSTDIR\contextmenu\NppShell.dll",CleanupDll'
+		ExecWait '"$winSysDir\rundll32.exe" "$INSTDIR\contextmenu\NppShell.dll",CleanupDll'
 	Delete "$INSTDIR\contextmenu\NppShell.msix"
 	
 	


### PR DESCRIPTION
Fix #16787

This pull request addresses a CWE-427: Uncontrolled Search Path Element in the Notepad++ uninstaller script (PowerEditor/installer/nsisInclude/uninstall.nsh).

Previously, the uninstaller called system binaries such as regsvr32.exe and rundll32.exe without specifying the full path, relying on the Windows search order. This could allow an attacker to execute a malicious binary if it is present in the uninstaller’s working directory (e.g., %TEMP%\\~nsu*.tmp).

This bug also allows arbitrary code execution as the recent CVE-2025-49144. However, exploitation requires admin privileges to drop malicious binaries in the temp directory, so the severity is lower. This patch ensures all regsvr32 and rundll32 calls use the full system path, matching the installer component.

The uninstaller should always call the intended system binaries from their official locations, regardless of the current working directory or the contents of any temporary directory.

TLDR: This bug also allows arbitrary code execution yet no privilege escalation is possible in the default configuration, but this is still a code hygiene and defense-in-depth issue. This is similar in nature to CVE-2025-49144, but with lower severity due to the admin privilege requirement. This patch ensures all regsvr32 and rundll32 calls use the full system path, matching the installer component.

Reference: CWE-427, CVE-2025-49144 and a similar CVE - CVE-2019-13164