### PR TITLE
Fix: Drag rectangle disappears on multi-monitor setups (#16805)

### DIFF
--- a/PowerEditor/src/WinControls/DockingWnd/Gripper.h
+++ b/PowerEditor/src/WinControls/DockingWnd/Gripper.h
@@ -27,8 +27,6 @@ class DockingCont;
 class DockingManager;
 
 
-
-
 // Used by getRectAndStyle() to draw the drag rectangle
 static const WORD DotPattern[] = 
 {
@@ -105,7 +103,7 @@ protected :
 	}
 
 private:
-    // Overlay window for multi-monitor drag rectangle (Issue #16805)
+	// Overlay window for multi-monitor drag rectangle (Issue #16805)
 	bool createOverlayWindow();
 	void destroyOverlayWindow();
 	static LRESULT CALLBACK overlayWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -140,7 +138,7 @@ private:
 
 	HBITMAP _hbm = nullptr;
 	HBRUSH _hbrush = nullptr;
-	
+
 	// Overlay window for multi-monitor support (Issue #16805)
 	HWND _hOverlayWnd = nullptr;
 	HDC _hdcOverlay = nullptr;
@@ -154,7 +152,7 @@ private:
 
 	// is class registered
 	static BOOL _isRegistered;
-	static BOOL _isOverlayClassRegistered;
+	static bool _isOverlayClassRegistered;
 
 	// get layout direction
 	bool _isRTL = false;


### PR DESCRIPTION
Fix #16805, fix #16155, fix #16077

This bug was pretty frustrating as it affected my daily workflow with Notepad++. I'm also the developer of the MultiReplace plugin, which uses the same docking framework and is affected by this issue. So I have a personal interest in getting this fixed properly and have tested it thoroughly.

---

## Problem

When dragging docking panels on certain multi-monitor configurations, the drag rectangle disappears after reaching approximately 60% of the primary monitor width. The window still docks correctly, but the visual feedback is lost.

**Setup that reproduces the issue:**
- Primary monitor: 3440×1440 (right)
- Secondary monitor: 1360×768 (left of primary)
- Result: Virtual screen origin at (-1360, 0)

## Root Cause

The classic desktop DC approach (`GetDC(NULL)`) has a fundamental limitation: the DC's clip region is constrained by an internal origin offset. When the virtual screen has negative coordinates (monitor positioned left of primary), the clip region cannot cover the full virtual screen.

Technical details:
- `GetDCOrgEx()` returns the DC origin offset
- The clip region is calculated relative to this origin  
- In the test setup: DCOrg=(1360,0), ClipBox=(-1360,0)-(2080,1440)
- This limits drawing to screen X < 2080 (60% of 3440)

## Solution

Replace the desktop DC drawing with a **layered overlay window** that spans the entire virtual screen:
```cpp
// Creates a transparent overlay covering all monitors
_hOverlayWnd = ::CreateWindowEx(
    WS_EX_LAYERED | WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_TRANSPARENT,
    L"NppGripperOverlay", L"", WS_POPUP,
    xVirtScreen, yVirtScreen, virtualWidth, virtualHeight, ...);
::SetLayeredWindowAttributes(_hOverlayWnd, RGB(255,0,255), 0, LWA_COLORKEY);
```

The layered window uses color-key transparency (magenta) so only the drag rectangle is visible. Since the window has its own coordinate system starting at (0,0), there are no clipping issues.

## Changes

**Gripper.h:**
- Removed `USE_LOCKWINDOWUPDATE` define (no longer needed)
- Removed `_hdc` member (no longer using desktop DC)
- Added overlay window members and helper functions
- Updated destructor to clean up overlay resources

**Gripper.cpp:**
- Added `createOverlayWindow()` / `destroyOverlayWindow()` functions
- Completely rewritten `drawRectangle()` to use overlay approach
- Removed all `LockWindowUpdate` related code

## Testing

- ✅ Single monitor (1920×1080)
- ✅ Dual monitor: secondary LEFT of primary (the problematic case)
- ✅ Dual monitor: secondary RIGHT of primary  
- ✅ Dragging across monitor boundaries
- ✅ ESC key cancellation
- ✅ Tab reordering within docking containers
- ✅ Normal docking operations unaffected

## Notes

- The fix is **isolated to the drawing method** - all coordinate calculations, hit-testing, and docking logic remain unchanged
- Backward compatible: single-monitor setups work exactly as before
- If overlay creation fails (e.g. out of memory), the function returns gracefully
- Performance: only the changed region is updated via BitBlt, not the entire screen