### PR TITLE
Fix typos in Slovak language file

### DIFF
--- a/PowerEditor/installer/nativeLang/slovak.xml
+++ b/PowerEditor/installer/nativeLang/slovak.xml
@@ -716,7 +716,7 @@
 					<Item id="44100" name="Zobraziť aktuálny súbor vo Firefoxe"/>
 					<Item id="44101" name="Zobraziť aktuálny súbor v Chrome"/>
 					<Item id="44103" name="Zobraziť aktuálny súbor v IE"/>
-					<Item id="44102" name="Zobraziť aktuálny súbor v Edge"/>
+					<Item id="44102" name="Zobraziť aktuálny súbor v Edgei"/>
 					<Item id="50003" name="Prepnúť na predchádzajúci dokument"/>
 					<Item id="50004" name="Prepnúť na nasledujúci dokument"/>
 					<Item id="44051" name="Zbaliť úroveň 1"/>


### PR DESCRIPTION
I found a few typos in the translation, and I don't think it's correct to decline the name of the EDGE browser.