### PR TITLE
Update Taiwanese Mandarin (v8.8.8)

### DIFF
--- a/PowerEditor/installer/nativeLang/taiwaneseMandarin.xml
+++ b/PowerEditor/installer/nativeLang/taiwaneseMandarin.xml
@@ -515,7 +515,7 @@ Translation note:
 				<Item id="1664" name="專案面板 3"/>
 				<Item id="1641" name="在目前文件中尋找全部"/>
 				<Item id="1686" name="透明度(&amp;Y)"/>
-				<Item id="1703" name=".&nbsp;可匹配換行(&amp;.)"/>
+				<Item id="1703" name="可匹配換行(&amp;.)"/>
 				<Item id="1721" name="▲"/>
 				<Item id="1723" name="▼ 找下一個"/>
 				<Item id="1725" name="複製所有已標記文字"/>


### PR DESCRIPTION
includes text improvements and the addition of missing translation text. for v8.8.8 see [f16d48c](https://github.com/for40255/notepad-plus-plus/commit/f16d48c9bc5695d4420f9f32619cace0404952ac)