### PR TITLE
Status bar: stop clipping the INS/OVR typing-mode indicator

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -448,7 +448,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	_statusBar.setPartWidth(STATUSBAR_CUR_POS, DPIManagerV2::scale(260, dpi));
 	_statusBar.setPartWidth(STATUSBAR_EOF_FORMAT, DPIManagerV2::scale(110, dpi));
 	_statusBar.setPartWidth(STATUSBAR_UNICODE_TYPE, DPIManagerV2::scale(120, dpi));
-	_statusBar.setPartWidth(STATUSBAR_TYPING_MODE, DPIManagerV2::scale(30, dpi));
+	_statusBar.setPartWidth(STATUSBAR_TYPING_MODE, DPIManagerV2::scale(40, dpi)); // 40 (not 30): "INS"/"OVR" was clipped to "IN"
 	_statusBar.display(willBeShown);
 
 	_pMainWindow = &_mainDocTab;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -3769,7 +3769,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			_statusBar.setPartWidth(STATUSBAR_CUR_POS, DPIManagerV2::scale(260, dpi));
 			_statusBar.setPartWidth(STATUSBAR_EOF_FORMAT, DPIManagerV2::scale(110, dpi));
 			_statusBar.setPartWidth(STATUSBAR_UNICODE_TYPE, DPIManagerV2::scale(120, dpi));
-			_statusBar.setPartWidth(STATUSBAR_TYPING_MODE, DPIManagerV2::scale(30, dpi));
+			_statusBar.setPartWidth(STATUSBAR_TYPING_MODE, DPIManagerV2::scale(40, dpi)); // 40 (not 30): "INS"/"OVR" was clipped to "IN"
 
 			return TRUE;
 		}


### PR DESCRIPTION
The typing-mode status-bar part was 30 DLU wide — too narrow for `INS`/`OVR` at some DPI/font combinations, so the trailing letter was cut off (`INS` shown as `IN`) when the window isn't maximised. Widen the part to 40 DLU (init path + DPI-change path).

Per review, this PR is now scoped to the INS/OVR fix only — the Incremental Search change has been dropped and the branch rebased on current master (conflict resolved). Addresses the INS/OVR part of #18142.

Built and verified locally (64-bit).
