### PR TITLE
Allow paste into search comboboxes to be multiline

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -955,6 +955,29 @@ bool str2Clipboard(const wstring &str2cpy, HWND hwnd)
 	return true;
 }
 
+std::wstring strFromClipboard()
+{
+	std::wstring clipboardText;
+	if (::OpenClipboard(NULL))
+	{
+		if (::IsClipboardFormatAvailable(CF_UNICODETEXT))
+		{
+			HANDLE hClipboardData = ::GetClipboardData(CF_UNICODETEXT);
+			if (hClipboardData)
+			{
+				wchar_t* pWc = static_cast<wchar_t*>(::GlobalLock(hClipboardData));
+				if (pWc)
+				{
+					clipboardText = pWc;
+					::GlobalUnlock(hClipboardData);
+				}
+			}
+		}
+		::CloseClipboard();
+	}
+	return clipboardText;
+}
+
 bool buf2Clipboard(const std::vector<Buffer*>& buffers, bool isFullPath, HWND hwnd)
 {
 	const wstring crlf = L"\r\n";

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -169,6 +169,7 @@ std::wstring stringTakeWhileAdmissable(const std::wstring& input, const std::wst
 double stodLocale(const std::wstring& str, _locale_t loc, size_t* idx = NULL);
 
 bool str2Clipboard(const std::wstring &str2cpy, HWND hwnd);
+std::wstring strFromClipboard();
 class Buffer;
 bool buf2Clipboard(const std::vector<Buffer*>& buffers, bool isFullPath, HWND hwnd);
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4936,6 +4936,20 @@ LRESULT FAR PASCAL FindReplaceDlg::comboEditProc(HWND hwnd, UINT message, WPARAM
 		return 0;
 
 	}
+	else if (message == WM_PASTE)
+	{
+		// needed to allow CR (i.e., multiline) into combobox text
+		wstring s = strFromClipboard();
+		const wchar_t* pWc = s.c_str();
+		size_t len = wcslen(pWc);
+		if (len > 0 && len < FINDREPLACE_MAXLENGTH)
+		{
+			::SendMessage(hwndCombo, CB_SETCURSEL, static_cast<WPARAM>(-1), 0); // remove selection - to allow using down arrow to get to last searched word
+			::SendMessage(hwndCombo, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(pWc));
+			::SendMessage(hwndCombo, CB_SETEDITSEL, 0, MAKELPARAM(0, -1)); // select all text - fast edit
+			return 0;
+		}
+	}
 	return CallWindowProc(originalComboEditProc, hwnd, message, wParam, lParam);
 }
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4941,6 +4941,12 @@ LRESULT FAR PASCAL FindReplaceDlg::comboEditProc(HWND hwnd, UINT message, WPARAM
 		// needed to allow CR (i.e., multiline) into combobox text;
 		// (the default functionality terminates the paste at the first CR character)
 
+		CLIPFORMAT cfColumnSelect = static_cast<CLIPFORMAT>(::RegisterClipboardFormat(L"MSDEVColumnSelect"));
+		if (::IsClipboardFormatAvailable(cfColumnSelect))
+		{
+			return 0;  // prevent paste of column block data
+		}
+
 		wstring clipboardText = strFromClipboard();
 
 		if (!clipboardText.empty())
@@ -4952,12 +4958,11 @@ LRESULT FAR PASCAL FindReplaceDlg::comboEditProc(HWND hwnd, UINT message, WPARAM
 			DWORD selEndIndex = HIWORD(selRange);
 
 			wstring newText = origText.substr(0, selStartIndex) + clipboardText + origText.substr(selEndIndex);
-			const wchar_t* pWcNewText = newText.c_str();
 
-			if (wcslen(pWcNewText) < FINDREPLACE_MAXLENGTH)
+			if (newText.length() < FINDREPLACE_MAXLENGTH)
 			{
 				::SendMessage(hwndCombo, CB_SETCURSEL, static_cast<WPARAM>(-1), 0); // remove selection - to allow using down arrow to get to last searched word
-				::SendMessage(hwndCombo, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(pWcNewText));
+				::SendMessage(hwndCombo, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(newText.c_str()));
 				::SendMessage(hwndCombo, CB_SETEDITSEL, 0, MAKELPARAM(0, -1)); // select all text - fast edit
 				return 0;
 			}

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4942,31 +4942,28 @@ LRESULT FAR PASCAL FindReplaceDlg::comboEditProc(HWND hwnd, UINT message, WPARAM
 		// (the default functionality terminates the paste at the first CR character)
 
 		CLIPFORMAT cfColumnSelect = static_cast<CLIPFORMAT>(::RegisterClipboardFormat(L"MSDEVColumnSelect"));
-		if (::IsClipboardFormatAvailable(cfColumnSelect))
+		if (!::IsClipboardFormatAvailable(cfColumnSelect))
 		{
-			return 0;  // prevent paste of column block data
-		}
-
-		wstring clipboardText = strFromClipboard();
-
-		if (!clipboardText.empty())
-		{
-			wstring origText = getTextFromCombo(hwndCombo);
-
-			DWORD selRange = (DWORD)::SendMessage(hwndCombo, CB_GETEDITSEL, NULL, NULL);
-			DWORD selStartIndex = LOWORD(selRange);
-			DWORD selEndIndex = HIWORD(selRange);
-
-			wstring newText = origText.substr(0, selStartIndex) + clipboardText + origText.substr(selEndIndex);
-
-			if (newText.length() < FINDREPLACE_MAXLENGTH)
+			wstring clipboardText = strFromClipboard();
+			if (!clipboardText.empty())
 			{
-				::SendMessage(hwndCombo, CB_SETCURSEL, static_cast<WPARAM>(-1), 0); // remove selection - to allow using down arrow to get to last searched word
-				::SendMessage(hwndCombo, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(newText.c_str()));
-				::SendMessage(hwndCombo, CB_SETEDITSEL, 0, MAKELPARAM(0, -1)); // select all text - fast edit
-				return 0;
+				wstring origText = getTextFromCombo(hwndCombo);
+
+				DWORD selRange = (DWORD)::SendMessage(hwndCombo, CB_GETEDITSEL, NULL, NULL);
+				DWORD selStartIndex = LOWORD(selRange);
+				DWORD selEndIndex = HIWORD(selRange);
+
+				wstring newText = origText.substr(0, selStartIndex) + clipboardText + origText.substr(selEndIndex);
+				if (newText.length() < FINDREPLACE_MAXLENGTH)
+				{
+					::SendMessage(hwndCombo, CB_SETCURSEL, static_cast<WPARAM>(-1), 0); // remove selection - to allow using down arrow to get to last searched word
+					::SendMessage(hwndCombo, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(newText.c_str()));
+					::SendMessage(hwndCombo, CB_SETEDITSEL, 0, MAKELPARAM(0, -1)); // select all text - fast edit
+				}
 			}
 		}
+
+		return 0;
 	}
 	return CallWindowProc(originalComboEditProc, hwnd, message, wParam, lParam);
 }


### PR DESCRIPTION
Fix #16952

I found it interesting that after 20+ years of life, there is no simple function to get the string in the clipboard -- I added one.