### PR TITLE
Fix multi-selection crash issue whe smart highlighting is enabled

### DIFF
--- a/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
@@ -152,7 +152,8 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 	}
 	
 	const wchar_t * text2FindW = pHighlightView->getSelectedTextToWChar(false); //do not expand selection (false)
-	if (!text2FindW) {
+	if (!text2FindW) 
+	{
 		return;
 	}
 	
@@ -170,5 +171,6 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 		highlightViewWithWord(unfocusView, text2FindW);
 	}
 }
+
 
 


### PR DESCRIPTION
Added null check for text2FindW to prevent potential crashes

Regression inserted by:
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/be59048c5e73f497526beb8a482fdb03d260525e#diff-2b3d58cb350e2b4529694796a633eed44b46ea376c85197e38c5144147972ab5

Fix #17086, fix #17126