### PR TITLE
Fix "-notabbar" & asNotepad.xml stopped hiding tabbar regression (from v8.7.9)

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.cpp
+++ b/PowerEditor/src/Notepad_plus_Window.cpp
@@ -159,7 +159,8 @@ void Notepad_plus_Window::init(HINSTANCE hInst, HWND parent, const wchar_t *cmdL
 		if (cmdLineParams->_isNoTab)
 		{
 			// Restore old settings when tab bar has been hidden from tab bar.
-			nppGUI._tabStatus = tabStatusOld;
+			if (!(tabStatusOld & TAB_HIDE))
+				nppGUI._forceTabbarVisible = true;
 		}
 	}
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -7364,7 +7364,14 @@ void NppParameters::createXmlTreeFromGUIParams()
 		pStr = (_nppGUI._tabStatus & TAB_MULTILINE) ? L"yes" : L"no";
 		GUIConfigElement->SetAttribute(L"multiLine", pStr);
 
-		pStr = (_nppGUI._tabStatus & TAB_HIDE) ? L"yes" : L"no";
+		if (_nppGUI._forceTabbarVisible)
+		{
+			pStr = L"no";
+		}
+		else
+		{
+			pStr = (_nppGUI._tabStatus & TAB_HIDE) ? L"yes" : L"no";
+		}
 		GUIConfigElement->SetAttribute(L"hide", pStr);
 
 		pStr = (_nppGUI._tabStatus & TAB_QUITONEMPTY) ? L"yes" : L"no";

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -848,6 +848,7 @@ struct NppGUI final
 	bool _menuBarShow = true;
 
 	int _tabStatus = (TAB_DRAWTOPBAR | TAB_DRAWINACTIVETAB | TAB_DRAGNDROP | TAB_REDUCE | TAB_CLOSEBUTTON | TAB_PINBUTTON);
+	bool _forceTabbarVisible = false;
 
 	bool _splitterPos = POS_VERTICAL;
 	int _userDefineDlgStatus = UDD_DOCKED;


### PR DESCRIPTION
The regression is due to the refactoring of tabbar.

Fix #16794