### PR TITLE
Update langs.model.xml: Keywords for Nim 2.2.6

### DIFF
--- a/PowerEditor/src/langs.model.xml
+++ b/PowerEditor/src/langs.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<NotepadPlus modelDate="20251224">
+<NotepadPlus modelDate="20260111">
    <!-- The keywords of the supported languages, don't touch them! -->
    <!-- For languages like C/C++ substyle1..8 entries, you may enter your own keywords in those entries,
         to have them show up in the "Default keywords" list shown in the Style Configurator -->
@@ -637,3 +637,4 @@
         </Language>
     </Languages>
 </NotepadPlus>
+


### PR DESCRIPTION
`let` is a keyword in Nim, and should be highlighted as such (like `var` etc.): https://nim-lang.org/docs/tut1.html#the-let-statement.

```nim
var a = 1
let b = 2
```