### PR TITLE
[xml] Update brazilian_portuguese.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
+++ b/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Brazilian Portuguese by Hélio de Souza and Luxy, updated: Jul 2021, for Notepad++ 8.1.2; last update by Marcello, 04 Jul 2026 for 8.9.6.4+
+<!-- Brazilian Portuguese by Hélio de Souza and Luxy, updated: Jul 2021, for Notepad++ 8.1.2; last update by Marcello, 21 Jul 2026 for 8.9.7+
 Translation note:
 1. Please install XML Tools plugin for formatting your XML translation. Via menu "Plugins -> XML Tools-> Pretty Print - indent only" command.
 2. All the comments are for explanation, they are not for translation.
 -->
 <NotepadPlus>
-	<Native-Langue name="Brazilian Portuguese" filename="brazilian_portuguese.xml" version="8.9.6.4">
+	<Native-Langue name="Brazilian Portuguese" filename="brazilian_portuguese.xml" version="8.9.7">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -1627,10 +1627,10 @@ O arquivo é de somente leitura e não pode ser salvo.
 Por favor, remova o atributo de somente leitura e depois salve o seu arquivo."/>
 		<ShortcutsXmlHMACMissing title="Aviso de Segurança" message="The security information for shortcuts.xml is missing in config.xml.
 
-Por motivos de segurança, a integridade do arquivo shortcuts.xml será checada. Para executar seu comando customizado, revise o arquivo aberto shortcuts.xml. Se o conteúdo do arquivo estiver OK, use &quot;Validar shortcuts.xml&quot; do menu para confirmar."/>
+Por motivos de segurança, a integridade do arquivo shortcuts.xml será checada. Para executar seu comando customizado, revise o arquivo aberto shortcuts.xml. Se o conteúdo do arquivo estiver OK, use &quot;Validar shortcuts.xml&quot; do menu &quot;Executar&quot; para confirmar."/>
 		<ShortcutsXmlTampered title="Aviso de Segurança" message="O arquivo shortcuts.xml parece ter sido alterado manualmente.
 
-Por motivos de segurança, revise o arquivo aberto shortcuts.xml. Se o conteúdo do arquivo estiver OK, use &quot;Validar shortcuts.xml&quot; do menu para confirmar."/>
+Por motivos de segurança, revise o arquivo aberto shortcuts.xml. Se o conteúdo do arquivo estiver OK, use &quot;Validar shortcuts.xml&quot; do menu &quot;Executar&quot; para confirmar."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Histórico da área de transferência"/>

--- a/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
+++ b/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
@@ -1473,10 +1473,10 @@ $STR_REPLACE$
 
 Efetuar a carga vai fazer com que o Windows automaticamente autentique neste servidor, potencialmente expondo suas informações de login no Windows.
 Carrega assim mesmo?"/>
-				<Item id="7" name="&amp;Ignorar"/>
-				<Item id="6" name="&amp;Carregar"/>
-				<Item id="2" name="&amp;Sempre ignore caminho de rede"/>
-				<Item id="4" name="Sempre carregue caminho de &amp;rede"/>
+				<Item id="7" name="Ignorar"/>
+				<Item id="6" name="Carregar"/>
+				<Item id="2" name="Sempre ignore caminho de rede"/>
+				<Item id="4" name="Sempre carregue caminho de rede"/>
 			</NetworkPathWarning>
 
 			<DebugInfo title="Informação de Depuração">

--- a/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
+++ b/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Brazilian Portuguese by Hélio de Souza and Luxy, updated: Jul 2021, for Notepad++ 8.1.2; last update by Marcello, 21 Jul 2026 for 8.9.7+
+<!-- Brazilian Portuguese by Hélio de Souza and Luxy, updated: Jul 2021, for Notepad++ 8.1.2; last update by Marcello, 29 Jul 2026 for 8.9.7+
 Translation note:
 1. Please install XML Tools plugin for formatting your XML translation. Via menu "Plugins -> XML Tools-> Pretty Print - indent only" command.
 2. All the comments are for explanation, they are not for translation.
@@ -1537,7 +1537,6 @@ Deseja recarregá-lo e perder as alterações feitas no Notepad++?"/>
 			<PrehistoricSystemDetected title="Sistema pré-histórico detectado" message="Parece que você ainda usa um sistema pré-histórico. Esse recurso funciona apenas em um sistema moderno. Desculpe."/>
 			<XpUpdaterProblem title="Atualizador do Notepad++" message="O atualizador do Notepad++ não é compatível com o Windows XP devido à camada de segurança obsoleta dele.
 Deseja ir para a página do Notepad++ e baixar a última versão?"/>
-			<GUpProxyConfNeedAdminMode title="Configurações de Proxy" message="Reinicie o Notepad++ como Admin para configurar o proxy."/>
 			<DocTooDirtyToMonitor title="Problema de monitoramento" message="O documento está sujo. Por favor, salve a modificação antes de monitorá-lo."/>
 			<DocNoExistToMonitor title="Problema de monitoramento" message="O arquivo deve existir para ser monitorado."/>
 			<FileTooBigToOpen title="Problema no tamanho do arquivo" message="Arquivo é muito grande para ser aberto pelo Notepad++"/>

--- a/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
+++ b/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
@@ -1476,7 +1476,7 @@ Carrega assim mesmo?"/>
 				<Item id="7" name="&amp;Ignorar"/>
 				<Item id="6" name="&amp;Carregar"/>
 				<Item id="2" name="&amp;Sempre ignore caminho de rede"/>
-				<Item id="4" name="Sempre carregue cami&amp;nho de rede"/>
+				<Item id="4" name="Sempre carregue caminho de &amp;rede"/>
 			</NetworkPathWarning>
 
 			<DebugInfo title="Informação de Depuração">

--- a/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
+++ b/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
@@ -1475,7 +1475,7 @@ Efetuar a carga vai fazer com que o Windows automaticamente autentique neste ser
 Carrega assim mesmo?"/>
 				<Item id="7" name="&amp;Ignorar"/>
 				<Item id="6" name="&amp;Carregar"/>
-				<Item id="2" name="&ampSempre ignore caminho de rede"/>
+				<Item id="2" name="&amp;Sempre ignore caminho de rede"/>
 				<Item id="4" name="Sempre carregue cami&amp;nho de rede"/>
 			</NetworkPathWarning>
 

--- a/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
+++ b/PowerEditor/installer/nativeLang/brazilian_portuguese.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Brazilian Portuguese by Hélio de Souza and Luxy, updated: Jul 2021, for Notepad++ 8.1.2; last update by Marcello, 29 Jul 2026 for 8.9.7+
+<!-- Brazilian Portuguese by Hélio de Souza and Luxy, updated: Jul 2021, for Notepad++ 8.1.2; last update by Marcello, 06 Aug 2026 for 8.9.7+
 Translation note:
 1. Please install XML Tools plugin for formatting your XML translation. Via menu "Plugins -> XML Tools-> Pretty Print - indent only" command.
 2. All the comments are for explanation, they are not for translation.
@@ -1466,6 +1466,18 @@ Você pode reativar esta janela de confirmação em Preferências depois."/>
 				<Item id="7" name="&amp;Não"/>
 				<Item id="4" name="Sem&amp;pre Sim"/>
 			</DoSaveAll><!-- HowToReproduce: Check the &quot;Enable Save All confirm dialog&quot; checkbox in Preference->MISC, now click &quot;Save all&quot; -->
+			<NetworkPathWarning title="Carregando sessão do Notepad++">
+				<Item id="1771" name="Aviso de Caminho de Rede:
+
+$STR_REPLACE$
+
+Efetuar a carga vai fazer com que o Windows automaticamente autentique neste servidor, potencialmente expondo suas informações de login no Windows.
+Carrega assim mesmo?"/>
+				<Item id="7" name="&amp;Ignorar"/>
+				<Item id="6" name="&amp;Carregar"/>
+				<Item id="2" name="&ampSempre ignore caminho de rede"/>
+				<Item id="4" name="Sempre carregue cami&amp;nho de rede"/>
+			</NetworkPathWarning>
 
 			<DebugInfo title="Informação de Depuração">
 				<Item id="1752" name="&amp;Copiar informação de depuração para a área de transferência"/>


### PR DESCRIPTION
Added translation for 'Make "Security Warning" for shortcuts.xml more explicit'.

<!--

Please do not create a pull request before reading the contribution guidelines: https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md.
Please do not create a pull request without linking it to an existing issue or creating a new one first unless it is for translation. 

If your pull request contains **only** XML localization files changes, please prefix the title with `[xml]`. This speeds up the automated XML validation.
If you are a new contributor or are unsure, please read the guide at https://npp-user-manual.org on how to submit a pull request for a translation.

New contributors should aim to submit small pull requests, ideally limited to 1–4 files and around 30 lines of code.

Add `fix #NNNNN` at the end of your opening comments to automatically link the pull request to the issue.

If you used AI to generate this pull request or the accompanying code, please let us know. This allows us to look out for common issues associated with generated code.

-->

<!-- You can delete all text below if pull request is only for a translation -->

- [x] I have read [contributing guidelines](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md)

fix #NNNNN
