### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.9.6.4

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -12,7 +12,8 @@ Additionnal information about Corsican localization:
 
 2. History of Corsican translation for Notepad++:
 
-	- Updated in 2026 by Patriccollu di Santa Maria è Sichè: Feb. 10th (v8.9.1+), Mar. 10th (v8.9.2+), May 17th (v8.9.5+)
+	- Updated in 2026 by Patriccollu di Santa Maria è Sichè: Feb. 10th (v8.9.1+), Mar. 10th (v8.9.2+), May 17th (v8.9.5+),
+			  June 15th (v8.9.6.4+)
 	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: Jan. 15th (v8.7.6), Mar. 1st (v8.7.8), Apr. 20th (v8.8),
 			  June 26th (v8.8.1+), July 24th (v8.8.3+), Sep. 30th (v8.8.5+), Dec. 12th (v8.8.9+)
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
@@ -37,7 +38,7 @@ Additionnal information about Corsican localization:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.9.5">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.9.6.4">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -122,6 +123,7 @@ Additionnal information about Corsican localization:
 					<Item id="41002" name="&amp;Apre…"/>
 					<Item id="41019" name="Espluratore"/>
 					<Item id="41020" name="Invitu di cumanda"/>
+					<Item id="41027" name="PowerShell"/>
 					<Item id="41025" name="Cartulare cum’&amp;è spaziu di travagliu"/>
 					<Item id="41003" name="&amp;Chjode"/>
 					<Item id="41004" name="Chjodeli &amp;tutti"/>
@@ -432,6 +434,7 @@ Additionnal information about Corsican localization:
 					<Item id="48511" name="Ingenerà per certi schedarii…"/>
 					<Item id="48512" name="Ingenerà in u preme’papei per a selezzione"/>
 					<Item id="49000" name="&amp;Lancià…"/>
+					<Item id="49001" name="Cunvalidà shortcuts.xml"/>
 
 					<Item id="50000" name="Cumpiimentu di funzione"/>
 					<Item id="50001" name="Cumpiimentu di parolla"/>
@@ -473,6 +476,7 @@ Additionnal information about Corsican localization:
 				<Item CMDID="1" name="Apre in"/>
 				<Item CMDID="41019" name="Apre cù l’espluratore u cartulare cuntenendu u schedariu"/>
 				<Item CMDID="41020" name="Apre cù l’invitu di cumanda u cartulare cuntenendu u schedariu"/>
+				<Item CMDID="41027" name="Apre cù PowerShell u cartulare cuntenendu u schedariu"/>
 				<Item CMDID="41025" name="Apre u cartulare cuntenendu u schedariu cum’è spaziu di travagliu"/>
 				<Item CMDID="41023" name="Apre in l’appiecazione predefinita"/>
 				<Item CMDID="41017" name="Rinuminà…"/>
@@ -715,6 +719,8 @@ Additionnal information about Corsican localization:
 				<MainCommandNames>
 					<Item id="41019" name="Apre cù l’espluratore u cartulare cuntenendu u schedariu"/>
 					<Item id="41020" name="Apre cù l’invitu di cumanda u cartulare cuntenendu u schedariu"/>
+					<Item id="41027" name="Apre cù PowerShell u cartulare cuntenendu u schedariu"/>
+					<Item id="41025" name="Apre u cartulare cuntenendu u schedariu cum’è spaziu di travagliu"/>
 					<Item id="41021" name="Risturà u schedariu chjosu pocu fà"/>
 					<Item id="45001" name="Cunversione di fine di linea à u furmatu Windows (CR LF)"/>
 					<Item id="45002" name="Cunversione di fine di linea à u furmatu Unix (LF)"/>
@@ -1210,7 +1216,8 @@ Additionnal information about Corsican localization:
 				</Highlighting>
 
 				<Print title="Stampà">
-					<Item id="6601" name="Stampà u &amp;numeru di linea"/>
+					<Item id="6601" name="Stamp&amp;à u numeru di linea"/>
+					<Item id="6616" name="Stampà &amp;FF (FormFeed) cum’è saltu di pagina"/>
 					<Item id="6602" name="Ozzioni di culore"/>
 					<Item id="6603" name="Tale è quale (&amp;WYSIWYG)"/>
 					<Item id="6604" name="In&amp;vertisce"/>
@@ -1220,8 +1227,8 @@ Additionnal information about Corsican localization:
 					<Item id="6612" name="&amp;Manca"/>
 					<Item id="6613" name="In&amp;sù"/>
 					<Item id="6614" name="&amp;Diritta"/>
-					<Item id="6615" name="In&amp;ghjò"/>
-					<Item id="6706" name="Gra&amp;ssu"/>
+					<Item id="6615" name="I&amp;nghjò"/>
+					<Item id="6706" name="&amp;Grassu"/>
 					<Item id="6707" name="&amp;Italicu"/>
 					<Item id="6708" name="Intestatura"/>
 					<Item id="6709" name="&amp;Parte à manu manca"/>
@@ -1649,9 +1656,15 @@ S’è vo avete bisognu di a funzione di ricerca RegEx à l’arritrosa, lighjit
 Ci vole à verificà a cundizione di ricerca prima di fà l’azzione."/> <!-- HowToReproduce: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/14897#issuecomment-2564316224 -->
 			<Need2Restart2ShowMenuShortcuts title="Notepad++ richiede d’esse rilanciatu" message="Ci vole à rilancià Notepad++ per affissà l’accurtatoghji di u listinu di diritta."/>
 			<NoAdminRight2ChangeReadOnlyFileAttribute title="Fiascu di u cambiamentu d’attributu di lettura sola di u schedariu" message="Ci vole à lancià Notepad++ in modu Amministratore per cambià l’attributi di u schedariu."/>
-			<ReadOnlyFileCannotBeSaved title="Fiascu d’arregistramentu ; schedariu in lettura sola" message="&quot;$STR_REPLACE$&quot;
+			<ReadOnlyFileCannotBeSaved title="Fiascu d’arregistramentu ; schedariu in lettura sola" message="« $STR_REPLACE$ »
 U schedariu hè in lettura sola è ùn pò micca esse arregistratu.
 Ci vole à caccià a lettura sola eppò arregistrà u vostru schedariu."/>
+			<ShortcutsXmlHMACMissing title="Avertimentu di sicurità" message="L’infurmazione di sicurità per shortcuts.xml hè assente in config.xml.
+
+Per raghjoni di sicurità, l’integrità di shortcuts.xml hà da esse verificata. Per lancià a vostra cumanda persunalizata, ci vole à esaminà u schedariu shortcuts.xml chì hè apertu. S’è u so cuntenutu hè currettu, impiegate l’ozzione « Cunvalidà shortcuts.xml » di u listinu « Lancià » per cunfirmallu."/>
+			<ShortcutsXmlTampered title="Avertimentu di sicurità" message="U schedariu shortcuts.xml pare esse statu mudificatu manualmente.
+
+Per raghjoni di sicurità, ci vole à esaminà u schedariu shortcuts.xml chì hè apertu. S’è u so cuntenutu hè currettu, impiegate l’ozzione « Cunvalidà shortcuts.xml » di u listinu « Lancià » per cunfirmallu."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Cronolugia di u preme’papei"/>
@@ -1709,6 +1722,7 @@ Ci vole à caccià a lettura sola eppò arregistrà u vostru schedariu."/>
 				<Item id="3518" name="Espluratore quì"/>
 				<Item id="3519" name="CMD quì"/>
 				<Item id="3520" name="Cupià u nome di schedariu"/>
+				<Item id="3521" name="PowerShell quì"/>
 			</Menu>
 		</FolderAsWorkspace>
 		<ProjectManager>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2026 by Patriccollu di Santa Maria è Sichè: Feb. 10th (v8.9.1+), Mar. 10th (v8.9.2+), May 17th (v8.9.5+),
-			  June 17h (v8.9.6.4+)
+			  June 24th (v8.9.6.4+)
 	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: Jan. 15th (v8.7.6), Mar. 1st (v8.7.8), Apr. 20th (v8.8),
 			  June 26th (v8.8.1+), July 24th (v8.8.3+), Sep. 30th (v8.8.5+), Dec. 12th (v8.8.9+)
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
@@ -566,6 +566,7 @@ Additionnal information about Corsican localization:
 				<Item id="1681" name="Circà :"/>
 				<Item id="1685" name="&amp;Rispettà a cassa"/>
 				<Item id="1690" name="&amp;Tuttu sopralineà"/>
+				<Item id="1691" name="&amp;Cuntera"/>
 			</IncrementalFind>
 			<FindCharsInRange title="Circà caratteri in una stesa…">
 				<Item id="2" name="C&amp;hjode"/>
@@ -1870,6 +1871,7 @@ U testu incullatu in stu campu cuntene caratteri invisibile (forse fine di linea
 			<progress-hits-title value="Occurrenze :"/>
 			<progress-cancel-info value="Abbandonu di l’operazione, aspittate per piacè…"/>
 			<find-in-files-progress-title value="Prugressione di a ricerca in i schedarii…"/>
+			<discover-file-candidates-title value="Scuperta di i schedarii candidati…"/>
 			<replace-in-files-confirm-title value="Cunfirmazione"/>
 			<replace-in-files-confirm-directory value="Da veru, vulete rimpiazzà tutte l’occurrenze in :"/>
 			<replace-in-files-confirm-filetype value="Per u(i) tipu(i) di schedariu :"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2026 by Patriccollu di Santa Maria è Sichè: Feb. 10th (v8.9.1+), Mar. 10th (v8.9.2+), May 17th (v8.9.5+),
-			  June 15th (v8.9.6.4+)
+			  June 17h (v8.9.6.4+)
 	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: Jan. 15th (v8.7.6), Mar. 1st (v8.7.8), Apr. 20th (v8.8),
 			  June 26th (v8.8.1+), July 24th (v8.8.3+), Sep. 30th (v8.8.5+), Dec. 12th (v8.8.9+)
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
@@ -1529,7 +1529,7 @@ Da veru, vulete apreli ?"/><!-- HowToReproduce: Check "Open all files of folder
 			<SettingsOnCloudError title="Parametri di u nivulu" message="Pare chì u chjassu di i parametri di u nivulu hè definitu nant’à un lettore in
 lettura sola, o in un cartulare chì richiede diritti d’accessu di scrittura.
 I vostri parametri di u nivulu anu da esse abbandunati. Ci vole à rimette un valore accetevule via u dialogu di Preferenze."/>
-			<FilePathNotFoundWarning title="Apertura di schedariu" message="U schedariu chì voi pruvate d’apre ùn esiste micca."/><!-- HowToReproduce: this message prevents from system failure. It's hard to reproduce. -->
+			<FilePathNotFoundWarning title="Apre u chjassu" message="U chjassu chì vo pruvate à apre ùn esiste micca."/>
 			<SessionFileInvalidError title="Ùn si pò micca caricà una sessione" message="U schedariu di sessione hè sia alteratu, sia inaccettevule."/><!-- HowToReproduce: Save current session via menu "File -> Save Session...", use another editor to modify the session you saved to make it an invalid xml file. Then load this invalid session via menu "File -> Load Session...". -->
 			<DroppingFolderAsProjectModeWarning title="Azzione inaccetevule" message="Pudete depone solu schedarii o cartulari ma micca tremindui, perchè site in u modu di dipositu Cartulare cum’è spaziu di travagliu.
 Ci vole à attivà l’ozzione « À u depone d’un cartulare, apre tutti i schedarii invece d’impiegallu cum’è spaziu di travagliu » in a sezzione « Cartulare predefinitu » di e Preferenze per fà què."/>
@@ -1848,6 +1848,7 @@ U testu incullatu in stu campu cuntene caratteri invisibile (forse fine di linea
 			<common-ok value="Vai"/>
 			<common-cancel value="Abbandunà"/>
 			<common-name value="Nome"/>
+			<common-error value="Sbagliu"/>
 			<tabrename-title value="Rinuminà l’unghjetta attuale"/>
 			<tabrename-newname value="Nome novu"/>
 			<splitter-rotate-left value="Girà à manca"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/24c7b5c63cece76dbc8c4f2607a27ebfe22fa614 Fix arbitrary code execution vulnerability via config.xml (CVE-2026-48778)
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/6b3dc52a9245c6d8c6287a8d6d93a30981c05feb Fix arbitrary code execution vulnerability via shortcuts.xml (CVE-2026-48778)
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/ea1508855e9c4528f6198ce9d345f13cb759ebf4 Verify shortcuts.xml integrity before running commands (CVE-2026-48800)
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/8a4c13ceb988a1926bd7ceafc82f5dab86f9f267 Update localization files
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/529b5c513854051936061db9b1ff46e10e9b86aa Add Print FormFeed as Page Break option

Updated on June 17<sup>th</sup> to add:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/7647a55ddf5d676d7bb552e7d526f01739a45fc9 Make message boxes dark via task dialogs
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/eb17eabc977a6f7957868af27eb05702bea5e7f7 Fix open relative paths as file & in explorer not working regression

Updated on June 24<sup>th</sup> to add:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/8aad27998387a9e8201f8d90dac8c307c8cb6870 Fix "Find in Files" unresponsive issue
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/6c26b987c31a3e081883f775355c3620ee66d0f2 Add an option to improve Incremental Search performance

Best regards,
Patriccollu.