### PR TITLE
Use new WinGUp cmdline parameter to override security error log path

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3683,7 +3683,7 @@ void Notepad_plus::command(int id)
 						param += sgd.authority_key_id();
 
 						param += L" -errLogPath=";
-						param += L"{QUOTE}%LOCALAPPDATA%\\Notepad++\\log\\securityError.log{QUOTE}";
+						param += L"\"%LOCALAPPDATA%\\Notepad++\\log\\securityError.log\"";
 					}
 					Process updater(updaterFullPath.c_str(), param.c_str(), updaterDir.c_str());
 

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -423,7 +423,7 @@ bool launchUpdater(const std::wstring& updaterFullPath, const std::wstring& upda
 	updaterParams += sgd.authority_key_id();
 
 	updaterParams += L" -errLogPath=";
-	updaterParams += L"{QUOTE}%LOCALAPPDATA%\\Notepad++\\log\\securityError.log{QUOTE}";
+	updaterParams += L"\"%LOCALAPPDATA%\\Notepad++\\log\\securityError.log\"";
 
 	Process updater(updaterFullPath.c_str(), updaterParams.c_str(), updaterDir.c_str());
 	updater.run();


### PR DESCRIPTION
The default path of WinGUp security log is %LOCALAPPDATA%\Wingup\log\securityError.log. 
The PR overrides it to %LOCALAPPDATA%\Nootepad++\log\securityError.log. 
Also adapt the new wingup quote placeholder ({QUOTE}).

ref: https://github.com/notepad-plus-plus/wingup/issues/100