### PR TITLE
Fix text scaling not applying on some controls

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -17,16 +17,15 @@
 #include <algorithm>
 #include <stdexcept>
 #include <shlwapi.h>
-#include <uxtheme.h>
-#include <cassert>
+#include <commctrl.h>
 #include <locale>
 #include "StaticDialog.h"
 #include "CustomFileDialog.h"
 #include "FileInterface.h"
 #include "Common.h"
 #include "Utf8.h"
-#include "Parameters.h"
 #include "Buffer.h"
+#include "dpiManagerV2.h"
 
 using namespace std;
 
@@ -1513,20 +1512,15 @@ wstring getDateTimeStrFrom(const wstring& dateTimeFormat, const SYSTEMTIME& st)
 // Don't forget to use DeleteObject(createdFont) before leaving the program
 HFONT createFont(const wchar_t* fontName, int fontSize, bool isBold, HWND hDestParent)
 {
-	HDC hdc = GetDC(hDestParent);
-
 	LOGFONT logFont{};
-	logFont.lfHeight = DPIManagerV2::scaleFont(fontSize, hDestParent);
+	const int fontSizeScaled = DPIManagerV2::scaleFontForFactor(fontSize);
+	logFont.lfHeight = DPIManagerV2::scaleFont(fontSizeScaled, hDestParent);
 	if (isBold)
 		logFont.lfWeight = FW_BOLD;
 
-	wcscpy_s(logFont.lfFaceName, fontName);
+	::wcsncpy_s(logFont.lfFaceName, fontName, size_t{ LF_FACESIZE - 1 });
 
-	HFONT newFont = CreateFontIndirect(&logFont);
-
-	ReleaseDC(hDestParent, hdc);
-
-	return newFont;
+	return ::CreateFontIndirectW(&logFont);
 }
 
 bool removeReadOnlyFlagFromFileAttributes(const wchar_t* fileFullPath)

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -90,22 +90,6 @@ void delLeftWordInEdit(HWND hEdit)
 	}
 }
 
-LRESULT run_swapButtonProc(WNDPROC oldEditProc, HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-	switch (message)
-	{
-		case WM_RBUTTONUP:
-		{
-			::SendMessage(GetParent(hwnd), message, wParam, lParam);
-			break;
-		}
-
-		default:
-			break;
-	}
-	return ::CallWindowProc(oldEditProc, hwnd, message, wParam, lParam);
-}
-
 int Searching::convertExtendedToString(const wchar_t * query, wchar_t * result, int length)
 {	//query may equal to result, since it always gets smaller
 	int i = 0, j = 0;
@@ -1609,8 +1593,7 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			const bool isMonospaced = NppParameters::getInstance().getNppGUI()._monospacedFontFindDlg;
 			if (isMonospaced)
 			{
-				static const UINT fontSize = DPIManagerV2::scaleFontForFactor(8);
-				hFont = createFont(L"Courier New", fontSize, false, _hSelf);
+				hFont = createFont(L"Courier New", 8, false, _hSelf);
 			}
 			else
 			{
@@ -1624,8 +1607,9 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 
 			LOGFONT lf{};
 			::GetObject(hFont, sizeof(lf), &lf);
-			static const UINT fontSize = DPIManagerV2::scaleFontForFactor(16) - 5;
-			lf.lfHeight = -(_dpiManager.scale(fontSize));
+			static const int fontSize = DPIManagerV2::scaleFontForFactor(16);
+			static const int fontSizeCorrection = DPIManagerV2::scaleFontForFactor(5);
+			lf.lfHeight = -(_dpiManager.scale(fontSize) - fontSizeCorrection);
 			_hComboBoxFont = ::CreateFontIndirect(&lf);
 
 			for (const auto& hComboBox : { hFindCombo, hReplaceCombo, hFiltersCombo, hDirCombo })
@@ -1654,8 +1638,6 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			::SetWindowTextW(::GetDlgItem(_hSelf, IDC_FINDNEXT), L"▼ Find Next");
 
 			_hSwapButton = ::GetDlgItem(_hSelf, IDD_FINDREPLACE_SWAP_BUTTON);
-			::SetWindowLongPtr(_hSwapButton, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
-			_oldSwapButtonProc = reinterpret_cast<WNDPROC>(::SetWindowLongPtr(_hSwapButton, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(swapButtonProc)));
 			::SetWindowTextW(_hSwapButton, L"⇅");
 
 			::SetWindowTextW(::GetDlgItem(_hSelf, IDD_RESIZE_TOGGLE_BUTTON), L"˄");
@@ -1913,7 +1895,9 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 			LOGFONT lf{};
 			HFONT font = reinterpret_cast<HFONT>(::SendDlgItemMessage(_hSelf, IDFINDWHAT, WM_GETFONT, 0, 0));
 			::GetObject(font, sizeof(lf), &lf);
-			lf.lfHeight = -(_dpiManager.scale(16) - 5);
+			static const int fontSize = DPIManagerV2::scaleFontForFactor(16);
+			static const int fontSizeCorrection = DPIManagerV2::scaleFontForFactor(5);
+			lf.lfHeight = -(_dpiManager.scale(fontSize) - fontSizeCorrection);
 			_hComboBoxFont = ::CreateFontIndirect(&lf);
 
 			for (auto idComboBox : { IDFINDWHAT, IDREPLACEWITH, IDD_FINDINFILES_FILTERS_COMBO, IDD_FINDINFILES_DIR_COMBO })

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -530,11 +530,6 @@ private:
 	ContextMenu _swapPopupMenu;
 	enum SwapButtonStatus {swap, down, up} _swapButtonStatus = swap;
 	HWND _hSwapButton = nullptr;
-	static LRESULT CALLBACK swapButtonProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
-		const auto dlg = (FindReplaceDlg*)(::GetWindowLongPtr(hwnd, GWLP_USERDATA));
-		return (run_swapButtonProc(dlg->_oldSwapButtonProc, hwnd, message, wParam, lParam));
-	}
-	WNDPROC _oldSwapButtonProc = nullptr;
 };
 
 //FindIncrementDlg: incremental search dialog, docked in rebar


### PR DESCRIPTION
- fix text scaling for FindReplace dlg buttons
- fix text scaling for Hash dlg edit controls
- remove unneeded subclass for FindReplace dlg swap button
- remove unused header includes in Common.cpp

fix #17167 