### PR TITLE
Fix comments and other highlighting in TCL

### DIFF
--- a/PowerEditor/installer/themes/Bespin.xml
+++ b/PowerEditor/installer/themes/Bespin.xml
@@ -255,25 +255,28 @@ Credits:
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="F8F8F8" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="55E439" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="FF3A83" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="F6F080" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="BDAE9D" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="1E9AE0" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="2A211C" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Black board.xml
+++ b/PowerEditor/installer/themes/Black board.xml
@@ -257,25 +257,28 @@ Credits:
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERSTOR" styleID="6" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="61CE3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="D8FA3C" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F8" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="AEAEAE" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FBDE2D" bgColor="0C1021" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Choco.xml
+++ b/PowerEditor/installer/themes/Choco.xml
@@ -257,25 +257,28 @@ Credits:
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="F1E694" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="8996A8" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="DA5659" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="7CA563" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="C3BE98" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="679D47" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="B3935C" bgColor="1A0F0B" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
+++ b/PowerEditor/installer/themes/DansLeRuSH-Dark.xml
@@ -1057,25 +1057,28 @@ Installation : Copy this file to "%APPDATA%\Notepad++\themes" and in a portable 
             <WordsStyle name="Q OPERATOR" styleID="24" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FF5757" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="9865A8" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="9865A8" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E6C74E" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="F57F3D" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="F57F3D" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="8F8F8F" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E6C74E" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6C74E" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="8F8F8F" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="9865A8" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="9865A8" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="FF5757" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="F57F3D" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="F57F3D" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="E6C74E" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="9865A8" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="666666" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="C7C7C7" bgColor="2E2E2E" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/DarkModeDefault.xml
+++ b/PowerEditor/installer/themes/DarkModeDefault.xml
@@ -1553,20 +1553,26 @@ License:             GPL2
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="DFC47D" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="DFC47D" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="DFC47D" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFEBDD" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="CC9393" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="CC9393" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="3" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tehex" desc="Tektronix extended HEX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Deep Black.xml
+++ b/PowerEditor/installer/themes/Deep Black.xml
@@ -258,25 +258,28 @@ https://notepad-plus-plus.org/donate/
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="00FF00" bgColor="000000" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A001D6" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Hello Kitty.xml
+++ b/PowerEditor/installer/themes/Hello Kitty.xml
@@ -922,25 +922,28 @@ so your enhanced file can be included in Notepad++ future release.
             <WordsStyle name="Q OPERATOR" styleID="24" fgColor="808080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="804000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="0000FF" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="8000FF" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="808080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="808080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="000080" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="000080" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="0000FF" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="600080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="0000FF" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="600080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF8000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="804000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="808080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="808080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="FF8000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="0000FF" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="008000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="008000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="008080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="008080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="008080" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="008080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="008080" bgColor="FFB0FF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="008080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="600080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="600080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="600080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="600080" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFB0FF" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/HotFudgeSundae.xml
+++ b/PowerEditor/installer/themes/HotFudgeSundae.xml
@@ -1089,11 +1089,13 @@ Installation:
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="B7975D" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="D92B10" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="0088CE" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="4AD231" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="3" fgColor="AFA7D6" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="">if else for while</WordsStyle>
-            <WordsStyle name="SUB BRACE" styleID="9" fgColor="0088CE" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="">bool long int char</WordsStyle>
+            <WordsStyle name="EXPAND" styleID="11" fgColor="0088CE" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="4AD231" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="4AD231" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AFA7D6" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="0088CE" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="6" fgColor="D6C479" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="CFBA28" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
@@ -1101,8 +1103,12 @@ Installation:
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="BCBB80" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="208008" bgColor="2B0F01" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="7578DB" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="B7975D" bgColor="2B0F01" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Mono Industrial.xml
+++ b/PowerEditor/installer/themes/Mono Industrial.xml
@@ -289,25 +289,28 @@ Credits:
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="A8B3AB" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="E98800" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="C23B00" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFFF" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="666C68" bgColor="222C28" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A39E64" bgColor="222C28" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Monokai.xml
+++ b/PowerEditor/installer/themes/Monokai.xml
@@ -289,25 +289,28 @@ Credits:
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type3" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="E6DB74" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="AE81FF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="66D9EF" bgColor="272822" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F2" bgColor="272822" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="75715E" bgColor="272822" fontName="" fontStyle="" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="F92672" bgColor="272822" fontName="" fontStyle="" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/MossyLawn.xml
+++ b/PowerEditor/installer/themes/MossyLawn.xml
@@ -1090,9 +1090,11 @@ Installation:
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="f2c476" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="FFBBAA" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="afcf90" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="561e0f" bgColor="58693D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="afcf90" bgColor="58693D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="ffdc87" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="afcf90" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="afcf90" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
@@ -1102,8 +1104,12 @@ Installation:
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="ffdc87" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="2a390e" bgColor="58693D" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="2a390e" bgColor="58693D" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="2a390e" bgColor="58693D" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="2a390e" bgColor="58693D" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="2a390e" bgColor="58693D" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="2a390e" bgColor="58693D" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="cbe248" bgColor="58693D" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="f2c476" bgColor="58693D" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Navajo.xml
+++ b/PowerEditor/installer/themes/Navajo.xml
@@ -1087,9 +1087,11 @@ Installation:
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="D92B10" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="3b4092" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="3b4092" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
@@ -1099,8 +1101,12 @@ Installation:
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="C00058" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="181880" bgColor="BA9C80" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="804040" bgColor="BA9C80" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="BA9C80" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Obsidian.xml
+++ b/PowerEditor/installer/themes/Obsidian.xml
@@ -971,25 +971,28 @@ Notepad++ Custom Style
             <WordsStyle name="Q OPERATOR" styleID="24" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="A082BD" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="93C763" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="678CB1" bgColor="293134" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FFCD22" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FF8409" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="E8E2B7" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="D39745" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="E8E2B7" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="93C763" bgColor="293134" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="93C763" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="93C763" bgColor="293134" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="93C763" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FFCD22" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="A082BD" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="FF8409" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="EC7600" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="66747B" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="66747B" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="6C788C" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="6C788C" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="6C788C" bgColor="293134" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="6C788C" bgColor="293134" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="66747B" bgColor="293134" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="66747B" bgColor="293134" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="93C763" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="93C763" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="93C763" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="93C763" bgColor="293134" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="E0E2E4" bgColor="293134" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Plastic Code Wrap.xml
+++ b/PowerEditor/installer/themes/Plastic Code Wrap.xml
@@ -289,25 +289,28 @@ Credits:
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFB454" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="55E439" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="FF3A83" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F8" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="1E9AE0" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="F6F080" bgColor="0B161D" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFAA00" bgColor="0B161D" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Ruby Blue.xml
+++ b/PowerEditor/installer/themes/Ruby Blue.xml
@@ -284,25 +284,28 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT" styleID="1" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF00FF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FF00FF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="F08047" bgColor="112435" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="F08047" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT" styleID="1" fgColor="3A8BDA" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT LINE" styleID="2" fgColor="3A8BDA" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="3A8BDA" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="3A8BDA" bgColor="112435" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="FFFF80" bgColor="112435" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="FFFFFF" bgColor="112435" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Solarized-light.xml
+++ b/PowerEditor/installer/themes/Solarized-light.xml
@@ -1098,9 +1098,11 @@ Installation:
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="657B83" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="CB4B16" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="268BD2" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="859900" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="268BD2" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="859900" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="859900" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="2AA198" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="268BD2" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
@@ -1110,8 +1112,12 @@ Installation:
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="2AA198" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="93A1A1" bgColor="FDF6E3" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="6C71C4" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="657B83" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Solarized.xml
+++ b/PowerEditor/installer/themes/Solarized.xml
@@ -1462,9 +1462,11 @@ Installation:
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="839496" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="CB4B16" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="268BD2" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="859900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="6C71C4" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="268BD2" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="859900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="6C71C4" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="859900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="6C71C4" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="2AA198" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="268BD2" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="6C71C4" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
@@ -1474,8 +1476,12 @@ Installation:
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="2AA198" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="586E75" bgColor="002B36" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="859900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="859900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="859900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="859900" bgColor="002B36" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="839496" bgColor="002B36" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/Twilight.xml
+++ b/PowerEditor/installer/themes/Twilight.xml
@@ -290,25 +290,28 @@ Credits:
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="E9C062" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="8996A8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="8F9D6A" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="CF6A4C" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize=""/>
             <WordsStyle name="COMMENT" styleID="1" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="F8F8F8" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="5F5A60" bgColor="141414" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="F9EE98" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="CDA869" bgColor="141414" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Vibrant Ink.xml
+++ b/PowerEditor/installer/themes/Vibrant Ink.xml
@@ -265,25 +265,28 @@ http://sourceforge.net/donate/index.php?group_id=95717
             <WordsStyle name="PREPROCESSOR COMMENT DOC" styleID="24" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="EDF8F9" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFCC00" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="99CC33" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="FF8000" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="FF6600" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFFF" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="9933CC" bgColor="000000" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="66FF00" bgColor="000000" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="A001D6" bgColor="000000" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />

--- a/PowerEditor/installer/themes/Zenburn.xml
+++ b/PowerEditor/installer/themes/Zenburn.xml
@@ -1516,20 +1516,26 @@ License:             GPL2
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="DFC47D" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="DFC47D" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="8CD0D3" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFEBDD" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="OPERATOR" styleID="6" fgColor="9F9D6D" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="CC9393" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="CC9393" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="3" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="3" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="7F9F7F" bgColor="3F3F3F" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="CEDF99" bgColor="3F3F3F" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tehex" desc="Tektronix extended HEX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="DCDCCC" bgColor="3F3F3F" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/khaki.xml
+++ b/PowerEditor/installer/themes/khaki.xml
@@ -1087,9 +1087,11 @@ Installation:
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="5f5f00" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="af0000" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="005f5f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="87005f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="5f005f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="005f5f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="87005f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="008060" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="87005f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="008060" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="005f00" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="005f5f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="870000" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
@@ -1099,8 +1101,12 @@ Installation:
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="005f5f" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="2" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="2" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="87875f" bgColor="d7d7af" fontName="" fontStyle="2" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="008060" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="008060" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="008060" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="008060" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="5f5f00" bgColor="d7d7af" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/installer/themes/vim Dark Blue.xml
+++ b/PowerEditor/installer/themes/vim Dark Blue.xml
@@ -917,25 +917,28 @@
             <WordsStyle name="Q OPERATOR" styleID="24" fgColor="FFA0A0" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
         </LexerType>
         <LexerType name="tcl" desc="TCL" ext="">
-            <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="804000" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="11" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="0000FF" bgColor="000040" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="16" fgColor="8000FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="NUMBER" styleID="4" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="STRING" styleID="6" fgColor="FFA0A0" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="CHARACTER" styleID="7" fgColor="FFA0A0" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="VERBATIM" styleID="13" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
-            <WordsStyle name="REGEX" styleID="14" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFBF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="MODIFIER" styleID="10" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="FFFFBF" bgColor="000040" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="FFFF00" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="FFFFBF" bgColor="000040" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="FFFF00" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type2" />
+            <WordsStyle name="NUMBER" styleID="3" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUB BRACE" styleID="9" fgColor="804000" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFBF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="6" fgColor="FFA0A0" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IDENTIFIER" styleID="7" fgColor="FFA0A0" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="WORD IN QUOTE" styleID="4" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="IN QUOTE" styleID="5" fgColor="FFA0A0" bgColor="000040" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC" styleID="3" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT LINE DOC" styleID="15" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD" styleID="17" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="COMMENT DOC KEYWORD ERROR" styleID="18" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFBF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="FFFFBF" bgColor="000040" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="FFFFBF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="80A0FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="8000FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="8000FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="8000FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="8000FF" bgColor="000040" fontName="" fontStyle="0" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="FFFFFF" bgColor="000040" fontName="" fontStyle="0" fontSize="" />

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -1463,8 +1463,15 @@ void ScintillaEditView::setJsLexer()
 
 void ScintillaEditView::setTclLexer()
 {
-	const char *tclInstrs;
-    const char *tclTypes;
+	const char *kw_TCL_KW;
+	const char *kw_TK_KW;
+	const char *kw_TK_CMD;
+	const char *kw_iTCL_KW;
+	const char *kw_EXPAND;
+	const char *kw_USER1;
+	const char *kw_USER2;
+	const char *kw_USER3;
+	const char *kw_USER4;
 
 
 	setLexerFromLangID(L_TCL);
@@ -1472,24 +1479,88 @@ void ScintillaEditView::setTclLexer()
 	const wchar_t *pKwArray[NB_LIST] = {NULL};
 	makeStyle(L_TCL, pKwArray);
 
-	basic_string<char> keywordListInstruction("");
-	basic_string<char> keywordListType("");
+	basic_string<char> keywordList_TCL_KW("");
+	basic_string<char> keywordList_TK_KW("");
+	basic_string<char> keywordList_TK_CMD("");
+	basic_string<char> keywordList_iTCL_KW("");
+	basic_string<char> keywordList_EXPAND("");
+	basic_string<char> keywordList_USER1("");
+	basic_string<char> keywordList_USER2("");
+	basic_string<char> keywordList_USER3("");
+	basic_string<char> keywordList_USER4("");
+
 	if (pKwArray[LANG_INDEX_INSTR])
 	{
 		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR];
-		keywordListInstruction = wstring2string(kwlW, CP_ACP);
+		keywordList_TCL_KW = wstring2string(kwlW, CP_ACP);
 	}
-	tclInstrs = concatToBuildKeywordList(keywordListInstruction, L_TCL, LANG_INDEX_INSTR);
+	kw_TCL_KW = concatToBuildKeywordList(keywordList_TCL_KW, L_TCL, LANG_INDEX_INSTR);
+
+	if (pKwArray[LANG_INDEX_INSTR2])
+	{
+		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_INSTR2];
+		keywordList_TK_KW = wstring2string(kwlW, CP_ACP);
+	}
+	kw_TK_KW = concatToBuildKeywordList(keywordList_TK_KW, L_TCL, LANG_INDEX_INSTR2);
 
 	if (pKwArray[LANG_INDEX_TYPE])
 	{
 		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE];
-		keywordListType = wstring2string(kwlW, CP_ACP);
+		keywordList_iTCL_KW = wstring2string(kwlW, CP_ACP);
 	}
-	tclTypes = concatToBuildKeywordList(keywordListType, L_TCL, LANG_INDEX_TYPE);
+	kw_iTCL_KW = concatToBuildKeywordList(keywordList_iTCL_KW, L_TCL, LANG_INDEX_TYPE);
 
-	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(tclInstrs));
-	execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(tclTypes));
+	if (pKwArray[LANG_INDEX_TYPE2])
+	{
+		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE2];
+		keywordList_TK_CMD = wstring2string(kwlW, CP_ACP);
+	}
+	kw_TK_CMD = concatToBuildKeywordList(keywordList_TK_CMD, L_TCL, LANG_INDEX_TYPE2);
+
+	if (pKwArray[LANG_INDEX_TYPE3])
+	{
+		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE3];
+		keywordList_EXPAND = wstring2string(kwlW, CP_ACP);
+	}
+	kw_EXPAND = concatToBuildKeywordList(keywordList_EXPAND, L_TCL, LANG_INDEX_TYPE3);
+
+	if (pKwArray[LANG_INDEX_TYPE4])
+	{
+		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE4];
+		keywordList_USER1 = wstring2string(kwlW, CP_ACP);
+	}
+	kw_USER1 = concatToBuildKeywordList(keywordList_USER1, L_TCL, LANG_INDEX_TYPE4);
+
+	if (pKwArray[LANG_INDEX_TYPE5])
+	{
+		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE5];
+		keywordList_USER2= wstring2string(kwlW, CP_ACP);
+	}
+	kw_USER2 = concatToBuildKeywordList(keywordList_USER2, L_TCL, LANG_INDEX_TYPE5);
+
+	if (pKwArray[LANG_INDEX_TYPE6])
+	{
+		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE6];
+		keywordList_USER3 = wstring2string(kwlW, CP_ACP);
+	}
+	kw_USER3 = concatToBuildKeywordList(keywordList_USER3, L_TCL, LANG_INDEX_TYPE6);
+
+	if (pKwArray[LANG_INDEX_TYPE7])
+	{
+		basic_string<wchar_t> kwlW = pKwArray[LANG_INDEX_TYPE7];
+		keywordList_USER4 = wstring2string(kwlW, CP_ACP);
+	}
+	kw_USER4 = concatToBuildKeywordList(keywordList_USER4, L_TCL, LANG_INDEX_TYPE7);
+
+	execute(SCI_SETKEYWORDS, 0, reinterpret_cast<LPARAM>(kw_TCL_KW));
+	execute(SCI_SETKEYWORDS, 1, reinterpret_cast<LPARAM>(kw_iTCL_KW));
+	execute(SCI_SETKEYWORDS, 2, reinterpret_cast<LPARAM>(kw_TK_KW));
+	execute(SCI_SETKEYWORDS, 3, reinterpret_cast<LPARAM>(kw_TK_CMD));
+	execute(SCI_SETKEYWORDS, 4, reinterpret_cast<LPARAM>(kw_EXPAND));
+	execute(SCI_SETKEYWORDS, 5, reinterpret_cast<LPARAM>(kw_USER1));
+	execute(SCI_SETKEYWORDS, 6, reinterpret_cast<LPARAM>(kw_USER2));
+	execute(SCI_SETKEYWORDS, 7, reinterpret_cast<LPARAM>(kw_USER3));
+	execute(SCI_SETKEYWORDS, 8, reinterpret_cast<LPARAM>(kw_USER4));
 }
 
 void ScintillaEditView::setObjCLexer(LangType langType)

--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<NotepadPlus modelDate="20251218">
+<NotepadPlus modelDate="20251223">
    <!-- The keywords of the supported languages, don't touch them! -->
    <!-- For languages like C/C++ substyle1..8 entries, you may enter your own keywords in those entries,
         to have them show up in the "Default keywords" list shown in the Style Configurator -->
@@ -565,11 +565,16 @@
             <Keywords name="substyle7"></Keywords>
             <Keywords name="substyle8"></Keywords>
         </Language>
-        <Language name="tcl" ext="tcl" commentLine="#">
+        <Language name="tcl" ext="tcl itcl" commentLine="#">
             <Keywords name="instre1">after append apply array auto_execok auto_import auto_load auto_load_index auto_qualify auto_reset bgerror binary break catch cd chan clock close concat continue coroutine dde dict default else elseif encoding env eof error eval exec exit expr fblocked fconfigure fcopy file fileevent filename flush for foreach format gets glob global history http if incr info interp join lappend lassign lindex linsert list llength lmap load lrange lrepeat lreplace lreverse lsearch lset lsort memory my namespace next nextto oo::class oo::copy oo::define oo::objdefine oo::object open package parray pid pkg_mkIndex platform proc puts pwd read regexp registry regsub rename return scan seek self set socket source split string subst switch tailcall tclLog tclMacPkgSearch tclPkgSetup tclPkgUnknown tell then throw time trace try unknown unload unset update uplevel upvar variable vwait while yield yeildto zlib</Keywords>
             <Keywords name="instre2">bell bind bindtags button canvas checkbutton console destroy entry event focus font frame grab grid image label labelframe listbox lower menu menubutton message option pack panedwindow place radiobutton raise scale scrollbar selection send spinbox text tk tkerror tkwait toplevel ttk::button ttk::checkbutton ttk::combobox ttk::entry ttk::frame ttk::intro ttk::label ttk::labeframe ttk::menubutton ttk::notebook ttk::panedwindow ttk::progressbar ttk::radiobutton ttk::scale ttk::scrollbar ttk::sizegrip ttk::spinbox ttk::style winfo wm</Keywords>
             <Keywords name="type1">@scope body class code common component configbody constructor define destructor hull import inherit itcl itk itk_component itk_initialize itk_interior itk_option iwidgets keep method private protected public</Keywords>
             <Keywords name="type2">tkButtonDown tkButtonEnter tkButtonInvoke tkButtonLeave tkButtonUp tkCancelRepeat tkCheckRadioInvoke tkDarken tkEntryAutoScan tkEntryBackspace tkEntryButton1 tkEntryClosestGap tkEntryInsert tkEntryKeySelect tkEntryMouseSelect tkEntryNextWord tkEntryPaste tkEntryPreviousWord tkEntrySeeInsert tkEntrySetCursor tkEntryTranspose tkEventMotifBindings tkFDGetFileTypes tkFirstMenu tkFocusGroup_Destroy tkFocusGroup_In tkFocusGroup_Out tkFocusOK tkListboxAutoScan tkListboxBeginExtend tkListboxBeginSelect tkListboxBeginToggle tkListboxCancel tkListboxDataExtend tkListboxExtendUpDown tkListboxMotion tkListboxSelectAll tkListboxUpDown tkMbButtonUp tkMbEnter tkMbLeave tkMbMotion tkMbPost tkMenuButtonDown tkMenuDownArrow tkMenuDup tkMenuEscape tkMenuFind tkMenuFindName tkMenuFirstEntry tkMenuInvoke tkMenuLeave tkMenuLeftArrow tkMenuMotion tkMenuNextEntry tkMenuNextMenu tkMenuRightArrow tkMenuUnpost tkMenuUpArrow tkMessageBox tkPostOverPoint tkRecolorTree tkRestoreOldGrab tkSaveGrabInfo tkScaleActivate tkScaleButton2Down tkScaleButtonDown tkScaleControlPress tkScaleDrag tkScaleEndDrag tkScaleIncrement tkScreenChanged tkScrollButton2Down tkScrollButtonDown tkScrollButtonUp tkScrollByPages tkScrollByUnits tkScrollDrag tkScrollEndDrag tkScrollSelect tkScrollStartDrag tkScrollToPos  tkScrollTopBottom tkTabToWindow tkTearOffMenu tkTextAutoScan tkTextButton1 tkTextClosestGap tkTextInsert tkTextKeyExtend tkTextKeySelect tkTextNextPara tkTextNextPos tkTextNextWord tkTextPaste tkTextPrevPara tkTextPrevPos tkTextResetAnchor tkTextScrollPages tkTextSelectTo tkTextSetCursor tkTextTranspose tkTextUpDownLine tkTraverseToMenu tkTraverseWithinMenu tk_bisque tk_chooseColor tk_dialog tk_focusFollowsMouse tk_focusNext tk_focusPrev tk_getOpenFile tk_getSaveFile tk_messageBox tk_optionMenu tk_popup tk_setPalette tk_textCopy tk_textCut tk_textPaste</Keywords>
+            <Keywords name="type3">expand</Keywords>
+            <Keywords name="type4"></Keywords>
+            <Keywords name="type5"></Keywords>
+            <Keywords name="type6"></Keywords>
+            <Keywords name="type7"></Keywords>
         </Language>
         <Language name="tehex" ext="tek" />
         <Language name="tex" ext="tex" commentLine="%"/>

--- a/PowerEditor/src/stylers.model.xml
+++ b/PowerEditor/src/stylers.model.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<NotepadPlus modelDate="20251214">
+<NotepadPlus modelDate="20251223">
     <LexerStyles>
         <LexerType name="actionscript" desc="ActionScript" ext="">
             <WordsStyle name="DEFAULT" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
@@ -1548,9 +1548,11 @@
         <LexerType name="tcl" desc="TCL" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="MODIFIER" styleID="10" fgColor="804000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="EXPAND" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="INSTRUCTION WORD" styleID="12" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
-            <WordsStyle name="TYPE WORD" styleID="13" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="EXPAND" styleID="11" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" keywordClass="type3" />
+            <WordsStyle name="TCL KEYWORD" styleID="12" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="instre1" />
+            <WordsStyle name="iTCL KEYWORD" styleID="13" fgColor="8000FF" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" keywordClass="type1" />
+            <WordsStyle name="TK KEYWORD" styleID="14" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="instre2" />
+            <WordsStyle name="TK COMMAND" styleID="15" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="type2" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="FF8000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUB BRACE" styleID="9" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="SUBSTITUTION" styleID="8" fgColor="808080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
@@ -1560,8 +1562,12 @@
             <WordsStyle name="IN QUOTE" styleID="5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="008000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="COMMENT BOX" styleID="17" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
-            <WordsStyle name="BLOCK COMMENT" styleID="18" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="COMMENT BOX" styleID="20" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="BLOCK COMMENT" styleID="21" fgColor="008080" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />
+            <WordsStyle name="USER1" styleID="16" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="type4" />
+            <WordsStyle name="USER2" styleID="17" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="type5" />
+            <WordsStyle name="USER3" styleID="18" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="type6" />
+            <WordsStyle name="USER4" styleID="19" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="1" fontSize="" keywordClass="type7" />
         </LexerType>
         <LexerType name="tehex" desc="Tektronix extended HEX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" fontSize="" />


### PR DESCRIPTION
- All themes (including stylers.model.xml) had wrong styleID for two of the four comment styles
- Most themes were using completely wrong style name/number pairs, so fix those
- LexTCL allows 9 different keyword lists, Notepad++ previously only enabled two of them.  Added in the hooks to use the other keyword lists, and made sure that all themes/stylers map the instre1-2 and type1-7 to correct styleID

resolves #17315