### PR TITLE
Fix JavaScript indent settings incorrect behaviour

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -9148,3 +9148,14 @@ COLORREF NppParameters::getFindDlgStatusMsgColor(int colourIndex)
 
 	return findDlgStatusMessageColor[colourIndex];
 }
+
+LanguageNameInfo NppParameters::getLangNameInfoFromNameID(const wstring& langNameID)
+{
+	LanguageNameInfo res;
+	for (LanguageNameInfo lnf : ScintillaEditView::_langNameInfoArray)
+	{
+		if (lnf._langName == langNameID)
+			return lnf;
+	}
+	return res;
+}

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1507,6 +1507,8 @@ private:
 	std::wstring _lastCmdLabel;
 };
 
+struct LanguageNameInfo;
+
 class NppParameters final
 {
 private:
@@ -1911,6 +1913,8 @@ public:
 	unsigned long getScintillaModEventMask() const { return _sintillaModEventMask; };
 	void addScintillaModEventMask(unsigned long mask2Add) { _sintillaModEventMask |= mask2Add; };
 	bool isAsNotepadStyle() const { return _asNotepadStyle; }
+
+	LanguageNameInfo getLangNameInfoFromNameID(const std::wstring& langNameID);
 
 private:
 	NppParameters();

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -4340,6 +4340,7 @@ void ScintillaEditView::setTabSettings(Lang* lang)
 		if (lang->_langID == L_JAVASCRIPT)
 		{
 			Lang* ljs = NppParameters::getInstance().getLangFromID(L_JS_EMBEDDED);
+			if (!ljs) return;
 			execute(SCI_SETTABWIDTH, ljs->_tabSize > 0 ? ljs->_tabSize : lang->_tabSize);
 			execute(SCI_SETUSETABS, !ljs->_isTabReplacedBySpace);
 			execute(SCI_SETBACKSPACEUNINDENTS, ljs->_isBackspaceUnindent);

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -1022,7 +1022,9 @@ void WordStyleDlg::setStyleListFromLexer(int index)
 		const wchar_t *langName = _lsArray.getLexerNameFromIndex(index - 1);
 		const wchar_t *ext = NppParameters::getInstance().getLangExtFromName(langName);
 		const wchar_t *userExt = (_lsArray.getLexerStylerByName(langName))->getLexerUserExt();
-		::SendDlgItemMessage(_hSelf, IDC_DEF_EXT_EDIT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(ext));
+
+		if (ext)
+			::SendDlgItemMessage(_hSelf, IDC_DEF_EXT_EDIT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(ext));
 
 		// WM_SETTEXT cause sending WM_COMMAND message with EN_CHANGE.
 		// That makes status dirty, even it shouldn't in this case.

--- a/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
+++ b/PowerEditor/src/WinControls/Preference/preferenceDlg.cpp
@@ -20,6 +20,8 @@
 #include "EncodingMapper.h"
 #include "localization.h"
 #include <algorithm>
+#include "ScintillaEditView.h"
+
 
 #define MyGetGValue(rgb)      (LOBYTE((rgb)>>8))
 
@@ -3990,7 +3992,9 @@ intptr_t CALLBACK IndentationSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 			const int nbLang = nppParam.getNbLang();
 			for (int i = 0; i < nbLang; ++i)
 			{
-				::SendDlgItemMessage(_hSelf, IDC_LIST_TABSETTNG, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(nppParam.getLangFromIndex(i)->_langName.c_str()));
+				LanguageNameInfo lni = nppParam.getLangNameInfoFromNameID(nppParam.getLangFromIndex(i)->_langName);
+				if (lni._shortName)
+					::SendDlgItemMessage(_hSelf, IDC_LIST_TABSETTNG, LB_ADDSTRING, 0, reinterpret_cast<LPARAM>(lni._shortName));
 			}
 			const int index2Begin = 0;
 			::SendDlgItemMessage(_hSelf, IDC_LIST_TABSETTNG, LB_SETCURSEL, index2Begin, 0);
@@ -4149,23 +4153,6 @@ intptr_t CALLBACK IndentationSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 									return FALSE;
 								}
 
-								if (lang->_langID == L_JS_EMBEDDED)
-								{
-									Lang* ljs = nppParam.getLangFromID(L_JAVASCRIPT);
-									if (!ljs)
-										return FALSE;
-
-									ljs->_tabSize = tabSize;
-								}
-								else if (lang->_langID == L_JAVASCRIPT)
-								{
-									Lang* ljavascript = nppParam.getLangFromID(L_JS_EMBEDDED);
-									if (!ljavascript)
-										return FALSE;
-
-									ljavascript->_tabSize = tabSize;
-								}
-
 								lang->_tabSize = tabSize;
 
 								// write in langs.xml
@@ -4248,21 +4235,6 @@ intptr_t CALLBACK IndentationSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 						if (!lang->_tabSize || lang->_tabSize == -1)
 							lang->_tabSize = nppGUI._tabSize;
 
-						if (lang->_langID == L_JS_EMBEDDED)
-						{
-							Lang *ljs = nppParam.getLangFromID(L_JAVASCRIPT);
-							if (!ljs) return FALSE;
-
-							ljs->_isTabReplacedBySpace = isTabReplacedBySpace;
-						}
-						else if (lang->_langID == L_JAVASCRIPT)
-						{
-							Lang *ljavascript = nppParam.getLangFromID(L_JS_EMBEDDED);
-							if (!ljavascript) return FALSE;
-
-							ljavascript->_isTabReplacedBySpace = isTabReplacedBySpace;
-						}
-
 						lang->_isTabReplacedBySpace = isTabReplacedBySpace;
 
 						// write in langs.xml
@@ -4291,21 +4263,6 @@ intptr_t CALLBACK IndentationSubDlg::run_dlgProc(UINT message, WPARAM wParam, LP
 						if (!lang) return FALSE;
 						if (!lang->_tabSize || lang->_tabSize == -1)
 							lang->_tabSize = nppGUI._tabSize;
-
-						if (lang->_langID == L_JS_EMBEDDED)
-						{
-							Lang* ljs = nppParam.getLangFromID(L_JAVASCRIPT);
-							if (!ljs) return FALSE;
-
-							ljs->_isBackspaceUnindent = isBackspaceUnindent;
-						}
-						else if (lang->_langID == L_JAVASCRIPT)
-						{
-							Lang* ljavascript = nppParam.getLangFromID(L_JS_EMBEDDED);
-							if (!ljavascript) return FALSE;
-
-							ljavascript->_isBackspaceUnindent = isBackspaceUnindent;
-						}
 
 						lang->_isBackspaceUnindent = isBackspaceUnindent;
 

--- a/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
+++ b/PowerEditor/src/WinControls/ProjectPanel/ProjectPanel.cpp
@@ -324,6 +324,9 @@ void ProjectPanel::destroyMenus()
 
 bool ProjectPanel::openWorkSpace(const wchar_t *projectFileName, bool force)
 {
+	if (!projectFileName)
+		return false;
+
 	if ((!force) && (_workSpaceFilePath.length() > 0))
 	{ // Return if it is better to keep the current workspace tree
 		wstring newWorkspace = projectFileName;


### PR DESCRIPTION
1. More understandable names: "javascript" to "Embedded JS" & "javascript.js" to "JavaScript".
2. Disassociate the value of Embedded JS & JavaScript.
3. Prevent from eventual crash due to null pointer.

Fix #16884