### PR TITLE
Fix corrupted file loading for UTF files with BOM, bigger than Notepad++ blockSize when using default system CP 65001

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1976,6 +1976,7 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const wchar_t * f
 		size_t lenConvert = 0;	//just in case conversion results in 0, but file not empty
 		bool isFirstTime = true;
 		int incompleteMultibyteChar = 0;
+		bool hasBOM = false;
 
 		do
 		{
@@ -1988,9 +1989,8 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const wchar_t * f
 
 			if (lenFile == 0) break;
 
-			bool hasBOM = false;
-            if (isFirstTime)
-            {
+			if (isFirstTime)
+			{
 				NppParameters& nppParamInst = NppParameters::getInstance();
 				const NppGUI& nppGui = nppParamInst.getNppGUI();
 
@@ -2023,8 +2023,8 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const wchar_t * f
 					fileFormat._language = detectLanguageFromTextBeginning((unsigned char *)data, lenFile);
 				}
 
-                isFirstTime = false;
-            }
+				isFirstTime = false;
+			}
 
 
 			if (fileFormat._encoding != -1)


### PR DESCRIPTION
Fix #17234

N++ loads files in chunks of blockSize (128 * 1024 + 4 == 131076). For the 1st chunk, it detects the possible BOM present, but for the later chunks not.

If there is the Windows Region Administrative feature "Beta: Use Unicode UTF-8 for worldwide language support" ON, N++ currently fails to correctly handle the file encoding for the later file-chunks loaded.