### PR TITLE
Lazy load & late redraw

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -208,6 +208,18 @@ Notepad_plus::~Notepad_plus()
 
 LRESULT Notepad_plus::init(HWND hwnd)
 {
+	struct defer_ {
+		HWND _hwnd;
+		defer_(HWND hwnd) : _hwnd(hwnd) {
+			SendMessage(_hwnd, WM_SETREDRAW, FALSE, 0);
+		}
+		~defer_() {
+			SendMessage(_hwnd, WM_SETREDRAW, TRUE, 0);
+			InvalidateRect(_hwnd, NULL, TRUE);
+			UpdateWindow(_hwnd);
+		}
+	} _defer(hwnd);
+
 	NppParameters& nppParam = NppParameters::getInstance();
 	NppGUI & nppGUI = nppParam.getNppGUI();
 	const UINT dpi = DPIManagerV2::getDpiForWindow(hwnd);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -883,7 +883,7 @@ LRESULT Notepad_plus::init(HWND hwnd)
 	loadBufferIntoView(_subEditView.getCurrentBufferID(), SUB_VIEW);
 	activateBuffer(_mainEditView.getCurrentBufferID(), MAIN_VIEW);
 	activateBuffer(_subEditView.getCurrentBufferID(), SUB_VIEW);
-
+	 
 	_mainEditView.grabFocus();
 
 	return TRUE;
@@ -4606,14 +4606,33 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 		else if (isOldMode || folderPaths.size() == 0) // old mode or new mode + only files
 		{
 			BufferID lastOpened = BUFFER_INVALID;
-			for (int i = 0; i < filesDropped; ++i)
+
+			std::optional defer = _DeferRedrawHelper(this);
+
+			if (filesDropped > 1)
 			{
-				wchar_t pathDropped[MAX_PATH]{};
-				::DragQueryFileW(hdrop, i, pathDropped, MAX_PATH);
-				BufferID test = doOpen(pathDropped);
-				if (test != BUFFER_INVALID)
-					lastOpened = test;
+				for (int i = 0; i < filesDropped; ++i)
+				{
+					wchar_t pathDropped[MAX_PATH]{};
+					::DragQueryFileW(hdrop, i, pathDropped, MAX_PATH);
+					BufferID test = MainFileManager.newPlaceholderDocument(pathDropped, SUB_VIEW, nullptr, true, nullptr);
+					if (test != BUFFER_INVALID)
+						lastOpened = test;
+				}
 			}
+			else
+			{
+				for (int i = 0; i < filesDropped; ++i)
+				{
+					wchar_t pathDropped[MAX_PATH]{};
+					::DragQueryFileW(hdrop, i, pathDropped, MAX_PATH);
+					BufferID test = doOpen(pathDropped);
+					if (test != BUFFER_INVALID)
+						lastOpened = test;
+				}
+			}
+
+			defer.reset();
 
 			if (lastOpened != BUFFER_INVALID)
 			{
@@ -4772,19 +4791,19 @@ bool Notepad_plus::isEmpty()
 	return isEmpty;
 }
 
-void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool dontClose)
+void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool* pDontClose, bool lazy)
 {
 	DocTabView * tabToOpen = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
 	ScintillaEditView * viewToOpen = (whichOne == MAIN_VIEW)?&_mainEditView:&_subEditView;
 
 	//check if buffer exists
-	int index = tabToOpen->getIndexByBuffer(id);
+	int index = lazy ? -1 : tabToOpen->getIndexByBuffer(id);
 	if (index != -1)	//already open, done
 		return;
 
 	BufferID idToClose = BUFFER_INVALID;
 	//Check if the tab has a single clean buffer. Close it if so
-	if (!dontClose && tabToOpen->nbItem() == 1)
+	if ((!pDontClose || !*pDontClose) && tabToOpen->nbItem() == 1)
 	{
 		idToClose = tabToOpen->getBufferByIndex(0);
 		Buffer * buf = MainFileManager.getBufferByID(idToClose);
@@ -4804,20 +4823,22 @@ void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool dontClose)
 		MainFileManager.closeBuffer(idToClose, viewToOpen);	//delete the buffer
 		if (_pDocumentListPanel)
 			_pDocumentListPanel->closeItem(idToClose, whichOne);
+		if (pDontClose)
+			*pDontClose = true;
 	}
 	else
 	{
-		tabToOpen->addBuffer(id);
+		tabToOpen->addBuffer(id, lazy);
 	}
 }
 
-bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne)
+bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool lazy)
 {
 	DocTabView * tabToClose = (whichOne == MAIN_VIEW) ? &_mainDocTab : &_subDocTab;
 	ScintillaEditView * viewToClose = (whichOne == MAIN_VIEW) ? &_mainEditView : &_subEditView;
 
 	//check if buffer exists
-	int index = tabToClose->getIndexByBuffer(id);
+	int index = lazy ? -2 : tabToClose->getIndexByBuffer(id);
 	if (index == -1)        //doesn't exist, done
 		return false;
 
@@ -4834,54 +4855,57 @@ bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne)
 		}
 	}
 
-	int active = tabToClose->getCurrentTabIndex();
-	if (active == index) //need an alternative (close real doc, put empty one back)
+	if (!lazy)
 	{
-		if (tabToClose->nbItem() == 1)  //need alternative doc, add new one. Use special logic to prevent flicker of adding new tab then closing other
+		int active = tabToClose->getCurrentTabIndex();
+		if (active == index) //need an alternative (close real doc, put empty one back)
 		{
-			BufferID newID = MainFileManager.newEmptyDocument();
-			MainFileManager.addBufferReference(newID, viewToClose);
-			tabToClose->setBuffer(0, newID);        //can safely use id 0, last (only) tab open
-			activateBuffer(newID, whichOne);        //activate. DocTab already activated but not a problem
-		}
-		else
-		{
-			int toActivate = 0;
-			//activate next doc, otherwise prev if not possible
-			if (size_t(active) == tabToClose->nbItem() - 1) //prev
+			if (tabToClose->nbItem() == 1)  //need alternative doc, add new one. Use special logic to prevent flicker of adding new tab then closing other
 			{
-				toActivate = active - 1;
+				BufferID newID = MainFileManager.newEmptyDocument();
+				MainFileManager.addBufferReference(newID, viewToClose);
+				tabToClose->setBuffer(0, newID);        //can safely use id 0, last (only) tab open
+				activateBuffer(newID, whichOne);        //activate. DocTab already activated but not a problem
 			}
 			else
 			{
-				toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
-			}
-
-			if (NppParameters::getInstance().getNppGUI()._styleMRU)
-			{
-				// After closing a file choose the file to activate based on MRU list and not just last file in the list.
-				TaskListInfo taskListInfo;
-				::SendMessage(_pPublicInterface->getHSelf(), WM_GETTASKLISTINFO, reinterpret_cast<WPARAM>(&taskListInfo), 0);
-				size_t i, n = taskListInfo._tlfsLst.size();
-				for (i = 0; i < n; i++)
+				int toActivate = 0;
+				//activate next doc, otherwise prev if not possible
+				if (size_t(active) == tabToClose->nbItem() - 1) //prev
 				{
-					const TaskLstFnStatus& tfs = taskListInfo._tlfsLst[i];
-					if (tfs._iView != whichOne || tfs._bufID == id)
-						continue;
-					toActivate = tfs._docIndex >= active ? tfs._docIndex - 1 : tfs._docIndex;
-					break;
+					toActivate = active - 1;
 				}
-			}
+				else
+				{
+					toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
+				}
 
-			tabToClose->deletItemAt((size_t)index); //delete first
-			_isFolding = true; // So we can ignore events while folding is taking place
-			activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
-			_isFolding = false;
+				if (NppParameters::getInstance().getNppGUI()._styleMRU)
+				{
+					// After closing a file choose the file to activate based on MRU list and not just last file in the list.
+					TaskListInfo taskListInfo;
+					::SendMessage(_pPublicInterface->getHSelf(), WM_GETTASKLISTINFO, reinterpret_cast<WPARAM>(&taskListInfo), 0);
+					size_t i, n = taskListInfo._tlfsLst.size();
+					for (i = 0; i < n; i++)
+					{
+						const TaskLstFnStatus& tfs = taskListInfo._tlfsLst[i];
+						if (tfs._iView != whichOne || tfs._bufID == id)
+							continue;
+						toActivate = tfs._docIndex >= active ? tfs._docIndex - 1 : tfs._docIndex;
+						break;
+					}
+				}
+
+				tabToClose->deletItemAt((size_t)index); //delete first
+				_isFolding = true; // So we can ignore events while folding is taking place
+				activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
+				_isFolding = false;
+			}
 		}
-	}
-	else
-	{
-		tabToClose->deletItemAt((size_t)index);
+		else
+		{
+			tabToClose->deletItemAt((size_t)index);
+		}
 	}
 
 	MainFileManager.closeBuffer(id, viewToClose);
@@ -5136,8 +5160,9 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHili
 	}
 
 	Buffer * pBuf = MainFileManager.getBufferByID(id);
+	bool lazy = pBuf->getStatus() == DOC_LAZYLOAD;
 	bool reload = pBuf->getNeedReload();
-	if (reload)
+	if (reload || lazy)
 	{
 		MainFileManager.reloadBuffer(id);
 		pBuf->setNeedReload(false);
@@ -5145,6 +5170,30 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHili
 
 	if (whichOne == MAIN_VIEW)
 	{
+		if (lazy)
+		{
+			auto it = _mainViewLazyMarks.find(id);
+			if (it != _mainViewLazyMarks.end())
+			{
+				//Force in the document so we can add the markers
+				//Don't use default methods because of performance
+				Buffer* buf = MainFileManager.getBufferByID(id);
+				Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
+				unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				for (size_t j = 0, len = it->second.size(); j < len; ++j)
+				{
+					_mainEditView.execute(SCI_MARKERADD, it->second[j], MARK_BOOKMARK);
+				}
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				_mainViewLazyMarks.erase(it);
+			}
+		}
+
 		if (_mainDocTab.activateBuffer(id))	//only activate if possible
 		{
 			_isFolding = true;
@@ -5156,6 +5205,30 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHili
 	}
 	else
 	{
+		if (lazy)
+		{
+			auto it = _subViewLazyMarks.find(id);
+			if (it != _subViewLazyMarks.end())
+			{
+				//Force in the document so we can add the markers
+				//Don't use default methods because of performance
+				Buffer* buf = MainFileManager.getBufferByID(id);
+				Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
+				unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				for (size_t j = 0, len = it->second.size(); j < len; ++j)
+				{
+					_subEditView.execute(SCI_MARKERADD, it->second[j], MARK_BOOKMARK);
+				}
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				_subViewLazyMarks.erase(it);
+			}
+		}
+
 		if (_subDocTab.activateBuffer(id))
 		{
 			_isFolding = true;
@@ -6692,6 +6765,7 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 			case DOC_UNNAMED: 	//nothing todo
 			case DOC_REGULAR: 	//nothing todo
 			case DOC_INACCESSIBLE: 	//nothing todo
+			case DOC_LAZYLOAD: 	//nothing todo
 			{
 				break;
 			}

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4633,6 +4633,7 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 					{
 						lastOpened = test;
 						if (_pDocumentListPanel)
+							_pDocumentListPanel->getHSelf();
 							_pDocumentListPanel->newItem(MainFileManager.getBufferByID(lastOpened), currentView());
 					}
 				}
@@ -9518,5 +9519,27 @@ void Notepad_plus::changeReadOnlyUserModeForAllOpenedTabs(const bool ro)
 					buf->setUserReadOnly(ro);
 			}
 		}
+	}
+}
+
+Notepad_plus::_DeferRedrawHelper::_DeferRedrawHelper(Notepad_plus* s) : _self(s) {
+	SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+	SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+	if (_self->_pDocumentListPanel)
+		SendMessage(_self->_pDocumentListPanel->getHSelf(), WM_SETREDRAW, FALSE, 0);
+}
+
+Notepad_plus::_DeferRedrawHelper::~_DeferRedrawHelper() {
+	SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+	SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+	InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
+	InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
+	UpdateWindow(_self->_mainDocTab.getHSelf());
+	UpdateWindow(_self->_subDocTab.getHSelf());
+	if (_self->_pDocumentListPanel)
+	{
+		SendMessage(_self->_pDocumentListPanel->getHSelf(), WM_SETREDRAW, TRUE, 0);
+		InvalidateRect(_self->_pDocumentListPanel->getHSelf(), NULL, TRUE);
+		UpdateWindow(_self->_pDocumentListPanel->getHSelf());
 	}
 }

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5279,11 +5279,6 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHili
 
 	notifyBufferActivated(id, whichOne);
 
-	int status = (int)pBuf->getStatus();
-	wchar_t buffer[1024];
-	_snwprintf(buffer, 1023, L"activateBuffer: %s, %d", pBuf->getCompactFileName(), status);
-	OutputDebugStringW(buffer);
-
 	return true;
 }
 

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4633,7 +4633,6 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 					{
 						lastOpened = test;
 						if (_pDocumentListPanel)
-							_pDocumentListPanel->getHSelf();
 							_pDocumentListPanel->newItem(MainFileManager.getBufferByID(lastOpened), currentView());
 					}
 				}

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4633,6 +4633,7 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 					{
 						lastOpened = test;
 						if (_pDocumentListPanel)
+							_pDocumentListPanel->getHSelf();
 							_pDocumentListPanel->newItem(MainFileManager.getBufferByID(lastOpened), currentView());
 					}
 				}
@@ -9517,5 +9518,27 @@ void Notepad_plus::changeReadOnlyUserModeForAllOpenedTabs(const bool ro)
 					buf->setUserReadOnly(ro);
 			}
 		}
+	}
+}
+
+Notepad_plus::_DeferRedrawHelper::_DeferRedrawHelper(Notepad_plus* s) : _self(s) {
+	SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+	SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+	if (_self->_pDocumentListPanel)
+		SendMessage(_self->_pDocumentListPanel->getHSelf(), WM_SETREDRAW, FALSE, 0);
+}
+
+Notepad_plus::_DeferRedrawHelper::~_DeferRedrawHelper() {
+	SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+	SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+	InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
+	InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
+	UpdateWindow(_self->_mainDocTab.getHSelf());
+	UpdateWindow(_self->_subDocTab.getHSelf());
+	if (_self->_pDocumentListPanel)
+	{
+		SendMessage(_self->_pDocumentListPanel->getHSelf(), WM_SETREDRAW, TRUE, 0);
+		InvalidateRect(_self->_pDocumentListPanel->getHSelf(), NULL, TRUE);
+		UpdateWindow(_self->_pDocumentListPanel->getHSelf());
 	}
 }

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4628,9 +4628,13 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 				{
 					wchar_t pathDropped[MAX_PATH]{};
 					::DragQueryFileW(hdrop, i, pathDropped, MAX_PATH);
-					BufferID test = MainFileManager.newPlaceholderDocument(pathDropped, MAIN_VIEW, nullptr, true, nullptr);
+					BufferID test = MainFileManager.newPlaceholderDocument(pathDropped, currentView(), nullptr, true, nullptr);
 					if (test != BUFFER_INVALID)
+					{
 						lastOpened = test;
+						if (_pDocumentListPanel)
+							_pDocumentListPanel->newItem(MainFileManager.getBufferByID(lastOpened), currentView());
+					}
 				}
 			}
 			else

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4832,13 +4832,13 @@ void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool* pDontClos
 	}
 }
 
-bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool lazy)
+bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool closing)
 {
 	DocTabView * tabToClose = (whichOne == MAIN_VIEW) ? &_mainDocTab : &_subDocTab;
 	ScintillaEditView * viewToClose = (whichOne == MAIN_VIEW) ? &_mainEditView : &_subEditView;
 
 	//check if buffer exists
-	int index = lazy ? -2 : tabToClose->getIndexByBuffer(id);
+	int index = closing ? -2 : tabToClose->getIndexByBuffer(id);
 	if (index == -1)        //doesn't exist, done
 		return false;
 
@@ -4855,7 +4855,7 @@ bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool lazy)
 		}
 	}
 
-	if (!lazy)
+	if (!closing)
 	{
 		int active = tabToClose->getCurrentTabIndex();
 		if (active == index) //need an alternative (close real doc, put empty one back)
@@ -5178,18 +5178,21 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHili
 				//Force in the document so we can add the markers
 				//Don't use default methods because of performance
 				Buffer* buf = MainFileManager.getBufferByID(id);
-				Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
-				unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
-				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-				_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
-				for (size_t j = 0, len = it->second.size(); j < len; ++j)
+				if (buf)
 				{
-					_mainEditView.execute(SCI_MARKERADD, it->second[j], MARK_BOOKMARK);
+					Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
+					unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
+					_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+					_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+					_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+					for (size_t j = 0, len = it->second.size(); j < len; ++j)
+					{
+						_mainEditView.execute(SCI_MARKERADD, it->second[j], MARK_BOOKMARK);
+					}
+					_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+					_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+					_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 				}
-				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-				_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 				_mainViewLazyMarks.erase(it);
 			}
 		}
@@ -5213,18 +5216,21 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHili
 				//Force in the document so we can add the markers
 				//Don't use default methods because of performance
 				Buffer* buf = MainFileManager.getBufferByID(id);
-				Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
-				unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
-				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-				_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
-				for (size_t j = 0, len = it->second.size(); j < len; ++j)
+				if (buf)
 				{
-					_subEditView.execute(SCI_MARKERADD, it->second[j], MARK_BOOKMARK);
+					Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
+					unsigned long MODEVENTMASK_ON = NppParameters::getInstance().getScintillaModEventMask();
+					_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+					_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+					_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+					for (size_t j = 0, len = it->second.size(); j < len; ++j)
+					{
+						_subEditView.execute(SCI_MARKERADD, it->second[j], MARK_BOOKMARK);
+					}
+					_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+					_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+					_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 				}
-				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-				_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 				_subViewLazyMarks.erase(it);
 			}
 		}

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1264,11 +1264,13 @@ bool Notepad_plus::replaceInOpenedFiles()
 	const bool isEntireDoc = true;
 	bool hasInvalidRegExpr = false;
 
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+
 	if (_mainWindowStatus & WindowMainActive)
 	{
-		for (size_t i = 0, len = _mainDocTab.nbItem(); i < len ; ++i)
+		for (size_t i = 0, len = mainDocBuffers.size(); i < len ; ++i)
 		{
-			pBuf = MainFileManager.getBufferByID(_mainDocTab.getBufferByIndex(i));
+			pBuf = MainFileManager.getBufferByID(mainDocBuffers[i]);
 			if (pBuf->isReadOnly())
 				continue;
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
@@ -1294,11 +1296,12 @@ bool Notepad_plus::replaceInOpenedFiles()
 
 	if (!hasInvalidRegExpr && (_mainWindowStatus & WindowSubActive))
 	{
-		for (size_t i = 0, len = _subDocTab.nbItem(); i < len; ++i)
+		std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+		for (size_t i = 0, len = subDocBuffers.size(); i < len; ++i)
 		{
-			BufferID bufId = _subDocTab.getBufferByIndex(i);
+			BufferID bufId = subDocBuffers[i];
 
-			if (_mainDocTab.getIndexByBuffer(bufId) != -1)
+			if (std::find(mainDocBuffers.begin(), mainDocBuffers.end(), bufId) != mainDocBuffers.end())
 			{
 				// cloned doc, replacements already done in main doc
 				continue;
@@ -2299,11 +2302,13 @@ bool Notepad_plus::findInOpenedFiles()
 
 	_findReplaceDlg.beginNewFilesSearch();
 
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+
 	if (_mainWindowStatus & WindowMainActive)
 	{
-		for (size_t i = 0, len = _mainDocTab.nbItem(); i < len ; ++i)
+		for (size_t i = 0, len = mainDocBuffers.size(); i < len ; ++i)
 		{
-			pBuf = MainFileManager.getBufferByID(_mainDocTab.getBufferByIndex(i));
+			pBuf = MainFileManager.getBufferByID(mainDocBuffers[i]);
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
 
 			setCodePageForInvisibleView(pBuf);
@@ -2324,17 +2329,20 @@ bool Notepad_plus::findInOpenedFiles()
 		}
 	}
 
-	size_t nbUniqueBuffers = _mainDocTab.nbItem();
+	size_t nbUniqueBuffers = mainDocBuffers.size();
 
 	if (!hasInvalidRegExpr && (_mainWindowStatus & WindowSubActive))
 	{
-		for (size_t i = 0, len2 = _subDocTab.nbItem(); i < len2 ; ++i)
+		std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+		for (size_t i = 0, len2 = subDocBuffers.size(); i < len2 ; ++i)
 		{
-			pBuf = MainFileManager.getBufferByID(_subDocTab.getBufferByIndex(i));
-			if (_mainDocTab.getIndexByBuffer(pBuf) != -1)
+			BufferID bufId = subDocBuffers[i];
+			pBuf = MainFileManager.getBufferByID(bufId);
+			if (std::find(mainDocBuffers.begin(), mainDocBuffers.end(), bufId) != mainDocBuffers.end())
 			{
 				continue;  // clone was already searched in main; skip re-searching in sub
 			}
+
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
 
 			setCodePageForInvisibleView(pBuf);
@@ -3534,9 +3542,10 @@ void Notepad_plus::removeAllHotSpot()
 	DocTabView* twoDocView[] { &_mainDocTab, &_subDocTab };
 	for (DocTabView* pDocView : twoDocView)
 	{
-		for (size_t i = 0; i < pDocView->nbItem(); ++i)
+		std::vector<BufferID> docBuffers = pDocView->getBuffersByIndex();
+		for (size_t i = 0; i < docBuffers.size(); ++i)
 		{
-			BufferID id = pDocView->getBufferByIndex(i);
+			BufferID id = docBuffers[i];
 			Buffer* buf = MainFileManager.getBufferByID(id);
 
 			if (buf->allowClickableLink()) // if it's not allowed clickabled link in the buffer, there's nothing to be cleared
@@ -4832,13 +4841,14 @@ void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool* pDontClos
 	}
 }
 
-bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool closing)
+bool Notepad_plus::removeBufferFromView(int index, BufferID id, int whichOne)
 {
 	DocTabView * tabToClose = (whichOne == MAIN_VIEW) ? &_mainDocTab : &_subDocTab;
 	ScintillaEditView * viewToClose = (whichOne == MAIN_VIEW) ? &_mainEditView : &_subEditView;
 
 	//check if buffer exists
-	int index = closing ? -2 : tabToClose->getIndexByBuffer(id);
+	if (index == -1)
+		index = tabToClose->getIndexByBuffer(id);
 	if (index == -1)        //doesn't exist, done
 		return false;
 
@@ -4855,57 +4865,54 @@ bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool closing)
 		}
 	}
 
-	if (!closing)
+	int active = tabToClose->getCurrentTabIndex();
+	if (active == index) //need an alternative (close real doc, put empty one back)
 	{
-		int active = tabToClose->getCurrentTabIndex();
-		if (active == index) //need an alternative (close real doc, put empty one back)
+		if (tabToClose->nbItem() == 1)  //need alternative doc, add new one. Use special logic to prevent flicker of adding new tab then closing other
 		{
-			if (tabToClose->nbItem() == 1)  //need alternative doc, add new one. Use special logic to prevent flicker of adding new tab then closing other
-			{
-				BufferID newID = MainFileManager.newEmptyDocument();
-				MainFileManager.addBufferReference(newID, viewToClose);
-				tabToClose->setBuffer(0, newID);        //can safely use id 0, last (only) tab open
-				activateBuffer(newID, whichOne);        //activate. DocTab already activated but not a problem
-			}
-			else
-			{
-				int toActivate = 0;
-				//activate next doc, otherwise prev if not possible
-				if (size_t(active) == tabToClose->nbItem() - 1) //prev
-				{
-					toActivate = active - 1;
-				}
-				else
-				{
-					toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
-				}
-
-				if (NppParameters::getInstance().getNppGUI()._styleMRU)
-				{
-					// After closing a file choose the file to activate based on MRU list and not just last file in the list.
-					TaskListInfo taskListInfo;
-					::SendMessage(_pPublicInterface->getHSelf(), WM_GETTASKLISTINFO, reinterpret_cast<WPARAM>(&taskListInfo), 0);
-					size_t i, n = taskListInfo._tlfsLst.size();
-					for (i = 0; i < n; i++)
-					{
-						const TaskLstFnStatus& tfs = taskListInfo._tlfsLst[i];
-						if (tfs._iView != whichOne || tfs._bufID == id)
-							continue;
-						toActivate = tfs._docIndex >= active ? tfs._docIndex - 1 : tfs._docIndex;
-						break;
-					}
-				}
-
-				tabToClose->deletItemAt((size_t)index); //delete first
-				_isFolding = true; // So we can ignore events while folding is taking place
-				activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
-				_isFolding = false;
-			}
+			BufferID newID = MainFileManager.newEmptyDocument();
+			MainFileManager.addBufferReference(newID, viewToClose);
+			tabToClose->setBuffer(0, newID);        //can safely use id 0, last (only) tab open
+			activateBuffer(newID, whichOne);        //activate. DocTab already activated but not a problem
 		}
 		else
 		{
-			tabToClose->deletItemAt((size_t)index);
+			int toActivate = 0;
+			//activate next doc, otherwise prev if not possible
+			if (size_t(active) == tabToClose->nbItem() - 1) //prev
+			{
+				toActivate = active - 1;
+			}
+			else
+			{
+				toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
+			}
+
+			if (NppParameters::getInstance().getNppGUI()._styleMRU)
+			{
+				// After closing a file choose the file to activate based on MRU list and not just last file in the list.
+				TaskListInfo taskListInfo;
+				::SendMessage(_pPublicInterface->getHSelf(), WM_GETTASKLISTINFO, reinterpret_cast<WPARAM>(&taskListInfo), 0);
+				size_t i, n = taskListInfo._tlfsLst.size();
+				for (i = 0; i < n; i++)
+				{
+					const TaskLstFnStatus& tfs = taskListInfo._tlfsLst[i];
+					if (tfs._iView != whichOne || tfs._bufID == id)
+						continue;
+					toActivate = tfs._docIndex >= active ? tfs._docIndex - 1 : tfs._docIndex;
+					break;
+				}
+			}
+
+			tabToClose->deletItemAt((size_t)index); //delete first
+			_isFolding = true; // So we can ignore events while folding is taking place
+			activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
+			_isFolding = false;
 		}
+	}
+	else
+	{
+		tabToClose->deletItemAt((size_t)index);
 	}
 
 	MainFileManager.closeBuffer(id, viewToClose);
@@ -5047,7 +5054,7 @@ void Notepad_plus::docOpenInNewInstance(FileTransferMode mode, int x, int y)
 	cmd.run(_pPublicInterface->getHSelf());
 	if (mode == TransferMove)
 	{
-		doClose(bufferID, currentView());
+		doClose(-1, bufferID, currentView());
 		if (noOpenedDoc())
 			::SendMessage(_pPublicInterface->getHSelf(), WM_CLOSE, 0, 0);
 	}
@@ -5125,7 +5132,7 @@ void Notepad_plus::docGotoAnotherEditView(FileTransferMode mode)
 		monitoringWasOn = buf->isMonitoringOn();
 
 		//just close the activate document, since thats the one we moved (no search)
-		doClose(_pEditView->getCurrentBufferID(), currentView());
+		doClose(-1, _pEditView->getCurrentBufferID(), currentView());
 	} // else it was cone, so leave it
 
 	//Activate the other view since thats where the document went
@@ -5962,24 +5969,25 @@ bool Notepad_plus::switchToFile(BufferID id)
 
 void Notepad_plus::getTaskListInfo(TaskListInfo *tli)
 {
-	int currentNbDoc = static_cast<int32_t>(_pDocTab->nbItem());
-	int nonCurrentNbDoc = static_cast<int32_t>(_pNonDocTab->nbItem());
+	std::vector<BufferID> currentNbDocBuffers = _pDocTab->getBuffersByIndex();
+	std::vector<BufferID> nonCurrentNbDocBuffers;
 
 	tli->_currentIndex = 0;
 
-	if (!viewVisible(otherView()))
-		nonCurrentNbDoc = 0;
+	if (viewVisible(otherView()))
+		nonCurrentNbDocBuffers = _pNonDocTab->getBuffersByIndex();
 
-	for (int i = 0 ; i < currentNbDoc ; ++i)
+	for (int i = 0 ; i < currentNbDocBuffers.size(); ++i)
 	{
-		BufferID bufID = _pDocTab->getBufferByIndex(i);
+		BufferID bufID = currentNbDocBuffers[i];
 		Buffer * b = MainFileManager.getBufferByID(bufID);
 		int status = b->isMonitoringOn()?tb_monitored:(b->isReadOnly()?tb_ro:(b->isDirty()?tb_unsaved:tb_saved));
 		tli->_tlfsLst.push_back(TaskLstFnStatus(currentView(), i, b->getFullPathName(), status, (void *)bufID, b->getDocColorId()));
 	}
-	for (int i = 0 ; i < nonCurrentNbDoc ; ++i)
+
+	for (int i = 0 ; i < nonCurrentNbDocBuffers.size(); ++i)
 	{
-		BufferID bufID = _pNonDocTab->getBufferByIndex(i);
+		BufferID bufID = nonCurrentNbDocBuffers[i];
 		Buffer * b = MainFileManager.getBufferByID(bufID);
 		int status = b->isMonitoringOn()?tb_monitored:(b->isReadOnly()?tb_ro:(b->isDirty()?tb_unsaved:tb_saved));
 		tli->_tlfsLst.push_back(TaskLstFnStatus(otherView(), i, b->getFullPathName(), status, (void *)bufID, b->getDocColorId()));
@@ -6546,9 +6554,10 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includeUntitled
 	docTab[1] = &_subDocTab;
 	for (size_t k = 0; k < nbElem; ++k)
 	{
-		for (size_t i = 0, len = docTab[k]->nbItem(); i < len ; ++i)
+		std::vector<BufferID> docBuffers = docTab[k]->getBuffersByIndex();
+		for (size_t i = 0, len = docBuffers.size(); i < len ; ++i)
 		{
-			BufferID bufID = docTab[k]->getBufferByIndex(i);
+			BufferID bufID = docBuffers[i];
 			ScintillaEditView *editView = k == 0 ? &_mainEditView : &_subEditView;
 			size_t activeIndex = k == 0 ? session._activeMainIndex : session._activeSubIndex;
 			vector<sessionFileInfo> *viewFiles = (vector<sessionFileInfo> *)(k == 0?&(session._mainViewFiles):&(session._subViewFiles));
@@ -6870,8 +6879,8 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 					{
 						//close in both views, doing current view last since that has to remain opened
 						bool isSnapshotMode = nppGUI.isSnapshotMode();
-						doClose(buffer->getID(), otherView(), isSnapshotMode);
-						doClose(buffer->getID(), currentView(), isSnapshotMode);
+						doClose(-1, buffer->getID(), otherView(), isSnapshotMode);
+						doClose(-1, buffer->getID(), currentView(), isSnapshotMode);
 						return;
 					}
 					else
@@ -9484,9 +9493,10 @@ void Notepad_plus::changeReadOnlyUserModeForAllOpenedTabs(const bool ro)
 	std::vector<DocTabView*> tabViews = { &_mainDocTab, &_subDocTab };
 	for (auto& pTabView : tabViews)
 	{
-		for (size_t i = 0; i < pTabView->nbItem(); ++i)
+		std::vector<BufferID> viewBuffers = pTabView->getBuffersByIndex();
+		for (size_t i = 0; i < viewBuffers.size(); ++i)
 		{
-			BufferID id = pTabView->getBufferByIndex(i);
+			BufferID id = viewBuffers[i];
 			if (id != BUFFER_INVALID)
 			{
 				Buffer* buf = MainFileManager.getBufferByID(id);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1264,11 +1264,13 @@ bool Notepad_plus::replaceInOpenedFiles()
 	const bool isEntireDoc = true;
 	bool hasInvalidRegExpr = false;
 
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+
 	if (_mainWindowStatus & WindowMainActive)
 	{
-		for (size_t i = 0, len = _mainDocTab.nbItem(); i < len ; ++i)
+		for (size_t i = 0, len = mainDocBuffers.size(); i < len ; ++i)
 		{
-			pBuf = MainFileManager.getBufferByID(_mainDocTab.getBufferByIndex(i));
+			pBuf = MainFileManager.getBufferByID(mainDocBuffers[i]);
 			if (pBuf->isReadOnly())
 				continue;
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
@@ -1294,11 +1296,12 @@ bool Notepad_plus::replaceInOpenedFiles()
 
 	if (!hasInvalidRegExpr && (_mainWindowStatus & WindowSubActive))
 	{
-		for (size_t i = 0, len = _subDocTab.nbItem(); i < len; ++i)
+		std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+		for (size_t i = 0, len = subDocBuffers.size(); i < len; ++i)
 		{
-			BufferID bufId = _subDocTab.getBufferByIndex(i);
+			BufferID bufId = subDocBuffers[i];
 
-			if (_mainDocTab.getIndexByBuffer(bufId) != -1)
+			if (std::find(mainDocBuffers.begin(), mainDocBuffers.end(), bufId) != mainDocBuffers.end())
 			{
 				// cloned doc, replacements already done in main doc
 				continue;
@@ -2299,11 +2302,13 @@ bool Notepad_plus::findInOpenedFiles()
 
 	_findReplaceDlg.beginNewFilesSearch();
 
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+
 	if (_mainWindowStatus & WindowMainActive)
 	{
-		for (size_t i = 0, len = _mainDocTab.nbItem(); i < len ; ++i)
+		for (size_t i = 0, len = mainDocBuffers.size(); i < len ; ++i)
 		{
-			pBuf = MainFileManager.getBufferByID(_mainDocTab.getBufferByIndex(i));
+			pBuf = MainFileManager.getBufferByID(mainDocBuffers[i]);
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
 
 			setCodePageForInvisibleView(pBuf);
@@ -2324,17 +2329,20 @@ bool Notepad_plus::findInOpenedFiles()
 		}
 	}
 
-	size_t nbUniqueBuffers = _mainDocTab.nbItem();
+	size_t nbUniqueBuffers = mainDocBuffers.size();
 
 	if (!hasInvalidRegExpr && (_mainWindowStatus & WindowSubActive))
 	{
-		for (size_t i = 0, len2 = _subDocTab.nbItem(); i < len2 ; ++i)
+		std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+		for (size_t i = 0, len2 = subDocBuffers.size(); i < len2 ; ++i)
 		{
-			pBuf = MainFileManager.getBufferByID(_subDocTab.getBufferByIndex(i));
-			if (_mainDocTab.getIndexByBuffer(pBuf) != -1)
+			BufferID bufId = subDocBuffers[i];
+			pBuf = MainFileManager.getBufferByID(bufId);
+			if (std::find(mainDocBuffers.begin(), mainDocBuffers.end(), bufId) != mainDocBuffers.end())
 			{
 				continue;  // clone was already searched in main; skip re-searching in sub
 			}
+
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, pBuf->getDocument());
 
 			setCodePageForInvisibleView(pBuf);
@@ -3534,9 +3542,10 @@ void Notepad_plus::removeAllHotSpot()
 	DocTabView* twoDocView[] { &_mainDocTab, &_subDocTab };
 	for (DocTabView* pDocView : twoDocView)
 	{
-		for (size_t i = 0; i < pDocView->nbItem(); ++i)
+		std::vector<BufferID> docBuffers = pDocView->getBuffersByIndex();
+		for (size_t i = 0; i < docBuffers.size(); ++i)
 		{
-			BufferID id = pDocView->getBufferByIndex(i);
+			BufferID id = docBuffers[i];
 			Buffer* buf = MainFileManager.getBufferByID(id);
 
 			if (buf->allowClickableLink()) // if it's not allowed clickabled link in the buffer, there's nothing to be cleared
@@ -4832,13 +4841,14 @@ void Notepad_plus::loadBufferIntoView(BufferID id, int whichOne, bool* pDontClos
 	}
 }
 
-bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool closing)
+bool Notepad_plus::removeBufferFromView(int index, BufferID id, int whichOne)
 {
 	DocTabView * tabToClose = (whichOne == MAIN_VIEW) ? &_mainDocTab : &_subDocTab;
 	ScintillaEditView * viewToClose = (whichOne == MAIN_VIEW) ? &_mainEditView : &_subEditView;
 
 	//check if buffer exists
-	int index = closing ? -2 : tabToClose->getIndexByBuffer(id);
+	if (index == -1)
+		index = tabToClose->getIndexByBuffer(id);
 	if (index == -1)        //doesn't exist, done
 		return false;
 
@@ -4855,57 +4865,54 @@ bool Notepad_plus::removeBufferFromView(BufferID id, int whichOne, bool closing)
 		}
 	}
 
-	if (!closing)
+	int active = tabToClose->getCurrentTabIndex();
+	if (active == index) //need an alternative (close real doc, put empty one back)
 	{
-		int active = tabToClose->getCurrentTabIndex();
-		if (active == index) //need an alternative (close real doc, put empty one back)
+		if (tabToClose->nbItem() == 1)  //need alternative doc, add new one. Use special logic to prevent flicker of adding new tab then closing other
 		{
-			if (tabToClose->nbItem() == 1)  //need alternative doc, add new one. Use special logic to prevent flicker of adding new tab then closing other
-			{
-				BufferID newID = MainFileManager.newEmptyDocument();
-				MainFileManager.addBufferReference(newID, viewToClose);
-				tabToClose->setBuffer(0, newID);        //can safely use id 0, last (only) tab open
-				activateBuffer(newID, whichOne);        //activate. DocTab already activated but not a problem
-			}
-			else
-			{
-				int toActivate = 0;
-				//activate next doc, otherwise prev if not possible
-				if (size_t(active) == tabToClose->nbItem() - 1) //prev
-				{
-					toActivate = active - 1;
-				}
-				else
-				{
-					toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
-				}
-
-				if (NppParameters::getInstance().getNppGUI()._styleMRU)
-				{
-					// After closing a file choose the file to activate based on MRU list and not just last file in the list.
-					TaskListInfo taskListInfo;
-					::SendMessage(_pPublicInterface->getHSelf(), WM_GETTASKLISTINFO, reinterpret_cast<WPARAM>(&taskListInfo), 0);
-					size_t i, n = taskListInfo._tlfsLst.size();
-					for (i = 0; i < n; i++)
-					{
-						const TaskLstFnStatus& tfs = taskListInfo._tlfsLst[i];
-						if (tfs._iView != whichOne || tfs._bufID == id)
-							continue;
-						toActivate = tfs._docIndex >= active ? tfs._docIndex - 1 : tfs._docIndex;
-						break;
-					}
-				}
-
-				tabToClose->deletItemAt((size_t)index); //delete first
-				_isFolding = true; // So we can ignore events while folding is taking place
-				activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
-				_isFolding = false;
-			}
+			BufferID newID = MainFileManager.newEmptyDocument();
+			MainFileManager.addBufferReference(newID, viewToClose);
+			tabToClose->setBuffer(0, newID);        //can safely use id 0, last (only) tab open
+			activateBuffer(newID, whichOne);        //activate. DocTab already activated but not a problem
 		}
 		else
 		{
-			tabToClose->deletItemAt((size_t)index);
+			int toActivate = 0;
+			//activate next doc, otherwise prev if not possible
+			if (size_t(active) == tabToClose->nbItem() - 1) //prev
+			{
+				toActivate = active - 1;
+			}
+			else
+			{
+				toActivate = active;    //activate the 'active' index. Since we remove the tab first, the indices shift (on the right side)
+			}
+
+			if (NppParameters::getInstance().getNppGUI()._styleMRU)
+			{
+				// After closing a file choose the file to activate based on MRU list and not just last file in the list.
+				TaskListInfo taskListInfo;
+				::SendMessage(_pPublicInterface->getHSelf(), WM_GETTASKLISTINFO, reinterpret_cast<WPARAM>(&taskListInfo), 0);
+				size_t i, n = taskListInfo._tlfsLst.size();
+				for (i = 0; i < n; i++)
+				{
+					const TaskLstFnStatus& tfs = taskListInfo._tlfsLst[i];
+					if (tfs._iView != whichOne || tfs._bufID == id)
+						continue;
+					toActivate = tfs._docIndex >= active ? tfs._docIndex - 1 : tfs._docIndex;
+					break;
+				}
+			}
+
+			tabToClose->deletItemAt((size_t)index); //delete first
+			_isFolding = true; // So we can ignore events while folding is taking place
+			activateBuffer(tabToClose->getBufferByIndex(toActivate), whichOne);     //then activate. The prevent jumpy tab behaviour
+			_isFolding = false;
 		}
+	}
+	else
+	{
+		tabToClose->deletItemAt((size_t)index);
 	}
 
 	MainFileManager.closeBuffer(id, viewToClose);
@@ -5047,7 +5054,7 @@ void Notepad_plus::docOpenInNewInstance(FileTransferMode mode, int x, int y)
 	cmd.run(_pPublicInterface->getHSelf());
 	if (mode == TransferMove)
 	{
-		doClose(bufferID, currentView());
+		doClose(-1, bufferID, currentView());
 		if (noOpenedDoc())
 			::SendMessage(_pPublicInterface->getHSelf(), WM_CLOSE, 0, 0);
 	}
@@ -5125,7 +5132,7 @@ void Notepad_plus::docGotoAnotherEditView(FileTransferMode mode)
 		monitoringWasOn = buf->isMonitoringOn();
 
 		//just close the activate document, since thats the one we moved (no search)
-		doClose(_pEditView->getCurrentBufferID(), currentView());
+		doClose(-1, _pEditView->getCurrentBufferID(), currentView());
 	} // else it was cone, so leave it
 
 	//Activate the other view since thats where the document went
@@ -5962,24 +5969,25 @@ bool Notepad_plus::switchToFile(BufferID id)
 
 void Notepad_plus::getTaskListInfo(TaskListInfo *tli)
 {
-	int currentNbDoc = static_cast<int32_t>(_pDocTab->nbItem());
-	int nonCurrentNbDoc = static_cast<int32_t>(_pNonDocTab->nbItem());
+	std::vector<BufferID> currentNbDocBuffers = _pDocTab->getBuffersByIndex();
+	std::vector<BufferID> nonCurrentNbDocBuffers;
 
 	tli->_currentIndex = 0;
 
-	if (!viewVisible(otherView()))
-		nonCurrentNbDoc = 0;
+	if (viewVisible(otherView()))
+		nonCurrentNbDocBuffers = _pNonDocTab->getBuffersByIndex();
 
-	for (int i = 0 ; i < currentNbDoc ; ++i)
+	for (int i = 0 ; i < currentNbDocBuffers.size(); ++i)
 	{
-		BufferID bufID = _pDocTab->getBufferByIndex(i);
+		BufferID bufID = currentNbDocBuffers[i];
 		Buffer * b = MainFileManager.getBufferByID(bufID);
 		int status = b->isMonitoringOn()?tb_monitored:(b->isReadOnly()?tb_ro:(b->isDirty()?tb_unsaved:tb_saved));
 		tli->_tlfsLst.push_back(TaskLstFnStatus(currentView(), i, b->getFullPathName(), status, (void *)bufID, b->getDocColorId()));
 	}
-	for (int i = 0 ; i < nonCurrentNbDoc ; ++i)
+
+	for (int i = 0 ; i < nonCurrentNbDocBuffers.size(); ++i)
 	{
-		BufferID bufID = _pNonDocTab->getBufferByIndex(i);
+		BufferID bufID = nonCurrentNbDocBuffers[i];
 		Buffer * b = MainFileManager.getBufferByID(bufID);
 		int status = b->isMonitoringOn()?tb_monitored:(b->isReadOnly()?tb_ro:(b->isDirty()?tb_unsaved:tb_saved));
 		tli->_tlfsLst.push_back(TaskLstFnStatus(otherView(), i, b->getFullPathName(), status, (void *)bufID, b->getDocColorId()));
@@ -6546,9 +6554,10 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includeUntitled
 	docTab[1] = &_subDocTab;
 	for (size_t k = 0; k < nbElem; ++k)
 	{
-		for (size_t i = 0, len = docTab[k]->nbItem(); i < len ; ++i)
+		std::vector<BufferID> docBuffers = docTab[k]->getBuffersByIndex();
+		for (size_t i = 0, len = docBuffers.size(); i < len ; ++i)
 		{
-			BufferID bufID = docTab[k]->getBufferByIndex(i);
+			BufferID bufID = docBuffers[i];
 			ScintillaEditView *editView = k == 0 ? &_mainEditView : &_subEditView;
 			size_t activeIndex = k == 0 ? session._activeMainIndex : session._activeSubIndex;
 			vector<sessionFileInfo> *viewFiles = (vector<sessionFileInfo> *)(k == 0?&(session._mainViewFiles):&(session._subViewFiles));
@@ -6870,8 +6879,8 @@ void Notepad_plus::notifyBufferChanged(Buffer * buffer, int mask)
 					{
 						//close in both views, doing current view last since that has to remain opened
 						bool isSnapshotMode = nppGUI.isSnapshotMode();
-						doClose(buffer->getID(), otherView(), isSnapshotMode);
-						doClose(buffer->getID(), currentView(), isSnapshotMode);
+						doClose(-1, buffer->getID(), otherView(), isSnapshotMode);
+						doClose(-1, buffer->getID(), currentView(), isSnapshotMode);
 						return;
 					}
 					else
@@ -9485,9 +9494,10 @@ void Notepad_plus::changeReadOnlyUserModeForAllOpenedTabs(const bool ro)
 	std::vector<DocTabView*> tabViews = { &_mainDocTab, &_subDocTab };
 	for (auto& pTabView : tabViews)
 	{
-		for (size_t i = 0; i < pTabView->nbItem(); ++i)
+		std::vector<BufferID> viewBuffers = pTabView->getBuffersByIndex();
+		for (size_t i = 0; i < viewBuffers.size(); ++i)
 		{
-			BufferID id = pTabView->getBufferByIndex(i);
+			BufferID id = viewBuffers[i];
 			if (id != BUFFER_INVALID)
 			{
 				Buffer* buf = MainFileManager.getBufferByID(id);

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4232,6 +4232,10 @@ void Notepad_plus::setTitle()
 	{
 		result += L"*";
 	}
+	else if (buf->getStatus() == DOC_LAZYLOAD)
+	{
+		result += L"(L)";
+	}
 
 	if (nppGUI._shortTitlebar)
 	{
@@ -5252,12 +5256,17 @@ bool Notepad_plus::activateBuffer(BufferID id, int whichOne, bool forceApplyHili
 			return false;
 	}
 
-	if (reload)
+	if (reload || lazy)
 	{
 		performPostReload(whichOne);
 	}
 
 	notifyBufferActivated(id, whichOne);
+
+	int status = (int)pBuf->getStatus();
+	wchar_t buffer[1024];
+	_snwprintf(buffer, 1023, L"activateBuffer: %s, %d", pBuf->getCompactFileName(), status);
+	OutputDebugStringW(buffer);
 
 	return true;
 }

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -4624,7 +4624,7 @@ void Notepad_plus::dropFiles(HDROP hdrop)
 				{
 					wchar_t pathDropped[MAX_PATH]{};
 					::DragQueryFileW(hdrop, i, pathDropped, MAX_PATH);
-					BufferID test = MainFileManager.newPlaceholderDocument(pathDropped, SUB_VIEW, nullptr, true, nullptr);
+					BufferID test = MainFileManager.newPlaceholderDocument(pathDropped, MAIN_VIEW, nullptr, true, nullptr);
 					if (test != BUFFER_INVALID)
 						lastOpened = test;
 				}

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -173,7 +173,7 @@ public:
 	BufferID doOpen(const std::wstring& fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const wchar_t *backupFileName = NULL, FILETIME fileNameTimestamp = {});
 	bool doReload(BufferID id, bool alert = true);
 	bool doSave(BufferID, const wchar_t * filename, bool isSaveCopy = false);
-	void doClose(BufferID, int whichOne, bool doDeleteBackup = false, bool lazy = false);
+	void doClose(int index, BufferID, int whichOne, bool doDeleteBackup = false);
 
 
 	void fileOpen();
@@ -472,7 +472,7 @@ private:
 	void docOpenInNewInstance(FileTransferMode mode, int x = 0, int y = 0);
 
 	void loadBufferIntoView(BufferID id, int whichOne, bool* pDontClose = nullptr, bool lazy = false);		//Doesn't _activate_ the buffer
-	bool removeBufferFromView(BufferID id, int whichOne, bool closing = false);	//Activates alternative of possible, or creates clean document if not clean already
+	bool removeBufferFromView(int index, BufferID id, int whichOne);	//Activates alternative of possible, or creates clean document if not clean already
 
 	bool activateBuffer(BufferID id, int whichOne, bool forceApplyHilite = false);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -682,17 +682,7 @@ private:
 
 	struct _DeferRedrawHelper {
 		Notepad_plus* _self;
-		_DeferRedrawHelper(Notepad_plus* s) : _self(s) {
-			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
-			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
-		}
-		~_DeferRedrawHelper() {
-			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
-			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
-			InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
-			InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
-			UpdateWindow(_self->_mainDocTab.getHSelf());
-			UpdateWindow(_self->_subDocTab.getHSelf());
-		}
+		_DeferRedrawHelper(Notepad_plus* s);
+		~_DeferRedrawHelper();
 	};
 };

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -472,7 +472,7 @@ private:
 	void docOpenInNewInstance(FileTransferMode mode, int x = 0, int y = 0);
 
 	void loadBufferIntoView(BufferID id, int whichOne, bool* pDontClose = nullptr, bool lazy = false);		//Doesn't _activate_ the buffer
-	bool removeBufferFromView(BufferID id, int whichOne, bool lazy = false);	//Activates alternative of possible, or creates clean document if not clean already
+	bool removeBufferFromView(BufferID id, int whichOne, bool closing = false);	//Activates alternative of possible, or creates clean document if not clean already
 
 	bool activateBuffer(BufferID id, int whichOne, bool forceApplyHilite = false);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);
@@ -691,6 +691,8 @@ private:
 			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
 			InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
 			InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
+			UpdateWindow(_self->_mainDocTab.getHSelf());
+			UpdateWindow(_self->_subDocTab.getHSelf());
 		}
 	};
 };

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -173,7 +173,7 @@ public:
 	BufferID doOpen(const std::wstring& fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const wchar_t *backupFileName = NULL, FILETIME fileNameTimestamp = {});
 	bool doReload(BufferID id, bool alert = true);
 	bool doSave(BufferID, const wchar_t * filename, bool isSaveCopy = false);
-	void doClose(BufferID, int whichOne, bool doDeleteBackup = false);
+	void doClose(BufferID, int whichOne, bool doDeleteBackup = false, bool lazy = false);
 
 
 	void fileOpen();
@@ -424,6 +424,10 @@ private:
 
 	std::vector<HWND> _sysTrayHiddenHwnd;
 
+	// lazyload marks
+	std::map<BufferID, std::vector<size_t>> _mainViewLazyMarks;
+	std::map<BufferID, std::vector<size_t>> _subViewLazyMarks;
+
 	BOOL notify(SCNotification *notification);
 	void command(int id);
 
@@ -467,8 +471,8 @@ private:
 	void docGotoAnotherEditView(FileTransferMode mode);	//TransferMode
 	void docOpenInNewInstance(FileTransferMode mode, int x = 0, int y = 0);
 
-	void loadBufferIntoView(BufferID id, int whichOne, bool dontClose = false);		//Doesn't _activate_ the buffer
-	bool removeBufferFromView(BufferID id, int whichOne);	//Activates alternative of possible, or creates clean document if not clean already
+	void loadBufferIntoView(BufferID id, int whichOne, bool* pDontClose = nullptr, bool lazy = false);		//Doesn't _activate_ the buffer
+	bool removeBufferFromView(BufferID id, int whichOne, bool lazy = false);	//Activates alternative of possible, or creates clean document if not clean already
 
 	bool activateBuffer(BufferID id, int whichOne, bool forceApplyHilite = false);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);
@@ -675,4 +679,18 @@ private:
 	int getIcoID(DockingDlgInterface* panel);
 	void loadPanelIcon(HINSTANCE hInst, DockingDlgInterface* panel, HICON* phIcon);
 	void refreshPanelIcon(HINSTANCE hInst, DockingDlgInterface* panel);
+
+	struct _DeferRedrawHelper {
+		Notepad_plus* _self;
+		_DeferRedrawHelper(Notepad_plus* s) : _self(s) {
+			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+		}
+		~_DeferRedrawHelper() {
+			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+			InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
+			InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
+		}
+	};
 };

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -173,8 +173,8 @@ public:
 	// since closing one view doesn't have to mean the document is gone
 	BufferID doOpen(const std::wstring& fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const wchar_t* backupFileName = NULL, FILETIME fileNameTimestamp = {});
 	bool doReload(BufferID id, bool alert = true);
-	bool doSave(BufferID, const wchar_t* filename, bool isSaveCopy = false);
-	void doClose(BufferID, int whichOne, bool doDeleteBackup = false);
+	bool doSave(BufferID, const wchar_t * filename, bool isSaveCopy = false);
+	void doClose(BufferID, int whichOne, bool doDeleteBackup = false, bool lazy = false);
 
 
 	void fileOpen();
@@ -431,6 +431,10 @@ private:
 
 	std::vector<HWND> _sysTrayHiddenHwnd;
 
+	// lazyload marks
+	std::map<BufferID, std::vector<size_t>> _mainViewLazyMarks;
+	std::map<BufferID, std::vector<size_t>> _subViewLazyMarks;
+
 	BOOL notify(SCNotification *notification);
 	void command(int id);
 
@@ -474,8 +478,8 @@ private:
 	void docGotoAnotherEditView(FileTransferMode mode);	//TransferMode
 	void docOpenInNewInstance(FileTransferMode mode, int x = 0, int y = 0);
 
-	void loadBufferIntoView(BufferID id, int whichOne, bool dontClose = false);		//Doesn't _activate_ the buffer
-	bool removeBufferFromView(BufferID id, int whichOne);	//Activates alternative of possible, or creates clean document if not clean already
+	void loadBufferIntoView(BufferID id, int whichOne, bool* pDontClose = nullptr, bool lazy = false);		//Doesn't _activate_ the buffer
+	bool removeBufferFromView(BufferID id, int whichOne, bool lazy = false);	//Activates alternative of possible, or creates clean document if not clean already
 
 	bool activateBuffer(BufferID id, int whichOne, bool forceApplyHilite = false);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);
@@ -682,4 +686,18 @@ private:
 	int getIcoID(DockingDlgInterface* panel);
 	void loadPanelIcon(HINSTANCE hInst, DockingDlgInterface* panel, HICON* phIcon);
 	void refreshPanelIcon(HINSTANCE hInst, DockingDlgInterface* panel);
+
+	struct _DeferRedrawHelper {
+		Notepad_plus* _self;
+		_DeferRedrawHelper(Notepad_plus* s) : _self(s) {
+			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
+		}
+		~_DeferRedrawHelper() {
+			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
+			InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
+			InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
+		}
+	};
 };

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -689,17 +689,7 @@ private:
 
 	struct _DeferRedrawHelper {
 		Notepad_plus* _self;
-		_DeferRedrawHelper(Notepad_plus* s) : _self(s) {
-			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
-			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, FALSE, 0);
-		}
-		~_DeferRedrawHelper() {
-			SendMessage(_self->_mainDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
-			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
-			InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
-			InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
-			UpdateWindow(_self->_mainDocTab.getHSelf());
-			UpdateWindow(_self->_subDocTab.getHSelf());
-		}
+		_DeferRedrawHelper(Notepad_plus* s);
+		~_DeferRedrawHelper();
 	};
 };

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -479,7 +479,7 @@ private:
 	void docOpenInNewInstance(FileTransferMode mode, int x = 0, int y = 0);
 
 	void loadBufferIntoView(BufferID id, int whichOne, bool* pDontClose = nullptr, bool lazy = false);		//Doesn't _activate_ the buffer
-	bool removeBufferFromView(BufferID id, int whichOne, bool lazy = false);	//Activates alternative of possible, or creates clean document if not clean already
+	bool removeBufferFromView(BufferID id, int whichOne, bool closing = false);	//Activates alternative of possible, or creates clean document if not clean already
 
 	bool activateBuffer(BufferID id, int whichOne, bool forceApplyHilite = false);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);
@@ -698,6 +698,8 @@ private:
 			SendMessage(_self->_subDocTab.getHSelf(), WM_SETREDRAW, TRUE, 0);
 			InvalidateRect(_self->_mainDocTab.getHSelf(), NULL, TRUE);
 			InvalidateRect(_self->_subDocTab.getHSelf(), NULL, TRUE);
+			UpdateWindow(_self->_mainDocTab.getHSelf());
+			UpdateWindow(_self->_subDocTab.getHSelf());
 		}
 	};
 };

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -174,7 +174,7 @@ public:
 	BufferID doOpen(const std::wstring& fileName, bool isRecursive = false, bool isReadOnly = false, int encoding = -1, const wchar_t* backupFileName = NULL, FILETIME fileNameTimestamp = {});
 	bool doReload(BufferID id, bool alert = true);
 	bool doSave(BufferID, const wchar_t * filename, bool isSaveCopy = false);
-	void doClose(BufferID, int whichOne, bool doDeleteBackup = false, bool lazy = false);
+	void doClose(int index, BufferID, int whichOne, bool doDeleteBackup = false);
 
 
 	void fileOpen();
@@ -479,7 +479,7 @@ private:
 	void docOpenInNewInstance(FileTransferMode mode, int x = 0, int y = 0);
 
 	void loadBufferIntoView(BufferID id, int whichOne, bool* pDontClose = nullptr, bool lazy = false);		//Doesn't _activate_ the buffer
-	bool removeBufferFromView(BufferID id, int whichOne, bool closing = false);	//Activates alternative of possible, or creates clean document if not clean already
+	bool removeBufferFromView(int index, BufferID id, int whichOne);	//Activates alternative of possible, or creates clean document if not clean already
 
 	bool activateBuffer(BufferID id, int whichOne, bool forceApplyHilite = false);			//activate buffer in that view if found
 	void notifyBufferActivated(BufferID bufid, int view);

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1116,9 +1116,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			size_t j = 0;
 			if (message != NPPM_GETOPENFILENAMESSECOND_DEPRECATED)
 			{
-				for (size_t i = 0; i < _mainDocTab.nbItem() && j < nbFileNames; ++i)
+				std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+				for (size_t i = 0; i < mainDocBuffers.size() && j < nbFileNames; ++i)
 				{
-					BufferID id = _mainDocTab.getBufferByIndex(i);
+					BufferID id = mainDocBuffers[i];
 					Buffer * buf = MainFileManager.getBufferByID(id);
 					lstrcpy(fileNames[j++], buf->getFullPathName());
 				}
@@ -1126,9 +1127,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 			if (message != NPPM_GETOPENFILENAMESPRIMARY_DEPRECATED)
 			{
-				for (size_t i = 0; i < _subDocTab.nbItem() && j < nbFileNames; ++i)
+				std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+				for (size_t i = 0; i < subDocBuffers.size() && j < nbFileNames; ++i)
 				{
-					BufferID id = _subDocTab.getBufferByIndex(i);
+					BufferID id = subDocBuffers[i];
 					Buffer * buf = MainFileManager.getBufferByID(id);
 					lstrcpy(fileNames[j++], buf->getFullPathName());
 				}
@@ -3757,9 +3759,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			const std::vector<DocTabView*> tabViews = { &_mainDocTab, &_subDocTab };
 			for (auto& pTabView : tabViews)
 			{
-				for (size_t i = 0; i < pTabView->nbItem(); ++i)
+				std::vector<BufferID> tabViewBuffers = pTabView->getBuffersByIndex();
+				for (size_t i = 0; i < tabViewBuffers.size(); ++i)
 				{
-					BufferID id = pTabView->getBufferByIndex(i);
+					BufferID id = tabViewBuffers[i];
 					if (id != BUFFER_INVALID)
 					{
 						Buffer* buf = MainFileManager.getBufferByID(id);
@@ -4265,9 +4268,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			Buffer* pBuf = NULL;
 			for (size_t v = 0; v < 2; ++v)
 			{
-				for (size_t i = 0, len = pTab[v]->nbItem(); i < len; ++i)
+				std::vector<BufferID> tabBuffers = pTab[v]->getBuffersByIndex();
+				for (size_t i = 0, len = tabBuffers.size(); i < len; ++i)
 				{
-					pBuf = MainFileManager.getBufferByID(pTab[v]->getBufferByIndex(i));
+					pBuf = MainFileManager.getBufferByID(tabBuffers[i]);
 
 					if (pBuf->getLangType() == L_SQL)
 					{

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1171,9 +1171,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			size_t j = 0;
 			if (message != NPPM_GETOPENFILENAMESSECOND_DEPRECATED)
 			{
-				for (size_t i = 0; i < _mainDocTab.nbItem() && j < nbFileNames; ++i)
+				std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+				for (size_t i = 0; i < mainDocBuffers.size() && j < nbFileNames; ++i)
 				{
-					BufferID id = _mainDocTab.getBufferByIndex(i);
+					BufferID id = mainDocBuffers[i];
 					Buffer * buf = MainFileManager.getBufferByID(id);
 					lstrcpy(fileNames[j++], buf->getFullPathName());
 				}
@@ -1181,9 +1182,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 
 			if (message != NPPM_GETOPENFILENAMESPRIMARY_DEPRECATED)
 			{
-				for (size_t i = 0; i < _subDocTab.nbItem() && j < nbFileNames; ++i)
+				std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+				for (size_t i = 0; i < subDocBuffers.size() && j < nbFileNames; ++i)
 				{
-					BufferID id = _subDocTab.getBufferByIndex(i);
+					BufferID id = subDocBuffers[i];
 					Buffer * buf = MainFileManager.getBufferByID(id);
 					lstrcpy(fileNames[j++], buf->getFullPathName());
 				}
@@ -3812,9 +3814,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			const std::vector<DocTabView*> tabViews = { &_mainDocTab, &_subDocTab };
 			for (auto& pTabView : tabViews)
 			{
-				for (size_t i = 0; i < pTabView->nbItem(); ++i)
+				std::vector<BufferID> tabViewBuffers = pTabView->getBuffersByIndex();
+				for (size_t i = 0; i < tabViewBuffers.size(); ++i)
 				{
-					BufferID id = pTabView->getBufferByIndex(i);
+					BufferID id = tabViewBuffers[i];
 					if (id != BUFFER_INVALID)
 					{
 						Buffer* buf = MainFileManager.getBufferByID(id);
@@ -4320,9 +4323,10 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			Buffer* pBuf = NULL;
 			for (size_t v = 0; v < 2; ++v)
 			{
-				for (size_t i = 0, len = pTab[v]->nbItem(); i < len; ++i)
+				std::vector<BufferID> tabBuffers = pTab[v]->getBuffersByIndex();
+				for (size_t i = 0, len = tabBuffers.size(); i < len; ++i)
 				{
-					pBuf = MainFileManager.getBufferByID(pTab[v]->getBufferByIndex(i));
+					pBuf = MainFileManager.getBufferByID(tabBuffers[i]);
 
 					if (pBuf->getLangType() == L_SQL)
 					{

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -1537,9 +1537,10 @@ void Notepad_plus::command(int id)
 				std::vector<Buffer*> buffers;
 				for (auto&& docTab : docTabs)
 				{
-					for (size_t i = 0, len = docTab->nbItem(); i < len; ++i)
+					std::vector<BufferID> docTabBuffers = docTab->getBuffersByIndex();
+					for (size_t i = 0, len = docTabBuffers.size(); i < len; ++i)
 					{
-						BufferID bufID = docTab->getBufferByIndex(i);
+						BufferID bufID = docTabBuffers[i];
 						Buffer* buf = MainFileManager.getBufferByID(bufID);
 						// Don't add duplicates because a buffer might be cloned in other view.
 						if (docTabs.size() < 2 || std::find(buffers.begin(), buffers.end(), buf) == buffers.end())

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -844,10 +844,10 @@ bool Notepad_plus::doSave(BufferID id, const wchar_t * filename, bool isCopy)
 	return res == SavingStatus::SaveOK;
 }
 
-void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool lazy)
+void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool closing)
 {
 	DocTabView *tabToClose = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
-	int i = lazy ? -2 : tabToClose->getIndexByBuffer(id);
+	int i = closing ? -2 : tabToClose->getIndexByBuffer(id);
 	if (i == -1)
 		return;
 
@@ -911,7 +911,7 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool 
 	}
 
 	//Do all the works
-	bool isBufRemoved = removeBufferFromView(id, whichOne, lazy);
+	bool isBufRemoved = removeBufferFromView(id, whichOne, closing);
 	BufferID hiddenBufferID = BUFFER_INVALID;
 	if (nbDocs == 1 && canHideView(whichOne))
 	{	//close the view if both visible
@@ -1478,7 +1478,7 @@ bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfo
 	bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 	for (const auto& i : buffersToClose)
 	{
-		doClose(i._bufID, i._iView, isSnapshotMode, true);
+		doClose(i._bufID, i._iView, isSnapshotMode);
 	}
 
 	return true;
@@ -1738,7 +1738,7 @@ bool Notepad_plus::fileCloseAllButCurrent()
 
 		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode, true);
+			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
 		}
     }
 
@@ -2644,7 +2644,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			}
 			else
 			{
-				_mainViewLazyMarks.emplace(lastOpened, std::move(session._mainViewFiles[i]._marks));
+				_mainViewLazyMarks.emplace(lastOpened, session._mainViewFiles[i]._marks);
 			}
 
 			++i;
@@ -2788,7 +2788,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			}
 			else
 			{
-				_subViewLazyMarks.emplace(lastOpened, std::move(session._subViewFiles[k]._marks));
+				_subViewLazyMarks.emplace(lastOpened, session._subViewFiles[k]._marks);
 			}
 
 			++k;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2578,7 +2578,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 		}
 		else
 		{
-			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)
@@ -2729,12 +2729,12 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 				else if (doesFileExist(pFn))
 					lastOpened = doOpen(pFn, false, false, session._subViewFiles[k]._encoding);
 				else
-					lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
+					lastOpened = MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 			}
 		}
 		else
 		{
-			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -844,10 +844,10 @@ bool Notepad_plus::doSave(BufferID id, const wchar_t * filename, bool isCopy)
 	return res == SavingStatus::SaveOK;
 }
 
-void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
+void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool lazy)
 {
 	DocTabView *tabToClose = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
-	int i = tabToClose->getIndexByBuffer(id);
+	int i = lazy ? -2 : tabToClose->getIndexByBuffer(id);
 	if (i == -1)
 		return;
 
@@ -911,7 +911,7 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
 	}
 
 	//Do all the works
-	bool isBufRemoved = removeBufferFromView(id, whichOne);
+	bool isBufRemoved = removeBufferFromView(id, whichOne, lazy);
 	BufferID hiddenBufferID = BUFFER_INVALID;
 	if (nbDocs == 1 && canHideView(whichOne))
 	{	//close the view if both visible
@@ -1198,6 +1198,8 @@ void Notepad_plus::unPinnedForAllBuffers()
 
 bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 {
+	_DeferRedrawHelper defer(this);
+
 	bool noSaveToAll = false;
 	bool saveToAll = false;
 
@@ -1382,20 +1384,23 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 		activateBuffer(_pNonDocTab->getBufferByIndex(0), otherView());
 		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), otherView(), doDeleteBackup);
+			doClose(_pNonDocTab->getBufferByIndex(i), otherView(), doDeleteBackup, true);
 		}
     }
 
 	activateBuffer(_pDocTab->getBufferByIndex(0), currentView());
 	for (auto i = static_cast<int>(_pDocTab->nbItem()) - 1; i >= 0; --i)
 	{	//close all from right to left
-		doClose(_pDocTab->getBufferByIndex(i), currentView(), doDeleteBackup);
+		doClose(_pDocTab->getBufferByIndex(i), currentView(), doDeleteBackup, true);
 	}
+
 	return true;
 }
 
 bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfos)
 {
+	_DeferRedrawHelper defer(this);
+
 	// First check if we need to save any file.
 
 	bool noSaveToAll = false;
@@ -1473,7 +1478,7 @@ bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfo
 	bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 	for (const auto& i : buffersToClose)
 	{
-		doClose(i._bufID, i._iView, isSnapshotMode);
+		doClose(i._bufID, i._iView, isSnapshotMode, true);
 	}
 
 	return true;
@@ -1560,6 +1565,8 @@ bool Notepad_plus::fileCloseAllUnchanged()
 
 bool Notepad_plus::fileCloseAllButCurrent()
 {
+	_DeferRedrawHelper defer(this);
+
 	BufferID current = _pEditView->getCurrentBufferID();
 	const int activeViewID = currentView();
 	int active = _pDocTab->getCurrentTabIndex();
@@ -1731,7 +1738,7 @@ bool Notepad_plus::fileCloseAllButCurrent()
 
 		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
+			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode, true);
 		}
     }
 
@@ -2419,7 +2426,8 @@ void Notepad_plus::fileNew()
 	BufferID newBufID = MainFileManager.newEmptyDocument();
 	if (newBufID != BUFFER_INVALID)
 	{
-		loadBufferIntoView(newBufID, currentView(), true); // true, because we want multiple new files if possible
+		bool dontClose = true;
+		loadBufferIntoView(newBufID, currentView(), &dontClose); // true, because we want multiple new files if possible
 		switchToFile(newBufID);
 	}
 }
@@ -2507,6 +2515,8 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 
 	int mainIndex2Update = -1;
 
+	std::optional defer = _DeferRedrawHelper(this);
+
 	// no session
 	if (!session.nbMainFiles() && !session.nbSubFiles())
 	{
@@ -2518,6 +2528,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 		return true;
 	}
 
+	bool dontCloseDefaultView = false;
 	for (size_t i = 0; i < session.nbMainFiles() ; )
 	{
 		const wchar_t *pFn = session._mainViewFiles[i]._fileName.c_str();
@@ -2536,22 +2547,13 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			isWow64Off = true;
 		}
 #endif
-		if (doesFileExist(pFn))
-		{
-			if (isSnapshotMode && !session._mainViewFiles[i]._backupFilePath.empty())
-				lastOpened = doOpen(pFn, false, false, session._mainViewFiles[i]._encoding, session._mainViewFiles[i]._backupFilePath.c_str(), session._mainViewFiles[i]._originalFileLastModifTimestamp);
-			else
-				lastOpened = doOpen(pFn, false, false, session._mainViewFiles[i]._encoding);
-		}
-		else if (isSnapshotMode && doesFileExist(session._mainViewFiles[i]._backupFilePath.c_str()))
+		if (isSnapshotMode && doesFileExist(session._mainViewFiles[i]._backupFilePath.c_str()))
 		{
 			lastOpened = doOpen(pFn, false, false, session._mainViewFiles[i]._encoding, session._mainViewFiles[i]._backupFilePath.c_str(), session._mainViewFiles[i]._originalFileLastModifTimestamp);
 		}
 		else
 		{
-			BufferID foundBufID = MainFileManager.getBufferFromName(pFn);
-			if (foundBufID == BUFFER_INVALID)
-				lastOpened = nppGUI._keepSessionAbsentFileEntries ? MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName) : BUFFER_INVALID;
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)
@@ -2623,20 +2625,28 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 
 			_mainDocTab.setIndividualTabColour(lastOpened, session._mainViewFiles[i]._individualTabColour);
 
-			//Force in the document so we can add the markers
-			//Don't use default methods because of performance
-			Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
-			unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
-			for (size_t j = 0, len = session._mainViewFiles[i]._marks.size(); j < len ; ++j)
+			if (buf->getStatus() != DOC_LAZYLOAD)
 			{
-				_mainEditView.execute(SCI_MARKERADD, session._mainViewFiles[i]._marks[j], MARK_BOOKMARK);
+				//Force in the document so we can add the markers
+				//Don't use default methods because of performance
+				Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
+				unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				for (size_t j = 0, len = session._mainViewFiles[i]._marks.size(); j < len; ++j)
+				{
+					_mainEditView.execute(SCI_MARKERADD, session._mainViewFiles[i]._marks[j], MARK_BOOKMARK);
+				}
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			}
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			else
+			{
+				_mainViewLazyMarks.emplace(lastOpened, std::move(session._mainViewFiles[i]._marks));
+			}
+
 			++i;
 		}
 		else
@@ -2677,7 +2687,8 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			isWow64Off = true;
 		}
 #endif
-		if (doesFileExist(pFn) || (isSnapshotMode && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str())))
+		//if (doesFileExist(pFn) || (isSnapshotMode && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str())))
+		if (isSnapshotMode && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str()))
 		{
 			//check if already open in main. If so, clone
 			BufferID clonedBuf = _mainDocTab.findBufferByName(pFn);
@@ -2690,15 +2701,15 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			{
 				if (isSnapshotMode && !session._subViewFiles[k]._backupFilePath.empty())
 					lastOpened = doOpen(pFn, false, false, session._subViewFiles[k]._encoding, session._subViewFiles[k]._backupFilePath.c_str(), session._subViewFiles[k]._originalFileLastModifTimestamp);
-				else
+				else if (doesFileExist(pFn))
 					lastOpened = doOpen(pFn, false, false, session._subViewFiles[k]._encoding);
+				else
+					lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 			}
 		}
 		else
 		{
-			BufferID foundBufID = MainFileManager.getBufferFromName(pFn);
-			if (foundBufID == BUFFER_INVALID)
-				lastOpened = nppGUI._keepSessionAbsentFileEntries ? MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName) : BUFFER_INVALID;
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)
@@ -2744,11 +2755,11 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 					pLn = L"";	//default user defined
 				}
 			}
+
 			buf->setLangType(typeToSet, pLn);
 			buf->setEncoding(session._subViewFiles[k]._encoding);
 			buf->setUserReadOnly(session._subViewFiles[k]._isUserReadOnly || nppGUI._isFullReadOnly || nppGUI._isFullReadOnlySavingForbidden);
 			buf->setPinned(session._subViewFiles[k]._isPinned);
-
 			buf->setUntitledTabRenamedStatus(session._subViewFiles[k]._isUntitledTabRenamed);
 
 			if (isSnapshotMode && !session._subViewFiles[k]._backupFilePath.empty() && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str()))
@@ -2758,20 +2769,27 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 
 			_subDocTab.setIndividualTabColour(lastOpened, session._subViewFiles[k]._individualTabColour);
 
-			//Force in the document so we can add the markers
-			//Don't use default methods because of performance
-			Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
-			unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
-			for (size_t j = 0, len = session._subViewFiles[k]._marks.size(); j < len ; ++j)
+			if (buf->getStatus() != DOC_LAZYLOAD)
 			{
-				_subEditView.execute(SCI_MARKERADD, session._subViewFiles[k]._marks[j], MARK_BOOKMARK);
+				//Force in the document so we can add the markers
+				//Don't use default methods because of performance
+				Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
+				unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				for (size_t j = 0, len = session._subViewFiles[k]._marks.size(); j < len; ++j)
+				{
+					_subEditView.execute(SCI_MARKERADD, session._subViewFiles[k]._marks[j], MARK_BOOKMARK);
+				}
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			}
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			else
+			{
+				_subViewLazyMarks.emplace(lastOpened, std::move(session._subViewFiles[k]._marks));
+			}
 
 			++k;
 		}
@@ -2782,6 +2800,9 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			allSessionFilesLoaded = false;
 		}
 	}
+
+	defer.reset();
+
 	if (subIndex2Update != -1)
 	{
 		_isFolding = true;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -844,10 +844,10 @@ bool Notepad_plus::doSave(BufferID id, const wchar_t * filename, bool isCopy)
 	return res == SavingStatus::SaveOK;
 }
 
-void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool closing)
+void Notepad_plus::doClose(int index, BufferID id, int whichOne, bool doDeleteBackup)
 {
 	DocTabView *tabToClose = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
-	int i = closing ? -2 : tabToClose->getIndexByBuffer(id);
+	int i = index != -1 ? index : tabToClose->getIndexByBuffer(id);
 	if (i == -1)
 		return;
 
@@ -911,7 +911,7 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool 
 	}
 
 	//Do all the works
-	bool isBufRemoved = removeBufferFromView(id, whichOne, closing);
+	bool isBufRemoved = removeBufferFromView(index, id, whichOne);
 	BufferID hiddenBufferID = BUFFER_INVALID;
 	if (nbDocs == 1 && canHideView(whichOne))
 	{	//close the view if both visible
@@ -1175,22 +1175,25 @@ bool Notepad_plus::fileClose(BufferID id, int curView)
 	if (isSnapshotMode && isCloned) // if Buffer is cloned then we don't delete backup file
 		doDeleteBackup = false;
 
-	doClose(bufferID, viewToClose, doDeleteBackup);
+	doClose(-1, bufferID, viewToClose, doDeleteBackup);
 	return true;
 }
 
 void Notepad_plus::unPinnedForAllBuffers()
 {
-	for (size_t i = 0; i < _mainDocTab.nbItem(); ++i)
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+
+	for (size_t i = 0; i < mainDocBuffers.size(); ++i)
 	{
-		BufferID id = _mainDocTab.getBufferByIndex(i);
+		BufferID id = mainDocBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		buf->setPinned(false);
 	}
 
-	for (size_t i = 0; i < _subDocTab.nbItem(); ++i)
+	for (size_t i = 0; i < subDocBuffers.size(); ++i)
 	{
-		BufferID id = _subDocTab.getBufferByIndex(i);
+		BufferID id = subDocBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		buf->setPinned(false);
 	}
@@ -1209,9 +1212,12 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 	//check in the both view
 	std::unordered_set<BufferID> uniqueBuffers;
 
-	for (size_t i = 0; i < _mainDocTab.nbItem() && !noSaveToAll; ++i)
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+
+	for (size_t i = 0; i < mainDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _mainDocTab.getBufferByIndex(i);
+		BufferID id = mainDocBuffers[i];
 		Buffer * buf = MainFileManager.getBufferByID(id);
 
 		// Put all the BufferID from main view to hash table
@@ -1293,9 +1299,9 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 		}
 	}
 
-	for (size_t i = 0; i < _subDocTab.nbItem() && !noSaveToAll; ++i)
+	for (size_t i = 0; i < subDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _subDocTab.getBufferByIndex(i);
+		BufferID id = subDocBuffers[i];
 		Buffer * buf = MainFileManager.getBufferByID(id);
 
 		// Is this buffer already included?
@@ -1379,19 +1385,27 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 	//Then start closing, inactive view first so the active is left open
     if (bothActive())
     {
-		//first close all docs in non-current view, which gets closed automatically
-		//Set active tab to the last one closed.
-		activateBuffer(_pNonDocTab->getBufferByIndex(0), otherView());
-		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
+		std::vector<BufferID> nonDocBuffers = _pNonDocTab->getBuffersByIndex();
+		if (!nonDocBuffers.empty())
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), otherView(), doDeleteBackup, true);
+			//first close all docs in non-current view, which gets closed automatically
+			//Set active tab to the last one closed.
+			activateBuffer(nonDocBuffers[0], otherView());
+			for (auto i = static_cast<int>(nonDocBuffers.size()) - 1; i >= 0; --i) //close all from right to left
+			{
+				doClose(i, nonDocBuffers[i], otherView(), doDeleteBackup);
+			}
 		}
     }
 
-	activateBuffer(_pDocTab->getBufferByIndex(0), currentView());
-	for (auto i = static_cast<int>(_pDocTab->nbItem()) - 1; i >= 0; --i)
-	{	//close all from right to left
-		doClose(_pDocTab->getBufferByIndex(i), currentView(), doDeleteBackup, true);
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
+	if (!docBuffers.empty())
+	{
+		activateBuffer(docBuffers[0], currentView());
+		for (auto i = static_cast<int>(docBuffers.size()) - 1; i >= 0; --i)
+		{	//close all from right to left
+			doClose(i, docBuffers[i], currentView(), doDeleteBackup);
+		}
 	}
 
 	return true;
@@ -1478,7 +1492,7 @@ bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfo
 	bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 	for (const auto& i : buffersToClose)
 	{
-		doClose(i._bufID, i._iView, isSnapshotMode);
+		doClose(-1, i._bufID, i._iView, isSnapshotMode);
 	}
 
 	return true;
@@ -1501,10 +1515,11 @@ bool Notepad_plus::fileCloseAllToRight()
 	// Indexes must go from high to low to deal with the fact that when one index is closed, any remaining
 	// indexes (smaller than the one just closed) will point to the wrong tab.
 	const int iActive = _pDocTab->getCurrentTabIndex();
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
 	std::vector<BufferViewInfo> bufsToClose;
-	for (int i = int(_pDocTab->nbItem()) - 1; i > iActive; i--)
+	for (int i = int(docBuffers.size()) - 1; i > iActive; i--)
 	{
-		bufsToClose.push_back(BufferViewInfo(_pDocTab->getBufferByIndex(i), currentView()));
+		bufsToClose.push_back(BufferViewInfo(docBuffers[i], currentView()));
 	}
 	return fileCloseAllGiven(bufsToClose);
 }
@@ -1512,33 +1527,25 @@ bool Notepad_plus::fileCloseAllToRight()
 void Notepad_plus::fileCloseAllButPinned()
 {
 	std::vector<BufferViewInfo> bufsToClose;
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
 
 	int iPinned = -1;
-	for (int j = 0; j < int(_mainDocTab.nbItem()); ++j)
+	for (int j = 0; j < int(mainDocBuffers.size()); ++j)
 	{
-		if (_mainDocTab.getBufferByIndex(j)->isPinned())
-			iPinned++;
+		if (mainDocBuffers[j]->isPinned())
+			bufsToClose.push_back(BufferViewInfo(mainDocBuffers[j], MAIN_VIEW));
 		else
 			break;
 	}
 	
-	for (int i = int(_mainDocTab.nbItem()) - 1; i > iPinned; i--)
-	{
-		bufsToClose.push_back(BufferViewInfo(_mainDocTab.getBufferByIndex(i), MAIN_VIEW));
-	}
-
-
 	iPinned = -1;
-	for (int j = 0; j < int(_subDocTab.nbItem()); ++j)
+	for (int j = 0; j < int(subDocBuffers.size()); ++j)
 	{
-		if (_subDocTab.getBufferByIndex(j)->isPinned())
-			iPinned++;
+		if (subDocBuffers[j]->isPinned())
+			bufsToClose.push_back(BufferViewInfo(subDocBuffers[j], SUB_VIEW));
 		else
 			break;
-	}
-	for (int i = int(_subDocTab.nbItem()) - 1; i > iPinned; i--)
-	{
-		bufsToClose.push_back(BufferViewInfo(_subDocTab.getBufferByIndex(i), SUB_VIEW));
 	}
 	
 	fileCloseAllGiven(bufsToClose);
@@ -1549,14 +1556,15 @@ bool Notepad_plus::fileCloseAllUnchanged()
 	// Indexes must go from high to low to deal with the fact that when one index is closed, any remaining
 	// indexes (smaller than the one just closed) will point to the wrong tab.
 	std::vector<BufferViewInfo> bufsToClose;
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
 
-	for (int i = int(_pDocTab->nbItem()) - 1; i >= 0; i--)
+	for (int i = int(docBuffers.size()) - 1; i >= 0; i--)
 	{
-		BufferID id = _pDocTab->getBufferByIndex(i);
+		BufferID id = docBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		if ((buf->isUntitled() && buf->docLength() == 0) || !buf->isDirty())
 		{
-			bufsToClose.push_back(BufferViewInfo(_pDocTab->getBufferByIndex(i), currentView()));
+			bufsToClose.push_back(BufferViewInfo(id, currentView()));
 		}
 	}
 
@@ -1578,10 +1586,13 @@ bool Notepad_plus::fileCloseAllButCurrent()
 
 	//closes all documents, makes the current view the only one visible
 
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+
 	//first check if we need to save any file
-	for (size_t i = 0; i < _mainDocTab.nbItem() && !noSaveToAll; ++i)
+	for (size_t i = 0; i < mainDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _mainDocTab.getBufferByIndex(i);
+		BufferID id = mainDocBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		if (id == current)
 			continue;
@@ -1641,7 +1652,7 @@ bool Notepad_plus::fileCloseAllButCurrent()
 			{
 				for (auto j = static_cast<int>(mainSaveOpIndex.size()) - 1; j >= 0; --j) //close all from right to left
 				{
-					doClose(_mainDocTab.getBufferByIndex(mainSaveOpIndex[j]), MAIN_VIEW, isSnapshotMode);
+					doClose(j, mainDocBuffers[mainSaveOpIndex[j]], MAIN_VIEW, isSnapshotMode);
 				}
 
 				return false;
@@ -1650,9 +1661,9 @@ bool Notepad_plus::fileCloseAllButCurrent()
 		}
 	}
 
-	for (size_t i = 0; i < _subDocTab.nbItem() && !noSaveToAll; ++i)
+	for (size_t i = 0; i < subDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _subDocTab.getBufferByIndex(i);
+		BufferID id = subDocBuffers[i];
 		Buffer * buf = MainFileManager.getBufferByID(id);
 		if (id == current)
 			continue;
@@ -1712,13 +1723,14 @@ bool Notepad_plus::fileCloseAllButCurrent()
 			{
 				for (auto j = static_cast<int>(mainSaveOpIndex.size()) - 1; j >= 0; --j) //close all from right to left
 				{
-					doClose(_mainDocTab.getBufferByIndex(mainSaveOpIndex[j]), MAIN_VIEW, isSnapshotMode);
+					doClose(j, mainDocBuffers[mainSaveOpIndex[j]], MAIN_VIEW, isSnapshotMode);
 				}
 
 				for (auto j = static_cast<int>(subSaveOpIndex.size()) - 1; j >= 0; --j) //close all from right to left
 				{
-					doClose(_subDocTab.getBufferByIndex(subSaveOpIndex[j]), SUB_VIEW, isSnapshotMode);
+					doClose(j, subDocBuffers[subSaveOpIndex[j]], SUB_VIEW, isSnapshotMode);
 				}
+
 				return false;
 			}
 
@@ -1731,39 +1743,49 @@ bool Notepad_plus::fileCloseAllButCurrent()
 	//Then start closing, inactive view first so the active is left open
     if (bothActive())
     {
-		//first close all docs in non-current view, which gets closed automatically
-		//Set active tab to the last one closed.
-		const int viewNo = otherView();
-		activateBuffer(_pNonDocTab->getBufferByIndex(0), viewNo);
-
-		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
+		std::vector<BufferID> nonDocBuffers = _pNonDocTab->getBuffersByIndex();
+		if (!nonDocBuffers.empty())
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
+			//first close all docs in non-current view, which gets closed automatically
+			//Set active tab to the last one closed.
+			const int viewNo = otherView();
+			activateBuffer(nonDocBuffers[0], viewNo);
+
+			for (auto i = static_cast<int>(nonDocBuffers.size()) - 1; i >= 0; --i) //close all from right to left
+			{
+				doClose(i, nonDocBuffers[i], viewNo, isSnapshotMode);
+			}
 		}
     }
 
-	const int viewNo = currentView();
-	size_t nbItems = _pDocTab->nbItem();
-	activateBuffer(_pDocTab->getBufferByIndex(0), viewNo);
-	
-	// After activateBuffer() call, if file is deleted, user will decide to keep or not the tab
-	// So here we check if the 1st tab is closed or not
-	size_t newNbItems = _pDocTab->nbItem();
-
-	if (nbItems > newNbItems) // the 1st tab has been removed
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
+	if (!docBuffers.empty())
 	{
-		// active tab move 1 position forward
-		active -= 1;
-	}
+		const int viewNo = currentView();
+		size_t nbItems = docBuffers.size();
+		activateBuffer(docBuffers[0], viewNo);
 
-	for (auto i = static_cast<int>(newNbItems) - 1; i >= 0; --i) //close all from right to left
-	{
-		if (i == active)	//don't close active index
+		// After activateBuffer() call, if file is deleted, user will decide to keep or not the tab
+		// So here we check if the 1st tab is closed or not
+		size_t newNbItems = _pDocTab->nbItem();
+
+		if (nbItems > newNbItems) // the 1st tab has been removed
 		{
-			continue;
+			// active tab move 1 position forward
+			active -= 1;
+			docBuffers.erase(docBuffers.begin());
 		}
-		doClose(_pDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
+
+		for (auto i = static_cast<int>(docBuffers.size()) - 1; i >= 0; --i) //close all from right to left
+		{
+			if (i == active)	//don't close active index
+			{
+				continue;
+			}
+			doClose(i, docBuffers[i], viewNo, isSnapshotMode);
+		}
 	}
+
 	return true;
 }
 
@@ -1943,10 +1965,11 @@ size_t Notepad_plus::getNbDirtyBuffer(int view)
 	if (view == SUB_VIEW)
 		pDocTabView = &_subDocTab;
 
+	std::vector<BufferID> docBuffers = pDocTabView->getBuffersByIndex();
 	size_t count = 0;
-	for (size_t i = 0; i < pDocTabView->nbItem(); ++i)
+	for (size_t i = 0; i < docBuffers.size(); ++i)
 	{
-		BufferID id = pDocTabView->getBufferByIndex(i);
+		BufferID id = docBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 
 		if (buf->isDirty())
@@ -1973,18 +1996,20 @@ bool Notepad_plus::fileSaveAll()
 	{
 		if (viewVisible(MAIN_VIEW))
 		{
-			for (size_t i = 0; i < _mainDocTab.nbItem(); ++i)
+			std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+			for (size_t i = 0; i < mainDocBuffers.size(); ++i)
 			{
-				BufferID idToSave = _mainDocTab.getBufferByIndex(i);
+				BufferID idToSave = mainDocBuffers[i];
 				fileSave(idToSave);
 			}
 		}
 
 		if (viewVisible(SUB_VIEW))
 		{
+			std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
 			for (size_t i = 0; i < _subDocTab.nbItem(); ++i)
 			{
-				BufferID idToSave = _subDocTab.getBufferByIndex(i);
+				BufferID idToSave = subDocBuffers[i];
 				fileSave(idToSave);
 			}
 		}
@@ -2384,8 +2409,8 @@ bool Notepad_plus::fileDelete(BufferID id)
 			return false;
 		}
 		bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
-		doClose(bufferID, MAIN_VIEW, isSnapshotMode);
-		doClose(bufferID, SUB_VIEW, isSnapshotMode);
+		doClose(-1, bufferID, MAIN_VIEW, isSnapshotMode);
+		doClose(-1, bufferID, SUB_VIEW, isSnapshotMode);
 
 		scnN.nmhdr.code = NPPN_FILEDELETED;
 		_pluginsManager.notify(&scnN);

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -849,10 +849,10 @@ bool Notepad_plus::doSave(BufferID id, const wchar_t * filename, bool isCopy)
 	return res == SavingStatus::SaveOK;
 }
 
-void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
+void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool lazy)
 {
 	DocTabView *tabToClose = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
-	int i = tabToClose->getIndexByBuffer(id);
+	int i = lazy ? -2 : tabToClose->getIndexByBuffer(id);
 	if (i == -1)
 		return;
 
@@ -916,7 +916,7 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup)
 	}
 
 	//Do all the works
-	bool isBufRemoved = removeBufferFromView(id, whichOne);
+	bool isBufRemoved = removeBufferFromView(id, whichOne, lazy);
 	BufferID hiddenBufferID = BUFFER_INVALID;
 	if (nbDocs == 1 && canHideView(whichOne))
 	{	//close the view if both visible
@@ -1203,6 +1203,8 @@ void Notepad_plus::unPinnedForAllBuffers()
 
 bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 {
+	_DeferRedrawHelper defer(this);
+
 	bool noSaveToAll = false;
 	bool saveToAll = false;
 
@@ -1387,20 +1389,23 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 		activateBuffer(_pNonDocTab->getBufferByIndex(0), otherView());
 		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), otherView(), doDeleteBackup);
+			doClose(_pNonDocTab->getBufferByIndex(i), otherView(), doDeleteBackup, true);
 		}
     }
 
 	activateBuffer(_pDocTab->getBufferByIndex(0), currentView());
 	for (auto i = static_cast<int>(_pDocTab->nbItem()) - 1; i >= 0; --i)
 	{	//close all from right to left
-		doClose(_pDocTab->getBufferByIndex(i), currentView(), doDeleteBackup);
+		doClose(_pDocTab->getBufferByIndex(i), currentView(), doDeleteBackup, true);
 	}
+
 	return true;
 }
 
 bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfos)
 {
+	_DeferRedrawHelper defer(this);
+
 	// First check if we need to save any file.
 
 	bool noSaveToAll = false;
@@ -1478,7 +1483,7 @@ bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfo
 	bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 	for (const auto& i : buffersToClose)
 	{
-		doClose(i._bufID, i._iView, isSnapshotMode);
+		doClose(i._bufID, i._iView, isSnapshotMode, true);
 	}
 
 	return true;
@@ -1565,6 +1570,8 @@ bool Notepad_plus::fileCloseAllUnchanged()
 
 bool Notepad_plus::fileCloseAllButCurrent()
 {
+	_DeferRedrawHelper defer(this);
+
 	BufferID current = _pEditView->getCurrentBufferID();
 	const int activeViewID = currentView();
 	int active = _pDocTab->getCurrentTabIndex();
@@ -1736,7 +1743,7 @@ bool Notepad_plus::fileCloseAllButCurrent()
 
 		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
+			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode, true);
 		}
     }
 
@@ -2424,7 +2431,8 @@ void Notepad_plus::fileNew()
 	BufferID newBufID = MainFileManager.newEmptyDocument();
 	if (newBufID != BUFFER_INVALID)
 	{
-		loadBufferIntoView(newBufID, currentView(), true); // true, because we want multiple new files if possible
+		bool dontClose = true;
+		loadBufferIntoView(newBufID, currentView(), &dontClose); // true, because we want multiple new files if possible
 		switchToFile(newBufID);
 	}
 }
@@ -2512,6 +2520,8 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 
 	int mainIndex2Update = -1;
 
+	std::optional defer = _DeferRedrawHelper(this);
+
 	// no session
 	if (!session.nbMainFiles() && !session.nbSubFiles())
 	{
@@ -2523,6 +2533,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 		return true;
 	}
 
+	bool dontCloseDefaultView = false;
 	for (size_t i = 0; i < session.nbMainFiles() ; )
 	{
 		const wchar_t *pFn = session._mainViewFiles[i]._fileName.c_str();
@@ -2541,22 +2552,13 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			isWow64Off = true;
 		}
 #endif
-		if (doesFileExist(pFn))
-		{
-			if (isSnapshotMode && !session._mainViewFiles[i]._backupFilePath.empty())
-				lastOpened = doOpen(pFn, false, false, session._mainViewFiles[i]._encoding, session._mainViewFiles[i]._backupFilePath.c_str(), session._mainViewFiles[i]._originalFileLastModifTimestamp);
-			else
-				lastOpened = doOpen(pFn, false, false, session._mainViewFiles[i]._encoding);
-		}
-		else if (isSnapshotMode && doesFileExist(session._mainViewFiles[i]._backupFilePath.c_str()))
+		if (isSnapshotMode && doesFileExist(session._mainViewFiles[i]._backupFilePath.c_str()))
 		{
 			lastOpened = doOpen(pFn, false, false, session._mainViewFiles[i]._encoding, session._mainViewFiles[i]._backupFilePath.c_str(), session._mainViewFiles[i]._originalFileLastModifTimestamp);
 		}
 		else
 		{
-			BufferID foundBufID = MainFileManager.getBufferFromName(pFn);
-			if (foundBufID == BUFFER_INVALID)
-				lastOpened = nppGUI._keepSessionAbsentFileEntries ? MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName) : BUFFER_INVALID;
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)
@@ -2628,20 +2630,28 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 
 			_mainDocTab.setIndividualTabColour(lastOpened, session._mainViewFiles[i]._individualTabColour);
 
-			//Force in the document so we can add the markers
-			//Don't use default methods because of performance
-			Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
-			unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
-			for (size_t j = 0, len = session._mainViewFiles[i]._marks.size(); j < len ; ++j)
+			if (buf->getStatus() != DOC_LAZYLOAD)
 			{
-				_mainEditView.execute(SCI_MARKERADD, session._mainViewFiles[i]._marks[j], MARK_BOOKMARK);
+				//Force in the document so we can add the markers
+				//Don't use default methods because of performance
+				Document prevDoc = _mainEditView.execute(SCI_GETDOCPOINTER);
+				unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_mainEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				for (size_t j = 0, len = session._mainViewFiles[i]._marks.size(); j < len; ++j)
+				{
+					_mainEditView.execute(SCI_MARKERADD, session._mainViewFiles[i]._marks[j], MARK_BOOKMARK);
+				}
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+				_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			}
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_mainEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_mainEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			else
+			{
+				_mainViewLazyMarks.emplace(lastOpened, std::move(session._mainViewFiles[i]._marks));
+			}
+
 			++i;
 		}
 		else
@@ -2684,7 +2694,8 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			isWow64Off = true;
 		}
 #endif
-		if (doesFileExist(pFn) || (isSnapshotMode && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str())))
+		//if (doesFileExist(pFn) || (isSnapshotMode && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str())))
+		if (isSnapshotMode && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str()))
 		{
 			//check if already open in main. If so, clone
 			BufferID clonedBuf = BUFFER_INVALID;
@@ -2700,15 +2711,15 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			{
 				if (isSnapshotMode && !session._subViewFiles[k]._backupFilePath.empty())
 					lastOpened = doOpen(pFn, false, false, session._subViewFiles[k]._encoding, session._subViewFiles[k]._backupFilePath.c_str(), session._subViewFiles[k]._originalFileLastModifTimestamp);
-				else
+				else if (doesFileExist(pFn))
 					lastOpened = doOpen(pFn, false, false, session._subViewFiles[k]._encoding);
+				else
+					lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 			}
 		}
 		else
 		{
-			BufferID foundBufID = MainFileManager.getBufferFromName(pFn);
-			if (foundBufID == BUFFER_INVALID)
-				lastOpened = nppGUI._keepSessionAbsentFileEntries ? MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName) : BUFFER_INVALID;
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)
@@ -2754,11 +2765,11 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 					pLn = L"";	//default user defined
 				}
 			}
+
 			buf->setLangType(typeToSet, pLn);
 			buf->setEncoding(session._subViewFiles[k]._encoding);
 			buf->setUserReadOnly(session._subViewFiles[k]._isUserReadOnly || nppGUI._isFullReadOnly || nppGUI._isFullReadOnlySavingForbidden);
 			buf->setPinned(session._subViewFiles[k]._isPinned);
-
 			buf->setUntitledTabRenamedStatus(session._subViewFiles[k]._isUntitledTabRenamed);
 
 			if (isSnapshotMode && !session._subViewFiles[k]._backupFilePath.empty() && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str()))
@@ -2768,20 +2779,27 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 
 			_subDocTab.setIndividualTabColour(lastOpened, session._subViewFiles[k]._individualTabColour);
 
-			//Force in the document so we can add the markers
-			//Don't use default methods because of performance
-			Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
-			unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
-			for (size_t j = 0, len = session._subViewFiles[k]._marks.size(); j < len ; ++j)
+			if (buf->getStatus() != DOC_LAZYLOAD)
 			{
-				_subEditView.execute(SCI_MARKERADD, session._subViewFiles[k]._marks[j], MARK_BOOKMARK);
+				//Force in the document so we can add the markers
+				//Don't use default methods because of performance
+				Document prevDoc = _subEditView.execute(SCI_GETDOCPOINTER);
+				unsigned long MODEVENTMASK_ON = nppParam.getScintillaModEventMask();
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_subEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+				for (size_t j = 0, len = session._subViewFiles[k]._marks.size(); j < len; ++j)
+				{
+					_subEditView.execute(SCI_MARKERADD, session._subViewFiles[k]._marks[j], MARK_BOOKMARK);
+				}
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
+				_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
+				_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
 			}
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
-			_subEditView.execute(SCI_SETDOCPOINTER, 0, prevDoc);
-			_subEditView.execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+			else
+			{
+				_subViewLazyMarks.emplace(lastOpened, std::move(session._subViewFiles[k]._marks));
+			}
 
 			++k;
 		}
@@ -2792,6 +2810,9 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			allSessionFilesLoaded = false;
 		}
 	}
+
+	defer.reset();
+
 	if (subIndex2Update != -1)
 	{
 		_isFolding = true;

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -849,10 +849,10 @@ bool Notepad_plus::doSave(BufferID id, const wchar_t * filename, bool isCopy)
 	return res == SavingStatus::SaveOK;
 }
 
-void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool closing)
+void Notepad_plus::doClose(int index, BufferID id, int whichOne, bool doDeleteBackup)
 {
 	DocTabView *tabToClose = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
-	int i = closing ? -2 : tabToClose->getIndexByBuffer(id);
+	int i = index != -1 ? index : tabToClose->getIndexByBuffer(id);
 	if (i == -1)
 		return;
 
@@ -916,7 +916,7 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool 
 	}
 
 	//Do all the works
-	bool isBufRemoved = removeBufferFromView(id, whichOne, closing);
+	bool isBufRemoved = removeBufferFromView(index, id, whichOne);
 	BufferID hiddenBufferID = BUFFER_INVALID;
 	if (nbDocs == 1 && canHideView(whichOne))
 	{	//close the view if both visible
@@ -1180,22 +1180,25 @@ bool Notepad_plus::fileClose(BufferID id, int curView)
 	if (isSnapshotMode && isCloned) // if Buffer is cloned then we don't delete backup file
 		doDeleteBackup = false;
 
-	doClose(bufferID, viewToClose, doDeleteBackup);
+	doClose(-1, bufferID, viewToClose, doDeleteBackup);
 	return true;
 }
 
 void Notepad_plus::unPinnedForAllBuffers()
 {
-	for (size_t i = 0; i < _mainDocTab.nbItem(); ++i)
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+
+	for (size_t i = 0; i < mainDocBuffers.size(); ++i)
 	{
-		BufferID id = _mainDocTab.getBufferByIndex(i);
+		BufferID id = mainDocBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		buf->setPinned(false);
 	}
 
-	for (size_t i = 0; i < _subDocTab.nbItem(); ++i)
+	for (size_t i = 0; i < subDocBuffers.size(); ++i)
 	{
-		BufferID id = _subDocTab.getBufferByIndex(i);
+		BufferID id = subDocBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		buf->setPinned(false);
 	}
@@ -1214,9 +1217,12 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 	//check in the both view
 	std::unordered_set<BufferID> uniqueBuffers;
 
-	for (size_t i = 0; i < _mainDocTab.nbItem() && !noSaveToAll; ++i)
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+
+	for (size_t i = 0; i < mainDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _mainDocTab.getBufferByIndex(i);
+		BufferID id = mainDocBuffers[i];
 		Buffer * buf = MainFileManager.getBufferByID(id);
 
 		// Put all the BufferID from main view to hash table
@@ -1298,9 +1304,9 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 		}
 	}
 
-	for (size_t i = 0; i < _subDocTab.nbItem() && !noSaveToAll; ++i)
+	for (size_t i = 0; i < subDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _subDocTab.getBufferByIndex(i);
+		BufferID id = subDocBuffers[i];
 		Buffer * buf = MainFileManager.getBufferByID(id);
 
 		// Is this buffer already included?
@@ -1384,19 +1390,27 @@ bool Notepad_plus::fileCloseAll(bool doDeleteBackup, bool isSnapshotMode)
 	//Then start closing, inactive view first so the active is left open
     if (bothActive())
     {
-		//first close all docs in non-current view, which gets closed automatically
-		//Set active tab to the last one closed.
-		activateBuffer(_pNonDocTab->getBufferByIndex(0), otherView());
-		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
+		std::vector<BufferID> nonDocBuffers = _pNonDocTab->getBuffersByIndex();
+		if (!nonDocBuffers.empty())
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), otherView(), doDeleteBackup, true);
+			//first close all docs in non-current view, which gets closed automatically
+			//Set active tab to the last one closed.
+			activateBuffer(nonDocBuffers[0], otherView());
+			for (auto i = static_cast<int>(nonDocBuffers.size()) - 1; i >= 0; --i) //close all from right to left
+			{
+				doClose(i, nonDocBuffers[i], otherView(), doDeleteBackup);
+			}
 		}
     }
 
-	activateBuffer(_pDocTab->getBufferByIndex(0), currentView());
-	for (auto i = static_cast<int>(_pDocTab->nbItem()) - 1; i >= 0; --i)
-	{	//close all from right to left
-		doClose(_pDocTab->getBufferByIndex(i), currentView(), doDeleteBackup, true);
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
+	if (!docBuffers.empty())
+	{
+		activateBuffer(docBuffers[0], currentView());
+		for (auto i = static_cast<int>(docBuffers.size()) - 1; i >= 0; --i)
+		{	//close all from right to left
+			doClose(i, docBuffers[i], currentView(), doDeleteBackup);
+		}
 	}
 
 	return true;
@@ -1483,7 +1497,7 @@ bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfo
 	bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 	for (const auto& i : buffersToClose)
 	{
-		doClose(i._bufID, i._iView, isSnapshotMode);
+		doClose(-1, i._bufID, i._iView, isSnapshotMode);
 	}
 
 	return true;
@@ -1506,10 +1520,11 @@ bool Notepad_plus::fileCloseAllToRight()
 	// Indexes must go from high to low to deal with the fact that when one index is closed, any remaining
 	// indexes (smaller than the one just closed) will point to the wrong tab.
 	const int iActive = _pDocTab->getCurrentTabIndex();
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
 	std::vector<BufferViewInfo> bufsToClose;
-	for (int i = int(_pDocTab->nbItem()) - 1; i > iActive; i--)
+	for (int i = int(docBuffers.size()) - 1; i > iActive; i--)
 	{
-		bufsToClose.push_back(BufferViewInfo(_pDocTab->getBufferByIndex(i), currentView()));
+		bufsToClose.push_back(BufferViewInfo(docBuffers[i], currentView()));
 	}
 	return fileCloseAllGiven(bufsToClose);
 }
@@ -1517,33 +1532,25 @@ bool Notepad_plus::fileCloseAllToRight()
 void Notepad_plus::fileCloseAllButPinned()
 {
 	std::vector<BufferViewInfo> bufsToClose;
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
 
 	int iPinned = -1;
-	for (int j = 0; j < int(_mainDocTab.nbItem()); ++j)
+	for (int j = 0; j < int(mainDocBuffers.size()); ++j)
 	{
-		if (_mainDocTab.getBufferByIndex(j)->isPinned())
-			iPinned++;
+		if (mainDocBuffers[j]->isPinned())
+			bufsToClose.push_back(BufferViewInfo(mainDocBuffers[j], MAIN_VIEW));
 		else
 			break;
 	}
 	
-	for (int i = int(_mainDocTab.nbItem()) - 1; i > iPinned; i--)
-	{
-		bufsToClose.push_back(BufferViewInfo(_mainDocTab.getBufferByIndex(i), MAIN_VIEW));
-	}
-
-
 	iPinned = -1;
-	for (int j = 0; j < int(_subDocTab.nbItem()); ++j)
+	for (int j = 0; j < int(subDocBuffers.size()); ++j)
 	{
-		if (_subDocTab.getBufferByIndex(j)->isPinned())
-			iPinned++;
+		if (subDocBuffers[j]->isPinned())
+			bufsToClose.push_back(BufferViewInfo(subDocBuffers[j], SUB_VIEW));
 		else
 			break;
-	}
-	for (int i = int(_subDocTab.nbItem()) - 1; i > iPinned; i--)
-	{
-		bufsToClose.push_back(BufferViewInfo(_subDocTab.getBufferByIndex(i), SUB_VIEW));
 	}
 	
 	fileCloseAllGiven(bufsToClose);
@@ -1554,14 +1561,15 @@ bool Notepad_plus::fileCloseAllUnchanged()
 	// Indexes must go from high to low to deal with the fact that when one index is closed, any remaining
 	// indexes (smaller than the one just closed) will point to the wrong tab.
 	std::vector<BufferViewInfo> bufsToClose;
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
 
-	for (int i = int(_pDocTab->nbItem()) - 1; i >= 0; i--)
+	for (int i = int(docBuffers.size()) - 1; i >= 0; i--)
 	{
-		BufferID id = _pDocTab->getBufferByIndex(i);
+		BufferID id = docBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		if ((buf->isUntitled() && buf->docLength() == 0) || !buf->isDirty())
 		{
-			bufsToClose.push_back(BufferViewInfo(_pDocTab->getBufferByIndex(i), currentView()));
+			bufsToClose.push_back(BufferViewInfo(id, currentView()));
 		}
 	}
 
@@ -1583,10 +1591,13 @@ bool Notepad_plus::fileCloseAllButCurrent()
 
 	//closes all documents, makes the current view the only one visible
 
+	std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+	std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
+
 	//first check if we need to save any file
-	for (size_t i = 0; i < _mainDocTab.nbItem() && !noSaveToAll; ++i)
+	for (size_t i = 0; i < mainDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _mainDocTab.getBufferByIndex(i);
+		BufferID id = mainDocBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 		if (id == current)
 			continue;
@@ -1646,7 +1657,7 @@ bool Notepad_plus::fileCloseAllButCurrent()
 			{
 				for (auto j = static_cast<int>(mainSaveOpIndex.size()) - 1; j >= 0; --j) //close all from right to left
 				{
-					doClose(_mainDocTab.getBufferByIndex(mainSaveOpIndex[j]), MAIN_VIEW, isSnapshotMode);
+					doClose(j, mainDocBuffers[mainSaveOpIndex[j]], MAIN_VIEW, isSnapshotMode);
 				}
 
 				return false;
@@ -1655,9 +1666,9 @@ bool Notepad_plus::fileCloseAllButCurrent()
 		}
 	}
 
-	for (size_t i = 0; i < _subDocTab.nbItem() && !noSaveToAll; ++i)
+	for (size_t i = 0; i < subDocBuffers.size() && !noSaveToAll; ++i)
 	{
-		BufferID id = _subDocTab.getBufferByIndex(i);
+		BufferID id = subDocBuffers[i];
 		Buffer * buf = MainFileManager.getBufferByID(id);
 		if (id == current)
 			continue;
@@ -1717,13 +1728,14 @@ bool Notepad_plus::fileCloseAllButCurrent()
 			{
 				for (auto j = static_cast<int>(mainSaveOpIndex.size()) - 1; j >= 0; --j) //close all from right to left
 				{
-					doClose(_mainDocTab.getBufferByIndex(mainSaveOpIndex[j]), MAIN_VIEW, isSnapshotMode);
+					doClose(j, mainDocBuffers[mainSaveOpIndex[j]], MAIN_VIEW, isSnapshotMode);
 				}
 
 				for (auto j = static_cast<int>(subSaveOpIndex.size()) - 1; j >= 0; --j) //close all from right to left
 				{
-					doClose(_subDocTab.getBufferByIndex(subSaveOpIndex[j]), SUB_VIEW, isSnapshotMode);
+					doClose(j, subDocBuffers[subSaveOpIndex[j]], SUB_VIEW, isSnapshotMode);
 				}
+
 				return false;
 			}
 
@@ -1736,39 +1748,49 @@ bool Notepad_plus::fileCloseAllButCurrent()
 	//Then start closing, inactive view first so the active is left open
     if (bothActive())
     {
-		//first close all docs in non-current view, which gets closed automatically
-		//Set active tab to the last one closed.
-		const int viewNo = otherView();
-		activateBuffer(_pNonDocTab->getBufferByIndex(0), viewNo);
-
-		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
+		std::vector<BufferID> nonDocBuffers = _pNonDocTab->getBuffersByIndex();
+		if (!nonDocBuffers.empty())
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
+			//first close all docs in non-current view, which gets closed automatically
+			//Set active tab to the last one closed.
+			const int viewNo = otherView();
+			activateBuffer(nonDocBuffers[0], viewNo);
+
+			for (auto i = static_cast<int>(nonDocBuffers.size()) - 1; i >= 0; --i) //close all from right to left
+			{
+				doClose(i, nonDocBuffers[i], viewNo, isSnapshotMode);
+			}
 		}
     }
 
-	const int viewNo = currentView();
-	size_t nbItems = _pDocTab->nbItem();
-	activateBuffer(_pDocTab->getBufferByIndex(0), viewNo);
-	
-	// After activateBuffer() call, if file is deleted, user will decide to keep or not the tab
-	// So here we check if the 1st tab is closed or not
-	size_t newNbItems = _pDocTab->nbItem();
-
-	if (nbItems > newNbItems) // the 1st tab has been removed
+	std::vector<BufferID> docBuffers = _pDocTab->getBuffersByIndex();
+	if (!docBuffers.empty())
 	{
-		// active tab move 1 position forward
-		active -= 1;
-	}
+		const int viewNo = currentView();
+		size_t nbItems = docBuffers.size();
+		activateBuffer(docBuffers[0], viewNo);
 
-	for (auto i = static_cast<int>(newNbItems) - 1; i >= 0; --i) //close all from right to left
-	{
-		if (i == active)	//don't close active index
+		// After activateBuffer() call, if file is deleted, user will decide to keep or not the tab
+		// So here we check if the 1st tab is closed or not
+		size_t newNbItems = _pDocTab->nbItem();
+
+		if (nbItems > newNbItems) // the 1st tab has been removed
 		{
-			continue;
+			// active tab move 1 position forward
+			active -= 1;
+			docBuffers.erase(docBuffers.begin());
 		}
-		doClose(_pDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
+
+		for (auto i = static_cast<int>(docBuffers.size()) - 1; i >= 0; --i) //close all from right to left
+		{
+			if (i == active)	//don't close active index
+			{
+				continue;
+			}
+			doClose(i, docBuffers[i], viewNo, isSnapshotMode);
+		}
 	}
+
 	return true;
 }
 
@@ -1948,10 +1970,11 @@ size_t Notepad_plus::getNbDirtyBuffer(int view)
 	if (view == SUB_VIEW)
 		pDocTabView = &_subDocTab;
 
+	std::vector<BufferID> docBuffers = pDocTabView->getBuffersByIndex();
 	size_t count = 0;
-	for (size_t i = 0; i < pDocTabView->nbItem(); ++i)
+	for (size_t i = 0; i < docBuffers.size(); ++i)
 	{
-		BufferID id = pDocTabView->getBufferByIndex(i);
+		BufferID id = docBuffers[i];
 		Buffer* buf = MainFileManager.getBufferByID(id);
 
 		if (buf->isDirty())
@@ -1978,18 +2001,20 @@ bool Notepad_plus::fileSaveAll()
 	{
 		if (viewVisible(MAIN_VIEW))
 		{
-			for (size_t i = 0; i < _mainDocTab.nbItem(); ++i)
+			std::vector<BufferID> mainDocBuffers = _mainDocTab.getBuffersByIndex();
+			for (size_t i = 0; i < mainDocBuffers.size(); ++i)
 			{
-				BufferID idToSave = _mainDocTab.getBufferByIndex(i);
+				BufferID idToSave = mainDocBuffers[i];
 				fileSave(idToSave);
 			}
 		}
 
 		if (viewVisible(SUB_VIEW))
 		{
+			std::vector<BufferID> subDocBuffers = _subDocTab.getBuffersByIndex();
 			for (size_t i = 0; i < _subDocTab.nbItem(); ++i)
 			{
-				BufferID idToSave = _subDocTab.getBufferByIndex(i);
+				BufferID idToSave = subDocBuffers[i];
 				fileSave(idToSave);
 			}
 		}
@@ -2389,8 +2414,8 @@ bool Notepad_plus::fileDelete(BufferID id)
 			return false;
 		}
 		bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
-		doClose(bufferID, MAIN_VIEW, isSnapshotMode);
-		doClose(bufferID, SUB_VIEW, isSnapshotMode);
+		doClose(-1, bufferID, MAIN_VIEW, isSnapshotMode);
+		doClose(-1, bufferID, SUB_VIEW, isSnapshotMode);
 
 		scnN.nmhdr.code = NPPN_FILEDELETED;
 		_pluginsManager.notify(&scnN);

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2583,7 +2583,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 		}
 		else
 		{
-			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)
@@ -2739,12 +2739,12 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 				else if (doesFileExist(pFn))
 					lastOpened = doOpen(pFn, false, false, session._subViewFiles[k]._encoding);
 				else
-					lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
+					lastOpened = MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 			}
 		}
 		else
 		{
-			lastOpened = MainFileManager.newPlaceholderDocument(pFn, SUB_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
+			lastOpened = MainFileManager.newPlaceholderDocument(pFn, MAIN_VIEW, userCreatedSessionName, true, &dontCloseDefaultView);
 		}
 #ifndef	_WIN64
 		if (isWow64Off)

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -849,10 +849,10 @@ bool Notepad_plus::doSave(BufferID id, const wchar_t * filename, bool isCopy)
 	return res == SavingStatus::SaveOK;
 }
 
-void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool lazy)
+void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool closing)
 {
 	DocTabView *tabToClose = (whichOne == MAIN_VIEW)?&_mainDocTab:&_subDocTab;
-	int i = lazy ? -2 : tabToClose->getIndexByBuffer(id);
+	int i = closing ? -2 : tabToClose->getIndexByBuffer(id);
 	if (i == -1)
 		return;
 
@@ -916,7 +916,7 @@ void Notepad_plus::doClose(BufferID id, int whichOne, bool doDeleteBackup, bool 
 	}
 
 	//Do all the works
-	bool isBufRemoved = removeBufferFromView(id, whichOne, lazy);
+	bool isBufRemoved = removeBufferFromView(id, whichOne, closing);
 	BufferID hiddenBufferID = BUFFER_INVALID;
 	if (nbDocs == 1 && canHideView(whichOne))
 	{	//close the view if both visible
@@ -1483,7 +1483,7 @@ bool Notepad_plus::fileCloseAllGiven(const std::vector<BufferViewInfo>& fileInfo
 	bool isSnapshotMode = NppParameters::getInstance().getNppGUI().isSnapshotMode();
 	for (const auto& i : buffersToClose)
 	{
-		doClose(i._bufID, i._iView, isSnapshotMode, true);
+		doClose(i._bufID, i._iView, isSnapshotMode);
 	}
 
 	return true;
@@ -1743,7 +1743,7 @@ bool Notepad_plus::fileCloseAllButCurrent()
 
 		for (auto i = static_cast<int>(_pNonDocTab->nbItem()) - 1; i >= 0; --i) //close all from right to left
 		{
-			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode, true);
+			doClose(_pNonDocTab->getBufferByIndex(i), viewNo, isSnapshotMode);
 		}
     }
 
@@ -2649,7 +2649,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			}
 			else
 			{
-				_mainViewLazyMarks.emplace(lastOpened, std::move(session._mainViewFiles[i]._marks));
+				_mainViewLazyMarks.emplace(lastOpened, session._mainViewFiles[i]._marks);
 			}
 
 			++i;
@@ -2798,7 +2798,7 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 			}
 			else
 			{
-				_subViewLazyMarks.emplace(lastOpened, std::move(session._subViewFiles[k]._marks));
+				_subViewLazyMarks.emplace(lastOpened, session._subViewFiles[k]._marks);
 			}
 
 			++k;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -132,8 +132,20 @@ Buffer::Buffer(FileManager * pManager, BufferID id, Document doc, DocFileStatus 
 
 void Buffer::doNotify(int mask)
 {
+	if (_currentStatus == DOC_LAZYLOAD)
+	{
+		_loadNotifyMask |= mask;
+		return;
+	}
+
 	if (_canNotify)
 	{
+		if (_loadNotifyMask)
+		{
+			mask |= _loadNotifyMask;
+			_loadNotifyMask = 0;
+		}
+
 		assert(_pManager != nullptr);
 		_pManager->beNotifiedOfBufferChange(this, mask);
 	}
@@ -274,7 +286,7 @@ void Buffer::updateTimeStamp()
 
 // Set full path file name in buffer object,
 // and determine its language by its extension.
-void Buffer::setFileName(const wchar_t *fn)
+void Buffer::setFileName(const wchar_t *fn, bool lazy)
 {
 	NppParameters& nppParamInst = NppParameters::getInstance();
 	if (_fullPathName == fn)
@@ -300,6 +312,12 @@ void Buffer::setFileName(const wchar_t *fn)
 			// compacting failed, use the original instead
 			_compactFileName = _fileName;
 		}
+	}
+
+	if (lazy)
+	{
+		doNotify(BufferChangeFilename);
+		return;
 	}
 
 	_isFromNetwork = PathIsNetworkPath(fn);
@@ -485,7 +503,7 @@ bool Buffer::checkFileState() // returns true if the status has been changed (it
 	}
 
 	bool isOK = false;
-	if (_currentStatus == DOC_INACCESSIBLE && !fileExists)	//document is absent on its first load - we set readonly and not dirty, and make it be as document which has been deleted
+	if ((_currentStatus == DOC_INACCESSIBLE || _currentStatus == DOC_LAZYLOAD) && !fileExists)	//document is absent on its first load - we set readonly and not dirty, and make it be as document which has been deleted
 	{
 		_currentStatus = DOC_DELETED;//DOC_INACCESSIBLE;
 		_isInaccessible = true;
@@ -493,6 +511,10 @@ bool Buffer::checkFileState() // returns true if the status has been changed (it
 		_isDirty = false;
 		_timeStamp = {};
 		doNotify(BufferChangeStatus | BufferChangeReadonly | BufferChangeTimestamp);
+		isOK = true;
+	}
+	else if (_currentStatus == DOC_LAZYLOAD && fileExists)
+	{
 		isOK = true;
 	}
 	else if (_currentStatus != DOC_DELETED && !fileExists)	//document has been deleted
@@ -777,7 +799,6 @@ void Buffer::setHideLineChanged(bool isHide, size_t location)
 	}
 }
 
-
 void Buffer::setDeferredReload() // triggers a reload on the next Document access
 {
 	_isDirty = false;	//when reloading, just set to false, since it should be marked as clean
@@ -918,7 +939,6 @@ void FileManager::closeBuffer(BufferID id, const ScintillaEditView* identifier)
 		_nbBufs--;
 	}
 }
-
 
 // backupFileName is sentinel of backup mode: if it's not NULL, then we use it (load it). Otherwise we use filename
 BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encoding, const wchar_t* backupFileName, FILETIME fileNameTimestamp)
@@ -1705,11 +1725,11 @@ BufferID FileManager::newEmptyDocument()
 	return id;
 }
 
-BufferID FileManager::newPlaceholderDocument(const wchar_t* missingFilename, int whichOne, const wchar_t* userCreatedSessionName)
+BufferID FileManager::newPlaceholderDocument(const wchar_t* missingFilename, int whichOne, const wchar_t* userCreatedSessionName, bool lazyLoaded, bool* pDontClose)
 {
 	NppParameters& nppParamInst = NppParameters::getInstance();
 
-	if (!nppParamInst.theWarningHasBeenGiven())
+	if (!lazyLoaded && !nppParamInst.theWarningHasBeenGiven())
 	{
 		int res = 0;
 		if (userCreatedSessionName)
@@ -1737,16 +1757,26 @@ BufferID FileManager::newPlaceholderDocument(const wchar_t* missingFilename, int
 		nppParamInst.setPlaceHolderEnable(res == IDYES);
 	}
 
-	if (!nppParamInst.isPlaceHolderEnabled())
+	if (!lazyLoaded && !nppParamInst.isPlaceHolderEnabled())
 		return BUFFER_INVALID;
 
 	BufferID buf = MainFileManager.newEmptyDocument();
 	if (buf == BUFFER_INVALID)
 		return BUFFER_INVALID;
 
-	_pNotepadPlus->loadBufferIntoView(buf, whichOne);
-	buf->setFileName(missingFilename);
-	buf->_currentStatus = DOC_INACCESSIBLE;
+	if (lazyLoaded)
+	{
+		buf->_currentStatus = DOC_LAZYLOAD;
+		buf->setFileName(missingFilename, true);
+		_pNotepadPlus->loadBufferIntoView(buf, whichOne, pDontClose, true);
+		buf->_needReloading = true;
+	}
+	else
+	{
+		_pNotepadPlus->loadBufferIntoView(buf, whichOne, pDontClose);
+		buf->setFileName(missingFilename, false);
+		buf->_currentStatus = DOC_INACCESSIBLE;
+	}
 
 	return buf;
 }

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -1135,6 +1135,16 @@ bool FileManager::reloadBuffer(BufferID id)
 		buf->setSavePointDirty(false);
 
 		setLoadedBufferEncodingAndEol(buf, unicodeConvertor, loadedFileFormat._encoding, loadedFileFormat._eolFormat);
+
+		if (buf->getStatus() == DOC_LAZYLOAD)
+		{
+			buf->setStatus(DOC_REGULAR);
+			buf->updateTimeStamp();
+		}
+	}
+	else if (buf->getStatus() == DOC_LAZYLOAD)
+	{
+		buf->setStatus(DOC_INACCESSIBLE);
 	}
 
 	return res;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -505,7 +505,7 @@ bool Buffer::checkFileState() // returns true if the status has been changed (it
 	bool isOK = false;
 	if ((_currentStatus == DOC_INACCESSIBLE || _currentStatus == DOC_LAZYLOAD) && !fileExists)	//document is absent on its first load - we set readonly and not dirty, and make it be as document which has been deleted
 	{
-		_currentStatus = DOC_DELETED;//DOC_INACCESSIBLE;
+		_currentStatus = _currentStatus == DOC_LAZYLOAD ? DOC_INACCESSIBLE : DOC_DELETED;
 		_isInaccessible = true;
 		_isFileReadOnly = true;
 		_isDirty = false;

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -33,7 +33,8 @@ enum DocFileStatus {
 	DOC_DELETED      = 0x04, // doesn't exist in environment anymore, but not DOC_UNNAMED
 	DOC_MODIFIED     = 0x08, // File in environment has changed
 	DOC_NEEDRELOAD   = 0x10, // File is modified & needed to be reload (by log monitoring)
-	DOC_INACCESSIBLE = 0x20  // File is absent on its load; this status is temporay for setting file not dirty & readonly; and it will be replaced to DOC_DELETED
+	DOC_INACCESSIBLE = 0x20, // File is absent on its load; this status is temporay for setting file not dirty & readonly; and it will be replaced to DOC_DELETED
+	DOC_LAZYLOAD     = 0x21
 };
 
 enum BufferStatusInfo {
@@ -91,7 +92,7 @@ public:
 	BufferID loadFile(const wchar_t * filename, Document doc = static_cast<Document>(NULL), int encoding = -1, const wchar_t *backupFileName = nullptr, FILETIME fileNameTimestamp = {});	//ID == BUFFER_INVALID on failure. If Doc == NULL, a new file is created, otherwise data is loaded in given document
 	BufferID newEmptyDocument();
 	// create an empty placeholder for a missing file when loading session
-	BufferID newPlaceholderDocument(const wchar_t * missingFilename, int whichOne, const wchar_t* userCreatedSessionName);
+	BufferID newPlaceholderDocument(const wchar_t * missingFilename, int whichOne, const wchar_t* userCreatedSessionName, bool lazyLoaded, bool* pDontClose);
 
 	//create Buffer from existing Scintilla, used from new Scintillas.
 	BufferID bufferFromDocument(Document doc, bool isMainEditZone);
@@ -172,7 +173,7 @@ public:
 	// this method 1. copies the file name
 	//             2. determines the language from the ext of file name
 	//             3. gets the last modified time
-	void setFileName(const wchar_t *fn);
+	void setFileName(const wchar_t *fn, bool lazy = false);
 
 	const wchar_t * getFullPathName() const { return _fullPathName.c_str(); }
 
@@ -485,4 +486,6 @@ private:
 
 	bool _isRTL = false;
 	bool _isPinned = false;
+
+	int _loadNotifyMask = 0;
 };

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -34,7 +34,7 @@ enum DocFileStatus {
 	DOC_MODIFIED     = 0x08, // File in environment has changed
 	DOC_NEEDRELOAD   = 0x10, // File is modified & needed to be reload (by log monitoring)
 	DOC_INACCESSIBLE = 0x20, // File is absent on its load; this status is temporay for setting file not dirty & readonly; and it will be replaced to DOC_DELETED
-	DOC_LAZYLOAD     = 0x21
+	DOC_LAZYLOAD     = 0x40  // File is present but not loaded, instead it is only loaded once active ( will affect operations requiring the buffer like search )
 };
 
 enum BufferStatusInfo {
@@ -121,8 +121,7 @@ public:
 	void enableAutoDetectEncoding4Loading() { isAutoDetectEncodingDisabled4Loading = false; }
 	void disableAutoDetectEncoding4Loading() { isAutoDetectEncodingDisabled4Loading = true; } // Disable the encoding auto-detection on loading file while switching among the different encoding.
 	                                                                                          // The value of isAutoDetectEncodingDisabled4Loading will be restored to false after each file loading 
-	                                                                                          // to restore the encoding auto-detection ability for other file loading operations. 
-
+	                                                                                          // to restore the encoding auto-detection ability for other file loading operations.
 private:
 	struct LoadedFileFormat {
 		LoadedFileFormat() = default;
@@ -394,7 +393,6 @@ public:
 
 	bool isPinned() const { return _isPinned; }
 	void setPinned(bool isPinned) { _isPinned = isPinned; }
-
 private:
 	int indexOfReference(const ScintillaEditView * identifier) const;
 

--- a/PowerEditor/src/ScintillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.cpp
@@ -41,6 +41,39 @@ static constexpr int docTabIconIDs[] = { IDI_SAVED_ICON, IDI_UNSAVED_ICON, IDI_R
 static constexpr int docTabIconIDs_darkMode[] = { IDI_SAVED_DM_ICON, IDI_UNSAVED_DM_ICON, IDI_READONLY_DM_ICON, IDI_READONLYSYS_DM_ICON, IDI_MONITORING_DM_ICON };
 static constexpr int docTabIconIDs_alt[] = { IDI_SAVED_ALT_ICON, IDI_UNSAVED_ALT_ICON, IDI_READONLY_ALT_ICON, IDI_READONLYSYS_ALT_ICON, IDI_MONITORING_ICON };
 
+static void encodeTabName(const Buffer* buffer, wchar_t* out, size_t outSize)
+{
+	//This code will read in one character at a time and duplicate every first ampersand(&).
+	//ex. If input is "test & test && test &&&" then output will be "test && test &&& test &&&&".
+	//Tab's caption must be encoded like this because otherwise tab control would make tab too small or too big for the text.
+
+	const wchar_t* in = buffer->getCompactFileName();
+	size_t i = 0;
+
+	while (*in != 0 && i < outSize)
+	{
+		i++;
+		if (*in == '&')
+		{
+			*out++ = '&';
+			*out++ = '&';
+			while (*(++in) == '&')
+				*out++ = '&';
+		}
+		else
+			*out++ = *in++;
+	}
+
+	if (buffer->getStatus() == DOC_LAZYLOAD && i - 4 < outSize)
+	{
+		*(out++) = L'(';
+		*(out++) = L'L';
+		*(out++) = L')';
+	}
+
+	*out = '\0';
+}
+
 void DocTabView::init(HINSTANCE hInst, HWND parent, ScintillaEditView* pView, unsigned char indexChoice, unsigned char buttonsStatus)
 {
 	TabBarPlus::init(hInst, parent, false, false, buttonsStatus);
@@ -77,6 +110,10 @@ void DocTabView::addBuffer(BufferID buffer, bool lazy)
 		return;
 	if (!lazy && getIndexByBuffer(buffer) != -1)	//no duplicates
 		return;
+
+	//We must make space for the added ampersand characters.
+	wchar_t encodedLabel[2 * MAX_PATH] = { '\0' };
+
 	const Buffer* buf = MainFileManager.getBufferByID(buffer);
 	TCITEM tie{};
 	tie.mask = TCIF_TEXT | TCIF_IMAGE | TCIF_PARAM;
@@ -85,8 +122,9 @@ void DocTabView::addBuffer(BufferID buffer, bool lazy)
 	if (_hasImgLst)
 		index = 0;
 	tie.iImage = index;
-	tie.pszText = const_cast<wchar_t*>(buf->getCompactFileName());
+	tie.pszText = encodedLabel;
 	tie.lParam = reinterpret_cast<LPARAM>(buffer);
+	encodeTabName(buffer, encodedLabel, sizeof(encodedLabel) / sizeof(encodedLabel[0]));
 	::SendMessage(_hSelf, TCM_INSERTITEM, _nbItem++, reinterpret_cast<LPARAM>(&tie));
 
 	if (lazy)
@@ -233,27 +271,7 @@ void DocTabView::bufferUpdated(const Buffer* buffer, int mask)
 	{
 		tie.mask |= TCIF_TEXT;
 		tie.pszText = encodedLabel;
-
-		{
-			const wchar_t* in = buffer->getCompactFileName();
-			wchar_t* out = encodedLabel;
-
-			//This code will read in one character at a time and duplicate every first ampersand(&).
-			//ex. If input is "test & test && test &&&" then output will be "test && test &&& test &&&&".
-			//Tab's caption must be encoded like this because otherwise tab control would make tab too small or too big for the text.
-
-			while (*in != 0)
-			if (*in == '&')
-			{
-				*out++ = '&';
-				*out++ = '&';
-				while (*(++in) == '&')
-					*out++ = '&';
-			}
-			else
-				*out++ = *in++;
-			*out = '\0';
-		}
+		encodeTabName(buffer, encodedLabel, sizeof(encodedLabel) / sizeof(encodedLabel[0]));
 	}
 
 	::SendMessage(_hSelf, TCM_SETITEM, index, reinterpret_cast<LPARAM>(&tie));

--- a/PowerEditor/src/ScintillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.cpp
@@ -71,11 +71,11 @@ void DocTabView::createIconSets()
 	_docTabIconListDarkMode.create(iconDpiDynamicalSize, _hInst, docTabIconIDs_darkMode, sizeof(docTabIconIDs_darkMode) / sizeof(int));
 }
 
-void DocTabView::addBuffer(BufferID buffer)
+void DocTabView::addBuffer(BufferID buffer, bool lazy)
 {
 	if (buffer == BUFFER_INVALID)	//valid only
 		return;
-	if (getIndexByBuffer(buffer) != -1)	//no duplicates
+	if (!lazy && getIndexByBuffer(buffer) != -1)	//no duplicates
 		return;
 	const Buffer* buf = MainFileManager.getBufferByID(buffer);
 	TCITEM tie{};
@@ -88,6 +88,10 @@ void DocTabView::addBuffer(BufferID buffer)
 	tie.pszText = const_cast<wchar_t*>(buf->getCompactFileName());
 	tie.lParam = reinterpret_cast<LPARAM>(buffer);
 	::SendMessage(_hSelf, TCM_INSERTITEM, _nbItem++, reinterpret_cast<LPARAM>(&tie));
+
+	if (lazy)
+		return;
+
 	bufferUpdated(buf, BufferChangeMask);
 
 	::SendMessage(_hParent, WM_SIZE, 0, 0);
@@ -244,7 +248,7 @@ void DocTabView::bufferUpdated(const Buffer* buffer, int mask)
 }
 
 
-void DocTabView::setBuffer(size_t index, BufferID id)
+void DocTabView::setBuffer(size_t index, BufferID id, bool lazy)
 {
 	if (index >= _nbItem)
 		return;
@@ -253,6 +257,9 @@ void DocTabView::setBuffer(size_t index, BufferID id)
 	tie.lParam = reinterpret_cast<LPARAM>(id);
 	tie.mask = TCIF_PARAM;
 	::SendMessage(_hSelf, TCM_SETITEM, index, reinterpret_cast<LPARAM>(&tie));
+
+	if (lazy)
+		return;
 
 	bufferUpdated(MainFileManager.getBufferByID(id), BufferChangeMask);	//update tab, everything has changed
 

--- a/PowerEditor/src/ScintillaComponent/DocTabView.cpp
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.cpp
@@ -155,6 +155,23 @@ BufferID DocTabView::findBufferByName(const wchar_t * fullfilename) //-1 if not 
 }
 
 
+
+std::vector<BufferID> DocTabView::getBuffersByIndex()
+{
+	std::vector<BufferID> result(_nbItem);
+
+	TCITEM tie{};
+	tie.lParam = -1;
+	tie.mask = TCIF_PARAM;
+	for (size_t i = 0; i < _nbItem; ++i)
+	{
+		::SendMessage(_hSelf, TCM_GETITEM, i, reinterpret_cast<LPARAM>(&tie));
+		result[i] = reinterpret_cast<BufferID>(tie.lParam);
+	}
+
+	return result;
+}
+
 int DocTabView::getIndexByBuffer(BufferID id)
 {
 	TCITEM tie{};

--- a/PowerEditor/src/ScintillaComponent/DocTabView.h
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.h
@@ -46,7 +46,7 @@ public:
 		TabBar::setImageList(_pIconListVector[_iconListIndexChoice]->getHandle());
 	}
 
-	void addBuffer(BufferID buffer);
+	void addBuffer(BufferID buffer, bool lazy = false);
 	void closeBuffer(BufferID buffer);
 	void bufferUpdated(const Buffer* buffer, int mask);
 
@@ -58,7 +58,7 @@ public:
 	int getIndexByBuffer(BufferID id);
 	BufferID getBufferByIndex(size_t index);
 
-	void setBuffer(size_t index, BufferID id);
+	void setBuffer(size_t index, BufferID id, bool lazy = false);
 
 	void reSizeTo(RECT & rc) override;
 

--- a/PowerEditor/src/ScintillaComponent/DocTabView.h
+++ b/PowerEditor/src/ScintillaComponent/DocTabView.h
@@ -55,6 +55,7 @@ public:
 	BufferID activeBuffer();
 	BufferID findBufferByName(const wchar_t * fullfilename);	//-1 if not found, something else otherwise
 
+	std::vector<BufferID> getBuffersByIndex();
 	int getIndexByBuffer(BufferID id);
 	BufferID getBufferByIndex(size_t index);
 
@@ -89,7 +90,6 @@ public:
 			index = 0;
 		return _pIconListVector[index]->getHandle();
 	}
-
 private :
 	ScintillaEditView *_pView = nullptr;
 

--- a/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
+++ b/PowerEditor/src/WinControls/ImageListSet/ImageListSet.cpp
@@ -38,7 +38,7 @@ void IconList::init(HINSTANCE hInst, int iconSize)
 	_hInst = hInst;
 	_iconSize = iconSize;
 	static constexpr int nbMore = 45;
-	_hImglst = ImageList_Create(iconSize, iconSize, ILC_COLOR32 | ILC_MASK, 0, nbMore);
+	_hImglst = ImageList_Create(iconSize, iconSize, ILC_COLOR32 | ILC_MASK, nbMore * 2, nbMore);
 	if (!_hImglst)
 		throw std::runtime_error("IconList::create : ImageList_Create() function returns null");
 }

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
@@ -226,6 +226,18 @@ bool ToolBar::init(HINSTANCE hInst, HWND hPere, toolBarStatusType type, const To
 {
 	Window::init(hInst, hPere);
 	
+	struct defer_ {
+		ToolBar* _self;
+		defer_(ToolBar* self) : _self(self) {
+			SendMessage(_self->getHSelf(), WM_SETREDRAW, FALSE, 0);
+		}
+		~defer_() {
+			SendMessage(_self->getHSelf(), WM_SETREDRAW, TRUE, 0);
+			InvalidateRect(_self->getHSelf(), NULL, TRUE);
+			UpdateWindow(_self->getHSelf());
+		}
+	} _defer(this);
+
 	_state = type;
 
 	_dpiManager.setDpi(hPere);

--- a/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
+++ b/PowerEditor/src/WinControls/ToolBar/ToolBar.cpp
@@ -257,6 +257,18 @@ bool ToolBar::init(HINSTANCE hInst, HWND hPere, toolBarStatusType type, const To
 {
 	Window::init(hInst, hPere);
 	
+	struct defer_ {
+		ToolBar* _self;
+		defer_(ToolBar* self) : _self(self) {
+			SendMessage(_self->getHSelf(), WM_SETREDRAW, FALSE, 0);
+		}
+		~defer_() {
+			SendMessage(_self->getHSelf(), WM_SETREDRAW, TRUE, 0);
+			InvalidateRect(_self->getHSelf(), NULL, TRUE);
+			UpdateWindow(_self->getHSelf());
+		}
+	} _defer(this);
+
 	_state = type;
 
 	_dpiManager.setDpi(hPere);


### PR DESCRIPTION
This PR contains multiple projects to achieve this goal:

- Enables lazy loading of files (np++ no longer loads all files)
- Adds helper to avoid redrawing win32 ui elements during loops (significantly speeds up np++)
- Replaces nasty loops accessing `getIndexByBuffer` with a prebuffering `getBuffersByIndex`

With these changes I can throw thousands(!!) of files into np++ without freezing up the whole ui forever. (#12019, #14000)

This is currently more of a hacky attempt from me/for my own issues but I'd like to leave it here as inspiration as this could be improved/fixed up/changed up to be used for release.

My method was to just throw ~2 thousand files into np++ and run vs profiler during various operations like opening/closing notepad++ or adding files by drag&drop.

Most bottlenecks were in SendMessage (mainly `getIndexByBuffer`), the code for setting markers and `Buffer::setFileName`

Happy for feedback & help in getting this further, im sure there are more corners to apply similar ideas to :)

This will require extra testing

Todos:

- [ ] Add setting to disable lazy loading
- [ ] Add checkbox in search/replace to load&include lazy files (slow)
- [ ] Lazyload "New ***" files (?)


<sup><sub>i did not make use of ai for this</sub></sup>