### PR TITLE
Add "nth of count" info to incremental search

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -6927,6 +6927,9 @@ void Notepad_plus::notifyBufferActivated(BufferID bufid, int view)
 		buf->checkFileState();
 	}
 
+	if (_incrementFindDlg.isCreated())
+		_incrementFindDlg.reInitNth();
+
 	_linkTriggered = true;
 }
 

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -2933,7 +2933,8 @@ intptr_t CALLBACK FindReplaceDlg::run_dlgProc(UINT message, WPARAM wParam, LPARA
 // true  : the text2find is found
 // false : the text2find is not found
 
-bool FindReplaceDlg::processFindNext(const wchar_t *txt2find, const FindOption *options, FindStatus *oFindStatus, FindNextType findNextType /* = FINDNEXTTYPE_FINDNEXT */)
+bool FindReplaceDlg::processFindNext(const wchar_t* txt2find,
+	const FindOption* options, FindStatus* oFindStatus, FindNextType findNextType /* = FINDNEXTTYPE_FINDNEXT */, MatchPosition* pMatch)
 {
 	if (oFindStatus)
 		*oFindStatus = FSFound;
@@ -3132,6 +3133,12 @@ bool FindReplaceDlg::processFindNext(const wchar_t *txt2find, const FindOption *
 
 	delete [] pText;
 
+	if (pMatch)
+	{
+		pMatch->start = start;
+		pMatch->end = end;
+	}
+
 	return true;
 }
 
@@ -3296,7 +3303,8 @@ int FindReplaceDlg::markAllInc(const FindOption *opt)
 	return nbFound;
 }
 
-int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool isEntire, const FindersInfo *pFindersInfo, int colourStyleID)
+int FindReplaceDlg::processAll(ProcessOperation op, const FindOption* opt,
+	bool isEntire, const FindersInfo* pFindersInfo, int colourStyleID, std::vector<MatchPosition>* pMatches)
 {
 	NativeLangSpeaker* pNativeSpeaker = (NppParameters::getInstance()).getNativeLangSpeaker();
 	if (op == ProcessReplaceAll && (*_ppEditView)->getCurrentBuffer()->isReadOnly())
@@ -3384,8 +3392,7 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 	findReplaceInfo._startRange = startPosition;
 	findReplaceInfo._endRange = endPosition;
 
-	int nbProcessed = processRange(op, findReplaceInfo, pFindersInfo, pOptions, colourStyleID);
-
+	int nbProcessed = processRange(op, findReplaceInfo, pFindersInfo, pOptions, colourStyleID, nullptr, pMatches);
 
 	// Turn ON the notifications after operations
 	(*_ppEditView)->execute(SCI_SETMODEVENTMASK, notifFlag);
@@ -3419,7 +3426,8 @@ int FindReplaceDlg::processAll(ProcessOperation op, const FindOption *opt, bool 
 	return nbProcessed;
 }
 
-int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findReplaceInfo, const FindersInfo * pFindersInfo, const FindOption *opt, int colourStyleID, ScintillaEditView *view2Process)
+int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo& findReplaceInfo, const FindersInfo* pFindersInfo,
+	const FindOption* opt, int colourStyleID, ScintillaEditView* view2Process, std::vector<MatchPosition>* pMatches)
 {
 	int nbProcessed = 0;
 
@@ -3540,6 +3548,14 @@ int FindReplaceDlg::processRange(ProcessOperation op, FindReplaceInfo & findRepl
 		{
 			//we found a result but outside our range, therefore do not process it
 			break;
+		}
+
+		if (pMatches)
+		{
+			MatchPosition match;
+			match.start = targetStart;
+			match.end = targetEnd;
+			pMatches->push_back(match);
 		}
 
 		intptr_t foundTextLen = targetEnd - targetStart;
@@ -6415,6 +6431,7 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 					(*(_pFRDlg->_ppEditView))->clearIndicator(SCE_UNIVERSAL_FOUND_STYLE_INC);
 					(*(_pFRDlg->_ppEditView))->grabFocus();
 					display(false);
+					reInitNth();
 					return TRUE;
 
 				case IDM_SEARCH_FINDINCREMENT:	// Accel table: Start incremental search
@@ -6431,7 +6448,7 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 				case IDM_SEARCH_FINDNEXT:		// Accel table: find next
 				case IDC_INCFINDPREVOK:
 				case IDC_INCFINDNXTOK:
-				case IDOK:
+				case IDOK:						// Enter key in the edit field
 					updateSearch = true;
 					advance = true;
 					forward = (LOWORD(wParam) == IDC_INCFINDNXTOK) ||
@@ -6448,6 +6465,10 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 
 				case IDC_INCFINDHILITEALL:
 					updateHiLight = true;
+					break;
+
+				case IDC_INCFINDCOUNT:
+					_nth = 0;
 					break;
 
 				case IDC_INCFINDTEXT:
@@ -6473,15 +6494,33 @@ intptr_t CALLBACK FindIncrementDlg::run_dlgProc(UINT message, WPARAM wParam, LPA
 			if (updateSearch)
 			{
 				FindStatus findStatus = FSFound;
-				bool isFound = _pFRDlg->processFindNext(str2Search.c_str(), &fo, &findStatus);
+				MatchPosition match;
+				bool isFound = _pFRDlg->processFindNext(str2Search.c_str(), &fo, &findStatus, FINDNEXTTYPE_FINDNEXT, &match);
+				if (!isFound)
+					_nth = 0;
 
 				fo._str2Search = str2Search;
 				int nbCounted = -1;
+
 				if (isCheckedOrNot(IDC_INCFINDCOUNT))
 				{
-					nbCounted = _pFRDlg->processAll(ProcessCountAll, &fo);
+					std::vector<MatchPosition> matches;
+					nbCounted = _pFRDlg->processAll(ProcessCountAll, &fo, false, nullptr, -1, &matches);
+					if (nbCounted && (match.start > -1) && (match.end > -1))
+					{
+						size_t totalMatches = matches.size();
+						for (size_t i = 0; i < totalMatches; ++i)
+						{
+							if ((match.start == matches[i].start) && (match.end == matches[i].end))
+							{
+								_nth = i + 1;
+								break;
+							}
+						}
+					}
 				}
-				setFindStatus(findStatus, nbCounted);
+
+				setFindStatus(findStatus, nbCounted, static_cast<int>(_nth));
 
 				// If case-sensitivity changed (to Match=yes), there may have been a matched selection that
 				// now does not match; so if Not Found, clear selection and put caret at beginning of what was
@@ -6549,7 +6588,7 @@ void FindIncrementDlg::markSelectedTextInc(bool enable, FindOption *opt)
 	_pFRDlg->markAllInc(opt);
 }
 
-void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted)
+void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted, int nth)
 {
 	wstring statusStr2Display;
 
@@ -6561,24 +6600,12 @@ void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted)
 
 	if (nbCounted >= 0)
 	{
-		statusStr2Display = pNativeSpeaker->getLocalizedStrFromID("IncrementalFind-FSFound", L"");
+		//statusStr2Display = pNativeSpeaker->getLocalizedStrFromID("IncrementalFind-FSFound", L"");
 
-		if (statusStr2Display.empty())
-		{
-			wchar_t strFindFSFound[128] = L"";
-
-			if (nbCounted == 1)
-				wsprintf(strFindFSFound, L"%d match", nbCounted);
-			else
-				wsprintf(strFindFSFound, L"%s matches", commafyInt(nbCounted).c_str());
-			statusStr2Display = strFindFSFound;
-		}
-		else
-		{
-			statusStr2Display = stringReplace(statusStr2Display, L"$INT_REPLACE$", std::to_wstring(nbCounted));
-		}
+		wchar_t strFindFSFound[128]{};
+		wsprintf(strFindFSFound, L"%d/%d", nth, nbCounted);
+		statusStr2Display = strFindFSFound;
 	}
-
 
 	switch (iStatus)
 	{
@@ -6587,12 +6614,28 @@ void FindIncrementDlg::setFindStatus(FindStatus iStatus, int nbCounted)
 			break;
 
 		case FindStatus::FSTopReached:
-			statusStr2Display = pNativeSpeaker->getLocalizedStrFromID("IncrementalFind-FSTopReached", strFSTopReached);
+		{
+			auto topReached = pNativeSpeaker->getLocalizedStrFromID("IncrementalFind-FSTopReached", strFSTopReached);
+
+			if (nbCounted > 0)
+				statusStr2Display += (L" - " + topReached);
+			else
+				statusStr2Display = topReached;
+
 			break;
+		}
 
 		case FindStatus::FSEndReached:
-			statusStr2Display = pNativeSpeaker->getLocalizedStrFromID("IncrementalFind-FSEndReached", strFSEndReached);
+		{
+			auto endReached = pNativeSpeaker->getLocalizedStrFromID("IncrementalFind-FSEndReached", strFSEndReached);
+
+			if (nbCounted > 0)
+				statusStr2Display += (L" - " + endReached);
+			else
+				statusStr2Display = endReached;
+
 			break;
+		}
 
 		case FindStatus::FSFound:
 			break;

--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.h
@@ -88,6 +88,12 @@ struct FindOption
 	bool _isMatchLineNumber = false; // always false for main search
 };
 
+struct MatchPosition
+{
+	intptr_t start = -1;
+	intptr_t end = -1;
+};
+
 //This class contains generic search functions as static functions for easy access
 class Searching {
 public:
@@ -275,15 +281,17 @@ public :
 	void initOptionsFromDlg();
 
 	void doDialog(DIALOG_TYPE whichType, bool isRTL = false, bool toShow = true);
-	bool processFindNext(const wchar_t *txt2find, const FindOption *options = NULL, FindStatus *oFindStatus = NULL, FindNextType findNextType = FINDNEXTTYPE_FINDNEXT);
-	bool processReplace(const wchar_t *txt2find, const wchar_t *txt2replace, const FindOption *options = NULL);
+	bool processFindNext(const wchar_t* txt2find,
+		const FindOption* options = nullptr, FindStatus* oFindStatus = nullptr, FindNextType findNextType = FINDNEXTTYPE_FINDNEXT, MatchPosition* pMatch = nullptr);
+	bool processReplace(const wchar_t* txt2find, const wchar_t* txt2replace, const FindOption* options = nullptr);
 
-	int markAll(const wchar_t *txt2find, int styleID);
-	int markAllInc(const FindOption *opt);
-	
+	int markAll(const wchar_t* txt2find, int styleID);
+	int markAllInc(const FindOption* opt);
 
-	int processAll(ProcessOperation op, const FindOption *opt, bool isEntire = false, const FindersInfo *pFindersInfo = nullptr, int colourStyleID = -1);
-	int processRange(ProcessOperation op, FindReplaceInfo & findReplaceInfo, const FindersInfo *pFindersInfo, const FindOption *opt = nullptr, int colourStyleID = -1, ScintillaEditView *view2Process = nullptr);
+	int processAll(ProcessOperation op, const FindOption* opt,
+		bool isEntire = false, const FindersInfo *pFindersInfo = nullptr, int colourStyleID = -1, std::vector<MatchPosition>* pMatches = nullptr);
+	int processRange(ProcessOperation op, FindReplaceInfo& findReplaceInfo, const FindersInfo* pFindersInfo,
+		const FindOption* opt = nullptr, int colourStyleID = -1, ScintillaEditView* view2Process = nullptr, std::vector<MatchPosition>* pMatches = nullptr);
 
 	void replaceAllInOpenedDocs();
 	void findAllIn(InWhat op);
@@ -546,13 +554,13 @@ public :
 		::SendDlgItemMessage(_hSelf, IDC_INCFINDTEXT, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(txt2find));
 	}
 
-	void setFindStatus(FindStatus iStatus, int nbCounted);
-	
-	FindStatus getFindStatus() {
-		return _findStatus;
-	}
+	void setFindStatus(FindStatus iStatus, int nbCounted, int nth);
+
+	FindStatus getFindStatus() { return _findStatus; }
 
 	void addToRebar(ReBar* rebar);
+	void reInitNth() { _nth = 0; }
+
 private :
 	bool _isRTL = false;
 	FindReplaceDlg *_pFRDlg = nullptr;
@@ -560,6 +568,7 @@ private :
 
 	ReBar* _pRebar = nullptr;
 	REBARBANDINFO _rbBand{};
+	intptr_t _nth = 0;
 
 	using Window::init;
 


### PR DESCRIPTION
Ref https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11613#issuecomment-1113695434

Fix #11899 

Follow up of https://github.com/notepad-plus-plus/notepad-plus-plus/pull/18179#issuecomment-4871558472

This is basically the @donho 1st commit https://github.com/notepad-plus-plus/notepad-plus-plus/pull/18179/commits/5995156cd0f251879187daa6e5b849e9b6470905 with my additional patch.

Should not bring any overhead, as all the needed functionality (especially the pre-generation of the list with all the matches) only uses an already existing code, now just only also propagated outside of the `FindReplaceDlg::processFindNext `and `FindReplaceDlg::processRange` funcs.