### PR TITLE
Fix timestamp negative value in session.xml

### DIFF
--- a/PowerEditor/src/NppXml.h
+++ b/PowerEditor/src/NppXml.h
@@ -201,7 +201,7 @@ namespace NppXml
 		attr.set_value(value);
 	}
 
-	inline void setUInt32Attribute(Element& elem, const char* name, unsigned long value) {
+	inline void setULongAttribute(Element& elem, const char* name, unsigned long value) {
 		auto attr = elem.attribute(name);
 		if (!attr)
 		{

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -4371,8 +4371,8 @@ void NppParameters::writeSession(const Session& session, const wchar_t* fileName
 				setBoolAttribute(fileNameNode, "userReadOnly", (vsFile._isUserReadOnly && !vsFile._isMonitoring));
 				NppXml::setAttribute(fileNameNode, "filename", wstring2string(vsFile._fileName).c_str());
 				NppXml::setAttribute(fileNameNode, "backupFilePath", wstring2string(vsFile._backupFilePath).c_str());
-				NppXml::setUInt32Attribute(fileNameNode, "originalFileLastModifTimestamp", vsFile._originalFileLastModifTimestamp.dwLowDateTime);
-				NppXml::setUInt32Attribute(fileNameNode, "originalFileLastModifTimestampHigh", vsFile._originalFileLastModifTimestamp.dwHighDateTime);
+				NppXml::setULongAttribute(fileNameNode, "originalFileLastModifTimestamp", vsFile._originalFileLastModifTimestamp.dwLowDateTime);
+				NppXml::setULongAttribute(fileNameNode, "originalFileLastModifTimestampHigh", vsFile._originalFileLastModifTimestamp.dwHighDateTime);
 				NppXml::setAttribute(fileNameNode, "tabColourId", vsFile._individualTabColour);
 				setBoolAttribute(fileNameNode, "RTL", vsFile._isRTL);
 				setBoolAttribute(fileNameNode, "tabPinned", vsFile._isPinned);


### PR DESCRIPTION
The value of originalFileLastModifTimestamp attibute could be negative. 
Solution: use 8 bytes capacity (int64) to contain 4 bytes unsigned value, in order to avoid negative result.