### PR TITLE
Update Themes - JavaScript.js edge case

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2452,10 +2452,6 @@ void NppParameters::updateStylesXml(TiXmlElement* rootUser, TiXmlElement* rootMo
 		if (modelLexerName.empty())
 			continue;
 
-		bool flag = false;
-		if (modelLexerName == L"javascript" || modelLexerName == L"javascript.js")
-			flag = true;
-
 		// map styleID numbers: index will be the target dot-js ID, intermediate index is fgColor/bgColor, stored value will be the source embedded-javascript color string
 		std::map <std::wstring, std::map<std::wstring, std::wstring>> mapColorsEmbeddedToDotJs;
 		if ((modelLexerName == L"javascript.js") && mapUserLexers.contains(L"javascript"))


### PR DESCRIPTION
per https://github.com/notepad-plus-plus/notepad-plus-plus/pull/17347#issuecomment-3753234119, need to specially handle the colors for old themes that were missing JavaScript.js, otherwise users will think that N++ broke their themes (which used to work due to the magic handling of missing-JavaScript.js-uses-embedded-JavaScript-lexer)