### PR TITLE
More efficiently get markers when storing a session.

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6383,12 +6383,12 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includeUntitled
 
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
 
-			long long nextMarkedLine = static_cast<long long>(_invisibleEditView.execute(SCI_MARKERNEXT, 0, (1 << MARK_BOOKMARK)));
-			while (nextMarkedLine != -1) {
+			auto nextMarkedLine = _invisibleEditView.execute(SCI_MARKERNEXT, 0, (1 << MARK_BOOKMARK));
+			while (nextMarkedLine != -1)
+			{
 				sfi._marks.push_back(nextMarkedLine);
-				nextMarkedLine = static_cast<long long>(_invisibleEditView.execute(SCI_MARKERNEXT, nextMarkedLine + 1, (1 << MARK_BOOKMARK)));
+				nextMarkedLine = _invisibleEditView.execute(SCI_MARKERNEXT, nextMarkedLine + 1, (1 << MARK_BOOKMARK));
 			}
-
 
 			if (i == activeIndex)
 			{


### PR DESCRIPTION
The code for retrieving markers when saving a session has been updated from calling SCI_MARKERGET for each line in the file to SCI_MARKERNEXT, which is more efficient.
