### PR TITLE
Fix startup crash when plugin config missing (Issue #873)

### DIFF
--- a/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
+++ b/PowerEditor/src/MISC/PluginsManager/PluginsManager.cpp
@@ -277,7 +277,7 @@ int PluginsManager::loadPluginFromPath(const wchar_t *pluginFilePath)
 		pluginExceptionAlert(pluginFileName, e);
 		return -1;
 	}
-	catch (wstring& s)
+	catch (wstring s)
 	{
 		if (pi && pi->_hLib)
 		{


### PR DESCRIPTION
Fixes https://github.com/notepad-plus-plus/nppPluginList/issues/873

When a plugin (like AndroidLogger) is installed but its configuration file is missing, the lexer initialization throws a `std::wstring` exception.
The previous code attempted to catch this with `catch (std::wstring& s)`, but C++ rules prevent a non-const lvalue reference from binding to a temporary object. This caused `std::terminate` to be called, crashing Notepad++ silently on startup.

This PR changes the catch block to `catch (std::wstring s)` (catch by value) to correctly capture the temporary string exception. This restores the intended behavior of showing a message box to the user instead of crashing.