### PR TITLE
double-click on file URI: change ShellExecute parameters to take the default action for the given app

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -388,7 +388,7 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 				// Open URL
 				wstring url = notifyView->getGenericTextAsString(static_cast<size_t>(startPos), static_cast<size_t>(endPos));
-				::ShellExecute(_pPublicInterface->getHSelf(), L"open", url.c_str(), NULL, NULL, SW_SHOW);
+				::ShellExecute(_pPublicInterface->getHSelf(), NULL, url.c_str(), NULL, NULL, SW_SHOWNORMAL);
 			}
 			break;
 		}
@@ -1269,3 +1269,4 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 	}
 	return FALSE;
 }
+


### PR DESCRIPTION
fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16941 
so that when double click a file URL ,  make the application take a default action, which may be different than "open". If there's no default, the "open" will be used automatically. 

Ref: https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutea#parameters 

The change for the last parameter, for how to display the window, suggested by: 
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/16941#issuecomment-3219202134 
And it makes sense based on https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow



