### PR TITLE
Pinned tabs are not affected by IDM_FILE_CLOSE/IDM_FILE_DELETE now

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -354,11 +354,10 @@ void Notepad_plus::command(int id)
 		case IDM_FILE_CLOSE:
 			if (!_pEditView->getCurrentBuffer()->isPinned() && fileClose()) 
                 checkDocState();
-			
 			break;
 
 		case IDM_FILE_DELETE:
-			if (fileDelete())
+			if (!_pEditView->getCurrentBuffer()->isPinned() && fileDelete())
                 checkDocState();
 			break;
 
@@ -4474,3 +4473,4 @@ void Notepad_plus::command(int id)
 			break;
 		}
 }
+


### PR DESCRIPTION
Closes #17430 

Now pinned tabs can't be closed with CTRL+W anymore.

Closing through clicking ```x```, as well as all other close operations, is not affected and still works as before.

Edit: 
IDM_FILE_DELETE doesn't affect pinned tabs anymore - this includes; keyboard-shortcuts as well as manual clicking on ```Move to Recycle Bin```.

**Note**
The change can feel a little inconsistent because shortcuts as well as options in the tab menu (right-click on a tab) are now blocked when the tab is pinned, but the ```x``` for closing of a tab is not affected because it gets handled differently.