### PR TITLE
Fix Search results vertical scroll not sync with OS mouse settings

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -278,6 +278,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 			// (mouse wheel vertical & horizontal scroll amount, DirectWrite rendering params, base elements, style etc.)
 			::SendMessage(_mainEditView.getHSelf(), WM_SETTINGCHANGE, wParam, lParam);
 			::SendMessage(_subEditView.getHSelf(), WM_SETTINGCHANGE, wParam, lParam);
+			HWND hFindResults = _findReplaceDlg.getHFindResults();
+			if (hFindResults != NULL)
+			{
+				::SendMessage(hFindResults, WM_SETTINGCHANGE, wParam, lParam);
+			}
 
 			return ::DefWindowProc(hwnd, message, wParam, lParam);
 		}


### PR DESCRIPTION
Send WM_SETTINGCHANGE message to find results window as well- #18194

We should pass the `WM_SETTINGCHANGE` message to search results window as well, so that it also honors changes related to OS mouse wheel scroll amount setting.

This is a minor addition to,

* Commit c7b3225f3ed05d232be125d062d4d3eb64f145dc
* PR #17300
