### PR TITLE
Respect Windows setting for mouse wheel horizontal scrolling amount

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -411,13 +411,12 @@ LRESULT ScintillaEditView::scintillaNew_Proc(HWND hwnd, UINT Message, WPARAM wPa
 			return TRUE;
 		}
 
-		case WM_MOUSEHWHEEL :
+		case WM_MOUSEHWHEEL:
 		{
-			::CallWindowProc(_scintillaDefaultProc, hwnd, WM_HSCROLL, ((short)HIWORD(wParam) > 0)?SB_LINERIGHT:SB_LINELEFT, 0);
-			return TRUE;
+			return ::CallWindowProc(_scintillaDefaultProc, hwnd, Message, wParam, lParam);
 		}
 
-		case WM_MOUSEWHEEL :
+		case WM_MOUSEWHEEL:
 		{
 			if (LOWORD(wParam) & MK_RBUTTON)
 			{


### PR DESCRIPTION
Fix #9480

Let the Scintilla handle the original WM_MOUSEHWHEEL (instead of changing it to WM_HSCROLL).
During its init, Scintilla-ctrl detects & store the relevant Windows mouse wheel horizontal SPI_GETWHEELSCROLLCHARS setting:
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/3daa59326d32f75b53cdc737fa7f8e841330daf5/scintilla/win32/ScintillaWin.cxx#L3558