### PR TITLE
enable Printer Driver Isolation

### DIFF
--- a/PowerEditor/src/notepad++.exe.manifest
+++ b/PowerEditor/src/notepad++.exe.manifest
@@ -45,6 +45,7 @@
 </trustInfo>
 <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+        <printerDriverIsolation xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</printerDriverIsolation>
         <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
         <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system, unaware</dpiAwareness>
         <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">false</gdiScaling>


### PR DESCRIPTION
Changes the manifest to make it so that interactions with printing drivers happen in a separate dedicated process provided by Windows (called `splwow64.exe`) so that they can't crash or otherwise interfere with Notepad++.
This takes effect for users on Windows 7 or newer, otherwise it falls back to the default behavior of everything happening in the program's main process.

https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#printerdriverisolation
https://peteronprogramming.wordpress.com/2018/01/22/application-level-printer-driver-isolation/

I tested this myself and confirmed that with this change attempting to print out a text file would result in a `splwow64.exe` process getting spawned and used. I also did some light testing with killing the `splwow64.exe` process which at worst would produce a non-fatal error saying the print failed in some way (starting a new print operation would work fine afterwards) but in most cases would result in Windows gracefully spawning a new instance of the process in the background to take the place of the old one.