### PR TITLE
Added -closeinstance flag

### DIFF
--- a/PowerEditor/installer/APIs/java.xml
+++ b/PowerEditor/installer/APIs/java.xml
@@ -4511,7 +4511,8 @@
 		<KeyWord name="SystemException" />
 		<KeyWord name="SystemFlavorMap" />
 		<KeyWord name="SystemIDResolver" />
-		<KeyWord name="SystemTray" />
+    <KeyWord name="SystemTray" />
+		<KeyWord name="CloseInstances" />    
 		<KeyWord name="TabableView" />
 		<KeyWord name="TabbedPaneUI" />
 		<KeyWord name="TabExpander" />

--- a/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
+++ b/PowerEditor/src/WinControls/AboutDlg/AboutDlg.cpp
@@ -663,7 +663,7 @@ const wchar_t COMMAND_ARG_HELP[] = L"Usage:\r\n\
 \r\n\
 notepad++ [--help] [-multiInst] [-noPlugin] [-lLanguage] [-udl=\"My UDL Name\"]\r\n\
 [-LlangCode] [-nLineNumber] [-cColumnNumber] [-pPosition] [-xLeftPos] [-yTopPos]\r\n\
-[-monitor] [-nosession] [-notabbar] [-systemtray] [-loadingTime] [-alwaysOnTop]\r\n\
+[-monitor] [-nosession] [-notabbar] [-systemtray] [-closeinstances] [-loadingTime] [-alwaysOnTop]\r\n\
 [-ro] [-fullReadOnly] [-fullReadOnlySavingForbidden] [-openSession] [-r]\r\n\
 [-qn=\"Easter egg name\" | -qt=\"a text to display.\" | -qf=\"D:\\my quote.txt\"]\r\n\
 [-qSpeed1|2|3] [-quickPrint] [-settingsDir=\"d:\\your settings dir\\\"]\r\n\


### PR DESCRIPTION
Used to close all instances of notepad++, useful in some circumstances when many windows are open or use of systemtray.

In my specific caseI use -systemtray at windows start(in a task/script) and for some reason it fails to remember recents so I'm stuck with a static list of recents. If I use taskkill before windows shuts down it will save them but if I add the same command to the shutdown script it doesn't. Not sure if this command will work(I have not rebooted but it does close all out instances. So still is useful. It might be better to do a more exact instance check to avoid potentially issues but this likely will work almost always.