### PR TITLE
Update php.xml - added 48 new functions

### DIFF
--- a/PowerEditor/installer/APIs/php.xml
+++ b/PowerEditor/installer/APIs/php.xml
@@ -1,9 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 @author      Geoffray Warnants - http://www.geoffray.be
 @contributor Krzysztof "Krzysiu" Blachnicki - https://github.com/Krzysiu
 @version     1.36.20260214
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <NotepadPlus>
     <AutoComplete>
         <KeyWord name="abs" func="yes">
@@ -14335,3 +14335,4 @@
         </KeyWord>
     </AutoComplete>
 </NotepadPlus>
+


### PR DESCRIPTION
Patch for missing definitions (includes PHP 8.x):
* Modern string operations (str_contains, str_starts_with, str_ends_with), 
* multi-byte string enhancements (mb_str_pad, mb_trim, mb_ucfirst, mb_lcfirst, mb_str_split, mb_chr, mb_ord),
* array & json validation (array_is_list, json_validate),
* system & math utilities (get_debug_type, get_mangled_object_vars, fdiv).