### PR TITLE
langs.xml update from model: fix the attr==ext strcmp

### DIFF
--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2403,7 +2403,7 @@ void NppParameters::updateLangXml(NppXml::Element& mainElemUser, const NppXml::E
 				const char* pcUserValue = NppXml::attribute(thisLanguageFromUser, attrName);
 				if (!pcUserValue)
 					NppXml::setAttribute(thisLanguageFromUser, attrName, NppXml::getValue(attrModel));
-				else if (std::strcmp(attrName, "ext"))
+				else if (std::strcmp(attrName, "ext")==0)
 				{
 					// Get both user and model values for the ext attribute
 					std::string sExtValues = std::string(pcUserValue) + " " + NppXml::getValue(attrModel);

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -2403,7 +2403,7 @@ void NppParameters::updateLangXml(NppXml::Element& mainElemUser, const NppXml::E
 				const char* pcUserValue = NppXml::attribute(thisLanguageFromUser, attrName);
 				if (!pcUserValue)
 					NppXml::setAttribute(thisLanguageFromUser, attrName, NppXml::getValue(attrModel));
-				else if (std::strcmp(attrName, "ext")==0)
+				else if (std::strcmp(attrName, "ext") == 0)
 				{
 					// Get both user and model values for the ext attribute
 					std::string sExtValues = std::string(pcUserValue) + " " + NppXml::getValue(attrModel);


### PR DESCRIPTION
- verified that an older langs.xml that didn't have `slnx` and `targets` in xml extension list correctly added those to the list when it loaded.

(underlying problem: strcmp returns 0 on match, but I forgot the ==0, so was checking for attributes _not_ matching ext)

resolves #18220

