### PR TITLE
Fix IDM_EDIT_OPENINFOLDER and file browser to reuse existing Explorer window

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -48,6 +48,10 @@
 #include "Utf8.h"
 #include "dpiManagerV2.h"
 
+#include <shlobj.h>
+#include <shellapi.h>
+#include <filesystem>
+
 using namespace std;
 
 void printInt(int int2print)
@@ -2389,4 +2393,23 @@ void expandEnv(wstring& path2Expand)
 			path2Expand = buffer2.data();
 		}
 	}
+}
+
+HRESULT OpenInExplorerAndSelect(const wchar_t* path)
+{
+    if (!doesPathExist(path))
+        return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
+
+    ScopedCOMInit com;
+    if (!com.isInitialized())
+        return E_FAIL;
+
+    ITEMIDLIST* pidl = nullptr;
+    HRESULT hr = ::SHParseDisplayName(path, nullptr, &pidl, 0, nullptr);
+    if (SUCCEEDED(hr))
+    {
+        hr = ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
+        ::CoTaskMemFree(pidl);
+    }
+    return hr;
 }

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -2395,7 +2395,7 @@ void expandEnv(wstring& path2Expand)
 	}
 }
 
-HRESULT OpenInExplorerAndSelect(const wchar_t* path)
+HRESULT openInExplorerAndSelect(const wchar_t* path)
 {
     if (!doesPathExist(path))
         return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -63,6 +63,7 @@ void writeFileContent(const wchar_t *file2write, const char *content2write);
 bool matchInList(const wchar_t *fileName, const std::vector<std::wstring> & patterns);
 bool matchInExcludeDirList(const wchar_t* dirName, const std::vector<std::wstring>& patterns, size_t level);
 bool allPatternsAreExclusion(const std::vector<std::wstring>& patterns);
+HRESULT OpenInExplorerAndSelect(const wchar_t* path);
 
 class WcharMbcsConvertor final
 {

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -63,7 +63,7 @@ void writeFileContent(const wchar_t *file2write, const char *content2write);
 bool matchInList(const wchar_t *fileName, const std::vector<std::wstring> & patterns);
 bool matchInExcludeDirList(const wchar_t* dirName, const std::vector<std::wstring>& patterns, size_t level);
 bool allPatternsAreExclusion(const std::vector<std::wstring>& patterns);
-HRESULT OpenInExplorerAndSelect(const wchar_t* path);
+HRESULT openInExplorerAndSelect(const wchar_t* path);
 
 class WcharMbcsConvertor final
 {

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -196,30 +196,13 @@ void Notepad_plus::command(int id)
 
 		case IDM_FILE_OPEN_FOLDER:
 		{
-			HRESULT hr = HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
-
-			ScopedCOMInit com;
-			if (com.isInitialized())
-			{
-				ITEMIDLIST* pidl = nullptr;
-				hr = ::SHParseDisplayName(_pEditView->getCurrentBuffer()->getFullPathName(), nullptr, &pidl, 0, nullptr);
-				if (SUCCEEDED(hr))
-				{
-					hr = ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
-					::CoTaskMemFree(pidl);
-				}
-			}
-
-			if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+			const wchar_t* fullPath = _pEditView->getCurrentBuffer()->getFullPathName();
+			if (OpenInExplorerAndSelect(fullPath) == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
 			{
 				// fallback (but without selecting the current file)
-				// - either the COM cannot be used or the above shell APIs mysteriously fail on some systems
-				//   with the "file not found" even though the file is there
-				// - do not use this fallback for any other possible error (like E_INVALIDARG, etc.)
 				::ShellExecuteW(_pPublicInterface->getHSelf(), L"explore",
-					std::filesystem::path(_pEditView->getCurrentBuffer()->getFullPathName()).parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+					std::filesystem::path(fullPath).parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 			}
-
 			break;
 		}
 
@@ -719,6 +702,53 @@ void Notepad_plus::command(int id)
 		break;
 
 		case IDM_EDIT_OPENINFOLDER:
+		{
+			if (_pEditView->execute(SCI_GETSELECTIONS) != 1)
+				return;
+
+			HWND hwnd = _pPublicInterface->getHSelf();
+
+			const int strSize = CURRENTWORD_MAXLENGTH;
+			auto currentWord = std::make_unique<wchar_t[]>(strSize);
+			std::fill_n(currentWord.get(), strSize, L'\0');
+
+			::SendMessage(hwnd, NPPM_GETFILENAMEATCURSOR, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentWord.get()));
+
+			wstring fullTargetPath;
+			if (doesPathExist(currentWord.get()))
+			{
+				fullTargetPath = currentWord.get();
+			}
+			else
+			{
+				auto currentDir = std::make_unique<wchar_t[]>(strSize);
+				std::fill_n(currentDir.get(), strSize, L'\0');
+				::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
+				fullTargetPath = currentDir.get();
+				fullTargetPath += L"\\";
+				fullTargetPath += currentWord.get();
+			}
+
+			if (!doesPathExist(fullTargetPath.c_str()))
+			{
+				_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
+					_pPublicInterface->getHSelf(),
+					L"The file/folder you're trying to open doesn't exist.",
+					L"Open in Folder",
+					MB_OK | MB_APPLMODAL);
+				return;
+			}
+
+			HRESULT hr = OpenInExplorerAndSelect(fullTargetPath.c_str());
+			if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+			{
+				// fallback to old method
+				wstring param = L"/select,\"" + fullTargetPath + L"\"";
+				::ShellExecute(hwnd, L"open", L"explorer.exe", param.c_str(), nullptr, SW_SHOWNORMAL);
+			}
+			break;
+		}
+
 		case IDM_EDIT_OPENASFILE:
 		{
 			if (_pEditView->execute(SCI_GETSELECTIONS) != 1) // Multi-Selection || Column mode || no selection
@@ -731,33 +761,18 @@ void Notepad_plus::command(int id)
 			std::fill_n(currentWord.get(), strSize, L'\0');
 
 			::SendMessage(hwnd, NPPM_GETFILENAMEATCURSOR, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentWord.get()));
-			
+
 			wchar_t cmd2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
-			if (id == IDM_EDIT_OPENINFOLDER)
-			{
-				if (!::GetWindowsDirectoryW(cmd2Exec, MAX_PATH))
-					return;
-
-				PathAppend(cmd2Exec, L"explorer.exe");
-
-				if (!doesFileExist(cmd2Exec))
-					return;
-			}
-			else
-			{
-				::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
-			}
+			::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
 
 			// Full file path: could be a folder or a file
 			if (doesPathExist(currentWord.get()))
 			{
-				wstring fullFilePath = id == IDM_EDIT_OPENINFOLDER ? L"/select," : L"";
-				fullFilePath += L"\"";
+				wstring fullFilePath = L"\"";
 				fullFilePath += currentWord.get();
 				fullFilePath += L"\"";
 
-				if (id == IDM_EDIT_OPENINFOLDER ||
-					(id == IDM_EDIT_OPENASFILE && !doesDirectoryExist(currentWord.get())))
+				if (!doesDirectoryExist(currentWord.get()))
 					::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
 			}
 			else // Relative file path - need concatenate with current full file path
@@ -767,14 +782,13 @@ void Notepad_plus::command(int id)
 
 				::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
 
-				wstring fullFilePath = id == IDM_EDIT_OPENINFOLDER ? L"/select," : L"";
-				fullFilePath += L"\"";
+				wstring fullFilePath = L"\"";
 				fullFilePath += currentDir.get();
 				fullFilePath += L"\\";
 				fullFilePath += currentWord.get();
+				fullFilePath += L"\"";
 
-				if ((id == IDM_EDIT_OPENASFILE && 
-					(!doesFileExist(fullFilePath.c_str() + 1)))) // + 1 for skipping the 1st char '"'
+				if (!doesFileExist(fullFilePath.c_str() + 1)) // +1 for skipping the 1st char '"'
 				{
 					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
 						_pPublicInterface->getHSelf(),
@@ -783,13 +797,11 @@ void Notepad_plus::command(int id)
 						MB_OK | MB_APPLMODAL);
 					return;
 				}
-				// else id == IDM_EDIT_OPENINFOLDER - do it anyway. (even the last part does not exist, it doesn't matter)
 
-				fullFilePath += L"\"";
 				::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
 			}
+			break;
 		}
-		break;
 
 		case IDM_EDIT_SEARCHONINTERNET:
 		{

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -197,7 +197,8 @@ void Notepad_plus::command(int id)
 		case IDM_FILE_OPEN_FOLDER:
 		{
 			const wchar_t* fullPath = _pEditView->getCurrentBuffer()->getFullPathName();
-			if (OpenInExplorerAndSelect(fullPath) == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+			HRESULT hr = OpenInExplorerAndSelect(fullPath);
+			if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
 			{
 				// fallback (but without selecting the current file)
 				::ShellExecuteW(_pPublicInterface->getHSelf(), L"explore",

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -197,7 +197,7 @@ void Notepad_plus::command(int id)
 		case IDM_FILE_OPEN_FOLDER:
 		{
 			const wchar_t* fullPath = _pEditView->getCurrentBuffer()->getFullPathName();
-			HRESULT hr = OpenInExplorerAndSelect(fullPath);
+			HRESULT hr = openInExplorerAndSelect(fullPath);
 			if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
 			{
 				// fallback (but without selecting the current file)
@@ -703,6 +703,7 @@ void Notepad_plus::command(int id)
 		break;
 
 		case IDM_EDIT_OPENINFOLDER:
+		case IDM_EDIT_OPENASFILE:
 		{
 			if (_pEditView->execute(SCI_GETSELECTIONS) != 1)
 				return;
@@ -715,91 +716,79 @@ void Notepad_plus::command(int id)
 
 			::SendMessage(hwnd, NPPM_GETFILENAMEATCURSOR, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentWord.get()));
 
-			wstring fullTargetPath;
-			if (doesPathExist(currentWord.get()))
+			if (id == IDM_EDIT_OPENINFOLDER)
 			{
-				fullTargetPath = currentWord.get();
-			}
-			else
-			{
-				auto currentDir = std::make_unique<wchar_t[]>(strSize);
-				std::fill_n(currentDir.get(), strSize, L'\0');
-				::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
-				fullTargetPath = currentDir.get();
-				fullTargetPath += L"\\";
-				fullTargetPath += currentWord.get();
-			}
+				wstring fullTargetPath;
+				if (doesPathExist(currentWord.get()))
+				{
+					fullTargetPath = currentWord.get();
+				}
+				else
+				{
+					auto currentDir = std::make_unique<wchar_t[]>(strSize);
+					std::fill_n(currentDir.get(), strSize, L'\0');
+					::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
+					fullTargetPath = currentDir.get();
+					fullTargetPath += L"\\";
+					fullTargetPath += currentWord.get();
+				}
 
-			if (!doesPathExist(fullTargetPath.c_str()))
-			{
-				_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
-					_pPublicInterface->getHSelf(),
-					L"The file/folder you're trying to open doesn't exist.",
-					L"Open in Folder",
-					MB_OK | MB_APPLMODAL);
-				return;
-			}
-
-			HRESULT hr = OpenInExplorerAndSelect(fullTargetPath.c_str());
-			if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
-			{
-				// Fallback: just open the parent folder without selecting the file
-				std::filesystem::path fsPath(fullTargetPath);
-				::ShellExecuteW(hwnd, L"explore", fsPath.parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
-			}
-			break;
-		}
-
-		case IDM_EDIT_OPENASFILE:
-		{
-			if (_pEditView->execute(SCI_GETSELECTIONS) != 1) // Multi-Selection || Column mode || no selection
-				return;
-
-			HWND hwnd = _pPublicInterface->getHSelf();
-
-			const int strSize = CURRENTWORD_MAXLENGTH;
-			auto currentWord = std::make_unique<wchar_t[]>(strSize);
-			std::fill_n(currentWord.get(), strSize, L'\0');
-
-			::SendMessage(hwnd, NPPM_GETFILENAMEATCURSOR, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentWord.get()));
-
-			wchar_t cmd2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
-			::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
-
-			// Full file path: could be a folder or a file
-			if (doesPathExist(currentWord.get()))
-			{
-				wstring fullFilePath = L"\"";
-				fullFilePath += currentWord.get();
-				fullFilePath += L"\"";
-
-				if (!doesDirectoryExist(currentWord.get()))
-					::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
-			}
-			else // Relative file path - need concatenate with current full file path
-			{
-				auto currentDir = std::make_unique<wchar_t[]>(strSize);
-				std::fill_n(currentDir.get(), strSize, L'\0');
-
-				::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
-
-				wstring fullFilePath = L"\"";
-				fullFilePath += currentDir.get();
-				fullFilePath += L"\\";
-				fullFilePath += currentWord.get();
-				fullFilePath += L"\"";
-
-				if (!doesFileExist(fullFilePath.c_str() + 1)) // +1 for skipping the 1st char '"'
+				if (!doesPathExist(fullTargetPath.c_str()))
 				{
 					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
 						_pPublicInterface->getHSelf(),
-						L"The file you're trying to open doesn't exist.",
-						L"File Open",
+						L"The file/folder you're trying to open doesn't exist.",
+						L"Open in Folder",
 						MB_OK | MB_APPLMODAL);
 					return;
 				}
 
-				::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
+				HRESULT hr = openInExplorerAndSelect(fullTargetPath.c_str());
+				if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+				{
+					// Fallback: open parent folder
+					std::filesystem::path fsPath(fullTargetPath);
+					::ShellExecuteW(hwnd, L"explore", fsPath.parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+				}
+			}
+			else // IDM_EDIT_OPENASFILE
+			{
+				wchar_t cmd2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
+				::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
+
+				if (doesPathExist(currentWord.get()))
+				{
+					wstring fullFilePath = L"\"";
+					fullFilePath += currentWord.get();
+					fullFilePath += L"\"";
+
+					if (!doesDirectoryExist(currentWord.get()))
+						::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
+				}
+				else
+				{
+					auto currentDir = std::make_unique<wchar_t[]>(strSize);
+					std::fill_n(currentDir.get(), strSize, L'\0');
+					::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
+
+					wstring fullFilePath = L"\"";
+					fullFilePath += currentDir.get();
+					fullFilePath += L"\\";
+					fullFilePath += currentWord.get();
+					fullFilePath += L"\"";
+
+					if (!doesFileExist(fullFilePath.c_str() + 1))
+					{
+						_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
+							_pPublicInterface->getHSelf(),
+							L"The file you're trying to open doesn't exist.",
+							L"File Open",
+							MB_OK | MB_APPLMODAL);
+						return;
+					}
+
+					::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
+				}
 			}
 			break;
 		}

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -743,9 +743,9 @@ void Notepad_plus::command(int id)
 			HRESULT hr = OpenInExplorerAndSelect(fullTargetPath.c_str());
 			if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
 			{
-				// fallback to old method
-				wstring param = L"/select,\"" + fullTargetPath + L"\"";
-				::ShellExecute(hwnd, L"open", L"explorer.exe", param.c_str(), nullptr, SW_SHOWNORMAL);
+				// Fallback: just open the parent folder without selecting the file
+				std::filesystem::path fsPath(fullTargetPath);
+				::ShellExecuteW(hwnd, L"explore", fsPath.parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 			}
 			break;
 		}

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -853,7 +853,7 @@ void FileBrowser::popupMenuCmd(int cmdID)
 				}
 				else
 				{
-					HRESULT hr = OpenInExplorerAndSelect(selPath.c_str());
+					HRESULT hr = openInExplorerAndSelect(selPath.c_str());
 					if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
 					{
 						// Fallback: open parent folder

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -861,7 +861,6 @@ void FileBrowser::popupMenuCmd(int cmdID)
 					}
 				}
 			}
-			break;
 		}
 		break;
 

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -840,37 +840,28 @@ void FileBrowser::popupMenuCmd(int cmdID)
 		case IDM_FILEBROWSER_EXPLORERHERE:
 		{
 			if (!selectedNode) return;
-			
 			wstring selPath = getNodePath(selectedNode);
 			if (doesPathExist(selPath.c_str()))
 			{
 				namespace fs = std::filesystem;
 				bool isFolder = fs::is_directory(selPath);
-
-				HRESULT hr = HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 				
 				if (isFolder)
 				{
+					// Just open the folder without selecting anything
 					::ShellExecuteW(getHSelf(), L"explore", selPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 				}
 				else
 				{
-					ScopedCOMInit com;
-					if (com.isInitialized())
-					{
-						ITEMIDLIST* pidl = nullptr;
-						hr = ::SHParseDisplayName(selPath.c_str(), nullptr, &pidl, 0, nullptr);
-						if (SUCCEEDED(hr))
-						{
-							hr = ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
-							::CoTaskMemFree(pidl);
-						}
-					}
-
+					HRESULT hr = OpenInExplorerAndSelect(selPath.c_str());
 					if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+					{
+						// Fallback: open parent folder
 						::ShellExecuteW(getHSelf(), L"explore", fs::path(selPath).parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+					}
 				}
 			}
+			break;
 		}
 		break;
 


### PR DESCRIPTION
Replace ShellExecute(explorer.exe /select) with SHOpenFolderAndSelectItems via a common helper function OpenInExplorerAndSelect().

- Add OpenInExplorerAndSelect() to Common.h/cpp (returns HRESULT)
- Update IDM_FILE_OPEN_FOLDER to use the common function
- Update IDM_EDIT_OPENINFOLDER (context menu "Open containing folder")
- Update IDM_FILEBROWSER_EXPLORERHERE (file browser "Explorer Here")

This avoids creating extra zombie explorer.exe processes that linger after closing the folder window.

Related issue: #17941
Suggested by: @xomx