### PR TITLE
More universal Clipboard Listener fix for sometime incorrectly disabled Ctrl+V Paste

### DIFF
--- a/PowerEditor/src/Notepad_plus_Window.h
+++ b/PowerEditor/src/Notepad_plus_Window.h
@@ -68,6 +68,36 @@ public:
 		DPIManagerV2::loadIcon(hinst, MAKEINTRESOURCE(IDI_M30ICON), ::GetSystemMetrics(SM_CXSMICON), ::GetSystemMetrics(SM_CYSMICON), icon);
 	}
 
+	bool addClipboardListener() {
+		if (!_isClipboardListener) {
+			_isClipboardListener = ::AddClipboardFormatListener(_hSelf);
+#ifndef NDEBUG
+			if (!_isClipboardListener) {
+				std::wstring msg = L"AddClipboardFormatListener failed!\n\nErrorCode: ";
+				msg += std::to_wstring(::GetLastError());
+				::MessageBoxW(_hSelf, msg.c_str(), L"Notepad_plus_Window::addClipboardListener", MB_OK | MB_APPLMODAL | MB_ICONWARNING);
+			}
+#endif
+		}
+		return _isClipboardListener;
+	}
+
+	void removeClipboardListener() {
+		if (_isClipboardListener) {
+			_isClipboardListener = false;
+#ifdef NDEBUG
+			::RemoveClipboardFormatListener(_hSelf);
+#else
+			BOOL bRemoved = ::RemoveClipboardFormatListener(_hSelf);
+			if (!bRemoved) {
+				std::wstring msg = L"RemoveClipboardFormatListener failed!\n\nErrorCode: ";
+				msg += std::to_wstring(::GetLastError());
+				::MessageBoxW(_hSelf, msg.c_str(), L"Notepad_plus_Window::removeClipboardListener", MB_OK | MB_APPLMODAL | MB_ICONWARNING);
+			}
+#endif
+		}
+	}
+
 private:
 	Notepad_plus _notepad_plus_plus_core;
 	static LRESULT CALLBACK Notepad_plus_Proc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
@@ -81,4 +111,6 @@ private:
 	std::wstring _userQuote; // keep the availability of this string for thread using
 
 	HICON _hIconAbsent = nullptr;
+
+	bool _isClipboardListener = false;
 };

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -179,6 +179,8 @@ LRESULT Notepad_plus_Window::runProc(HWND hwnd, UINT message, WPARAM wParam, LPA
 
 				SetOSAppRestart();
 
+				addClipboardListener();
+
 				return lRet;
 			}
 			catch (std::exception& ex)
@@ -2741,6 +2743,8 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				// currently it is used only in the Notepad_plus::backupDocument worker thread,
 				// use it in such a thread like:	if (g_bNppExitFlag.load()) -> finish work of & exit the thread
 
+				_pPublicInterface->removeClipboardListener();
+
 				if (_beforeSpecialView._isFullScreen)	//closing, return to windowed mode
 					fullScreenToggle();
 				if (_beforeSpecialView._isPostIt)		//closing, return to windowed mode
@@ -2900,6 +2904,12 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			::SendMessage(curTabView->getHSelf(), WM_LBUTTONDBLCLK, wParam, lParam);
 
 			return TRUE;
+		}
+
+		case WM_CLIPBOARDUPDATE:
+		{
+			checkClipboard();
+			return 0;
 		}
 
 		case NPPM_INTERNAL_MINIMIZED_TRAY:

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -511,7 +511,6 @@ void Notepad_plus::command(int id)
 			{
 				::SendMessage(focusedHwnd, WM_CUT, 0, 0);
 			}
-			checkClipboard(); // for enabling possible Paste command
 			break;
 		}
 
@@ -537,7 +536,6 @@ void Notepad_plus::command(int id)
 				else
 					::SendMessage(focusedHwnd, WM_COPY, 0, 0);
 			}
-			checkClipboard(); // for enabling possible Paste command
 			break;
 		}
 
@@ -635,9 +633,8 @@ void Notepad_plus::command(int id)
 			if (id == IDM_EDIT_CUT_BINARY)
 				_pEditView->execute(SCI_REPLACESEL, 0, reinterpret_cast<LPARAM>(""));
 
-			checkClipboard(); // for enabling possible Paste command
+			break;
 		}
-		break;
 
 		case IDM_EDIT_PASTE:
 		{


### PR DESCRIPTION
Fix #18118

STR in the issue 1st post, i.e.:

<img width="1398" height="700" alt="npp-clipboard-paste-problem-1" src="https://github.com/user-attachments/assets/f6f42554-5100-473e-8466-234813f74db3" />

<img width="1361" height="879" alt="npp-clipboard-paste-problem-2" src="https://github.com/user-attachments/assets/418f0de4-8652-4e34-83fd-9988f12bb8f8" />

---

This PR also reverts now unneeded changes from the previous commit https://github.com/notepad-plus-plus/notepad-plus-plus/commit/13b08d0a5c3b81df6f36c72208d520bf62419ad0