### PR TITLE
Improve Rust handling: keywords and autoCompletion

### DIFF
--- a/PowerEditor/installer/APIs/rust.xml
+++ b/PowerEditor/installer/APIs/rust.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<NotepadPlus>
+    <AutoComplete language="Rust">
+        <Environment ignoreCase="no" startFunc="(" stopFunc=")" paramSeparator="," terminal=";" />
+
+        <!-- Strict keywords -->
+        <KeyWord name="as" />
+        <KeyWord name="async" />
+        <KeyWord name="await" />
+        <KeyWord name="break" />
+        <KeyWord name="const" />
+        <KeyWord name="continue" />
+        <KeyWord name="crate" />
+        <KeyWord name="dyn" />
+        <KeyWord name="else" />
+        <KeyWord name="enum" />
+        <KeyWord name="extern" />
+        <KeyWord name="false" />
+        <KeyWord name="fn" />
+        <KeyWord name="for" />
+        <KeyWord name="if" />
+        <KeyWord name="impl" />
+        <KeyWord name="in" />
+        <KeyWord name="let" />
+        <KeyWord name="loop" />
+        <KeyWord name="match" />
+        <KeyWord name="mod" />
+        <KeyWord name="move" />
+        <KeyWord name="mut" />
+        <KeyWord name="pub" />
+        <KeyWord name="ref" />
+        <KeyWord name="return" />
+        <KeyWord name="Self" />
+        <KeyWord name="self" />
+        <KeyWord name="static" />
+        <KeyWord name="struct" />
+        <KeyWord name="super" />
+        <KeyWord name="trait" />
+        <KeyWord name="true" />
+        <KeyWord name="type" />
+        <KeyWord name="unsafe" />
+        <KeyWord name="use" />
+        <KeyWord name="where" />
+        <KeyWord name="while" />
+
+        <!-- Reserved for future use -->
+        <KeyWord name="abstract" />
+        <KeyWord name="become" />
+        <KeyWord name="box" />
+        <KeyWord name="do" />
+        <KeyWord name="final" />
+        <KeyWord name="macro" />
+        <KeyWord name="override" />
+        <KeyWord name="priv" />
+        <KeyWord name="typeof" />
+        <KeyWord name="unsized" />
+        <KeyWord name="virtual" />
+        <KeyWord name="yield" />
+        <KeyWord name="gen" />
+        <KeyWord name="try" />
+
+        <!-- Weak Keywords -->
+        <KeyWord name="'static" />
+        <KeyWord name="macro_rules" />
+        <KeyWord name="raw" />
+        <KeyWord name="safe" />
+        <KeyWord name="union" />
+
+        <!-- Primitive types -->
+        <KeyWord name="bool" />
+        <KeyWord name="char" />
+        <KeyWord name="f32" />
+        <KeyWord name="f64" />
+        <KeyWord name="i128" />
+        <KeyWord name="i16" />
+        <KeyWord name="i32" />
+        <KeyWord name="i64" />
+        <KeyWord name="i8" />
+        <KeyWord name="isize" />
+        <KeyWord name="str" />
+        <KeyWord name="u128" />
+        <KeyWord name="u16" />
+        <KeyWord name="u32" />
+        <KeyWord name="u64" />
+        <KeyWord name="u8" />
+        <KeyWord name="usize" />
+
+        <!-- Common macros -->
+        <KeyWord name="eprintln!" func="yes">
+            <Overload retVal="()" descr="Prints to standard error with newline">
+                <Param name="format string (...)" />
+            </Overload>
+        </KeyWord>
+        <KeyWord name="format!" func="yes">
+            <Overload retVal="String" descr="Returns a formatted `String`">
+                <Param name="format string (...)" />
+            </Overload>
+        </KeyWord>
+        <KeyWord name="println!" func="yes">
+            <Overload retVal="()" descr="Prints to standard output with newline">
+                <Param name="format string (...)" />
+            </Overload>
+        </KeyWord>
+        <KeyWord name="print!" func="yes">
+            <Overload retVal="()" descr="Prints to standard output">
+                <Param name="format string (...)" />
+            </Overload>
+        </KeyWord>
+
+        <!-- System macros -->
+        <KeyWord name="macro_rules!" func="yes" />
+        <KeyWord name="dbg!" func="yes" />
+        <KeyWord name="assert!" func="yes" />
+        <KeyWord name="assert_eq!" func="yes" />
+        <KeyWord name="assert_ne!" func="yes" />
+        <KeyWord name="debug_assert!" func="yes" />
+        <KeyWord name="debug_assert_eq!" func="yes" />
+        <KeyWord name="panic!" func="yes" />
+        <KeyWord name="todo!" func="yes" />
+        <KeyWord name="unimplemented!" func="yes" />
+        <KeyWord name="unreachable!" func="yes" />
+        <KeyWord name="write!" func="yes" />
+        <KeyWord name="writeln!" func="yes" />
+        <KeyWord name="format_args!" func="yes" />
+        <KeyWord name="vec!" func="yes" />
+        <KeyWord name="concat!" func="yes" />
+        <KeyWord name="concat_idents!" func="yes" />
+        <KeyWord name="stringify!" func="yes" />
+        <KeyWord name="include!" func="yes" />
+        <KeyWord name="include_str!" func="yes" />
+        <KeyWord name="include_bytes!" func="yes" />
+        <KeyWord name="env!" func="yes" />
+        <KeyWord name="option_env!" func="yes" />
+        <KeyWord name="file!" func="yes" />
+        <KeyWord name="line!" func="yes" />
+        <KeyWord name="column!" func="yes" />
+        <KeyWord name="module_path!" func="yes" />
+        <KeyWord name="cfg!" func="yes" />
+        <KeyWord name="compile_error!" func="yes" />
+
+        <!-- Common types & constructors -->
+        <KeyWord name="Option::unwrap" func="yes">
+            <Overload retVal="T" descr="Returns the contained `Some` value, panics if `None`" />
+        </KeyWord>
+        <KeyWord name="String::new" func="yes">
+            <Overload retVal="String" descr="Creates a new, empty `String`" />
+        </KeyWord>
+        <KeyWord name="Vec::new" func="yes">
+            <Overload retVal="Vec&lt;T&gt;" descr="Creates a new, empty `Vec&lt;T&gt;`" />
+        </KeyWord>
+
+    </AutoComplete>
+</NotepadPlus>

--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -520,7 +520,7 @@
             <Keywords name="instre1">ARGF ARGV BEGIN END ENV FALSE DATA NIL RUBY_PATCHLEVEL RUBY_PLATFORM RUBY_RELEASE_DATE RUBY_VERSION PLATFORM RELEASE_DATE STDERR STDIN STDOUT TOPLEVEL_BINDING TRUE __ENCODING__ __END__ __FILE__ __LINE__ alias and begin break case class def defined? do else elsif end ensure false for if in module next nil not or raise redo rescue retry return self super then true undef unless until when while yield</Keywords>
         </Language>
         <Language name="rust" ext="rs" commentLine="//" commentStart="/*" commentEnd="*/">
-            <Keywords name="instre1">abstract as async become box break const continue crate do dyn else enum extern false final fn for if impl in let loop macro match mod move mut override priv pub ref return self static struct super trait true try type typeof unsafe unsized use virtual where while yield</Keywords>
+            <Keywords name="instre1">abstract as async await become box break const continue crate do dyn else enum extern false final fn for gen if impl in let loop macro macro_rules match mod move mut override priv pub raw ref return safe self static struct super trait true try type typeof union unsafe unsized use virtual where while yield</Keywords>
             <Keywords name="instre2">bool char f32 f64 i128 i16 i32 i64 i8 isize str u128 u16 u32 u64 u8 usize</Keywords>
             <Keywords name="type1">Self</Keywords>
             <Keywords name="type2"></Keywords>


### PR DESCRIPTION
- add autoCompletion file (resolves #16904)
- update keywords to match AC and https://doc.rust-lang.org/reference/keywords.html
    - macros (like `assert!`) and lifetime (like `'static`) don't need to be in keyword lists: they are handled internal to the Rust lexer based on the trailing `!` or leading `'`