### PR TITLE
Add NPPM_GETSETTINGSDIRPATH message

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
+++ b/PowerEditor/src/MISC/PluginsManager/Notepad_plus_msgs.h
@@ -1025,7 +1025,15 @@ enum Platform { PF_UNKNOWN, PF_X86, PF_X64, PF_IA64, PF_ARM64 };
 	// Return toolbar icon set choice as an integer value. Here are 5 possible values:
 	// 0 (Fluent UI: small), 1 (Fluent UI: large), 2 (Filled Fluent UI: small), 3 (Filled Fluent UI: large) and 4 (Standard icons: small).
 
-	// For RUNCOMMAND_USER
+	#define NPPM_GETSETTINGSDIRPATH (NPPMSG + 119)
+	// int NPPM_GETSETTINGSDIRPATH(size_t strLen, wchar_t *settingsDirPath)
+	// Get -settingsDir path. It's useful if plugins want to store its settings with the rest of Notepad++ configuration, if this path is set.
+	// wParam[in]: strLen - size of allocated buffer "settingsDirPath"
+	// lParam[out]: settingsDirPath - Users should call it with settingsDirPath be NULL to get the required number of wchar_t (not including the terminating nul character),
+	//              allocate settingsDirPath buffer with the return value + 1, then call it again to get the path.
+	// Returns the number of wchar_t copied/to copy. If the return value is 0, then this path is not set, or the "strLen" is not enough to copy the path.
+
+// For RUNCOMMAND_USER
 	#define VAR_NOT_RECOGNIZED 0
 	#define FULL_CURRENT_PATH 1
 	#define CURRENT_DIRECTORY 2

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3218,6 +3218,20 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			return settingsOnCloudPath.length();
 		}
 
+		case NPPM_GETSETTINGSDIRPATH:
+		{
+			wstring settingsDirPath = nppParam.getCmdSettingsDir();
+			if (lParam != 0)
+			{
+				if (settingsDirPath.length() >= static_cast<size_t>(wParam))
+				{
+					return 0;
+				}
+				lstrcpy(reinterpret_cast<wchar_t *>(lParam), settingsDirPath.c_str());
+			}
+			return settingsDirPath.length();
+		}
+
 		case NPPM_SETLINENUMBERWIDTHMODE:
 		{
 			if (lParam != LINENUMWIDTH_DYNAMIC && lParam != LINENUMWIDTH_CONSTANT)

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -1892,6 +1892,10 @@ public:
 		_cmdSettingsDir = settingsDir;
 	};
 
+	const std::wstring getCmdSettingsDir() {
+		return _cmdSettingsDir;
+	};
+
 	void setTitleBarAdd(const std::wstring& titleAdd) {
 		_titleBarAdditional = titleAdd;
 	}

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -318,6 +318,12 @@ intptr_t CALLBACK DebugInfoDlg::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			_debugInfoStr += cloudPath.empty() ? L"OFF" : cloudPath;
 			_debugInfoStr += L"\r\n";
 
+			// -settingsDir Path
+			_debugInfoStr += L"SettingsDir Config: ";
+			const wstring& settingsDirPath = nppParam.getCmdSettingsDir();
+			_debugInfoStr += settingsDirPath.empty() ? L"OFF" : settingsDirPath;
+			_debugInfoStr += L"\r\n";
+
 			// Periodic Backup
 			_debugInfoStr += L"Periodic Backup: ";
 			_debugInfoStr += nppGui.isSnapshotMode() ? L"ON" : L"OFF";


### PR DESCRIPTION
This message reports the -settingsDir value to plugins.

- based on the NPPM_GETSETTINGSONCLOUDPATH message implementation
- add associated getter for that nppParam private entry (needed to retrive private attribute value to pass string to plugins)
- add “SettingsDir Config:” to the DebugInfo, since there's now a getter for it

resolves #16944