### PR TITLE
Fix #17945: restore elevated window on WM_COPYDATA open request

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -768,6 +768,20 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 					wchar_t *fileNamesW = static_cast<wchar_t *>(pCopyData->lpData);
 					const CmdLineParamsDTO & cmdLineParams = nppParam.getCmdLineParams();
 					loadCommandlineParams(fileNamesW, &cmdLineParams);
+					
+					const bool restoredFromTray = (::SendMessage(hwnd, NPPM_INTERNAL_RESTOREFROMTRAY, 0, 0) != FALSE);
+					if (!restoredFromTray)
+					{
+						if (::IsIconic(hwnd))
+							::ShowWindow(hwnd, SW_RESTORE);
+						else if (!::IsWindowVisible(hwnd))
+						{
+							::ShowWindow(hwnd, SW_SHOW);
+							::SendMessage(hwnd, WM_SIZE, 0, 0);
+						}
+					}
+
+					::SetForegroundWindow(hwnd);					
 					break;
 				}
 			}


### PR DESCRIPTION
Fixes #17945

When Notepad++ is running elevated (Admin mode ON) and minimized, opening a file from Explorer starts a non-elevated second instance. Due to UIPI/foreground-activation restrictions, the non-elevated process cannot reliably restore/activate the elevated minimized window via ShowWindow/SetForegroundWindow, even though the open request is delivered via WM_COPYDATA.

This change restores the window from inside the elevated instance itself in the WM_COPYDATA receiver path (COPYDATA_FILENAMESW). It restores from tray first (NPPM_INTERNAL_RESTOREFROMTRAY), otherwise restores from minimized (SW_RESTORE), with a best-effort SetForegroundWindow.

Tests:
- Admin mode ON, minimized to taskbar: open file from Explorer -> window restores and file opens
- Minimize to tray ON: open file from Explorer -> restores from tray and file opens