### PR TITLE
Code enhancement: Make returned value safer

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -971,8 +971,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			if (message == NPPM_GETCURRENTWORD)
 			{
 				auto txtW = _pEditView->getSelectedTextToWChar();
-				if (txtW)
-					wcscpy_s(str.get(), strSize, txtW);
+				wcscpy_s(str.get(), strSize, txtW.c_str());
 			}
 			else if (message == NPPM_GETCURRENTLINESTR)
 			{
@@ -1008,8 +1007,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			int hasSlash = 0;
 
 			auto txtW = _pEditView->getSelectedTextToWChar(); // this is either the selected text, or the word under the cursor if there is no selection
-			if (txtW)
-				wcscpy_s(str.get(), strSize, txtW);
+			wcscpy_s(str.get(), strSize, txtW.c_str());
 
 			hasSlash = FALSE;
 			for (int i = 0; str[i] != 0; i++)

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1394,8 +1394,8 @@ void Notepad_plus::command(int id)
 			}
 
 			auto str = _pEditView->getSelectedTextToWChar(false);
-			if (str)         // the selected text is not empty, then use it
-				_incrementFindDlg.setSearchText(str, _pEditView->getCurrentBuffer()->getUnicodeMode() != uni8Bit);
+			if (!str.empty())         // the selected text is not empty, then use it
+				_incrementFindDlg.setSearchText(str.c_str(), _pEditView->getCurrentBuffer()->getUnicodeMode() != uni8Bit);
 
 			_incrementFindDlg.display();
 		}
@@ -1497,7 +1497,7 @@ void Notepad_plus::command(int id)
 		case IDM_SEARCH_VOLATILE_FINDPREV :
 		{
 			auto str = _pEditView->getSelectedTextToWChar();
-			if (!str) return;
+			if (str.empty()) return;
 
 			FindOption op;
 			op._isMatchCase = false;
@@ -1507,7 +1507,7 @@ void Notepad_plus::command(int id)
 			op._whichDirection = (id == IDM_SEARCH_VOLATILE_FINDNEXT ? DIR_DOWN : DIR_UP);
 
 			FindStatus status = FSNoMessage;
-			_findReplaceDlg.processFindNext(str, &op, &status);
+			_findReplaceDlg.processFindNext(str.c_str(), &op, &status);
 			if (status == FSEndReached)
 			{
 				wstring msg = _nativeLangSpeaker.getLocalizedStrFromID("find-status-end-reached", FIND_STATUS_END_REACHED_TEXT);
@@ -1541,9 +1541,9 @@ void Notepad_plus::command(int id)
 
 			auto selectedText = _pEditView->getSelectedTextToWChar(true);
 
-			if (selectedText)
+			if (!selectedText.empty())
 			{
-				_findReplaceDlg.markAll(selectedText, styleID);
+				_findReplaceDlg.markAll(selectedText.c_str(), styleID);
 			}
 		}
 		break;
@@ -3510,8 +3510,8 @@ void Notepad_plus::command(int id)
 			{
 				int iQuote = -1;
 				auto authorW = _pEditView->getSelectedTextToWChar();
-				if (authorW)
-					iQuote = getQuoteIndexFrom(authorW);
+				if (!authorW.empty())
+					iQuote = getQuoteIndexFrom(authorW.c_str());
 
 				if (iQuote == -1)
 				{

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -421,8 +421,8 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 				if (nppGui._smartHiliteOnAnotherView)
 				{
 					auto selectedText = _pEditView->getSelectedTextToWChar(false);
-					if (selectedText)
-						_smartHighlighter.highlightViewWithWord(notifyView, selectedText);
+					if (!selectedText.empty())
+						_smartHighlighter.highlightViewWithWord(notifyView, selectedText.c_str());
 				}
 				break;
 			}

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -5382,11 +5382,11 @@ wstring FindReplaceDlg::setSearchText()
 {
 	const NppGUI& nppGui = NppParameters::getInstance().getNppGUI();
 	Sci_Position selStrCharNum = 0;
-	const wchar_t* selStr = (*_ppEditView)->getSelectedTextToWChar(true, &selStrCharNum);
+	auto selStr = (*_ppEditView)->getSelectedTextToWChar(true, &selStrCharNum);
 
-	if (selStr && selStrCharNum <= nppGui._fillFindWhatThreshold)
+	if (!selStr.empty() && selStrCharNum <= nppGui._fillFindWhatThreshold)
 	{
-		setSearchText(selStr);
+		setSearchText(selStr.c_str());
 		return selStr;
 	}
 	return L"";
@@ -5401,11 +5401,11 @@ wstring FindReplaceDlg::setSearchTextWithSettings()
 	if (nppGui._fillFindFieldWithSelected)
 	{
 		Sci_Position selStrCharNum = 0;
-		const wchar_t* selStr = (*_ppEditView)->getSelectedTextToWChar(nppGui._fillFindFieldSelectCaret, &selStrCharNum);
+		auto selStr = (*_ppEditView)->getSelectedTextToWChar(nppGui._fillFindFieldSelectCaret, &selStrCharNum);
 
-		if (selStr && selStrCharNum <= nppGui._fillFindWhatThreshold)
+		if (!selStr.empty() && selStrCharNum <= nppGui._fillFindWhatThreshold)
 		{
-			setSearchText(selStr);
+			setSearchText(selStr.c_str());
 			return selStr;
 		}
 	}
@@ -6322,7 +6322,7 @@ void FindIncrementDlg::markSelectedTextInc(bool enable, FindOption *opt)
 		return;
 
 	auto text2Find = (*(_pFRDlg->_ppEditView))->getSelectedTextToWChar(false);	//do not expand selection (false)
-	if (!text2Find)
+	if (text2Find.empty())
 		return;
 
 	opt->_str2Search = text2Find;

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2834,8 +2834,7 @@ char * ScintillaEditView::getSelectedTextToMultiChar(char * txt, size_t size, bo
 }
 
 // get the selected text & selected text character number (not the multi-chars lenghth for the allocation, if selCharNumber is not nul).
-// This function returns the pointer of wide char string (wchar_t *) that we don't need to and should not deallocate.  
-const wchar_t * ScintillaEditView::getSelectedTextToWChar(bool expand, Sci_Position* selCharNumber)
+wstring ScintillaEditView::getSelectedTextToWChar(bool expand, Sci_Position* selCharNumber)
 {
 	WcharMbcsConvertor& wmc = WcharMbcsConvertor::getInstance();
 	size_t cp = execute(SCI_GETCODEPAGE);
@@ -2855,7 +2854,7 @@ const wchar_t * ScintillaEditView::getSelectedTextToWChar(bool expand, Sci_Posit
 		*selCharNumber = selNum;
 
 	if (selNum == 0)
-		return nullptr;
+		return L"";
 
 	// then get the selected string's total bytes (without counting the last NULL char)
 	auto neededByte = execute(SCI_GETSELTEXT, 0, 0);

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.h
@@ -463,7 +463,7 @@ public:
 	void getVisibleStartAndEndPosition(intptr_t* startPos, intptr_t* endPos);
     char * getWordFromRange(char * txt, size_t size, size_t pos1, size_t pos2);
 	char * getSelectedTextToMultiChar(char * txt, size_t size, bool expand = true);
-	const wchar_t* getSelectedTextToWChar(bool expand = true, Sci_Position* selCharNumber = nullptr);
+	std::wstring getSelectedTextToWChar(bool expand = true, Sci_Position* selCharNumber = nullptr);
     char * getWordOnCaretPos(char * txt, size_t size);
 
 	intptr_t searchInTarget(const wchar_t * Text2Find, size_t lenOfText2Find, size_t fromPos, size_t toPos) const;

--- a/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
+++ b/PowerEditor/src/ScintillaComponent/SmartHighlighter.cpp
@@ -151,11 +151,8 @@ void SmartHighlighter::highlightView(ScintillaEditView * pHighlightView, Scintil
 			return;
 	}
 	
-	const wchar_t * text2FindW = pHighlightView->getSelectedTextToWChar(false); //do not expand selection (false)
-	if (!text2FindW) 
-	{
-		return;
-	}
+	auto text2FindW = pHighlightView->getSelectedTextToWChar(false); //do not expand selection (false)
+	if (text2FindW.empty()) return;
 	
 	highlightViewWithWord(pHighlightView, text2FindW);
 


### PR DESCRIPTION
A crash regression (#17087) has been caused by the returned null pointer.
This PR makes the returned value safer: use empty string instead.