### PR TITLE
Fix context menu shortcut not aligning to the right, when using tab character directly instead of entity reference `&#x9;`

### DIFF
--- a/PowerEditor/src/NppXml.h
+++ b/PowerEditor/src/NppXml.h
@@ -43,6 +43,10 @@ namespace NppXml
 		return doc->load_file(filename, pugi::parse_cdata | pugi::parse_escapes | pugi::parse_eol | pugi::parse_comments | pugi::parse_declaration);
 	}
 
+	[[nodiscard]] inline bool loadFileContextMenu(Document doc, const wchar_t* filename) {
+		return doc->load_file(filename, pugi::parse_cdata | pugi::parse_escapes | pugi::parse_eol);
+	}
+
 	[[nodiscard]] inline bool loadFileShortcut(Document doc, const wchar_t* filename) {
 		return doc->load_file(filename, pugi::parse_cdata | pugi::parse_escapes | pugi::parse_comments | pugi::parse_declaration);
 	}

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -1630,7 +1630,7 @@ bool NppParameters::load()
 	}
 
 	_pXmlContextMenuDoc = new NppXml::NewDocument();
-	loadOkay = NppXml::loadFile(_pXmlContextMenuDoc, _contextMenuPath.c_str());
+	loadOkay = NppXml::loadFileContextMenu(_pXmlContextMenuDoc, _contextMenuPath.c_str());
 	if (!loadOkay)
 	{
 		delete _pXmlContextMenuDoc;
@@ -1645,7 +1645,7 @@ bool NppParameters::load()
 	pathAppend(_tabContextMenuPath, L"tabContextMenu.xml");
 
 	_pXmlTabContextMenuDoc = new NppXml::NewDocument();
-	loadOkay = NppXml::loadFile(_pXmlTabContextMenuDoc, _tabContextMenuPath.c_str());
+	loadOkay = NppXml::loadFileContextMenu(_pXmlTabContextMenuDoc, _tabContextMenuPath.c_str());
 	if (!loadOkay)
 	{
 		delete _pXmlTabContextMenuDoc;


### PR DESCRIPTION
fix #17467