### PR TITLE
[xml] Update japanese.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/japanese.xml
+++ b/PowerEditor/installer/nativeLang/japanese.xml
@@ -1587,12 +1587,6 @@ Notepad++ を管理者権限で立ち上げますか？"/>
 			<LanguageMenuCompactWarning title="言語メニューをまとめる" message="この設定は次回の起動時に反映されます"/><!-- HowToReproduce: toggle "Make language menu compact" via Preferences dialog "Language/Language Menu. -->
 			<SwitchUnsavedThemeWarning title="$STR_REPLACE$" message="テーマへの変更が保存されていません。
 テーマを切り替える前に、変更を保存しますか？"/><!-- HowToReproduce: In the Style Configurator dialog change some theme and switch to other theme without saving. -->
-			<MacroAndRunCmdlWarning title="「マクロ」「実行」の互換性について" message="Notepad++ 8.5.2 以前で作成された「マクロ」「実行」の各項目は、このバージョンの Notepad++ とは互換性がない場合があります。
-各項目をテストしていただき、適宜修正をお願いします。
-
-代案として、Notepad++ 8.5.2 に戻し、以前のデータを復元することもできます。
-以前の「shortcuts.xml」は「shortcuts.xml.v8.5.2.backup」としてバックアップされています。
-復元されるときは、「shortcuts.xml.v8.5.2.backup」を「shortcuts.xml」にリネームしてください。"/><!-- HowToReproduce: Close Notepad++, remove shortcuts.xml.v8.5.2.backup & v852ShortcutsCompatibilityWarning.xml if present, relaunch Notepad++, delete or modify a shortcuts via Shortcut Mapper, close Notepad++, then the message will show up -->
 			<FullReadOnlySavingForbidden title="保存に失敗しました" message="ファイルを保存できません。
 Notepad++ が強制読み取り専用モードのため、ファイルの保存を行いませんでした。"/>
 			<NotEnoughRoom4Saving title="保存に失敗しました" message="保存に失敗しました。


### PR DESCRIPTION
Update Japanese translation text for these commits:
* Fix Find in Files failing to search file content on the disk (0e02d07)
* Reword "ignore unsaved Changes In Opened Files" option (189f98b)
* Add an option to disable selected text drag-and-drop (86ca844)
* Remove unnecessary obsolete XML files (b38180a)