### PR TITLE
fix possible FindReplaceDlg::processFindNext heap memory leak

### DIFF
--- a/PowerEditor/src/MISC/md5/md5Dlgs.cpp
+++ b/PowerEditor/src/MISC/md5/md5Dlgs.cpp
@@ -360,6 +360,7 @@ void HashFromTextDlg::generateHash()
 				break;
 
 				default:
+					delete[] text;
 					return;
 			}
 
@@ -444,6 +445,7 @@ void HashFromTextDlg::generateHashPerLine()
 							break;
 
 							default:
+								delete[] text;
 								return;
 						}
 

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -471,6 +471,8 @@ void Notepad_plus::command(int id)
 
 			::GlobalUnlock(hglbCopy);
 
+			pBinText.reset(nullptr); // free possible big membuf ASAP
+
 			// Place the handle on the clipboard.
 			if (!::SetClipboardData(CF_TEXT, hglbCopy))
 			{
@@ -3477,6 +3479,7 @@ void Notepad_plus::command(int id)
 						break;
 
 						default:
+							delete[] selectedStr;
 							return;
 					}
 					for (int i = 0; i < hashLen; i++)

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -3061,6 +3061,7 @@ bool FindReplaceDlg::processFindNext(const wchar_t *txt2find, const FindOption *
 	else if (posFind == FIND_INVALID_REGULAR_EXPRESSION)
 	{ // error
 		setStatusbarMessageWithRegExprErr(*_ppEditView);
+		delete[] pText;
 		return false;
 	}
 
@@ -3655,8 +3656,9 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 
 			default:
 			{
-				delete [] pTextFind;
-				delete [] pTextReplace;
+				delete[] pTextFind;
+				if (pTextReplace)
+					delete[] pTextReplace;
 				return nbProcessed;
 			}
 
@@ -3672,8 +3674,9 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		findReplaceInfo._endRange += replaceDelta;									//adjust end of range in case of replace
 	}
 
-	delete [] pTextFind;
-	delete [] pTextReplace;
+	delete[] pTextFind;
+	if (pTextReplace)
+		delete[] pTextReplace;
 
 	if (nbProcessed > 0)
 	{

--- a/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
+++ b/PowerEditor/src/WinControls/ClipboardHistory/clipboardHistoryPanel.cpp
@@ -295,7 +295,8 @@ intptr_t CALLBACK ClipboardHistoryPanel::run_dlgProc(UINT message, WPARAM wParam
 							catch (...)
 							{
 								MessageBox(_hSelf,	L"Cannot process this clipboard data in the history:\nThe data is too large to be treated.", L"Clipboard problem", MB_OK | MB_APPLMODAL);
-								delete[] c;
+								if (c)
+									delete[] c;
 							}
 						}
 					}


### PR DESCRIPTION
plus some minor stuff (I forbade calling delete[] on nullptrs, as the standard C++ delete[] operator, which checks itself internally for possible nullptr ok, can be also overloaded somehow)

@donho 
Really important fix (possible heap memory leak) is only for:
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/c367ab8966767779f1eb28c7df252a6e10a7e7d2/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp#L3061-L3065

as you've already (coincidentally by your stack2heap fixes) fixed the 2nd one I found in:
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/c367ab8966767779f1eb28c7df252a6e10a7e7d2/PowerEditor/src/NppCommands.cpp#L431-L439

where was previously possible to exit without `delete[] pBinText` on multiple places.

md5Dlgs.cpp fixed places cannot be (currently) reached, but IMO it's better to fix them too (the same applies for NppCommands.cpp IDM_TOOL_SHA256_GENERATEINTOCLIPBOARD and IDM_TOOL_SHA512_GENERATEINTOCLIPBOARD cases).

I don't think this PR deserves its own issue but if you thinks opposite, I'll create it(?).