### PR TITLE
Fix Splitter-bar leaving visual artifacts when dragging

### DIFF
--- a/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
+++ b/PowerEditor/src/WinControls/SplitterContainer/Splitter.cpp
@@ -343,8 +343,8 @@ LRESULT CALLBACK Splitter::spliterWndProc(UINT uMsg, WPARAM wParam, LPARAM lPara
 					}
 				}
 
-				static long lastRedrawTime = 0;
-				const long currTime = ::GetTickCount();
+				static u_long lastRedrawTime = 0;
+				const u_long currTime = ::GetTickCount();
 
 				if (currTime - lastRedrawTime > 5)
 				{
@@ -788,3 +788,4 @@ void Splitter::adjustZoneToDraw(RECT& rc2def, ZONE_TYPE whichZone)
 	rc2def.right = x1;
 	rc2def.bottom = y1;
 }
+


### PR DESCRIPTION
Closes #17450 

Through capping the call frequency of ```::SendMessage(_hParent, WM_RESIZE_CONTAINER, _rect.left, _rect.top);``` in ```WM_MOUSEMOVE```, the issue disappears. I’m no expert, but I would guess that ```WM_MOUSEMOVE``` (and with it the redraw functions) gets called so often that Windows just can’t keep up.

Note(s):
Capping the calls to ```::SendMessage(_hParent, WM_RESIZE_CONTAINER, _rect.left, _rect.top);``` alone is enough to fix the issue, but I capped it for all three draw functions so that everything moves at the same speed.

This issue seems somewhat related to #17334, as the limiting also greatly reduces the flickering described there.
 


**Before** 

https://github.com/user-attachments/assets/1571b743-1362-40eb-92a9-767f7136fd66



**After**

https://github.com/user-attachments/assets/8d0bf2d2-d44a-410d-bffa-2703a083ddcd



**#17334 before** 

https://github.com/user-attachments/assets/21675686-2591-4e46-88cd-f770169b9049



**#17334 after** 

https://github.com/user-attachments/assets/4942c4a6-ce28-4c11-93dd-bc05eec99d73

