### PR TITLE
Make updater check interity & authenticity of server-returned XML (XMLDsig)

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -9973,6 +9973,15 @@ void  NppParameters::buildGupParams(std::wstring& params) const
 	SecurityGuard sgd;
 
 	//
+	// Verify integrity & authenticiy of server-returned XML (XMLDsig) 
+	//
+
+	params += L" -chkCert4InfoXML";
+
+	params += L" -chkCertKeyId4XML=";
+	params += sgd.signer_key_id();
+
+	//
 	// Verify integrity & authenticiy of the downloaded installer
 	//
 


### PR DESCRIPTION
This security enhancement depends on:
https://github.com/notepad-plus-plus/wingup/pull/102