### PR TITLE
Fixed UDL import not updating language menu immediately

### DIFF
--- a/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
+++ b/PowerEditor/src/ScintillaComponent/UserDefineDialog.cpp
@@ -1412,6 +1412,14 @@ intptr_t CALLBACK UserDefineDialog::run_dlgProc(UINT message, WPARAM wParam, LPA
                         {
                             auto i = ::SendDlgItemMessage(_hSelf, IDC_LANGNAME_COMBO, CB_GETCURSEL, 0, 0);
                             reloadLangCombo();
+
+                            HWND hNpp = ::GetParent(_hSelf);
+                            HMENU m = reinterpret_cast<HMENU>(::SendMessage(hNpp, NPPM_INTERNAL_GETMENU, 0, 0));
+                            int newIndex = nppParam.getNbUserLang() - 1;
+                            const wchar_t* newName = nppParam.getULCFromIndex(newIndex)->getName();
+                            ::InsertMenu(::GetSubMenu(m, MENUINDEX_LANGUAGE), IDM_LANG_USER + newIndex, MF_BYCOMMAND, IDM_LANG_USER + newIndex + 1, newName);
+                            ::DrawMenuBar(hNpp);
+
                             ::SendDlgItemMessage(_hSelf, IDC_LANGNAME_COMBO, CB_SETCURSEL, i, 0);
                             
                             pNativeSpeaker->messageBox("UDL_importSuccessful",


### PR DESCRIPTION
Fix: UDL import not updating language menu without restarting Notepad++

When importing a User Defined Language, the newly imported language would not appear in the Language menu until Notepad++ was restarted. The import handler updated the dropdown menu inside the UDL dialog but did not have the code to update the main Language dropdown. This fix adds the necessary code to update the Language menu on a successful import.

Fixes #17909