### PR TITLE
Always link with /DEBUG:FULL

### DIFF
--- a/PowerEditor/visual.net/notepadPlus.Cpp.props
+++ b/PowerEditor/visual.net/notepadPlus.Cpp.props
@@ -47,7 +47,8 @@
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <OutputFile>$(OutDir)notepad++.exe</OutputFile>
       <Version>1.0</Version>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(OutDir)notepadPlus.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>..\..\scintilla\bin;$(IntDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
@@ -73,7 +74,6 @@
       <FixedBaseAddress>false</FixedBaseAddress>
       <TypeLibraryFile>/TLBID</TypeLibraryFile>
       <TypeLibraryResourceID>5</TypeLibraryResourceID>
-      <ProgramDatabaseFile>$(OutDir)notepadPlus.pdb</ProgramDatabaseFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -97,11 +97,9 @@
     </ClCompile>
     <Link>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <TypeLibraryResourceID>1</TypeLibraryResourceID>
-      <ProgramDatabaseFile>$(OutDir)npp.pdb</ProgramDatabaseFile>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <PostBuildEvent>


### PR DESCRIPTION
Simple change:
Always produce debug symbols & with the same name, there is no downside to it.

Why?
This makes dumps useful compared to previous behaviour (debug:none), where debugging is just not useful.

As a side bonus .. as notepad++ release binaries are signed: [Windows Error Reporting/werfault ***unconditionally*** auto-reports crashes to Microsoft](https://learn.microsoft.com/en-us/windows/win32/wer/windows-error-reporting), so these pdbs could be used by the maintainers to identify unreported/common crashes

The pdbs could/should(?) also be appended to releases as extra download link (and/or on github).
For size, as of right now, these are about 31mb using v143/vs2022

Would solve #382

<sup><sub>no ai was used, i just got annoyed by the lack of syms</sub></sup>