### PR TITLE
Fix color picker forgetting custom colors after restart

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -5521,8 +5521,18 @@ void NppParameters::feedGUIParameters(const NppXml::Element& element)
 		if (!nm)
 			continue;
 
+		// <GUIConfig name="ColorPickerCustomColors" color0="..." ... color15="..." />
+		if (std::strcmp(nm, "ColorPickerCustomColors") == 0)
+		{
+			auto& customColors = _nppGUI._colorPickerCustomColors;
+			for (size_t i = 0; i < customColors.size(); ++i)
+			{
+				const std::string attrName = "color" + std::to_string(i);
+				customColors[i] = static_cast<COLORREF>(NppXml::intAttribute(childNode, attrName.c_str(), static_cast<int>(customColors[i])));
+			}
+		}
 		// <GUIConfig name="ToolBar" visible="yes" fluentColor="0" fluentCustomColor="0" fluentMono="no">standard</GUIConfig>
-		if (std::strcmp(nm, "ToolBar") == 0)
+		else if (std::strcmp(nm, "ToolBar") == 0)
 		{
 			_nppGUI._toolbarShow = getBoolAttribute(childNode, "visible", _nppGUI._toolbarShow);
 
@@ -7706,6 +7716,19 @@ void NppParameters::createXmlTreeFromGUIParams()
 		setBoolAttribute(GUIConfigElement, "lightTbFluentMono", lightTbInfo._tbUseMono);
 		NppXml::setAttribute(GUIConfigElement, "lightTabIconSet", lightDefaults._tabIconSet);
 		setBoolAttribute(GUIConfigElement, "lightTabUseTheme", lightDefaults._tabUseTheme);
+	}
+
+	// <GUIConfig name="ColorPickerCustomColors" color0="..." ... color15="..." />
+	{
+		NppXml::Element GUIConfigElement = NppXml::createChildElement(newGUIRoot, "GUIConfig");
+		NppXml::setAttribute(GUIConfigElement, "name", "ColorPickerCustomColors");
+
+		const auto& customColors = _nppGUI._colorPickerCustomColors;
+		for (size_t i = 0; i < customColors.size(); ++i)
+		{
+			const std::string attrName = "color" + std::to_string(i);
+			NppXml::setAttribute(GUIConfigElement, attrName.c_str(), static_cast<int>(customColors[i]));
+		}
 	}
 
 	// <GUIConfig name="ScintillaPrimaryView" lineNumberMargin="show" lineNumberDynamicWidth="yes" bookMarkMargin="show" indentGuideLine="show"

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -709,6 +709,12 @@ struct NppGUI final
 	bool _statusBarShow = true;
 	bool _menuBarShow = true;
 
+	// The 16 custom color slots of the Windows color picker (ChooseColor), persisted
+	// across restarts (issue #4782). ChooseColorW reads/writes this array in place.
+	std::array<COLORREF, 16> _colorPickerCustomColors{ {
+		white, white, white, white, white, white, white, white,
+		white, white, white, white, white, white, white, white } };
+
 	int _tabStatus = (TAB_DRAWTOPBAR | TAB_DRAWINACTIVETAB | TAB_DRAGNDROP | TAB_REDUCE | TAB_CLOSEBUTTON | TAB_PINBUTTON);
 	bool _forceTabbarVisible = false;
 	UINT _tabCompactLabelLen = 0; // 0 ... no compacting

--- a/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
+++ b/PowerEditor/src/WinControls/ColourPicker/ColourPopup.cpp
@@ -223,11 +223,10 @@ intptr_t CALLBACK ColourPopup::run_dlgProc(UINT message, WPARAM wParam, LPARAM l
 			{
 				case IDOK:
 				{
-					static constexpr COLORREF white = RGB(0xFF, 0xFF, 0xFF);
-					static constinit std::array<COLORREF, 16> customColors{ {
-						white, white, white, white, white, white, white, white,
-						white, white, white, white, white, white, white, white,
-					} };
+					// The 16 custom color slots are persisted across restarts (issue #4782):
+					// ChooseColorW reads/writes this array in place, and it is saved to
+					// config.xml on exit.
+					auto& customColors = NppParameters::getInstance().getNppGUI()._colorPickerCustomColors;
 
 					CHOOSECOLOR cc{};
 					cc.lStructSize = sizeof(CHOOSECOLOR);


### PR DESCRIPTION
Fixes #4782.

The 16 custom-color slots of the Windows color picker (`ChooseColor`) are held in a process-local `static` array, so colors a user defines are remembered while Notepad++ stays open but silently reset to white on every restart, and every color picker in the app loses them. This is inconsistent with how the rest of Notepad++ remembers user settings (and with how custom colors persist elsewhere on Windows), so it reads as a defect rather than a missing feature.

Fix: persist the 16 slots in `config.xml` as a new `<GUIConfig name="ColorPickerCustomColors">` element — read in `feedGUIParameters`, written in `writeGUIParams`, following the existing `DarkMode` custom-color pattern. `ChooseColorW`'s `lpCustColors` points directly at that persisted `NppGUI` member, so the dialog reads and updates the slots in place; they are saved on exit like every other setting and shared by every color picker. ~34 lines across 3 files, no new UI.

Built and verified locally (64-bit): custom colors defined in the picker survive a restart.
