### PR TITLE
Fix: empty file opens as ANSI with code page 65001

### DIFF
--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -2148,10 +2148,11 @@ bool FileManager::loadFileData(Document doc, int64_t fileSize, const wchar_t * f
 		const NewDocDefaultSettings & ndds = (nppParam.getNppGUI()).getNewDocDefaultSettings(); // for ndds._format
 		fileFormat._eolFormat = ndds._format;
 
-		//for empty files, if the default for new files is UTF8, and "Apply to opened ANSI files" is set, apply it
+		// for empty files, if the default for new files is UTF8, and "Apply to opened ANSI files" is set, apply it
+		// if the system code page is UTF-8, empty files without a forced encoding must be UTF8
 		if ((fileSize == 0) && (fileFormat._encoding < 1))
 		{
-			if (ndds._unicodeMode == uniUTF8_NoBOM && ndds._openAnsiAsUtf8)
+			if ((ndds._unicodeMode == uniUTF8_NoBOM && ndds._openAnsiAsUtf8) || NppParameters::getInstance().isCurrentSystemCodepageUTF8())
 				fileFormat._encoding = SC_CP_UTF8;
 		}
 	}


### PR DESCRIPTION
In Notepad++ 8.8.8 and 8.8.9, when the system code page is UTF-8, ANSI encoding is disabled; however, an empty file is still opened as ANSI, causing user confusion. The problem was reported in Issue #17258.

This is a minimal fix for the problem. It might not be the *best* fix. Please re-engineer, or close and replace with, a better approach, if someone has one.

* It seems to me that the sub-preference **New Document** | **Encoding** | **UTF-8** | **Apply to opened ANSI files** should be disabled and *checked*, rather than unchecked, when the system code page is UTF-8. However, that does not appear to me to be a trivial change, and by itself, it still wouldn’t fully fix this problem, as that box doesn’t apply when a BOM encoding or a character set encoding is specified for new documents. (I can see the logic in saying a zero-length document doesn’t include a BOM, so it can’t be opened as a BOM encoding; but why a zero-length document is opened as ANSI when a character set encoding has been specified for new documents puzzles me. In any case, we must not use ANSI when the system code page is UTF-8, so applying UTF-8 for all zero-length documents without an encoding already set is the simplest way to avoid the problem. Testing shows that if the user opens a zero-length file and then selects a character set encoding, this change does not block the user’s choice from taking effect.)

* I have not tested how this might apply to sessions. (I don’t use them, and I’m really not familiar enough with them to guess what or how to test.)