### PR TITLE
Allow both toolkits v143 & v145 to build the project

### DIFF
--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -36,7 +36,21 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <!--
+      Allow both v143 (default, Win7-compatible) and v145 (VS2026).
+      VS2022 users → v143
+      VS2026 users → v145 (if forced by environment)
+      Release builds should continue using v143.
+    -->
+
+    <!-- Default toolset: v143 -->
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">v143</PlatformToolset>
+
+    <!-- Allow v145 if VS2026 sets it -->
+    <PlatformToolset Condition="'$(PlatformToolset)'=='v145'">v145</PlatformToolset>
+
+    <!-- Allow explicit v143 -->
+    <PlatformToolset Condition="'$(PlatformToolset)'=='v143'">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/lexilla/src/Lexilla.vcxproj
+++ b/lexilla/src/Lexilla.vcxproj
@@ -36,7 +36,21 @@
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <!--
+      Allow both v143 (default, Win7-compatible) and v145 (VS2026).
+      VS2022 users → v143
+      VS2026 users → v145 (if forced by environment)
+      Release builds should continue using v143.
+    -->
+
+    <!-- Default toolset: v143 -->
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">v143</PlatformToolset>
+
+    <!-- Allow v145 if VS2026 sets it -->
+    <PlatformToolset Condition="'$(PlatformToolset)'=='v145'">v145</PlatformToolset>
+
+    <!-- Allow explicit v143 -->
+    <PlatformToolset Condition="'$(PlatformToolset)'=='v143'">v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/scintilla/win32/Scintilla.vcxproj
+++ b/scintilla/win32/Scintilla.vcxproj
@@ -36,7 +36,21 @@
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <!--
+      Allow both v143 (default, Win7-compatible) and v145 (VS2026).
+      VS2022 users → v143
+      VS2026 users → v145 (if forced by environment)
+      Release builds should continue using v143.
+    -->
+
+    <!-- Default toolset: v143 -->
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">v143</PlatformToolset>
+
+    <!-- Allow v145 if VS2026 sets it -->
+    <PlatformToolset Condition="'$(PlatformToolset)'=='v145'">v145</PlatformToolset>
+
+    <!-- Allow explicit v143 -->
+    <PlatformToolset Condition="'$(PlatformToolset)'=='v143'">v143</PlatformToolset>
     <TargetName>lib$(ProjectName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
By default, use v143 for the retrocompatibility of Windows 7; and allow to use v145 for CI build.

Fix https://github.com/notepad-plus-plus/notepad-plus-plus/commit/75186d90307d033da95323f79ace87ff8d331a44#commitcomment-188315301