### PR TITLE
Installer fix - Enable updating (overwriting) of auto-completion files

### DIFF
--- a/PowerEditor/installer/nsisInclude/autoCompletion.nsh
+++ b/PowerEditor/installer/nsisInclude/autoCompletion.nsh
@@ -16,7 +16,7 @@
 
 
 SectionGroup "Auto-completion Files" autoCompletionComponent
-	SetOverwrite off
+	SetOverwrite on
 
 	${MementoSection} "C" C
 		SetOutPath "$INSTDIR\autoCompletion"


### PR DESCRIPTION
Fix #14749

A long-standing bug - even the oldest (Sep 9, 2016) autoCompletion.nsh has the NSIS `SetOverwrite off` set, which means that once installed, the N++ autocompletion files are impossible to update with possible newer versions later.

Ref: [NSIS doc](https://nsis.sourceforge.io/Reference/SetOverwrite)

