### PR TITLE
fix macro playback mismatched undo actions

### DIFF
--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -227,7 +227,7 @@ public:
 	bool undoStreamComment(bool tryBlockComment = true);
 
 	bool addCurrentMacro();
-	void macroPlayback(Macro);
+	void macroPlayback(Macro macro, std::vector<Document>* pDocs4EndUAIn = nullptr);
 
     void loadLastSession();
 	bool loadSession(Session & session, bool isSnapshotMode = false, const wchar_t* userCreatedSessionName = nullptr);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -49,60 +49,75 @@ using namespace std;
 
 std::mutex command_mutex;
 
-void Notepad_plus::macroPlayback(Macro macro)
+void Notepad_plus::macroPlayback(Macro macro, std::vector<Document>* pDocs4EndUAIn)
 {
 	_playingBackMacro = true;
 
-	Document curSciDoc = _pEditView->getCurrentBuffer()->getDocument();
-	Document prevSciDoc = curSciDoc;
+	std::vector<Document>* pDocs4EndUA = nullptr;
+	if (pDocs4EndUAIn)
+	{
+		// continue with the passed param doc list
+		pDocs4EndUA = pDocs4EndUAIn;
+	}
+	else
+	{
+		// use local doc list
+		pDocs4EndUA = new std::vector<Document>;
+		if (!pDocs4EndUA)
+			return;
+	}
 
-	_pEditView->execute(SCI_BEGINUNDOACTION);
-
-	std::vector<Document> docs4EndUA;
-	docs4EndUA.push_back(curSciDoc); // store for possible ending undo action later
-
+	Document prevSciDoc = 0;
 	for (Macro::iterator step = macro.begin(); step != macro.end(); ++step)
 	{
+		Document curSciDoc = _pEditView->getCurrentBuffer()->getDocument();
+		if (curSciDoc != prevSciDoc)
+		{
+			// macro step is going to work with different Scintilla Document object
+			// (for which the undo actions are bound)
+
+			if (std::find(pDocs4EndUA->begin(), pDocs4EndUA->end(), curSciDoc) == pDocs4EndUA->end())
+			{
+				// not in the list of the macro affected docs so far
+				_pEditView->execute(SCI_BEGINUNDOACTION); // the macro step will touch another doc, open another undo action
+				pDocs4EndUA->push_back(curSciDoc); // store for possible ending undo action later
+			}
+
+			prevSciDoc = curSciDoc; // remember the doc switch
+		}
+
 		if (step->isScintillaMacro())
 			step->PlayBack(_pPublicInterface, _pEditView);
 		else
 			_findReplaceDlg.execSavedCommand(step->_message, step->_lParameter, string2wstring(step->_sParameter, CP_UTF8));
-
-		curSciDoc = _pEditView->getCurrentBuffer()->getDocument();
-		if (curSciDoc != prevSciDoc)
-		{
-			// last macro step caused changing of the currently active Scintilla Document object
-			// (for which the undo actions are bound)
-
-			if (std::find(docs4EndUA.begin(), docs4EndUA.end(), curSciDoc) == docs4EndUA.end())
-			{
-				// not in the list of the macro affected docs so far
-				_pEditView->execute(SCI_BEGINUNDOACTION); // the macro step touched another doc, open another undo action
-				docs4EndUA.push_back(curSciDoc); // store for possible ending undo action later
-			}
-
-			prevSciDoc = curSciDoc; // remember the change
-		}
 	}
 
-	Document invisSciDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER); // store the view original doc
-	while (!docs4EndUA.empty())
+	if (!pDocs4EndUAIn)
 	{
-		Document doc = docs4EndUA.back();
-		if (MainFileManager.getBufferFromDocument(doc) == BUFFER_INVALID)
+		// handle all the affected docs undo actions closing (for local-only doc list)
+
+		Document invisSciDoc = _invisibleEditView.execute(SCI_GETDOCPOINTER); // store the view's original doc
+		while (!pDocs4EndUA->empty())
 		{
-			// affected doc no longer exists (a macro step closed its associated Notepad++ tab/buffer),
-			// the ending undo action is not needed (until Notepad++ supports tab/buffer closing undo)
+			Document doc = pDocs4EndUA->back();
+			if (MainFileManager.getBufferFromDocument(doc) == BUFFER_INVALID)
+			{
+				// affected doc no longer exists (a macro step closed its associated Notepad++ tab/buffer),
+				// the ending undo action is not needed (until Notepad++ supports tab/buffer closing undo)
+			}
+			else
+			{
+				// complete the open undo action for existing doc object
+				_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, doc);
+				_invisibleEditView.execute(SCI_ENDUNDOACTION);
+			}
+			pDocs4EndUA->pop_back();
 		}
-		else
-		{
-			// complete the open undo action for existing doc object
-			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, doc);
-			_invisibleEditView.execute(SCI_ENDUNDOACTION);
-		}
-		docs4EndUA.pop_back();
+		_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, invisSciDoc); // restore
+
+		delete pDocs4EndUA;
+		pDocs4EndUA = nullptr;
 	}
-	_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, invisSciDoc); // restore
 
 	_playingBackMacro = false;
 }


### PR DESCRIPTION
Fix #9426 

Fix longstanding issue with single-undo could revert too many document changes at once.

Scintilla document undo actions have to be enclosed by the `SCI_BEGINUNDOACTION` and `SCI_ENDUNDOACTION` calls. Previously, while using a Notepad++ macro containing a step(s) changing the currently active document/tab (either by switching to another Notepad++ tab or to view with a non-cloned doc), it was possible to leave the starting `SCI_BEGINUNDOACTION` unmatched by the ending `SCI_ENDUNDOACTION`. And after there was that open & unmatched undo action, all the consequent user edits in the associated document have been always reverted back all the way to this unmatched `SCI_BEGINUNDOACTION` point by the Ctrl+Z (until the affected document or Notepad++ was not reload, then it has been fixed but only until next such macro use...).

STR:
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9426#issuecomment-3692996246

More details:
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9426#issuecomment-3691993486
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/9426#issuecomment-3692947513
