### PR TITLE
Add zoom synchronization across views option

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2685,6 +2685,8 @@ void Notepad_plus::checkSyncState()
 		_toolBar.setCheck(IDM_VIEW_SYNSCROLLV, false);
 		_toolBar.setCheck(IDM_VIEW_SYNSCROLLH, false);
 		checkMenuItem(IDM_VIEW_ZOOM_SYNC, false);
+		ScintillaViewParams& svp = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
+		svp._zoomSync = false;
 	}
 	enableCommand(IDM_VIEW_SYNSCROLLV, canDoSync, MENU | TOOLBAR);
 	enableCommand(IDM_VIEW_SYNSCROLLH, canDoSync, MENU | TOOLBAR);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -348,7 +348,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 
 	_zoomOriginalValue = _pEditView->execute(SCI_GETZOOM);
 	_mainEditView.execute(SCI_SETZOOM, svp._zoom);
-	_subEditView.execute(SCI_SETZOOM, svp._zoom2);
+	_subEditView.execute(SCI_SETZOOM, svp._zoomSync ? svp._zoom : svp._zoom2);
 
 	::SendMessage(hwnd, NPPM_INTERNAL_SETMULTISELECTION, 0, 0);
 
@@ -2684,9 +2684,11 @@ void Notepad_plus::checkSyncState()
 		checkMenuItem(IDM_VIEW_SYNSCROLLH, false);
 		_toolBar.setCheck(IDM_VIEW_SYNSCROLLV, false);
 		_toolBar.setCheck(IDM_VIEW_SYNSCROLLH, false);
+		checkMenuItem(IDM_VIEW_ZOOM_SYNC, false);
 	}
 	enableCommand(IDM_VIEW_SYNSCROLLV, canDoSync, MENU | TOOLBAR);
 	enableCommand(IDM_VIEW_SYNSCROLLH, canDoSync, MENU | TOOLBAR);
+	enableCommand(IDM_VIEW_ZOOM_SYNC, canDoSync, MENU);
 }
 
 void Notepad_plus::setupColorSampleBitmapsOnMainMenuItems()
@@ -5184,6 +5186,9 @@ void Notepad_plus::staticCheckMenuAndTB() const
 	checkMenuItem(IDM_VIEW_WRAP, b);
 	_toolBar.setCheck(IDM_VIEW_WRAP, b);
 	checkMenuItem(IDM_VIEW_WRAP_SYMBOL, _pEditView->isWrapSymbolVisible());
+
+	// Zoom sync
+	checkMenuItem(IDM_VIEW_ZOOM_SYNC, NppParameters::getInstance().getSVP()._zoomSync);
 }
 
 
@@ -5732,7 +5737,21 @@ void Notepad_plus::saveScintillasZoom()
 	NppParameters& nppParam = NppParameters::getInstance();
 	ScintillaViewParams & svp = (ScintillaViewParams &)nppParam.getSVP();
 	svp._zoom = _mainEditView.execute(SCI_GETZOOM);
-	svp._zoom2 = _subEditView.execute(SCI_GETZOOM);
+	svp._zoom2 = svp._zoomSync ? svp._zoom : _subEditView.execute(SCI_GETZOOM);
+}
+
+void Notepad_plus::syncZoom()
+{
+	const NppParameters& nppParam = NppParameters::getInstance();
+	const ScintillaViewParams& svp = nppParam.getSVP();
+	if (!svp._zoomSync) return;
+	if (!viewVisible(MAIN_VIEW) || !viewVisible(SUB_VIEW)) return;
+
+	_isSyncingZoom = true;
+	intptr_t zoom = _pEditView->execute(SCI_GETZOOM);
+	ScintillaEditView* otherView = (_pEditView == &_mainEditView) ? &_subEditView : &_mainEditView;
+	otherView->execute(SCI_SETZOOM, zoom);
+	_isSyncingZoom = false;
 }
 
 bool Notepad_plus::addCurrentMacro()

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -2684,9 +2684,10 @@ void Notepad_plus::checkSyncState()
 		checkMenuItem(IDM_VIEW_SYNSCROLLH, false);
 		_toolBar.setCheck(IDM_VIEW_SYNSCROLLV, false);
 		_toolBar.setCheck(IDM_VIEW_SYNSCROLLH, false);
-		checkMenuItem(IDM_VIEW_ZOOM_SYNC, false);
-		ScintillaViewParams& svp = const_cast<ScintillaViewParams&>(NppParameters::getInstance().getSVP());
-		svp._zoomSync = false;
+	}
+	else
+	{
+		syncZoom();
 	}
 	enableCommand(IDM_VIEW_SYNSCROLLV, canDoSync, MENU | TOOLBAR);
 	enableCommand(IDM_VIEW_SYNSCROLLH, canDoSync, MENU | TOOLBAR);

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -400,6 +400,7 @@ private:
 
 	bool _isFileOpening = false;
 	bool _isAdministrator = false;
+	bool _isSyncingZoom = false;
 
 	bool _isNppSessionSavedAtExit = false; // guard flag, it prevents emptying of the Notepad++ session.xml in case of multiple WM_ENDSESSION or WM_CLOSE messages
 
@@ -486,6 +487,7 @@ private:
 	void checkUndoState();
 	void checkMacroState();
 	void checkSyncState();
+	void syncZoom();
 	void setupColorSampleBitmapsOnMainMenuItems();
 	void dropFiles(HDROP hdrop);
 	void checkModifiedDocument(bool bCheckOnlyCurrentBuffer);

--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -774,6 +774,8 @@ BEGIN
             MENUITEM "Zoom &In (Ctrl+Mouse Wheel Up)",       IDM_VIEW_ZOOMIN
             MENUITEM "Zoom &Out (Ctrl+Mouse Wheel Down)",    IDM_VIEW_ZOOMOUT
             MENUITEM "&Restore Default Zoom",                IDM_VIEW_ZOOMRESTORE
+            MENUITEM SEPARATOR
+            MENUITEM "&Synchronize Across Views",            IDM_VIEW_ZOOM_SYNC
         END
         POPUP "&Move/Clone Current Document"
         BEGIN

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -2700,16 +2700,30 @@ void Notepad_plus::command(int id)
 		case IDM_VIEW_ZOOMIN:
 		{
 			_pEditView->execute(SCI_ZOOMIN);
+			syncZoom();
 			break;
 		}
 		case IDM_VIEW_ZOOMOUT:
 			_pEditView->execute(SCI_ZOOMOUT);
+			syncZoom();
 			break;
 
 		case IDM_VIEW_ZOOMRESTORE:
 			//Zoom factor of 0 points means default view
 			_pEditView->execute(SCI_SETZOOM, 0);//_zoomOriginalValue);
+			syncZoom();
 			break;
+
+		case IDM_VIEW_ZOOM_SYNC:
+		{
+			NppParameters& nppParam = NppParameters::getInstance();
+			ScintillaViewParams& svp = (ScintillaViewParams&)nppParam.getSVP();
+			svp._zoomSync = !svp._zoomSync;
+			checkMenuItem(IDM_VIEW_ZOOM_SYNC, svp._zoomSync);
+			if (svp._zoomSync)
+				syncZoom();
+			break;
+		}
 
 		case IDM_VIEW_SYNSCROLLV:
 		{

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -469,6 +469,18 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 			ScintillaEditView* unfocusView = isFromPrimary ? &_subEditView : &_mainEditView;
 			_smartHighlighter.highlightView(notifyView, unfocusView);
+
+			if (!_isSyncingZoom)
+			{
+				_isSyncingZoom = true;
+				const ScintillaViewParams& svp = NppParameters::getInstance().getSVP();
+				if (svp._zoomSync && viewVisible(MAIN_VIEW) && viewVisible(SUB_VIEW))
+				{
+					intptr_t zoom = notifyView->execute(SCI_GETZOOM);
+					unfocusView->execute(SCI_SETZOOM, zoom);
+				}
+				_isSyncingZoom = false;
+			}
 			break;
 		}
 

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -6702,6 +6702,7 @@ void NppParameters::feedScintillaParam(const NppXml::Element& element)
 
 	_svp._zoom = static_cast<intptr_t>(NppXml::int64Attribute(element, "zoom", _svp._zoom));
 	_svp._zoom2 = static_cast<intptr_t>(NppXml::int64Attribute(element, "zoom2", _svp._zoom2));
+	_svp._zoomSync = getBoolAttribute(element, "zoomSync", _svp._zoomSync);
 
 	// White Space visibility State
 	_svp._whiteSpaceShow = getBoolAttribute(element, "whiteSpaceShow", _svp._whiteSpaceShow, STR_BOOL_SHOWHIDE);
@@ -6993,6 +6994,7 @@ bool NppParameters::writeScintillaParams()
 	NppXml::setAttribute(scintNode, "edgeMultiColumnPos", edgeColumnPosStr);
 	NppXml::setAttribute(scintNode, "zoom", _svp._zoom);
 	NppXml::setAttribute(scintNode, "zoom2", _svp._zoom2);
+	setBoolAttribute(scintNode, "zoomSync", _svp._zoomSync);
 	setBoolAttribute(scintNode, "whiteSpaceShow", _svp._whiteSpaceShow, STR_BOOL_SHOWHIDE);
 	setBoolAttribute(scintNode, "eolShow", _svp._eolShow, STR_BOOL_SHOWHIDE);
 	NppXml::setAttribute(scintNode, "eolMode", _svp._eolMode);

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -899,6 +899,7 @@ struct ScintillaViewParams
 	std::vector<size_t> _edgeMultiColumnPos;
 	intptr_t _zoom = 0;
 	intptr_t _zoom2 = 0;
+	bool _zoomSync = false;
 	bool _whiteSpaceShow = false;
 	bool _eolShow = false;
 	enum crlfMode {plainText = 0, roundedRectangleText = 1, plainTextCustomColor = 2, roundedRectangleTextCustomColor = 3};

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -401,6 +401,7 @@
 
     #define    IDM_VIEW_NPC                       (IDM_VIEW + 130)
     #define    IDM_VIEW_NPC_CCUNIEOL              (IDM_VIEW + 131)
+    #define    IDM_VIEW_ZOOM_SYNC                 (IDM_VIEW + 132)
 
     #define    IDM_VIEW_GOTO_ANOTHER_VIEW        10001
     #define    IDM_VIEW_CLONE_TO_ANOTHER_VIEW    10002


### PR DESCRIPTION
Fix #17862: When a document is open in both views, zooming in one view now optionally mirrors to the other. A "Synchronize Across Views" toggle has been added to the View > Zoom submenu, consistent with the existing horizontal/vertical scroll sync options. The setting is off by default and persists across sessions.
Changes:
1. menuCmdID.h — added IDM_VIEW_ZOOM_SYNC
2. Notepad_plus.rc — added menu item to Zoom submenu
3. Parameters.h / Parameters.cpp — added _zoomSync flag with config read/write
4. Notepad_plus.h / Notepad_plus.cpp — added _isSyncingZoom guard and syncZoom() implementation
5. NppCommands.cpp — toggle handler and zoom command propagation
6. NppNotification.cpp — SCN_ZOOM handler for Ctrl+Mouse Wheel sync