### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.9.2

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -1020,7 +1020,7 @@ Additionnal information about Corsican localization:
 
 				<Tabbar title="Barra d’unghjette">
 					<Item id="6107" name="Riduce"/>
-					<Item id="6108" name="Bluccà (senza sguillà é depone)"/>
+					<Item id="6108" name="Bluccà (senza sguillà è depone)"/>
 					<Item id="6109" name="Cambià u culore di l’unghjette inattive"/>
 					<Item id="6110" name="Barra culurita nant’à l’unghjetta attiva"/>
 					<Item id="6111" name="Affissà i buttoni nant’à l’unghjette inattive"/>
@@ -1055,7 +1055,7 @@ Additionnal information about Corsican localization:
 					<Item id="6239" name="Cunservà a selezzione in casu di cliccu dirittu fora di a selezzione"/>
 					<Item id="6245" name="Attivà u spaziu virtuale"/>
 					<Item id="6214" name="Attivà a copia o a tagliatura di linea senza selezzione"/>
-					<Item id="6266" name="Disattivà u sguillà é depone di u testu selezziunatu"/>
+					<Item id="6266" name="Disattivà u sguillà è depone di u testu selezziunatu"/>
 					<Item id="6225" name="Appiecà u culore persunalizatu à u primu pianu di u testu selezziunatu"/>
 					<Item id="6651" name="Indicadore di linea currente"/>
 					<Item id="6652" name="Nisunu"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/0e02d0784a9e60a1aeec0acab95cd236e5a8a569 Fix Find in Files failing to search file content on the disk
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/189f98b19da7e919e7508d750ef6a89e9a136a48 Reword "ignore unsaved Changes In Opened Files" option
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/86ca8447b320b87b9e858094923f86cab29b22f3 Add an option to disable selected text drag-and-drop
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/b38180a361c85f7d84c442237cf0ca6a3f79a78e Remove unnecessary obsolete XML files

Best regards,
Patriccollu.