### PR TITLE
Reword German FolderAsWorspaceSubfolderExists

### DIFF
--- a/PowerEditor/installer/nativeLang/german.xml
+++ b/PowerEditor/installer/nativeLang/german.xml
@@ -1541,8 +1541,8 @@ Soll die Datei trotzdem gespeichert werden?"/>
 			<LoadLangsFailed title="Konfigurator" message="Laden der Datei 'langs.xml' ist fehlgeschlagen!
 Soll die Datei 'langs.xml' wiederhergestellt werden?"/>
 			<LoadLangsFailedFinal title="Konfigurator" message="Laden der Datei 'langs.xml' ist fehlgeschlagen!"/>
-			<FolderAsWorspaceSubfolderExists title="'Verzeichnis als Arbeitsbereich'-Problem" message="Ein Unterverzeichnis existiert im Verzeichnis das hinzugefügt werden soll.
-Bitte dieses Verzeichnis vorher entfernen bevor das Verzeichnis &quot;$STR_REPLACE$&quot; hinzugefügt wird."/>
+			<FolderAsWorspaceSubfolderExists title="'Verzeichnis als Arbeitsbereich'-Problem" message="Ein Unterverzeichnis existiert im Verzeichnis, das hinzugefügt werden soll.
+Bitte das Unterverzeichnis aus dem Arbeitsbereich entfernen, bevor das Verzeichnis &quot;$STR_REPLACE$&quot; hinzugefügt wird."/>
 
 			<ProjectPanelChanged title="$STR_REPLACE$" message="Der Arbeitsbereich wurde geändert. Soll er jetzt gespeichert werden?"/>
 			<ProjectPanelSaveError title="$STR_REPLACE$" message="Ein Fehler ist beim Speichern der Arbeitsbereichsdatei aufgetreten.


### PR DESCRIPTION
This PR modifies the error message for the following case:

Add a folder like "c:\temp\aFolder\" into "Folder as Workspace" panel, then try to add "c:\temp\".

The German message was incomprehensible and did not mention the workspace panel at all - it was just telling to "remove this folder", but not whether it meant the root folder or the sub-folder, and to remove it from where.

Also fixes a comma error.