### PR TITLE
Fix "Find in Files" is initially unresponsive when searching a large folder structure

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1833,6 +1833,7 @@ The text pasted into this field includes invisible (maybe line-ending) character
 			<progress-hits-title value="Hits:"/>
 			<progress-cancel-info value="Cancelling operation, please wait..."/>
 			<find-in-files-progress-title value="Find In Files progress..."/>
+			<discover-file-candidates-title value="Discovering file candidates..."/>
 			<replace-in-files-confirm-title value="Are you sure?"/>
 			<replace-in-files-confirm-directory value="Are you sure you want to replace all occurrences in:"/>
 			<replace-in-files-confirm-filetype value="For file type:"/>

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1812,13 +1812,33 @@ void Notepad_plus::removeDuplicateLines()
 
 }
 
-void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const vector<wstring> & patterns, vector<wstring> & fileNames, bool isRecursive, bool isInHiddenDir, Progress * progress)
+class MatchedFileNameProgress final
 {
-	if (progress && progress->isCancelled())
+public:
+	explicit MatchedFileNameProgress(Progress & progress) : _pProgress(&progress) {}
+	// Updates progress if enough time has passed and returns whether search should continue
+	bool report(const wchar_t * currentPath, int nbHitsSoFar)
 	{
-		return;
+		static constexpr std::chrono::milliseconds updateInterval{ 50 };
+		const auto now = std::chrono::steady_clock::now();
+		if (now - _pLastUpdateTime >= updateInterval)
+		{
+			if (_pProgress->isCancelled())
+			{
+				return false;
+			}
+			_pLastUpdateTime = now;
+			_pProgress->setInfo(currentPath, nbHitsSoFar);
+		}
+		return true;
 	}
+private:
+	std::chrono::steady_clock::time_point _pLastUpdateTime = std::chrono::steady_clock::now();
+	Progress* _pProgress;
+};
 
+void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const vector<wstring> & patterns, vector<wstring> & fileNames, bool isRecursive, bool isInHiddenDir, MatchedFileNameProgress* progress)
+{
 	level++;
 
 	wstring dirFilter(dir);
@@ -1830,11 +1850,6 @@ void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const v
 	{
 		do
 		{
-			if (progress && progress->isCancelled())
-			{
-				break;
-			}
-
 			if (foundData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 			{
 				if (!isInHiddenDir && (foundData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN))
@@ -1861,23 +1876,12 @@ void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const v
 					wstring pathFile(dir);
 					pathFile += foundData.cFileName;
 					fileNames.push_back(pathFile.c_str());
-
-					if (progress)
-					{
-						// Major slowdown if we update per-file for large directories.
-						// To make the UX a little nicer, waterfall the divisor so that "rare" patterns still update the UI.
-						const size_t fileCount = fileNames.size();
-						const size_t divisor =
-							fileCount <= 100 ? 1 :
-							fileCount <= 1000 ? 100 :
-							fileCount <= 10000 ? 1000 :
-							10000;
-						if (fileCount % divisor == 0)
-						{
-							progress->setInfo(fileNames.back().c_str(), static_cast<int>(fileCount));
-						}
-					}
 				}
+			}
+
+			if (progress && !progress->report(dir, static_cast<int>(fileNames.size())))
+			{
+				break;
 			}
 		} while (::FindNextFile(hFindFile, &foundData));
 		::FindClose(hFindFile);
@@ -1903,7 +1907,8 @@ bool Notepad_plus::createFilelistForFiles(vector<wstring> & fileNames)
 	progress.open(_findReplaceDlg.getHSelf(), msg.c_str());
 	progress.setInfo(L"", 0);
 
-	getMatchedFileNames(dir2Search, 0, patterns2Match, fileNames, isRecursive, isInHiddenDir, &progress);
+	MatchedFileNameProgress matchedFileNameProgress{ progress };
+	getMatchedFileNames(dir2Search, 0, patterns2Match, fileNames, isRecursive, isInHiddenDir, &matchedFileNameProgress);
 
 	return !progress.isCancelled();
 }

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1812,8 +1812,13 @@ void Notepad_plus::removeDuplicateLines()
 
 }
 
-void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const vector<wstring> & patterns, vector<wstring> & fileNames, bool isRecursive, bool isInHiddenDir)
+void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const vector<wstring> & patterns, vector<wstring> & fileNames, bool isRecursive, bool isInHiddenDir, Progress * progress)
 {
+	if (progress && progress->isCancelled())
+	{
+		return;
+	}
+
 	level++;
 
 	wstring dirFilter(dir);
@@ -1825,6 +1830,11 @@ void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const v
 	{
 		do
 		{
+			if (progress && progress->isCancelled())
+			{
+				break;
+			}
+
 			if (foundData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 			{
 				if (!isInHiddenDir && (foundData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN))
@@ -1840,7 +1850,7 @@ void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const v
 						wstring pathDir(dir);
 						pathDir += foundData.cFileName;
 						pathDir += L"\\";
-						getMatchedFileNames(pathDir.c_str(), level, patterns, fileNames, isRecursive, isInHiddenDir);
+						getMatchedFileNames(pathDir.c_str(), level, patterns, fileNames, isRecursive, isInHiddenDir, progress);
 					}
 				}
 			}
@@ -1851,6 +1861,22 @@ void Notepad_plus::getMatchedFileNames(const wchar_t *dir, size_t level, const v
 					wstring pathFile(dir);
 					pathFile += foundData.cFileName;
 					fileNames.push_back(pathFile.c_str());
+
+					if (progress)
+					{
+						// Major slowdown if we update per-file for large directories.
+						// To make the UX a little nicer, waterfall the divisor so that "rare" patterns still update the UI.
+						const size_t fileCount = fileNames.size();
+						const size_t divisor =
+							fileCount <= 100 ? 1 :
+							fileCount <= 1000 ? 100 :
+							fileCount <= 10000 ? 1000 :
+							10000;
+						if (fileCount % divisor == 0)
+						{
+							progress->setInfo(fileNames.back().c_str(), static_cast<int>(fileCount));
+						}
+					}
 				}
 			}
 		} while (::FindNextFile(hFindFile, &foundData));
@@ -1871,8 +1897,15 @@ bool Notepad_plus::createFilelistForFiles(vector<wstring> & fileNames)
 
 	bool isRecursive = _findReplaceDlg.isRecursive();
 	bool isInHiddenDir = _findReplaceDlg.isInHiddenDir();
-	getMatchedFileNames(dir2Search, 0, patterns2Match, fileNames, isRecursive, isInHiddenDir);
-	return true;
+
+	Progress progress(_pPublicInterface->getHinst());
+	wstring msg = _nativeLangSpeaker.getLocalizedStrFromID("discover-file-candidates-title", L"Discovering file candidates...");
+	progress.open(_findReplaceDlg.getHSelf(), msg.c_str());
+	progress.setInfo(L"", 0);
+
+	getMatchedFileNames(dir2Search, 0, patterns2Match, fileNames, isRecursive, isInHiddenDir, &progress);
+
+	return !progress.isCancelled();
 }
 
 bool Notepad_plus::createFilelistForProjects(vector<wstring> & fileNames)

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -593,7 +593,7 @@ private:
 	bool findInOpenedFiles();
 	bool findInCurrentFile(bool isEntireDoc);
 
-	void getMatchedFileNames(const wchar_t *dir, size_t level, const std::vector<std::wstring> & patterns, std::vector<std::wstring> & fileNames, bool isRecursive, bool isInHiddenDir);
+	void getMatchedFileNames(const wchar_t *dir, size_t level, const std::vector<std::wstring> & patterns, std::vector<std::wstring> & fileNames, bool isRecursive, bool isInHiddenDir, Progress * progress = nullptr);
 	void doSynScroll(HWND hW);
 	void setWorkingDir(const wchar_t *dir);
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -145,6 +145,7 @@ class ProjectPanel;
 class DocumentMap;
 class FunctionListPanel;
 class FileBrowser;
+class MatchedFileNameProgress;
 struct QuoteParams;
 
 class Notepad_plus final
@@ -593,7 +594,7 @@ private:
 	bool findInOpenedFiles();
 	bool findInCurrentFile(bool isEntireDoc);
 
-	void getMatchedFileNames(const wchar_t *dir, size_t level, const std::vector<std::wstring> & patterns, std::vector<std::wstring> & fileNames, bool isRecursive, bool isInHiddenDir, Progress * progress = nullptr);
+	void getMatchedFileNames(const wchar_t *dir, size_t level, const std::vector<std::wstring> & patterns, std::vector<std::wstring> & fileNames, bool isRecursive, bool isInHiddenDir, MatchedFileNameProgress* progress = nullptr);
 	void doSynScroll(HWND hW);
 	void setWorkingDir(const wchar_t *dir);
 


### PR DESCRIPTION
Fix #11774 

I simply added the same progress bar to file discovery as is used for searching/replacing within the file list.
The performance impact is very minimal in my testing but the UX is significantly improved.

The nicest benefit is the ability to cancel these long discoveries without force-quitting.