### PR TITLE
Let NFO check for global override using setStyle

### DIFF
--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2113,7 +2113,7 @@ void ScintillaEditView::defineDocType(LangType typeDoc)
 					nfoStyle._colorStyle = pDefStyle->_colorStyle;
 				}
 			}
-			setSpecialStyle(nfoStyle);
+			setStyle(nfoStyle);
 			execute(SCI_STYLECLEARALL);
 
 			Buffer* buf = MainFileManager.getBufferByID(_currentBufferID);


### PR DESCRIPTION
Hi i saw an issue on NFO not being able to be overriden when checkboxed, thought i could contribute something here. Btw this is my first ever attempt at open source contribution, sorry if I am not sure on title and commit guideline like i saw some start commits with FIX. Do let me know if I need to update anything. Thank you for your patience!
https://github.com/notepad-plus-plus/notepad-plus-plus/issues/17402