### PR TITLE
Fix Notepad++ installer use in multi-user sessions environment

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -175,7 +175,7 @@ closeRunningNppCheckDone:
 
 	; handle the possible Silent Mode (/S) & already running Notepad++ (without this an incorrect partial installation is possible)
 	IfSilent 0 notInSilentMode
-	System::Call 'kernel32::OpenMutex(i 0x100000, b 0, t "nppInstance") i .R0'
+	System::Call 'kernel32::OpenMutex(i 0x100000, b 0, t "Global\nppInstanceGlb") i .R0'
 	IntCmp $R0 0 nppNotRunning
 	StrCpy $runningNppDetected "true"
 	System::Call 'kernel32::CloseHandle(i $R0)' ; a Notepad++ instance is running, tidy-up the opened mutex handle only

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -49,14 +49,14 @@ FunctionEnd
 !macro CheckIfRunning un
 	Function ${un}CheckIfRunning
 		Check:
-		System::Call 'kernel32::OpenMutex(i 0x100000, b 0, t "nppInstance") i .R0'
+		System::Call 'kernel32::OpenMutex(i 0x100000, b 0, t "Global\nppInstanceGlb") i .R0'
 		
 		IntCmp $R0 0 NotRunning
 			StrCpy $runningNppDetected "true"
 			System::Call 'kernel32::CloseHandle(i $R0)'
 			MessageBox MB_RETRYCANCEL|MB_DEFBUTTON1|MB_ICONSTOP "Cannot continue the installation: Notepad++ is running.\
 			          $\n$\n\
-                      Please close Notepad++, then click ''Retry''." IDRETRY Retry IDCANCEL Cancel
+                      First, please make sure that all the Notepad++ instances are closed (this also applies to other possible logged in user sessions), and then click the ''Retry''." IDRETRY Retry IDCANCEL Cancel
 			Retry:
 				Goto Check
 			

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -505,6 +505,72 @@ DWORD nppUacCreateEmptyFile(const wchar_t* wszNewEmptyFilePath)
 	return ERROR_SUCCESS;
 }
 
+// create (or obtain handle to existing) system-wide Notepad++ mutex
+#include <sddl.h> // Security Descriptor Definition Language
+#ifdef _MSC_VER
+#pragma warning(disable : 4996) // for GetVersion
+#endif
+bool secureGlobalNppMutex()
+{
+	// we cannot use NULL here for the following CreateMutex lpMutexAttributes 1st param, otherwise we will get
+	// ERROR_ACCESS_DENIED for any consequent Create/OpenMutex calls later if the mutex has been previously created in a thread
+	// that is impersonating a different user (or service), example:
+	// https://web.archive.org/web/20151215210112/http://blogs.msdn.com/b/winsdk/archive/2009/11/10/access-denied-on-a-mutex.aspx
+
+	// obtaining medium integrity level security descriptor by the help of SDDL, here:
+	// - D: means DACL (Discretionary Access Control List), S: means SACL (System ACL)
+	// - the general format of an ACE (Access Control Entry) string: (type;flags;rights;object-guid;inherit-object-guid;sid)
+	// - more details in:
+	//   https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings
+	//   https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
+
+	LPCWSTR pwszStringSecDesc;
+	if ((LOBYTE(LOWORD(::GetVersion()))) >= 6)
+		pwszStringSecDesc = L"D:(A;;GA;;;WD)(A;;GA;;;AN)S:(ML;;NW;;;ME)"; // WinVista+
+	else
+		pwszStringSecDesc = L"D:(A;;GA;;;WD)(A;;GA;;;AN)"; // WinXP-
+
+	PSECURITY_DESCRIPTOR pSecDesc = nullptr;
+	if (!::ConvertStringSecurityDescriptorToSecurityDescriptorW(pwszStringSecDesc, SDDL_REVISION_1, &pSecDesc, NULL))
+	{
+#ifdef _DEBUG
+		std::string msg = "Notepad++::secureGlobalNppMutex() - ConvertStringSecurityDescriptorToSecurityDescriptor failed with error-code: " \
+			+ std::to_string(::GetLastError());
+		::OutputDebugStringA(msg.c_str());
+#endif // _DEBUG
+		return false;
+	}
+
+	SECURITY_ATTRIBUTES SecAttr{};
+	SecAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+	SecAttr.lpSecurityDescriptor = pSecDesc;
+	SecAttr.bInheritHandle = FALSE;
+
+	bool bRet = false;
+	::SetLastError(NO_ERROR);
+	if (::CreateMutexW(&SecAttr, FALSE, L"Global\\nppInstanceGlb") == NULL)
+	{
+#ifdef _DEBUG
+		std::string msg = "Notepad++::secureGlobalNppMutex() - CreateMutex failed with error-code: " + std::to_string(::GetLastError());
+		::OutputDebugStringA(msg.c_str());
+#endif // _DEBUG
+	}
+	else
+	{
+		// all ok
+		// Note: We let the system automatically close for us the obtained outstanding mutex handle when the Notepad++ process ends.
+		bRet = true;
+	}
+
+	if (pSecDesc)
+		::LocalFree(pSecDesc);
+
+	return bRet;
+}
+#ifdef _MSC_VER
+#pragma warning(default : 4996)
+#endif
+
 } // namespace
 
 
@@ -514,7 +580,35 @@ std::chrono::steady_clock::time_point g_nppStartTimePoint{};
 int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance*/, _In_ PWSTR pCmdLine, _In_ int /*nShowCmd*/)
 {
 	g_nppStartTimePoint = std::chrono::steady_clock::now();
-	
+
+	// DEBUG: TEMP: (will be removed in the final PR version) //////////////////////////
+	HANDLE hNppGlobalMtx = ::OpenMutexW(SYNCHRONIZE, FALSE, L"Global\\nppInstanceGlb");
+	if (hNppGlobalMtx)
+	{
+		::CloseHandle(hNppGlobalMtx);
+		::MessageBoxW(NULL, L"DEBUG: Global OpenMutex succeeded, we are not alone...", L"Notepad++ wWinMain", MB_OK | MB_APPLMODAL);
+	}
+	else
+	{
+		DWORD dwError = ::GetLastError();
+		if (dwError == ERROR_FILE_NOT_FOUND)
+		{
+			::MessageBoxW(NULL, L"DEBUG: Global OpenMutex did not find a handle, it means we should be alone...", L"Notepad++ wWinMain", MB_OK | MB_APPLMODAL);
+		}
+		else
+		{
+			std::wstring msg = L"DEBUG: Global OpenMutex failed with error-code: " + std::to_wstring(dwError);
+			::MessageBoxW(NULL, msg.c_str(), L"Notepad++ wWinMain", MB_OK | MB_APPLMODAL | MB_ICONERROR);
+		}
+	}
+	///////////////////////////////////////////////////////////////////////////////////
+
+	// try to create (or obtain handle to) Notepad++ instance mutex in the system Global-namespace
+	// - it will not be used further in the Notepad++ app in any way, only from external processes like from the Notepad++ installers
+	// - so a (malicious or unaware) other logged in user cannot misuse this by creating the same global mutex before us
+	//   and prevent starting or influence behavior of the Notepad++ app
+	secureGlobalNppMutex();
+
 	// Notepad++ UAC OPS /////////////////////////////////////////////////////////////////////////////////////////////
 	if ((lstrlenW(pCmdLine) > 0) && (__argc >= 2)) // safe (if pCmdLine is NULL, lstrlen returns 0)
 	{


### PR DESCRIPTION
Fix #17052 , Fix #14251

STR for testing in the issue: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/17052#issuecomment-3358630925

Related also to the PR #15230

TODO:
- [ ] update wingup project accordingly
- [ ] in the future, extend also the scope of the `/closeRunningNpp` installer param (from the current per-user session to be also system-wide, will probably need [WTSAPI](https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/))
- [ ] until the above `/closeRunningNpp` is not updated, add a note to the N++ user manual about the current limitation