### PR TITLE
Fix regression of wrong auto-completion parameter attribute name

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -6225,7 +6225,7 @@ void NppParameters::feedGUIParameters(const NppXml::Element& element)
 		{
 			{
 				using enum NppGUI::AutocStatus;
-				_nppGUI._autocStatus = getRangeDefaultAttribute(childNode, "action", autoc_none, autoc_both, _nppGUI._autocStatus);
+				_nppGUI._autocStatus = getRangeDefaultAttribute(childNode, "autoCAction", autoc_none, autoc_both, _nppGUI._autocStatus);
 			}
 
 			// from preferenceDlg.cpp


### PR DESCRIPTION
fix https://github.com/notepad-plus-plus/notepad-plus-plus/commit/683e23f4aadb0306204085b31e1ba215a05574ad#commitcomment-178346310

regression from https://github.com/notepad-plus-plus/notepad-plus-plus/commit/dc6a1168da8cb7aa021a8ff2f1fcc762ab10626b