### PR TITLE
Ensure searchResult stays last after styles XML merge

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2750,6 +2750,28 @@ void NppParameters::updateStylesXml(const NppXml::Element& rootUser, const std::
 		}
 	}
 
+	// Ensure searchResult LexerType is always the last child of mainElemUser,
+	// regardless of where it appeared in the original XML or where new entries
+	// were appended during the merge above.
+	NppXml::Element searchResultNode;
+	for (NppXml::Element lexerNode = NppXml::firstChildElement(mainElemUser, "LexerType");
+		lexerNode;
+		lexerNode = NppXml::nextSiblingElement(lexerNode, "LexerType"))
+	{
+		const char* name = NppXml::attribute(lexerNode, "name");
+		if (name && std::strcmp(name, "searchResult") == 0)
+		{
+			searchResultNode = lexerNode;
+			break;
+		}
+	}
+
+	if (searchResultNode)
+	{
+		NppXml::deleteChild(mainElemUser, searchResultNode);
+		NppXml::insertEndChild(mainElemUser, searchResultNode);
+	}
+
 	return;
 }
 


### PR DESCRIPTION
Fixes https://github.com/notepad-plus-plus/notepad-plus-plus/pull/17299#issuecomment-4826979782

### Problem

When `updateStylesXml()` merges missing `LexerType` entries from the model file into a theme, new entries are appended at the end of the `LexerStyles` block. This means `searchResult` can end up mid-list — either because new languages were appended after it during the merge, or because it wasn't already the last entry in the original theme XML due to an earlier merge.

I noticed this for example in Zenburn.xml after the v8.8.9 theme update (#17299), where `gdscript` and `mssql` ended up below `searchResult`.

### Fix

After the merge loop completes, locate the `searchResult` `LexerType` node, remove it from its current position, and re-insert it as the last child of `LexerStyles`. If `searchResult` is absent the guard condition ensures nothing breaks.

The fix is minimal and surgical — it does not reorder any other languages, and has no effect on themes where `searchResult` is already last.