### PR TITLE
Fix empty submenus in compact language menu and optimize redraws

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -583,8 +583,23 @@ LRESULT Notepad_plus::init(HWND hwnd)
 			nppGUI._excludedLangList[i]._cmdID = cmdID;
 			nppGUI._excludedLangList[i]._langName = itemName;
 			::DeleteMenu(hLangMenu, cmdID, MF_BYCOMMAND);
-			DrawMenuBar(hwnd);
 		}
+
+		// If compact language menu is enabled, remove any submenus that became empty after exclusion
+		if (nppGUI._isLangMenuCompact)
+		{
+			int nbItems = ::GetMenuItemCount(hLangMenu);
+			for (int i = nbItems - 1; i >= 0; --i)
+			{
+				HMENU hSubMenu = ::GetSubMenu(hLangMenu, i);
+				if (hSubMenu && ::GetMenuItemCount(hSubMenu) == 0)
+				{
+					::RemoveMenu(hLangMenu, i, MF_BYPOSITION);
+				}
+			}
+		}
+
+		::DrawMenuBar(hwnd);
 	}
 
 	// Add User Defined Languages Entry


### PR DESCRIPTION
Fixes #18202

### Description of the Issue
This PR addresses a UI bug in the "Compact Language Menu" where excluding all languages starting with a specific letter (e.g., all "P" languages) leaves an empty letter-group submenu in the Language menu.

Additionally, it fixes a performance inefficiency where `DrawMenuBar()` was being called inside the exclusion loop, causing redundant redraw operations for every excluded language during application initialization.

### Solution
1. **Empty Submenu Cleanup:** Added a check after the exclusion loop to identify submenus with a menu item count of 0. These empty submenus are now correctly removed using `RemoveMenu`.
2. **Performance Optimization:** Moved the `DrawMenuBar()` call outside the loop to ensure the menu bar is only redrawn once after all exclusions are processed.
3. **Logic:** The cleanup uses a reverse-index loop to safely handle menu item removal.

This fix is based on the detailed root cause analysis provided by @vlakoff.

### Verification
- Confirmed that empty letter-group submenus are now removed from the Language menu in compact mode.
- Confirmed that the Language menu remains functional and correctly filtered in both normal and compact modes.
- Verified that application startup performance is improved by reducing redundant system calls to `DrawMenuBar`.