### PR TITLE
Fix regression of open relative paths as file/in explorer

### DIFF
--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1495,7 +1495,8 @@ Are you sure you want to open them?"/><!-- HowToReproduce: Check "Open all files
 			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,
 or on a folder needed privilege right for writing access.
 Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
-			<FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<FilePathNotFoundWarning title="Open File" message="The file you're trying to open doesn't exist."/>
+			<PathNotFoundWarning title="Open Containing Folder in Explorer" message="The path you're trying to open doesn't exist."/>
 			<SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/><!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
 			<DroppingFolderAsProjectModeWarning title="Invalid action" message="You can only drop files or folders but not both, because you're in dropping Folder as Project mode.
 You have to enable &quot;Open all files of folder instead of launching Folder as Workspace on folder dropping&quot; in &quot;Default Directory&quot; section of Preferences dialog to make this operation work."/>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -1495,8 +1495,7 @@ Are you sure you want to open them?"/><!-- HowToReproduce: Check "Open all files
 			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,
 or on a folder needed privilege right for writing access.
 Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
-			<FilePathNotFoundWarning title="Open File" message="The file you're trying to open doesn't exist."/>
-			<PathNotFoundWarning title="Open Containing Folder in Explorer" message="The path you're trying to open doesn't exist."/>
+			<FilePathNotFoundWarning title="Open Path" message="The path you're trying to open doesn't exist."/>
 			<SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/><!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
 			<DroppingFolderAsProjectModeWarning title="Invalid action" message="You can only drop files or folders but not both, because you're in dropping Folder as Project mode.
 You have to enable &quot;Open all files of folder instead of launching Folder as Workspace on folder dropping&quot; in &quot;Default Directory&quot; section of Preferences dialog to make this operation work."/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1495,7 +1495,8 @@ Are you sure you want to open them?"/><!-- HowToReproduce: Check "Open all files
 			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,
 or on a folder needed privilege right for writing access.
 Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
-			<FilePathNotFoundWarning title="File Open" message="The file you're trying to open doesn't exist."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<FilePathNotFoundWarning title="Open File" message="The file you're trying to open doesn't exist."/>
+			<PathNotFoundWarning title="Open Containing Folder in Explorer" message="The path you're trying to open doesn't exist."/>
 			<SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/><!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
 			<DroppingFolderAsProjectModeWarning title="Invalid action" message="You can only drop files or folders but not both, because you're in dropping Folder as Project mode.
 You have to enable &quot;Open all files of folder instead of launching Folder as Workspace on folder dropping&quot; in &quot;Default Directory&quot; section of Preferences dialog to make this operation work."/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -1495,8 +1495,7 @@ Are you sure you want to open them?"/><!-- HowToReproduce: Check "Open all files
 			<SettingsOnCloudError title="Settings on Cloud" message="It seems the path of settings on cloud is set on a read only drive,
 or on a folder needed privilege right for writing access.
 Your settings on cloud will be canceled. Please reset a coherent value via Preference dialog."/>
-			<FilePathNotFoundWarning title="Open File" message="The file you're trying to open doesn't exist."/>
-			<PathNotFoundWarning title="Open Containing Folder in Explorer" message="The path you're trying to open doesn't exist."/>
+			<FilePathNotFoundWarning title="Open Path" message="The path you're trying to open doesn't exist."/>
 			<SessionFileInvalidError title="Could not Load Session" message="Session file is either corrupted or not valid."/><!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
 			<DroppingFolderAsProjectModeWarning title="Invalid action" message="You can only drop files or folders but not both, because you're in dropping Folder as Project mode.
 You have to enable &quot;Open all files of folder instead of launching Folder as Workspace on folder dropping&quot; in &quot;Default Directory&quot; section of Preferences dialog to make this operation work."/>

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -2474,19 +2474,22 @@ void expandEnv(wstring& path2Expand)
 
 HRESULT openInExplorerAndSelect(const wchar_t* path)
 {
-    if (!doesPathExist(path))
-        return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
+	if (!doesPathExist(path))
+		return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 
-    ScopedCOMInit com;
-    if (!com.isInitialized())
-        return E_FAIL;
+	ScopedCOMInit com;
+	if (!com.isInitialized())
+		return E_FAIL;
 
-    ITEMIDLIST* pidl = nullptr;
-    HRESULT hr = ::SHParseDisplayName(path, nullptr, &pidl, 0, nullptr);
-    if (SUCCEEDED(hr))
-    {
-        hr = ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
-        ::CoTaskMemFree(pidl);
-    }
-    return hr;
+	std::filesystem::path canonicalPath(path);
+	canonicalPath = std::filesystem::weakly_canonical(canonicalPath).make_preferred();
+
+	ITEMIDLIST* pidl = nullptr;
+	HRESULT hr = ::SHParseDisplayName(canonicalPath.c_str(), nullptr, &pidl, 0, nullptr);
+	if (SUCCEEDED(hr))
+	{
+		hr = ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
+		::CoTaskMemFree(pidl);
+	}
+	return hr;
 }

--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -2481,11 +2481,8 @@ HRESULT openInExplorerAndSelect(const wchar_t* path)
 	if (!com.isInitialized())
 		return E_FAIL;
 
-	std::filesystem::path canonicalPath(path);
-	canonicalPath = std::filesystem::weakly_canonical(canonicalPath).make_preferred();
-
 	ITEMIDLIST* pidl = nullptr;
-	HRESULT hr = ::SHParseDisplayName(canonicalPath.c_str(), nullptr, &pidl, 0, nullptr);
+	HRESULT hr = ::SHParseDisplayName(path, nullptr, &pidl, 0, nullptr);
 	if (SUCCEEDED(hr))
 	{
 		hr = ::SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -742,24 +742,36 @@ void Notepad_plus::command(int id)
 
 			::SendMessage(hwnd, NPPM_GETFILENAMEATCURSOR, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentWord.get()));
 
+			std::wstring fullTargetPath;
+			DWORD dwRequiredSize = ::ExpandEnvironmentStringsW(currentWord.get(), nullptr, 0);
+			if (dwRequiredSize > 0)
+			{
+				// Try to expand environment strings, nevertheless currentWord is copied with or without expansion
+				fullTargetPath.resize(dwRequiredSize, L'\0');
+				::ExpandEnvironmentStringsW(currentWord.get(), fullTargetPath.data(), dwRequiredSize);
+				if (!fullTargetPath.empty() && fullTargetPath.back() == L'\0')
+					fullTargetPath.pop_back(); // remove superfluous null-terminator (added by ExpandEnvironmentStringsW)
+			}
+			else
+			{
+				// Fallback: Copy currentWord
+				fullTargetPath = currentWord.get();
+			}
+
+			if (!doesPathExist(fullTargetPath.c_str()))
+			{
+				// Concatenate relative path
+				auto currentDir = std::make_unique<wchar_t[]>(strSize);
+				std::fill_n(currentDir.get(), strSize, L'\0');
+				::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
+
+				fullTargetPath = currentDir.get();
+				fullTargetPath += L"\\";
+				fullTargetPath += currentWord.get();
+			}
+
 			if (id == IDM_EDIT_OPENSELECTEDFILEFOLDERINEXPLORER)
 			{
-				wstring fullTargetPath;
-				if (doesPathExist(currentWord.get()))
-				{
-					fullTargetPath = currentWord.get();
-				}
-				else
-				{
-					auto currentDir = std::make_unique<wchar_t[]>(strSize);
-					std::fill_n(currentDir.get(), strSize, L'\0');
-					::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
-
-					fullTargetPath = currentDir.get();
-					fullTargetPath += L"\\";
-					fullTargetPath += currentWord.get();
-				}
-
 				if (!doesPathExist(fullTargetPath.c_str()))
 				{
 					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
@@ -782,26 +794,7 @@ void Notepad_plus::command(int id)
 			}
 			else // IDM_EDIT_OPENSELECTEDFILETOEDIT
 			{
-				wchar_t cmd2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
-				::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
-
-				wstring fullFilePath;
-				if (doesPathExist(currentWord.get()))
-				{
-					fullFilePath = currentWord.get();
-				}
-				else
-				{
-					auto currentDir = std::make_unique<wchar_t[]>(strSize);
-					std::fill_n(currentDir.get(), strSize, L'\0');
-					::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
-
-					fullFilePath = currentDir.get();
-					fullFilePath += L"\\";
-					fullFilePath += currentWord.get();
-				}
-
-				if (!doesFileExist(fullFilePath.c_str()))
+				if (!doesFileExist(fullTargetPath.c_str()))
 				{
 					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
 						_pPublicInterface->getHSelf(),
@@ -811,8 +804,11 @@ void Notepad_plus::command(int id)
 					return;
 				}
 
-				fullFilePath = L"\"" + fullFilePath + L"\"";
-				::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
+				wchar_t cmd2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
+				::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
+
+				fullTargetPath = L"\"" + fullTargetPath + L"\"";
+				::ShellExecute(hwnd, L"open", cmd2Exec, fullTargetPath.c_str(), L".", SW_SHOW);
 			}
 			break;
 		}

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -770,12 +770,14 @@ void Notepad_plus::command(int id)
 					return;
 				}
 
-				HRESULT hr = openInExplorerAndSelect(fullTargetPath.c_str());
+				std::filesystem::path canonicalPath(fullTargetPath.c_str());
+				canonicalPath = canonicalPath.lexically_normal();
+
+				HRESULT hr = openInExplorerAndSelect(canonicalPath.c_str());
 				if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
 				{
 					// Fallback: open parent folder
-					std::filesystem::path fsPath(fullTargetPath);
-					::ShellExecuteW(hwnd, L"explore", fsPath.parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+					::ShellExecuteW(hwnd, L"explore", canonicalPath.parent_path().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 				}
 			}
 			else // IDM_EDIT_OPENSELECTEDFILETOEDIT

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -747,10 +747,9 @@ void Notepad_plus::command(int id)
 			if (dwRequiredSize > 0)
 			{
 				// Try to expand environment strings, nevertheless currentWord is copied with or without expansion
-				fullTargetPath.resize(dwRequiredSize, L'\0');
-				::ExpandEnvironmentStringsW(currentWord.get(), fullTargetPath.data(), dwRequiredSize);
-				if (!fullTargetPath.empty() && fullTargetPath.back() == L'\0')
-					fullTargetPath.pop_back(); // remove superfluous null-terminator (added by ExpandEnvironmentStringsW)
+				auto targetPath = std::make_unique<wchar_t[]>(dwRequiredSize);
+				::ExpandEnvironmentStringsW(currentWord.get(), targetPath.get(), dwRequiredSize);
+				fullTargetPath = targetPath.get();
 			}
 			else
 			{
@@ -804,11 +803,11 @@ void Notepad_plus::command(int id)
 					return;
 				}
 
-				wchar_t cmd2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
-				::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
+				wchar_t npp2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
+				::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(npp2Exec));
 
 				fullTargetPath = L"\"" + fullTargetPath + L"\"";
-				::ShellExecute(hwnd, L"open", cmd2Exec, fullTargetPath.c_str(), L".", SW_SHOW);
+				::ShellExecute(hwnd, L"open", npp2Exec, fullTargetPath.c_str(), L".", SW_SHOW);
 			}
 			break;
 		}

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -762,10 +762,10 @@ void Notepad_plus::command(int id)
 
 				if (!doesPathExist(fullTargetPath.c_str()))
 				{
-					_nativeLangSpeaker.messageBox("PathNotFoundWarning",
+					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
 						_pPublicInterface->getHSelf(),
 						L"The path you're trying to open doesn't exist.",
-						L"Open Containing Folder in Explorer",
+						L"Open Path",
 						MB_OK | MB_APPLMODAL);
 					return;
 				}
@@ -803,8 +803,8 @@ void Notepad_plus::command(int id)
 				{
 					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
 						_pPublicInterface->getHSelf(),
-						L"The file you're trying to open doesn't exist.",
-						L"Open File",
+						L"The path you're trying to open doesn't exist.",
+						L"Open Path",
 						MB_OK | MB_APPLMODAL);
 					return;
 				}

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -754,6 +754,7 @@ void Notepad_plus::command(int id)
 					auto currentDir = std::make_unique<wchar_t[]>(strSize);
 					std::fill_n(currentDir.get(), strSize, L'\0');
 					::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
+
 					fullTargetPath = currentDir.get();
 					fullTargetPath += L"\\";
 					fullTargetPath += currentWord.get();
@@ -761,10 +762,10 @@ void Notepad_plus::command(int id)
 
 				if (!doesPathExist(fullTargetPath.c_str()))
 				{
-					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
+					_nativeLangSpeaker.messageBox("PathNotFoundWarning",
 						_pPublicInterface->getHSelf(),
 						L"The path you're trying to open doesn't exist.",
-						L"Open in Folder",
+						L"Open Containing Folder in Explorer",
 						MB_OK | MB_APPLMODAL);
 					return;
 				}
@@ -782,14 +783,10 @@ void Notepad_plus::command(int id)
 				wchar_t cmd2Exec[CURRENTWORD_MAXLENGTH] = { '\0' };
 				::SendMessage(hwnd, NPPM_GETNPPFULLFILEPATH, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(cmd2Exec));
 
+				wstring fullFilePath;
 				if (doesPathExist(currentWord.get()))
 				{
-					wstring fullFilePath = L"\"";
-					fullFilePath += currentWord.get();
-					fullFilePath += L"\"";
-
-					if (!doesDirectoryExist(currentWord.get()))
-						::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
+					fullFilePath = currentWord.get();
 				}
 				else
 				{
@@ -797,24 +794,23 @@ void Notepad_plus::command(int id)
 					std::fill_n(currentDir.get(), strSize, L'\0');
 					::SendMessage(hwnd, NPPM_GETCURRENTDIRECTORY, CURRENTWORD_MAXLENGTH, reinterpret_cast<LPARAM>(currentDir.get()));
 
-					wstring fullFilePath = L"\"";
-					fullFilePath += currentDir.get();
+					fullFilePath = currentDir.get();
 					fullFilePath += L"\\";
 					fullFilePath += currentWord.get();
-					fullFilePath += L"\"";
-
-					if (!doesFileExist(fullFilePath.c_str() + 1))
-					{
-						_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
-							_pPublicInterface->getHSelf(),
-							L"The path you're trying to open doesn't exist.",
-							L"File Open",
-							MB_OK | MB_APPLMODAL);
-						return;
-					}
-
-					::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
 				}
+
+				if (!doesFileExist(fullFilePath.c_str()))
+				{
+					_nativeLangSpeaker.messageBox("FilePathNotFoundWarning",
+						_pPublicInterface->getHSelf(),
+						L"The file you're trying to open doesn't exist.",
+						L"Open File",
+						MB_OK | MB_APPLMODAL);
+					return;
+				}
+
+				fullFilePath = L"\"" + fullFilePath + L"\"";
+				::ShellExecute(hwnd, L"open", cmd2Exec, fullFilePath.c_str(), L".", SW_SHOW);
 			}
 			break;
 		}


### PR DESCRIPTION
Fix regression of open relative paths as file, fix regression of open relative paths in explorer, add separate messages to translations

Fix #18114

Introduced in d380109a7a5aeabc8f6c89ee97b1e3fc302fc9aa

See comments:
first regression: https://github.com/notepad-plus-plus/notepad-plus-plus/commit/d380109a7a5aeabc8f6c89ee97b1e3fc302fc9aa#diff-ce3b24898ed0287ecacacc4d6c1712fb9eaf1ed67b36fd87315b8e80950de03aR804
second regressions: https://github.com/notepad-plus-plus/notepad-plus-plus/commit/d380109a7a5aeabc8f6c89ee97b1e3fc302fc9aa#diff-b24b3194baf7cdfb71dcaba855cf7a9e228d1a332404f056959d33736b119052R2485

See related reports in community:
first regression, with STR: https://community.notepad-plus-plus.org/post/105696
first regression, another report: https://community.notepad-plus-plus.org/post/105690
second regression: https://community.notepad-plus-plus.org/post/105700

Address additionally the separation of message box messages, resolves inconsistency in the UI and translations:
https://github.com/notepad-plus-plus/notepad-plus-plus/commit/d380109a7a5aeabc8f6c89ee97b1e3fc302fc9aa#r188071820