### PR TITLE
Use modern subclass for URLCtrl

### DIFF
--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -158,12 +158,6 @@ intptr_t CALLBACK FolderStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LP
             return SharedParametersDialog::run_dlgProc(Message, wParam, lParam);
         }
 
-        case WM_DPICHANGED_AFTERPARENT:
-        {
-            _pageLink.destroy();
-            return TRUE;
-        }
-
         case WM_COMMAND:
         {
             switch (wParam)
@@ -200,11 +194,7 @@ intptr_t CALLBACK FolderStyleDialog::run_dlgProc(UINT Message, WPARAM wParam, LP
                     return SharedParametersDialog::run_dlgProc(Message, wParam, lParam);
             }
         }
-        case WM_DESTROY:
-        {
-            _pageLink.destroy();
-            return TRUE;
-        }
+
         default :
             return SharedParametersDialog::run_dlgProc(Message, wParam, lParam);
     }

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.h
@@ -45,7 +45,6 @@ public :
 
 	void destroy() override {
 		//_emailLink.destroy();
-		_pageLink.destroy();
 		if (_hIcon != nullptr)
 		{
 			::DestroyIcon(_hIcon);

--- a/PowerEditor/src/WinControls/AboutDlg/URLCtrl.h
+++ b/PowerEditor/src/WinControls/AboutDlg/URLCtrl.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "Window.h"
-#include "Common.h"
+#include <string>
 
 class URLCtrl : public Window {
 public:
@@ -36,14 +36,10 @@ protected :
 	HWND _msgDest = nullptr;
 	unsigned long _cmdID = 0;
 
-    WNDPROC  _oldproc = nullptr;
     COLORREF _linkColor = RGB(0xFF, 0xFF, 0xFF);
     COLORREF _visitedColor = RGB(0xFF, 0xFF, 0xFF);
     bool  _clicking = false;
 
-    static LRESULT CALLBACK URLCtrlProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam){
-        return ((URLCtrl *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->runProc(hwnd, Message, wParam, lParam);
-    }
-    LRESULT runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
+	static LRESULT CALLBACK URLCtrlProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
+	LRESULT runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
 };
-

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.cpp
@@ -277,8 +277,6 @@ intptr_t CALLBACK WordStyleDlg::run_dlgProc(UINT Message, WPARAM wParam, LPARAM 
 		{
 			_dpiManager.setDpiWP(wParam);
 
-			_goToSettings.destroy();
-
 			const int cpDynamicalSize = _dpiManager.scale(25);
 			move2CtrlRight(IDC_FG_STATIC, _pFgColour->getHSelf(), cpDynamicalSize, cpDynamicalSize);
 			move2CtrlRight(IDC_BG_STATIC, _pBgColour->getHSelf(), cpDynamicalSize, cpDynamicalSize);
@@ -1399,8 +1397,6 @@ void WordStyleDlg::doDialog(bool isRTL)
 
 void WordStyleDlg::destroy()
 {
-	_goToSettings.destroy();
-
 	if (_pFgColour != nullptr)
 	{
 		_pFgColour->destroy();

--- a/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
+++ b/PowerEditor/src/WinControls/ColourPicker/WordStyleDlg.h
@@ -72,9 +72,6 @@ class WordStyleDlg : public StaticDialog
 public :
 	WordStyleDlg() = default;
 	~WordStyleDlg() override {
-		_goToSettings.destroy();
-		_globalOverrideLinkTip.destroy();
-
 		if (_globalOverrideTip)
 			::DestroyWindow(_globalOverrideTip);
 	}

--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -1177,7 +1177,6 @@ intptr_t CALLBACK PluginsAdminDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 		case WM_DPICHANGED:
 		{
 			_dpiManager.setDpiWP(wParam);
-			_repoLink.destroy();
 
 			const size_t szColVer = _dpiManager.scale(100);
 			const size_t szColName = szColVer * 2;
@@ -1328,12 +1327,6 @@ intptr_t CALLBACK PluginsAdminDlg::run_dlgProc(UINT message, WPARAM wParam, LPAR
 				}
 			}
 
-			return TRUE;
-		}
-
-		case WM_DESTROY:
-		{
-			_repoLink.destroy();
 			return TRUE;
 		}
 	}


### PR DESCRIPTION
- delegate HFONT object management to the object instead of the parent, including dpi handling
- clean header includes

fix #17149 