### PR TITLE
Fix: allow Ctrl+drag selection to copy instead of reset

### DIFF
--- a/scintilla/src/Editor.cxx
+++ b/scintilla/src/Editor.cxx
@@ -4912,7 +4912,8 @@ void Editor::ButtonDownWithModifiers(Point pt, unsigned int curTime, KeyMod modi
 							return;
 						}
 						// Switch to just the click position
-						SetSelection(newPos, newPos);
+						// Commented it out because code below prevents the user from starting drag and copy
+						//SetSelection(newPos, newPos);
 					}
 					if (!sel.Range(selectionPart).Empty()) {
 						inDragDrop = DragDrop::initial;


### PR DESCRIPTION
### Summary
When selecting text and holding Ctrl, clicking or dragging causes the selection to be cleared.  
This behavior is inconsistent with standard Windows editors where **Ctrl + drag** should initiate a copy-drag operation.

### Fix
- Commented out the line that resets selection when Ctrl key is pressed during mouse click/drag.
- Now:
  1. Select a sentence.
  2. Hold Ctrl.
  3. Drag the selection → Copy-drag starts as expected.

### Related Issue
Fixes #17028

### Before
- Select text → Hold Ctrl → Click → Selection was lost.

### After
- Select text → Hold Ctrl → Drag → Drag-and-copy operation works correctly.
