### PR TITLE
Recomend search open AND closed issues in bug/feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -6,9 +6,10 @@ title: "[BUG] <title>"
 body:
 - type: checkboxes
   attributes:
-    label: Is there an existing issue for this?
+    label: Is there an existing issue (open or closed) for this?
     description: |
-      Please search to see if an issue already exists for the bug you encountered.
+      Please search both opened and closed issues to see if an issue already exists 
+      for the bug you encountered. (Remove `is:open` from search bar.)
       If the issue is for a plugin (except for mimeTools, NppConverter, and NppExport),
       report it to the plugin author rather than here.
     options:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -6,8 +6,10 @@ title: "[Feature request] <title>"
 body:
 - type: checkboxes
   attributes:
-    label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the feature you request.
+    label: Is there an existing issue (open or closed) for this?
+    description:  |
+      Please search both opened and closed issues to see if an issue already exists 
+      for the feature you request. (Remove `is:open` from search bar.)
     options:
     - label: I have searched the existing issues
       required: true


### PR DESCRIPTION
per https://github.com/notepad-plus-plus/notepad-plus-plus/issues/18217#issuecomment-4970072102, users rarely include closed issues in their search, so they miss many duplicate issues.