### PR TITLE
Update Slovak localization version to 8.9.3

### DIFF
--- a/PowerEditor/installer/nativeLang/slovak.xml
+++ b/PowerEditor/installer/nativeLang/slovak.xml
@@ -3,7 +3,7 @@
 	Slovak localization for Notepad++
 -->
 <NotepadPlus>
-	<Native-Langue name="Slovenčina" filename="slovak.xml" version="8.9.2">
+	<Native-Langue name="Slovenčina" filename="slovak.xml" version="8.9.3">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -1772,6 +1772,7 @@ Hľadá vo všetkých súboroch okrem všetkých priečinkov log alebo logs reku
 			<find-status-scope-all value="v celom súbore"/>
 			<find-status-scope-backward value="od začiatku súboru po kurzor"/>
 			<find-status-scope-forward value="od kurzoru po koniec súboru"/>
+			<find-status-replace-invalid-replace-chars value="Nahradiť: v dokumente ANSI nie je možné nahradiť text, ktorý nie je kódovaný v ANSI"/>
 			<find-status-invisible-chars-findWhat value="Do poľa &quot;Hľadať&quot; alebo &quot;Nahradiť čím&quot; boli vložené neviditeľné znaky"/>
 			<find-status-invisible-chars-findWhat-tip value="Upozornenie: Neviditeľné znaky v poli vyhľadávania (alebo nahradenia).
 Text vložený do tohto poľa obsahuje neviditeľné znaky (asi znaky konca riadka). Ak ich neodstránite, budú zahrnuté do vyhľadávaného (alebo nahradzovaného) textu."/>


### PR DESCRIPTION
Fix searching Unicode character mismatches with ANSI character '?' 
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/409a810d32970cbb99967e4d8fe655eb69c840be