### PR TITLE
Fix various clang warnings

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3911,15 +3911,6 @@ void Notepad_plus::command(int id)
 		{
 			WindowsDlg _windowsDlg;
 			_windowsDlg.init(_pPublicInterface->getHinst(), _pPublicInterface->getHSelf(), _pDocTab);
-
-            const TiXmlNodeA *nativeLangA = _nativeLangSpeaker.getNativeLangA();
-			TiXmlNodeA *dlgNode = NULL;
-			if (nativeLangA)
-			{
-				dlgNode = nativeLangA->FirstChild("Dialog");
-				if (dlgNode)
-					dlgNode = _nativeLangSpeaker.searchDlgNode(dlgNode, "Window");
-			}
 			_windowsDlg.doDialog();
 		}
 		break;

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -623,6 +623,7 @@ int hexStrVal(const wchar_t *str)
 
 int getKwClassFromName(const wchar_t *str)
 {
+	if(!str) return -1;
 	if (!lstrcmp(L"instre1", str)) return LANG_INDEX_INSTR;
 	if (!lstrcmp(L"instre2", str)) return LANG_INDEX_INSTR2;
 	if (!lstrcmp(L"type1", str)) return LANG_INDEX_TYPE;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -349,13 +349,16 @@ void ScintillaEditView::init(HINSTANCE hInst, HWND hPere)
 	if (_defaultCharList.empty())
 	{
 		auto defaultCharListLen = execute(SCI_GETWORDCHARS);
-		char *defaultCharList = new char[defaultCharListLen + 1];
-		if(defaultCharList)
+		if(defaultCharListLen > 0)
 		{
-			execute(SCI_GETWORDCHARS, 0, reinterpret_cast<LPARAM>(defaultCharList));
-			defaultCharList[defaultCharListLen] = '\0';
-			_defaultCharList = defaultCharList;
-			delete[] defaultCharList;
+			char *defaultCharList = new char[defaultCharListLen + 1];
+			if(defaultCharList)
+			{
+				execute(SCI_GETWORDCHARS, 0, reinterpret_cast<LPARAM>(defaultCharList));
+				defaultCharList[defaultCharListLen] = '\0';
+				_defaultCharList = defaultCharList;
+				delete[] defaultCharList;
+			}
 		}
 	}
 	unsigned long MODEVENTMASK_ON = nppParams.getScintillaModEventMask();

--- a/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
+++ b/PowerEditor/src/WinControls/FunctionList/functionParser.cpp
@@ -409,7 +409,7 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 		// dataToSearch & data2ToSearch are optional
 		if (!_functionNameExprArray.size() && !_classNameExprArray.size())
 		{
-			wchar_t foundData[1024];
+			wchar_t foundData[1024] {};
 			(*ppEditView)->getGenericText(foundData, 1024, targetStart, targetEnd);
 
 			fi._data = foundData; // whole found data
@@ -418,7 +418,7 @@ void FunctionParser::funcParse(std::vector<foundInfo> & foundInfos, size_t begin
 		}
 		else
 		{
-			intptr_t foundPos;
+			intptr_t foundPos = -1;
 			if (_functionNameExprArray.size())
 			{
 				fi._data = parseSubLevel(targetStart, targetEnd, _functionNameExprArray, foundPos, ppEditView);

--- a/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
+++ b/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
@@ -27,8 +27,6 @@ bool Splitter::_isHorizontalFixedRegistered = false;
 bool Splitter::_isVerticalFixedRegistered = false;
 
 
-#define SPLITTER_SIZE 8
-
 void Splitter::init( HINSTANCE hInst, HWND hPere, int splitterSize, double iSplitRatio, DWORD dwFlags)
 {
 	if (hPere == NULL)
@@ -205,7 +203,7 @@ int Splitter::getClickZone(WH which)
 			? (which == WH::width ? _splitterSize  : HIEGHT_MINIMAL)
 			: (which == WH::width ? HIEGHT_MINIMAL : _splitterSize);
 	}
-	else // (_spiltterSize > 8)
+	else // (_splitterSize > 8)
 	{
 		return isVertical()
 			? ((which == WH::width) ? 8  : 15)
@@ -514,8 +512,8 @@ void Splitter::gotoRightBottom()
 
 void Splitter::drawSplitter()
 {
-	PAINTSTRUCT ps;
-	RECT rc, rcToDraw1, rcToDraw2, TLrc, BRrc;
+	PAINTSTRUCT ps {};
+	RECT rc {}, rcToDraw1 {}, rcToDraw2 {}, TLrc {}, BRrc {};
 
 	HDC hdc = ::BeginPaint(_hSelf, &ps);
 	getClientRect(rc);
@@ -649,7 +647,7 @@ void Splitter::rotate()
 
 void Splitter::paintArrow(HDC hdc, const RECT &rect, Arrow arrowDir)
 {
-	RECT rc;
+	RECT rc {};
 	rc.left = rect.left;
 	rc.top = rect.top;
 	rc.right = rect.right;
@@ -717,14 +715,14 @@ void Splitter::adjustZoneToDraw(RECT& rc2def, ZONE_TYPE whichZone)
 	if (_splitterSize < 4)
 		return;
 
-	int x0, y0, x1, y1, w, h;
+	int x0 = 0, y0 = 0, x1 = 0, y1 = 0, w = 0, h = 0;
 
 	if (/*(4 <= _splitterSize) && */(_splitterSize <= 8))
 	{
 		w = (isVertical() ? 4 : 7);
 		h = (isVertical() ? 7 : 4);
 	}
-	else // (_spiltterSize > 8)
+	else // (_splitterSize > 8)
 	{
 		w = (isVertical() ? 6  : 11);
 		h = (isVertical() ? 11 : 6);

--- a/PowerEditor/src/WinControls/TabBar/TabBar.cpp
+++ b/PowerEditor/src/WinControls/TabBar/TabBar.cpp
@@ -1392,21 +1392,15 @@ void TabBarPlus::drawItem(DRAWITEMSTRUCT* pDrawItemStruct, bool isDarkMode)
 	const COLORREF colorActiveBg = isDarkMode ? NppDarkMode::getCtrlBackgroundColor() : ::GetSysColor(COLOR_BTNFACE);
 	const COLORREF colorInactiveBgBase = isDarkMode ? NppDarkMode::getBackgroundColor() : ::GetSysColor(COLOR_BTNFACE);
 	
-	COLORREF colorInactiveBg = liteGrey;
-	COLORREF colorActiveText = ::GetSysColor(COLOR_BTNTEXT);
-	COLORREF colorInactiveText = grey;
+	COLORREF colorInactiveBg = _inactiveBgColour;
+	COLORREF colorActiveText = _activeTextColour;
+	COLORREF colorInactiveText = _inactiveTextColour;
 
 	if (!NppDarkMode::useTabTheme() && isDarkMode)
 	{
 		colorInactiveBg = NppDarkMode::getBackgroundColor();
 		colorActiveText = NppDarkMode::getTextColor();
 		colorInactiveText = NppDarkMode::getDarkerTextColor();
-	}
-	else
-	{
-		colorInactiveBg = _inactiveBgColour;
-		colorActiveText = _activeTextColour;
-		colorInactiveText = _inactiveTextColour;
 	}
 
 	HDC hDC = pDrawItemStruct->hDC;


### PR DESCRIPTION
- avoid clang warning : no newline at end of file [-Wnewline-eof]
- avoid issues from clang warning : extra ';' after member function definition [-Wextra-semi]
- clang analyser issues: PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp:341:40: warning: Use of memory allocated with size zero [cplusplus.NewDelete]
- PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp:578:23: warning: The left operand of '==' is a garbage value [core.UndefinedBinaryOperatorResult]
- additionally check str within the method for null and don't rely on checks at caller side
- clang analyser issue: PowerEditor/src/NppCommands.cpp:3895:6: warning: Value stored to 'dlgNode' is never read [deadcode.DeadStores] 
-- removed likely unused code
-- removed commented code
- avoid clang analyser issue: PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp:655:10: warning: Assigned value is garbage or undefined [core.uninitialized.Assign] 
  --  init vars
  --  remove unused define
  --  fixed typo
- avoid clang analyser issues: PowerEditor/src/WinControls/FunctionList/functionParser.cpp:425:13: warning: Assigned value is garbage or undefined [core.uninitialized.Assign]
- PowerEditor/src/WinControls/FunctionList/functionParser.cpp:436:14: warning: Assigned value is garbage or undefined [core.uninitialized.Assign]
- avoid clang analyser issue: PowerEditor/src/WinControls/TabBar/TabBar.cpp:1128:11: warning: Value stored to 'colorActiveText' during its initialization is never read [deadcode.DeadStores]