### PR TITLE
Improve UX: Allow editing read-only files and redirect Save to Save As

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -1769,17 +1769,12 @@ bool Notepad_plus::fileSave(BufferID bufferID)
 
 	if (buf->isDirty())
 	{
-		if (buf->isReadOnly()) //cannot save if readonly in Notepad++ or in Windows
+		if (buf->isReadOnly())
 		{
-			_nativeLangSpeaker.messageBox("ReadOnlyFileCannotBeSaved",
-				_pPublicInterface->getHSelf(),
-				L"\"$STR_REPLACE$\"\rThe file is read-only and cannot be saved.\rPlease remove read-only then save your file.",
-				L"Save Failed - File is Read-Only",
-				MB_OK | MB_ICONWARNING,
-				0,
-				buf->getFullPathName());
-			
-			return false;
+			// If the document is read-only (either on disk or via user toggle), redirect the 
+			// "Save" action to "Save As". bu allows users to modify read-only files as 
+			// templates and save them to a new path instead of showing a "Save Failed" error.
+			return fileSaveAs(bufferID);
 		}
 
 		if (buf->isUntitled())

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2466,7 +2466,11 @@ void ScintillaEditView::bufferUpdated(Buffer * buffer, int mask)
 
 		if (mask & BufferChangeReadonly)
 		{
-			execute(SCI_SETREADONLY, _currentBuffer->isReadOnly());
+			// We only enforce a locked editor if the user has explicitly toggled the "Read-Only" state 
+			// within Notepad++ (UserReadOnly). If the file is only read-only at the file system level 
+			// (FileReadOnly), we keep the editor unlocked to allow modifications, which can then 
+			// be saved to a different file via the "Save As" redirection logic.
+			execute(SCI_SETREADONLY, _currentBuffer->getUserReadOnly());
 		}
 
 		if (mask & BufferChangeUnicode)


### PR DESCRIPTION
Fixes #17972


### Description of the Issue
Currently, Notepad++ locks the editor entirely for files marked as "Read-Only" in the file system. This forces users into an interrupted workflow: to make a change and save it as a new file, they must first close the app (veya go to Explorer), remove the file attribute, and return to the editor.

This behavior was identified as a UX improvement area by @muratsarpay in issue #17972.

### Solution
This PR implements a more modern "template-based" workflow for read-only documents:

1. **Editor Unlock:** The Scintilla editor now remains unlocked if the file is only read-only on disk (`FileReadOnly`). It only remains locked if the user explicitly toggles the "Read-Only" status within the app (`UserReadOnly`).
2. **Smart Save Redirection:** When a user attempts to "Save" (Ctrl+S) a read-only document, the application now automatically redirects the action to the "Save As" dialog instead of failing with an error. 
3. **Safety:** The original file on disk remains protected as the user is forced to choose a new file path to save their changes.

Special thanks to @muratsarpay for suggesting this improvement in #17972.

### Verification
- Verified: Users can type into a file marked as read-only on disk immediately upon opening.
- Verified: Pressing Ctrl+S on a read-only file correctly opens the "Save As" dialog.
- Verified: The original file attributes are respected (Save still fails, but Redirection provides the fix).
- Verified: Manual "Toggle Read-Only" (UserReadOnly) still correctly locks the editor as expected.