### PR TITLE
Fix #16839: NFO font is hardcoded to Lucida Console

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -1868,8 +1868,6 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 
 			Style nfoStyle;
 			nfoStyle._styleID = STYLE_DEFAULT;
-			nfoStyle._fontName = L"Lucida Console";
-			nfoStyle._fontSize = 10;
 
 			if (pStyler)
 			{
@@ -1879,6 +1877,8 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 					nfoStyle._bgColor = pDefStyle->_bgColor;
 					nfoStyle._fgColor = pDefStyle->_fgColor;
 					nfoStyle._colorStyle = pDefStyle->_colorStyle;
+					nfoStyle._fontName = pDefStyle->_fontName;
+					nfoStyle._fontSize = pDefStyle->_fontSize;
 				}
 			}
 			setSpecialStyle(nfoStyle);


### PR DESCRIPTION
This change allows setting the font for NFO files.

Fixes #16839