### PR TITLE
[FaW] Remember tree expand/collapse state across sessions

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -973,7 +973,9 @@ bool Notepad_plus::saveFileBrowserParam()
 	{
 		vector<wstring> rootPaths = _pFileBrowser->getRoots();
 		wstring selectedItemPath = _pFileBrowser->getSelectedItemPath();
-		return (NppParameters::getInstance()).writeFileBrowserSettings(rootPaths, selectedItemPath);
+		auto expandedPaths = _pFileBrowser->getExpandedPaths();
+		std::unordered_set<std::wstring> transportPaths(expandedPaths.begin(), expandedPaths.end());
+		return (NppParameters::getInstance()).writeFileBrowserSettings(rootPaths, selectedItemPath, transportPaths);
 	}
 	return true; // nothing to save so true is returned
 }
@@ -7589,6 +7591,9 @@ void Notepad_plus::launchFileBrowser(const vector<wstring> & folders, const wstr
 	{
 		_pFileBrowser->deleteAllFromTree();
 	}
+
+	NppParameters& nppParam = NppParameters::getInstance();
+	_pFileBrowser->setExpandedPaths(nppParam.getFileBrowserExpandedPaths());
 
 	for (size_t i = 0; i <folders.size(); ++i)
 	{

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3244,7 +3244,30 @@ bool NppParameters::getSessionFromXmlTree(const NppXml::Document& pSessionDoc, S
 			const char* fileName = NppXml::attribute(childNode, "foldername");
 			if (fileName && fileName[0])
 			{
-				session._fileBrowserRoots.push_back(string2wstring(fileName));
+				std::wstring rootFolder = string2wstring(fileName);
+				session._fileBrowserRoots.push_back(rootFolder);
+
+				std::unordered_set<std::wstring> seenLower;
+				for (NppXml::Element expNode = NppXml::firstChildElement(childNode, "expanded");
+					expNode;
+					expNode = NppXml::nextSiblingElement(expNode, "expanded"))
+				{
+					const char* pathAttr = NppXml::attribute(expNode, "path");
+					if (!pathAttr || !pathAttr[0])
+						continue;
+
+					std::wstring expandedPath = string2wstring(pathAttr);
+					std::wstring lowerExpanded = stringToLower(expandedPath);
+					std::wstring lowerRoot = stringToLower(rootFolder);
+					if (lowerExpanded.rfind(lowerRoot, 0) != 0)
+						continue;
+
+					if (seenLower.find(lowerExpanded) != seenLower.end())
+						continue;
+					seenLower.insert(lowerExpanded);
+
+					session._fileBrowserExpandedPaths.insert(expandedPath);
+				}
 			}
 		}
 	}
@@ -3298,7 +3321,30 @@ void NppParameters::feedFileBrowserParameters(const NppXml::Element& element)
 		const char* filePath = NppXml::attribute(childNode, "foldername");
 		if (filePath && filePath[0])
 		{
-			_fileBrowserRoot.push_back(string2wstring(filePath));
+			std::wstring rootFolder = string2wstring(filePath);
+			_fileBrowserRoot.push_back(rootFolder);
+
+			std::unordered_set<std::wstring> seenLower;
+			for (NppXml::Element expNode = NppXml::firstChildElement(childNode, "expanded");
+				expNode;
+				expNode = NppXml::nextSiblingElement(expNode, "expanded"))
+			{
+				const char* pathAttr = NppXml::attribute(expNode, "path");
+				if (!pathAttr || !pathAttr[0])
+					continue;
+
+				std::wstring expandedPath = string2wstring(pathAttr);
+				std::wstring lowerExpanded = stringToLower(expandedPath);
+				std::wstring lowerRoot = stringToLower(rootFolder);
+				if (lowerExpanded.rfind(lowerRoot, 0) != 0)
+					continue;
+
+				if (seenLower.find(lowerExpanded) != seenLower.end())
+					continue;
+				seenLower.insert(lowerExpanded);
+
+				_fileBrowserExpandedPaths.insert(expandedPath);
+			}
 		}
 	}
 }
@@ -4415,6 +4461,23 @@ void NppParameters::writeSession(const Session& session, const wchar_t* fileName
 			{
 				NppXml::Element fileNameNode = NppXml::createChildElement(fileBrowserRootNode, "root");
 				NppXml::setAttribute(fileNameNode, "foldername", wstring2string(fbRoot));
+
+				std::vector<std::wstring> sortedExpanded;
+				for (const auto& ep : session._fileBrowserExpandedPaths)
+				{
+					std::wstring lowerEp = stringToLower(ep);
+					std::wstring lowerRoot = stringToLower(fbRoot);
+					if (lowerEp.rfind(lowerRoot, 0) == 0)
+					{
+						sortedExpanded.push_back(ep);
+					}
+				}
+				std::sort(sortedExpanded.begin(), sortedExpanded.end());
+				for (const auto& ep : sortedExpanded)
+				{
+					NppXml::Element expNode = NppXml::createChildElement(fileNameNode, "expanded");
+					NppXml::setAttribute(expNode, "path", wstring2string(ep));
+				}
 			}
 		}
 	}
@@ -5120,7 +5183,7 @@ bool NppParameters::writeProjectPanelsSettings()
 	return true;
 }
 
-bool NppParameters::writeFileBrowserSettings(const std::vector<std::wstring>& rootPaths, const std::wstring& latestSelectedItemPath)
+bool NppParameters::writeFileBrowserSettings(const std::vector<std::wstring>& rootPaths, const std::wstring& latestSelectedItemPath, const std::unordered_set<std::wstring>& expandedPaths)
 {
 	if (!_xmlUserDoc._doc) return false;
 
@@ -5149,6 +5212,23 @@ bool NppParameters::writeFileBrowserSettings(const std::vector<std::wstring>& ro
 		{
 			NppXml::Element fbRootNode = NppXml::createChildElement(fileBrowserRootNode, "root");
 			NppXml::setAttribute(fbRootNode, "foldername", wstring2string(rootPath));
+
+			std::vector<std::wstring> sortedExpanded;
+			for (const auto& ep : expandedPaths)
+			{
+				std::wstring lowerEp = stringToLower(ep);
+				std::wstring lowerRoot = stringToLower(rootPath);
+				if (lowerEp.rfind(lowerRoot, 0) == 0)
+				{
+					sortedExpanded.push_back(ep);
+				}
+			}
+			std::sort(sortedExpanded.begin(), sortedExpanded.end());
+			for (const auto& ep : sortedExpanded)
+			{
+				NppXml::Element expNode = NppXml::createChildElement(fbRootNode, "expanded");
+				NppXml::setAttribute(expNode, "path", wstring2string(ep));
+			}
 		}
 	}
 

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -32,6 +32,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -157,6 +158,7 @@ struct Session
 	std::vector<sessionFileInfo> _mainViewFiles;
 	std::vector<sessionFileInfo> _subViewFiles;
 	std::vector<std::wstring> _fileBrowserRoots;
+	std::unordered_set<std::wstring> _fileBrowserExpandedPaths;
 };
 
 
@@ -1477,7 +1479,7 @@ public:
 
 	bool writeProjectPanelsSettings();
 	bool writeColumnEditorSettings();
-	bool writeFileBrowserSettings(const std::vector<std::wstring>& rootPaths, const std::wstring& latestSelectedItemPath);
+	bool writeFileBrowserSettings(const std::vector<std::wstring>& rootPaths, const std::wstring& latestSelectedItemPath, const std::unordered_set<std::wstring>& expandedPaths = {});
 
 	static NppXml::Element getChildElementByAttribute(const NppXml::Element& element, const char* childName, const char* attributeName, const char* attributeVal);
 
@@ -1613,6 +1615,8 @@ public:
 
 	const std::vector<std::wstring>& getFileBrowserRoots() const { return _fileBrowserRoot; }
 	const std::wstring& getFileBrowserSelectedItemPath() const { return _fileBrowserSelectedItemPath; }
+	const std::unordered_set<std::wstring>& getFileBrowserExpandedPaths() const { return _fileBrowserExpandedPaths; }
+	void setFileBrowserExpandedPaths(std::unordered_set<std::wstring> paths) { _fileBrowserExpandedPaths = std::move(paths); }
 
 	void setWorkSpaceFilePath(int i, const wchar_t *wsFile);
 
@@ -1902,6 +1906,7 @@ private:
 
 	std::vector<std::wstring> _fileBrowserRoot;
 	std::wstring _fileBrowserSelectedItemPath;
+	std::unordered_set<std::wstring> _fileBrowserExpandedPaths;
 
 	Accelerator* _pAccelerator = nullptr;
 	ScintillaAccelerator* _pScintAccelerator = nullptr;

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cwchar>
+#include <functional>
 #include <string>
 #include <vector>
 #include <filesystem>
@@ -44,6 +45,23 @@
 #include "menuCmdID.h"
 #include "resource.h"
 
+
+std::size_t CaseInsensitivePathHash::operator()(const std::wstring& s) const noexcept
+{
+	return std::hash<std::wstring>{}(stringToLower(s));
+}
+
+bool CaseInsensitivePathEq::operator()(const std::wstring& a, const std::wstring& b) const noexcept
+{
+	return stringToLower(a) == stringToLower(b);
+}
+
+static bool startsWithCaseInsensitive(const std::wstring& path, const std::wstring& prefix)
+{
+	std::wstring lowerPath = stringToLower(path);
+	std::wstring lowerPrefix = stringToLower(prefix);
+	return lowerPath.rfind(lowerPrefix, 0) == 0;
+}
 
 enum ItemIdx
 {
@@ -734,6 +752,25 @@ void FileBrowser::notified(LPNMHDR notification)
 						_treeView.setItemImage(nmtv->itemNew.hItem, INDEX_OPEN_ROOT, INDEX_OPEN_ROOT);
 					}
 				}
+
+				if (notification->hwndFrom == _treeView.getHSelf() && !_isApplyingPersistedState)
+				{
+					recordExpandStateChange(nmtv->itemNew.hItem, nmtv->action == TVE_EXPAND);
+
+					if (nmtv->action == TVE_EXPAND)
+					{
+						for (HTREEITEM hChild = _treeView.getChildFrom(nmtv->itemNew.hItem);
+							hChild != nullptr;
+							hChild = _treeView.getNextSibling(hChild))
+						{
+							std::wstring childPath = getNodePath(hChild);
+							if (!childPath.empty() && _expandedPaths.find(childPath) != _expandedPaths.end())
+							{
+								_treeView.expand(hChild);
+							}
+						}
+					}
+				}
 			}
 			break;
 
@@ -827,10 +864,11 @@ void FileBrowser::popupMenuCmd(int cmdID)
 			if (_treeView.getParent(selectedNode) != nullptr || rootPath == nullptr)
 				return;
 
+			std::wstring removedRootPath = *rootPath;
 			size_t nbFolderUpdaters = _folderUpdaters.size();
 			for (size_t i = 0; i < nbFolderUpdaters; ++i)
 			{
-				if (_folderUpdaters[i]->_rootFolder._rootPath == *rootPath)
+				if (_folderUpdaters[i]->_rootFolder._rootPath == removedRootPath)
 				{
 					_folderUpdaters[i]->stopWatcher();
 					_folderUpdaters.erase(_folderUpdaters.begin() + i);
@@ -838,6 +876,7 @@ void FileBrowser::popupMenuCmd(int cmdID)
 					break;
 				}
 			}
+			purgeExpandStateForRoot(removedRootPath);
 		}
 		break;
 		
@@ -973,7 +1012,8 @@ void FileBrowser::popupMenuCmd(int cmdID)
 			wstring folderPath = folderBrowser(_hParent, openWorkspaceStr);
 			if (!folderPath.empty())
 			{
-				addRootFolder(folderPath);
+				purgeExpandStateForRoot(folderPath);
+				addRootFolder(folderPath, true);
 			}
 		}
 		break;
@@ -1043,7 +1083,7 @@ void FileBrowser::getDirectoryStructure(const wchar_t *dir, const std::vector<ws
 	}
 }
 
-void FileBrowser::addRootFolder(wstring rootFolderPath)
+void FileBrowser::addRootFolder(wstring rootFolderPath, bool isUserInitiatedAdd)
 {
 	if (!doesDirectoryExist(rootFolderPath.c_str()))
 		return;
@@ -1101,7 +1141,16 @@ void FileBrowser::addRootFolder(wstring rootFolderPath)
 	getDirectoryStructure(rootFolderPath.c_str(), patterns2Match, directoryStructure, true, false);
 	HTREEITEM hRootItem = createFolderItemsFromDirStruct(nullptr, directoryStructure);
 	_treeView.customSorting(hRootItem, categorySortFunc, 0, true); // needed here for possible *nix like storages (Samba, WebDAV, WSL, ...)
-	_treeView.expand(hRootItem);
+
+	if (isUserInitiatedAdd)
+	{
+		_treeView.fold(hRootItem);
+	}
+	else
+	{
+		applyExpandStateFor(hRootItem);
+	}
+
 	_folderUpdaters.push_back(new FolderUpdater(directoryStructure, this));
 	_folderUpdaters[_folderUpdaters.size() - 1]->startWatcher();
 }
@@ -1128,6 +1177,12 @@ HTREEITEM FileBrowser::createFolderItemsFromDirStruct(HTREEITEM hParentItem, con
 		sortingDataArray.push_back(customData);
 
 		hFolderItem = _treeView.addItem(directoryStructure._name.c_str(), hParentItem, INDEX_CLOSE_NODE, reinterpret_cast<LPARAM>(customData));
+	}
+
+	std::wstring folderPath = getNodePath(hFolderItem);
+	if (!folderPath.empty())
+	{
+		_materializedPaths.insert(folderPath);
 	}
 
 	for (const auto& folder : directoryStructure._subFolders)
@@ -1518,6 +1573,79 @@ bool FileBrowser::renameInTree(const wstring& rootPath, HTREEITEM node, const st
 	_treeView.customSorting(_treeView.getParent(foundItem), categorySortFunc, 0, false);
 
 	return true;
+}
+
+void FileBrowser::setExpandedPaths(const std::unordered_set<std::wstring>& paths)
+{
+	_expandedPaths.clear();
+	for (const auto& p : paths)
+	{
+		_expandedPaths.insert(p);
+	}
+}
+
+std::unordered_set<std::wstring, CaseInsensitivePathHash, CaseInsensitivePathEq> FileBrowser::getExpandedPaths() const
+{
+	std::unordered_set<std::wstring, CaseInsensitivePathHash, CaseInsensitivePathEq> result;
+	for (const auto& entry : _expandedPaths)
+	{
+		if (_materializedPaths.find(entry) != _materializedPaths.end())
+		{
+			result.insert(entry);
+		}
+	}
+	return result;
+}
+
+void FileBrowser::applyExpandStateFor(HTREEITEM rootHItem)
+{
+	_isApplyingPersistedState = true;
+
+	std::function<void(HTREEITEM)> walkAndExpand = [&](HTREEITEM hItem)
+	{
+		if (!hItem)
+			return;
+
+		std::wstring path = getNodePath(hItem);
+		if (_expandedPaths.find(path) != _expandedPaths.end())
+		{
+			_treeView.expand(hItem);
+
+			for (HTREEITEM hChild = _treeView.getChildFrom(hItem);
+				hChild != nullptr;
+				hChild = _treeView.getNextSibling(hChild))
+			{
+				walkAndExpand(hChild);
+			}
+		}
+	};
+
+	walkAndExpand(rootHItem);
+
+	_isApplyingPersistedState = false;
+}
+
+void FileBrowser::recordExpandStateChange(HTREEITEM hItem, bool expanded)
+{
+	std::wstring path = getNodePath(hItem);
+	if (path.empty())
+		return;
+
+	if (expanded)
+		_expandedPaths.insert(path);
+	else
+		_expandedPaths.erase(path);
+}
+
+void FileBrowser::purgeExpandStateForRoot(const std::wstring& rootPath)
+{
+	for (auto it = _expandedPaths.begin(); it != _expandedPaths.end(); )
+	{
+		if (startsWithCaseInsensitive(*it, rootPath))
+			it = _expandedPaths.erase(it);
+		else
+			++it;
+	}
 }
 
 int CALLBACK FileBrowser::categorySortFunc(LPARAM lParam1, LPARAM lParam2, LPARAM /*lParamSort*/)

--- a/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
+++ b/PowerEditor/src/WinControls/FileBrowser/fileBrowser.h
@@ -20,6 +20,7 @@
 #include <windows.h>
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "DockingDlgInterface.h"
@@ -118,6 +119,16 @@ struct SortingData4lParam {
 };
 
 
+struct CaseInsensitivePathHash
+{
+	std::size_t operator()(const std::wstring& s) const noexcept;
+};
+
+struct CaseInsensitivePathEq
+{
+	bool operator()(const std::wstring& a, const std::wstring& b) const noexcept;
+};
+
 class FileBrowser : public DockingDlgInterface {
 public:
 	FileBrowser(): DockingDlgInterface(IDD_FILEBROWSER) {}
@@ -137,7 +148,13 @@ public:
 
 	std::wstring getNodePath(HTREEITEM node) const;
 	std::wstring getNodeName(HTREEITEM node) const;
-	void addRootFolder(std::wstring rootFolderPath);
+	void addRootFolder(std::wstring rootFolderPath, bool isUserInitiatedAdd = false);
+
+	void applyExpandStateFor(HTREEITEM rootHItem);
+	void recordExpandStateChange(HTREEITEM hItem, bool expanded);
+	void purgeExpandStateForRoot(const std::wstring& rootPath);
+	std::unordered_set<std::wstring, CaseInsensitivePathHash, CaseInsensitivePathEq> getExpandedPaths() const;
+	void setExpandedPaths(const std::unordered_set<std::wstring>& paths);
 
 	HTREEITEM getRootFromFullPath(const std::wstring & rootPath) const;
 	HTREEITEM findChildNodeFromName(HTREEITEM parent, const std::wstring& label) const;
@@ -160,6 +177,11 @@ protected:
 	std::vector<HIMAGELIST> _iconListVector;
 
 	TreeView _treeView;
+
+	std::unordered_set<std::wstring, CaseInsensitivePathHash, CaseInsensitivePathEq> _expandedPaths;
+	std::unordered_set<std::wstring, CaseInsensitivePathHash, CaseInsensitivePathEq> _materializedPaths;
+	bool _isApplyingPersistedState = false;
+
 	HIMAGELIST _hImaLst = nullptr;
 
 	HMENU _hGlobalMenu = NULL;


### PR DESCRIPTION
## Summary

- **Persist the expand/collapse state** of every folder node the user has interacted with in the Folder as Workspace (FaW) panel across Notepad++ restarts
- Freshly added root folders always appear **collapsed** (not auto-expanded)
- State is stored as `<expanded path="...">` child elements under each `<root>` in the existing `<FileBrowser>` block in `config.xml` (and mirrored into session files)
- Writes piggyback on the single existing save trigger (`saveFileBrowserParam` at shutdown) — no per-interaction disk writes

## Motivation

Closes https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5979
Closes https://github.com/notepad-plus-plus/notepad-plus-plus/issues/4057

This need surfaced during daily usage of my [FaW filter/search bar feature](https://github.com/notepad-plus-plus/notepad-plus-plus/pull/18060) — the treeview resetting to always-expand-all-roots on every N++ restart caused me great annoyance when working with large project trees. Users who carefully arrange their expand/collapse layout lose it every single time.

## Implementation details

**Files changed** (5 files, ~250 lines added):
- `fileBrowser.h` / `fileBrowser.cpp` — `_expandedPaths` set (case-insensitive), capture/apply/purge methods, `TVN_ITEMEXPANDED` handler records state changes on the primary `_treeView` only
- `Parameters.h` / `Parameters.cpp` — `_fileBrowserExpandedPaths` member, read/write in `feedFileBrowserParameters` / `writeFileBrowserSettings` / `writeSession` / `getSessionFromXmlTree`
- `Notepad_plus.cpp` — wire `saveFileBrowserParam` to pass expanded paths, `launchFileBrowser` to restore them

**XML format** (backward-compatible — unknown child elements are ignored by older versions):
```xml
<FileBrowser latestSelectedItem="...">
    <root foldername="C:\project">
        <expanded path="C:\project\src" />
        <expanded path="C:\project\src\utils" />
    </root>
</FileBrowser>
```

**Key design choices:**
- Case-insensitive path matching via custom hash/eq on `std::unordered_set`
- Lazy child expansion: when a parent is expanded, only its immediate children with persisted state are auto-expanded (avoids full tree walk)
- Root removal purges associated expanded paths
- `_materializedPaths` tracks which folders actually exist in the tree, so stale paths are never written back

## Manual verification

All scenarios tested on Win10 x64, Debug build 2c9750dfe.

- **S1 — Restore tree state across restarts**: PASS. Expanded `projectA → src → components`, left `tests` collapsed. After restart, exact layout restored. `config.xml` confirmed three `<expanded>` entries; `tests` absent.
- **S2 — Freshly added root starts collapsed**: PASS. Added `projectB` while `projectA` had expanded subtree — `projectB` appeared collapsed, `projectA` state unchanged. Persisted correctly across restart.
- **S2b — Re-add purges descendant state**: PASS. Expanded `projectB\docs`, removed root, re-added — `projectB` reappeared collapsed with no leftover descendant state. `config.xml` confirmed clean.
- **S3 — Filesystem changes between sessions**: PASS. Deleted `components` folder on disk, created `helpers` sibling. After restart: `projectA\src` still expanded, `components` gone (no ghost node), `helpers` appeared collapsed. Stale `<expanded>` entry pruned on next save.
- **S4 — Missing/corrupt persisted state**: PASS. Injected empty `path=""`, missing attribute, and out-of-root path entries — all silently ignored, tree usable. Fully corrupted `<FileBrowser>` XML causes Notepad++ to reset to default config entirely (existing TinyXML2 failsafe behavior, not introduced by this feature).
- **S5 — Filter interaction (FR-010)**: PASS. Filter auto-expanded `tests` chain in search result tree; clearing filter restored pre-filter layout. Closing Notepad++ with filter active preserved pre-filter state — `tests` did not leak into `<expanded>` entries.
- **S6 — Descendant state preserved across parent collapse**: PASS. Collapsed `projectA` root, re-expanded — `src` and `components` still expanded, `tests` still collapsed. Same behavior after restart.
- **S7 — Performance (SC-003)**: PASS. With 550+ folders all expanded: 220ms startup (vs 185ms baseline). Visible ~1s hang from Win32 TreeView processing 550+ TVE_EXPAND operations — attributable to the tree control, not persistence logic. Real-world project trees (20–50 folders, 100–150 files): 185–200ms, no visible delay.
- **S8 — Write-failure non-disruption (FR-008)**: PASS. Set `config.xml` read-only, made FaW changes, closed — clean shutdown, no error dialog, no crash. Restart reflected last successfully-written state. After clearing read-only, normal persistence resumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
