### PR TITLE
Implement Notepad++ UAC-elevated ops possibility

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -1537,7 +1537,24 @@ bool toggleReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath, bool& isC
 	}
 	else
 	{
-		// probably the ERROR_ACCESS_DENIED (5) (TODO: UAC-prompt candidate)
+		if (::GetLastError() == ERROR_ACCESS_DENIED)
+		{
+			// try to set elevated
+			wstring strCmdLineParams = NPP_UAC_SETFILEATTRIBUTES_SIGN;
+			strCmdLineParams += L" \"" + to_wstring(dwFileAttribs) + L"\" \"";
+			strCmdLineParams += fileFullPath;
+			strCmdLineParams += L"\"";
+			DWORD dwNppUacOpError = invokeNppUacOp(strCmdLineParams);
+			if (dwNppUacOpError == NO_ERROR)
+			{
+				isChangedToReadOnly = (dwFileAttribs & FILE_ATTRIBUTE_READONLY) != 0;
+				return true;
+			}
+			else
+			{
+				::SetLastError(dwNppUacOpError); // set that as our current thread one for a possible reporting later
+			}
+		}
 		return false;
 	}
 }
@@ -2154,3 +2171,44 @@ void ControlInfoTip::hide()
 }
 
 #pragma warning(default:4996)
+
+DWORD invokeNppUacOp(std::wstring& strCmdLineParams)
+{
+	if ((strCmdLineParams.length() == 0) || (strCmdLineParams.length() > (USHRT_MAX / sizeof(WCHAR))))
+	{
+		// no cmdline or it exceeds the current max WinOS 32767 WCHARs
+		return ERROR_INVALID_PARAMETER;
+	}
+
+	wstring strBuf(MAX_PATH/2, L'\0');
+	do
+	{
+		strBuf.resize(strBuf.length() * 2, L'\0');
+		if (strBuf.length() > (USHRT_MAX / sizeof(WCHAR)))
+			return ERROR_FILENAME_EXCED_RANGE;
+		::SetLastError(NO_ERROR);
+		if (!::GetModuleFileNameW(NULL, &strBuf[0], static_cast<DWORD>(strBuf.length())))
+			return ::GetLastError();
+	} while (::GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+
+	SHELLEXECUTEINFOW sei{};
+	sei.cbSize = sizeof(SHELLEXECUTEINFOW);
+	sei.lpVerb = L"runas"; // UAC prompt
+	sei.nShow = SW_SHOWNORMAL;
+	sei.fMask = SEE_MASK_NOCLOSEPROCESS; // sei.hProcess member receives the launched process handle
+	sei.lpFile = strBuf.c_str(); // notepad++.exe fullpath
+	sei.lpParameters = strCmdLineParams.c_str();
+	if (!::ShellExecuteExW(&sei))
+		return ::GetLastError();
+
+	// wait for the elevated Notepad++ process to finish
+	DWORD dwError = NO_ERROR;
+	if (sei.hProcess) // beware - do not check here for the INVALID_HANDLE_VALUE (valid GetCurrentProcess() pseudohandle)
+	{
+		::WaitForSingleObject(sei.hProcess, INFINITE);
+		::GetExitCodeProcess(sei.hProcess, &dwError);
+		::CloseHandle(sei.hProcess);
+	}
+
+	return dwError;
+}

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -335,4 +335,5 @@ private:
 
 #define NPP_UAC_SAVE_SIGN L"#UAC-SAVE#"
 #define NPP_UAC_SETFILEATTRIBUTES_SIGN L"#UAC-SETFILEATTRIBUTES#"
+#define NPP_UAC_MOVEFILE_SIGN L"#UAC-MOVEFILE#"
 DWORD invokeNppUacOp(std::wstring& strCmdLineParams);

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -331,3 +331,8 @@ private:
 	ControlInfoTip(const ControlInfoTip&) = delete;
 	ControlInfoTip& operator=(const ControlInfoTip&) = delete;
 };
+
+
+#define NPP_UAC_SAVE_SIGN L"#UAC-SAVE#"
+#define NPP_UAC_SETFILEATTRIBUTES_SIGN L"#UAC-SETFILEATTRIBUTES#"
+DWORD invokeNppUacOp(std::wstring& strCmdLineParams);

--- a/PowerEditor/src/MISC/Common/FileInterface.h
+++ b/PowerEditor/src/MISC/Common/FileInterface.h
@@ -48,6 +48,10 @@ public:
 		return write(str.c_str(), str.length());
 	};
 
+	DWORD getLastErrorCode() {
+		return _dwErrorCode;
+	};
+
 private:
 	HANDLE	_hFile		{INVALID_HANDLE_VALUE};
 	bool	_written	{false};
@@ -56,4 +60,6 @@ private:
 	const DWORD _accessParam  { GENERIC_READ | GENERIC_WRITE };
 	const DWORD _shareParam   { FILE_SHARE_READ | FILE_SHARE_WRITE };
 	const DWORD _attribParam  { FILE_ATTRIBUTE_NORMAL };
+
+	DWORD _dwErrorCode{ NO_ERROR };
 };

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -683,8 +683,11 @@ bool Notepad_plus::doSave(BufferID id, const wchar_t * filename, bool isCopy)
 	}
 	else if (res == SavingStatus::SaveWritingFailed)
 	{
-		wstring errorMessage = GetLastErrorAsString(GetLastError());
-		::MessageBox(_pPublicInterface->getHSelf(), errorMessage.c_str(), L"Save failed", MB_OK | MB_ICONWARNING);
+		if (!(NppParameters::getInstance()).isEndSessionCritical()) // can we report to the user?
+		{
+			wstring errorMessage = GetLastErrorAsString(::GetLastError());
+			::MessageBox(_pPublicInterface->getHSelf(), errorMessage.c_str(), L"Save failed", MB_OK | MB_ICONWARNING);
+		}
 	}
 	else if (res == SavingStatus::SaveOpenFailed)
 	{

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1398,9 +1398,11 @@ SavingStatus FileManager::saveBuffer(BufferID id, const wchar_t* filename, bool 
 			return SavingStatus::SaveOpenFailed; // cannot be solved by the UAC-prompt
 
 		// ERROR_ACCESS_DENIED, swap to temporary file copy for the UAC elevation way
+
 		wchar_t wszBuf[MAX_PATH + 1]{};
 		if (::GetTempPath(MAX_PATH, wszBuf) == 0)
 			return SavingStatus::SaveOpenFailed; // cannot continue
+
 		strTempFile = wszBuf;
 		strTempFile += L"npp-" + std::to_wstring(GetUnixSysTimeInMilliseconds()) + L".tmp"; // make unique temporary filename
 		if (!UnicodeConvertor.openFile(strTempFile.c_str()))
@@ -1461,6 +1463,7 @@ SavingStatus FileManager::saveBuffer(BufferID id, const wchar_t* filename, bool 
 	if (!strTempFile.empty())
 	{
 		// elevated saving/overwriting of the original file by the help of the tempfile
+		// (notepad++.exe #UAC-SAVE# temp_file_path dest_file_path)
 		wstring strCmdLineParams = NPP_UAC_SAVE_SIGN;
 		strCmdLineParams += L" \"" + strTempFile + L"\" \"";
 		strCmdLineParams += fullpath;

--- a/PowerEditor/src/Utf8_16.h
+++ b/PowerEditor/src/Utf8_16.h
@@ -148,11 +148,14 @@ public:
 	size_t convert(char* p, size_t _size);
 	char* getNewBuf() { return reinterpret_cast<char*>(m_pNewBuf); }
 
+	DWORD getLastFileErrorState() { return m_dwLastFileError; }
+
 protected:
 	UniMode m_eEncoding;
 	std::unique_ptr<Win32_IO_File> m_pFile;
 	ubyte* m_pNewBuf;
 	size_t m_nBufSize;
 	bool m_bFirstWrite;
+	DWORD m_dwLastFileError;
 };
 

--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -1077,7 +1077,7 @@ wstring CustomFileDialog::doSaveDlg()
 
 	CurrentDirBackup backup;
 
-	_impl->addFlags(FOS_PATHMUSTEXIST | FOS_FILEMUSTEXIST | FOS_FORCEFILESYSTEM);
+	_impl->addFlags(FOS_PATHMUSTEXIST | FOS_FILEMUSTEXIST | FOS_FORCEFILESYSTEM | FOS_NOTESTFILECREATE);
 	bool bOk = _impl->show();
 	return bOk ? _impl->getResultFilename() : L"";
 }

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -408,6 +408,72 @@ bool launchUpdater(const std::wstring& updaterFullPath, const std::wstring& upda
 	return true;
 }
 
+DWORD nppUacSave(const wchar_t* wszTempFilePath, const wchar_t* wszProtectedFilePath2Save)
+{
+	if (!doesFileExist(wszTempFilePath))
+		return ERROR_FILE_NOT_FOUND;
+	if (lstrlenW(wszProtectedFilePath2Save) == 0)
+		return ERROR_INVALID_PARAMETER;
+
+	DWORD dwRetCode = ERROR_SUCCESS;
+
+	bool isOutputReadOnly = false;
+	bool isOutputHidden = false;
+	bool isOutputSystem = false;
+	WIN32_FILE_ATTRIBUTE_DATA attributes{};
+	attributes.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
+	if (getFileAttributesExWithTimeout(wszProtectedFilePath2Save, &attributes))
+	{
+		if (attributes.dwFileAttributes != INVALID_FILE_ATTRIBUTES && !(attributes.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+		{
+			isOutputReadOnly = (attributes.dwFileAttributes & FILE_ATTRIBUTE_READONLY) != 0;
+			isOutputHidden = (attributes.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+			isOutputSystem = (attributes.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) != 0;
+			if (isOutputReadOnly) attributes.dwFileAttributes &= ~FILE_ATTRIBUTE_READONLY;
+			if (isOutputHidden) attributes.dwFileAttributes &= ~FILE_ATTRIBUTE_HIDDEN;
+			if (isOutputSystem) attributes.dwFileAttributes &= ~FILE_ATTRIBUTE_SYSTEM;
+			if (isOutputReadOnly || isOutputHidden || isOutputSystem)
+				::SetFileAttributes(wszProtectedFilePath2Save, attributes.dwFileAttributes); // temporarily remove the problematic ones
+		}
+	}
+
+	// cannot use simple MoveFile here as it retains the tempfile permissions when on the same volume...
+	if (!::CopyFileW(wszTempFilePath, wszProtectedFilePath2Save, FALSE))
+	{
+		// fails if the destination file exists and has the R/O and/or Hidden attribute set
+		dwRetCode = ::GetLastError();
+	}
+	else
+	{
+		// ok, now dispose of the tempfile used
+		::DeleteFileW(wszTempFilePath);
+	}
+
+	// set back the possible original file attributes
+	if (isOutputReadOnly || isOutputHidden || isOutputSystem)
+	{
+		if (isOutputReadOnly) attributes.dwFileAttributes |= FILE_ATTRIBUTE_READONLY;
+		if (isOutputHidden) attributes.dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;
+		if (isOutputSystem) attributes.dwFileAttributes |= FILE_ATTRIBUTE_SYSTEM;
+		::SetFileAttributes(wszProtectedFilePath2Save, attributes.dwFileAttributes);
+	}
+
+	return dwRetCode;
+}
+
+DWORD nppUacSetFileAttributes(const DWORD dwFileAttribs, const wchar_t* wszFilePath)
+{
+	if (!doesFileExist(wszFilePath))
+		return ERROR_FILE_NOT_FOUND;
+	if (dwFileAttribs == INVALID_FILE_ATTRIBUTES || (dwFileAttribs & FILE_ATTRIBUTE_DIRECTORY))
+		return ERROR_INVALID_PARAMETER;
+
+	if (!::SetFileAttributes(wszFilePath, dwFileAttribs))
+		return ::GetLastError();
+
+	return ERROR_SUCCESS;
+}
+
 } // namespace
 
 
@@ -417,6 +483,31 @@ std::chrono::steady_clock::time_point g_nppStartTimePoint{};
 int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*/, _In_ PWSTR pCmdLine, _In_ int /*nShowCmd*/)
 {
 	g_nppStartTimePoint = std::chrono::steady_clock::now();
+	
+	// Notepad++ UAC OPS /////////////////////////////////////////////////////////////////////////////////////////////
+	if ((lstrlenW(pCmdLine) > 0) && (__argc >= 2)) // safe (if pCmdLine is NULL, lstrlen returns 0)
+	{
+		const wchar_t* wszNppUacOpSign = __wargv[1];
+
+		if ((__argc == 4) && (wcscmp(wszNppUacOpSign, NPP_UAC_SAVE_SIGN) == 0))
+		{
+			// __wargv[x]: 2 ... tempFilePath, 3  ...  protectedFilePath2Save
+			return static_cast<int>(nppUacSave(__wargv[2], __wargv[3]));
+		}
+
+		if ((__argc == 4) && (wcscmp(wszNppUacOpSign, NPP_UAC_SETFILEATTRIBUTES_SIGN) == 0))
+		{
+			// __wargv[x]: 2 ... dwFileAttributes (string), 3  ...  filePath
+			try
+			{
+				return static_cast<int>(nppUacSetFileAttributes(static_cast<DWORD>(std::stoul(std::wstring(__wargv[2]))), __wargv[3]));
+			}
+			catch ([[maybe_unused]] const std::exception& e)
+			{
+				return static_cast<int>(ERROR_INVALID_PARAMETER); // conversion error (check e.what() for details)
+			}
+		}
+	} // Notepad++ UAC OPS////////////////////////////////////////////////////////////////////////////////////////////
 
 	bool TheFirstOne = true;
 	::SetLastError(NO_ERROR);

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -410,10 +410,10 @@ bool launchUpdater(const std::wstring& updaterFullPath, const std::wstring& upda
 
 DWORD nppUacSave(const wchar_t* wszTempFilePath, const wchar_t* wszProtectedFilePath2Save)
 {
+	if ((lstrlenW(wszTempFilePath) == 0) || (lstrlenW(wszProtectedFilePath2Save) == 0)) // safe check (lstrlen returns 0 for possible nullptr)
+		return ERROR_INVALID_PARAMETER;
 	if (!doesFileExist(wszTempFilePath))
 		return ERROR_FILE_NOT_FOUND;
-	if (lstrlenW(wszProtectedFilePath2Save) == 0)
-		return ERROR_INVALID_PARAMETER;
 
 	DWORD dwRetCode = ERROR_SUCCESS;
 
@@ -463,6 +463,8 @@ DWORD nppUacSave(const wchar_t* wszTempFilePath, const wchar_t* wszProtectedFile
 
 DWORD nppUacSetFileAttributes(const DWORD dwFileAttribs, const wchar_t* wszFilePath)
 {
+	if (lstrlenW(wszFilePath) == 0) // safe check (lstrlen returns 0 for possible nullptr)
+		return ERROR_INVALID_PARAMETER;
 	if (!doesFileExist(wszFilePath))
 		return ERROR_FILE_NOT_FOUND;
 	if (dwFileAttribs == INVALID_FILE_ATTRIBUTES || (dwFileAttribs & FILE_ATTRIBUTE_DIRECTORY))


### PR DESCRIPTION
Fix #886 , fix #8655 , fix #9561 , fix #10302 , fix #14990 , fix #15008 , fix #15137 , fix #15323 ,
related https://github.com/Hsilgos/nppsaveasadmin/issues/34  and https://github.com/Hsilgos/nppsaveasadmin/issues/35

Some more details with pics & STR in: https://community.notepad-plus-plus.org/post/102242 and https://community.notepad-plus-plus.org/post/102254

This native N++ UAC-ops implementation is not meant only to substitute the deprecated problematic (it seriously interferes with the Notepad++ FlushFileBuffers WINAPI used) NppSaveAsAdminPlugin but also to serve for any possible future Notepad++ operation which will need the rights elevation.

It does only the originally requested (but with insufficient rights denied) op and then the elevated Notepad++ instance immediately exits, leaving the user in its original Notepad++ instance as if nothing special happened. It does not depend on any Notepad++ features ON/OFF like the backup-snapshot or multi-inst mode. Furthermore, all these new UAC-ops are executed at the very start of the Notepad++ wWinMain, thus not influenced at all by the Notepad++ mutex stuff. Moreover, there is no need for a separate executable project (a signed "NppAdminAccess.exe" UAC elevation helper app), just this one&only Notepad++.exe project as before.

Currently, only the NPP_UAC_SAVE and  NPP_UAC_SETFILEATTRIBUTES are implemented.

~~Unfortunately, the Notepad++ COM SaveAs dialog currently cannot benefit from it because of its inherent insufficient-rights checking~~:

<img width="491" height="370" alt="npp-SaveAsDlg-InsufficientRightsChecking" src="https://github.com/user-attachments/assets/7a3ef794-485e-4065-9050-191360f0ca62" />

---

Summary of the changes:

added last `_dwErrorCode` in:
.\PowerEditor\src\MISC\Common\FileInterface.h
.\PowerEditor\src\MISC\Common\FileInterface.cpp

added `getLastFileErrorState()` & `m_dwLastFileError` in:
.\PowerEditor\src\Utf8_16.h
.\PowerEditor\src\Utf8_16.cpp

N++ UAC ops signatures definitions & new `invokeNppUacOp` common func, `toggleReadOnlyFlagFromFileAttributes` func adjustment for the NPP_UAC_SETFILEATTRIBUTES_SIGN in:
.\PowerEditor\src\MISC\Common\Common.h
.\PowerEditor\src\MISC\Common\Common.cpp

`FileManager::saveBuffer` adjustment for the NPP_UAC_SAVE_SIGN in:
.\PowerEditor\src\ScintillaComponent\Buffer.cpp

UAC ops handling at the very start of `wWinMain` + added new NPP_UAC_ handling `nppUacSave` and `nppUacSetFileAttributes` funcs in:
.\PowerEditor\src\winmain.cpp

only fixing the `Notepad_plus::doSave` for `isEndSessionCritical()` in:
.\PowerEditor\src\NppIO.cpp
