### PR TITLE
Allow on-the-fly updating of mouse wheel scroll amount according to the OS setting changes

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -319,6 +319,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				}
 			}
 
+			// let the Scintilla to update according to the possible changed OS settings
+			// (mouse wheel vertical & horizontal scroll amount, DirectWrite rendering params, base elements, style etc.)
+			::SendMessage(_mainEditView.getHSelf(), WM_SETTINGCHANGE, wParam, lParam);
+			::SendMessage(_subEditView.getHSelf(), WM_SETTINGCHANGE, wParam, lParam);
+
 			return ::DefWindowProc(hwnd, message, wParam, lParam);
 		}
 


### PR DESCRIPTION
Make the previous PR #17193 more user-friendly.

Let the Scintilla to update its internals according to the possible changed OS settings. This allows to update without relaunching Notepad++ for the changes to take effect.

Currently it means for mouse wheel vertical & horizontal scroll amount, DirectWrite rendering params, base elements & style.

For details see:
https://github.com/notepad-plus-plus/notepad-plus-plus/blob/7f17447a98a95cf477906fde6950db86e3f38a64/scintilla/win32/ScintillaWin.cxx#L2423

Kudos to @ozone10 