### PR TITLE
 Fix Find-in-Files macro playback ignoring empty Filters

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4746,13 +4746,13 @@ void FindReplaceDlg::setFindInFilesDirFilter(const wchar_t *dir, const wchar_t *
 {
 	if (dir)
 	{
-		_options._directory = dir;
+		_env->_directory = dir;
 		::SetDlgItemText(_hSelf, IDD_FINDINFILES_DIR_COMBO, dir);
 	}
 
 	if (filters)
 	{
-		_options._filters = filters;
+		_env->_filters = filters;
 		::SetDlgItemText(_hSelf, IDD_FINDINFILES_FILTERS_COMBO, filters);
 	}
 }


### PR DESCRIPTION
                                                                                                                                                               
  Fix #8170 - Find-in-Files macro playback returns 0 hits when Filters box was empty

  `setFindInFilesDirFilter()` wrote to `_options` directly instead of through
  `_env`. During macro playback, `_env` points to a temporary `FindOption` object,
  so the default `*.*` filter was written to the wrong object — leaving the
  temporary's `_filters` empty and matching nothing.

  Changed `_options._directory` and `_options._filters` to `_env->_directory` and
  `_env->_filters`. Since `_env == &_options` during normal operation, behavior
  is unchanged outside of macro playback.
