### PR TITLE
Improve documentation for DockedWidgetData::pszModuleName

### DIFF
--- a/PowerEditor/src/WinControls/DockingWnd/Docking.h
+++ b/PowerEditor/src/WinControls/DockingWnd/Docking.h
@@ -57,19 +57,21 @@ typedef struct DockedWidgetData {            // DockedWidget data (old name: tTb
 	HICON hIconTab = nullptr;                // icon for tabs
 	const wchar_t* pszAddInfo = nullptr;     // for plugin to display additional information
 
+	// [REQUIRED] It's the plugin file name with its extension (e.g. L"MyPlugin.dll"). 
+	// It is used as a unique identifier to reload and initialize the docking window on application startup.
+	const wchar_t* pszModuleName = nullptr;
+
 	// internal data, do not use !!!
 	RECT rcFloat = {};                       // floating position
 	int iPrevCont = 0;                       // stores the privious container (toggling between float and dock)
-	const wchar_t* pszModuleName = nullptr;  // it's the plugin file name. It's used to identify the plugin
 } DockedWidgetData, tTbData;
 
 
 struct tDockMgr {
 	HWND hWnd = nullptr;                  // the docking manager wnd
-	RECT rcRegion[DOCKCONT_MAX] = {{}};   // position of docked dialogs
+	RECT rcRegion[DOCKCONT_MAX] = { {} };   // position of docked dialogs
 };
 
 
 #define	HIT_TEST_THICKNESS		20
 #define SPLITTER_WIDTH			4
-


### PR DESCRIPTION
Fixes #18224

### Description of the Issue
Plugin developers often misunderstand the purpose and correct format of `DockedWidgetData.pszModuleName`. It is frequently mistaken for a simple name rather than a file name with a `.dll` extension. Additionally, it was placed under the "internal data" comment, which misled developers into thinking they shouldn't use it.

Incorrect usage of this field causes the Docking Manager to fail in reloading and initializing the plugin's docking dialog on application startup.

### Solution
1. Moved `pszModuleName` out of the "internal data, do not use !!!" section.
2. Added a comment clarifying that it is a **required** field and must include the `.dll` extension (e.g., `L"MyPlugin.dll"`).
3. Fixed a typo in the `iPrevCont` comment (`privious` -> `previous`).

This improvement aims to reduce issues like the ones reported in various plugin repositories where docking panels won't stay pinned or visible after relaunch.