### PR TITLE
Incremental Search: skip the running match count on very large files

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -6475,7 +6475,18 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 				bool isFound = _pFRDlg->processFindNext(str2Search.c_str(), &fo, &findStatus);
 
 				fo._str2Search = str2Search;
-				int nbCounted = _pFRDlg->processAll(ProcessCountAll, &fo);
+
+				// Counting every match on each keystroke scans the whole document, which
+				// makes incremental search sluggish on very large files (issue #11613).
+				// Past the large-file threshold, skip the running total: the search itself
+				// still works (processFindNext above), we just don't display the count.
+				int nbCounted = -1;
+				const NppGUI& nppGui = NppParameters::getInstance().getNppGUI();
+				const LRESULT docLength = (*(_pFRDlg->_ppEditView))->execute(SCI_GETLENGTH);
+				const bool skipCountForLargeFile = nppGui._largeFileRestriction._isEnabled
+					&& docLength >= nppGui._largeFileRestriction._largeFileSizeDefInByte;
+				if (!skipCountForLargeFile)
+					nbCounted = _pFRDlg->processAll(ProcessCountAll, &fo);
 				setFindStatus(findStatus, nbCounted);
 
 				// If case-sensitivity changed (to Match=yes), there may have been a matched selection that


### PR DESCRIPTION
Fixes #11613.

Incremental Search recomputes the total match count (`processAll(ProcessCountAll)`) on **every keystroke**, which scans the entire document and makes typing sluggish on very large files.

When the user has the large-file restriction enabled and the document is at or above that threshold, skip the running total: the search itself (`processFindNext`) still works and navigates as usual — only the "N matches" readout is omitted. Users who haven't enabled the restriction are unaffected and still get the count. This matches how Notepad++ already trims features past the large-file threshold.

Built and verified locally (64-bit).
