### PR TITLE
`ByteIterator` and `UTF8Iterator` should have non-`explicit` default ctors

### DIFF
--- a/scintilla/src/Document.cxx
+++ b/scintilla/src/Document.cxx
@@ -3141,7 +3141,9 @@ public:
 	const Document *doc;
 	Sci::Position position;
 
-	explicit ByteIterator(const Document *doc_=nullptr, Sci::Position position_=0) noexcept :
+	ByteIterator() noexcept :
+		ByteIterator(nullptr) {}
+	explicit ByteIterator(const Document *doc_, Sci::Position position_=0) noexcept :
 		doc(doc_), position(position_) {
 	}
 	char operator*() const noexcept {
@@ -3206,7 +3208,9 @@ public:
 	using pointer = wchar_t*;
 	using reference = wchar_t&;
 
-	explicit UTF8Iterator(const Document *doc_=nullptr, Sci::Position position_=0) noexcept :
+	UTF8Iterator() noexcept :
+		UTF8Iterator(nullptr) {}
+	explicit UTF8Iterator(const Document *doc_, Sci::Position position_=0) noexcept :
 		doc(doc_), position(position_) {
 		if (doc) {
 			ReadCharacter();


### PR DESCRIPTION
`ByteIterator` and `UTF8Iterator` are bidirectional iterators that are passed to `<regex>` machinery. They have `explicit` default ctors, apparently unintentionally. (`explicit` is extremely useful and desirable to prevent 1-arg ctors from being used for implicit conversions, but here due to the default arguments it was also applying to 0-arg and 2-arg calls.) Most of the time this doesn't matter, but an `explicit` default ctor can prevent code from compiling in certain cases. (In the case that brought this to my attention, putting these iterators into an aggregate, and then initializing that with `Aggregate{}`, invokes Standardese that attempts to implicitly default construct your iterators, which fails to compile due to the `explicit`.)

The C++ Standard requires forward-or-stronger iterators to be default constructible, but only explicitly, so as far as I can tell this is not a conformance problem and your code is technically correct as written. (I'll be adjusting MSVC's STL, which I maintain, to continue to handle your current code.) However, I believe it's better to allow implicit default construction of these iterator types, which is what this PR proposes.