### PR TITLE
Fix accidental data loss by adding safety warning for large pastes over selection (#18249)

### DIFF
--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -78,6 +78,7 @@
 
 using namespace std;
 
+
 std::mutex command_mutex;
 
 void Notepad_plus::macroPlayback(Macro macro, std::vector<Document>* pDocs4EndUAIn)
@@ -153,7 +154,66 @@ void Notepad_plus::macroPlayback(Macro macro, std::vector<Document>* pDocs4EndUA
 	_playingBackMacro = false;
 }
 
+/*
+ * Triggers a warning if a massive selection is being overwritten by a significantly smaller clipboard text.
+ * Designed to prevent accidental data loss while ensuring high performance and macro compatibility.
+ */
+static bool confirmLargePaste(ScintillaEditView* pView, bool isMacroPlaying)
+{
+	// 1. Macro Safety: Never interrupt macro playback with a UI popup.
+	if (isMacroPlaying)
+	{
+		return true;
+	}
 
+	// 2. Performance: Calculate selection length.
+	size_t totalSelLen = 0;
+	const size_t nbSelections = pView->execute(SCI_GETSELECTIONS);
+	for (size_t i = 0; i < nbSelections; ++i)
+	{
+		totalSelLen += (pView->execute(SCI_GETSELECTIONNEND, i) - pView->execute(SCI_GETSELECTIONNSTART, i));
+	}
+
+	// High threshold to minimize user annoyance (500k characters).
+	const size_t threshold = 500000;
+	if (totalSelLen < threshold)
+	{
+		return true;
+	}
+
+	// 3. Clipboard Reliability & Performance:
+	size_t clipboardLen = 0;
+	if (::OpenClipboard(pView->getHSelf()))
+	{
+		HANDLE hData = ::GetClipboardData(CF_UNICODETEXT);
+		if (hData)
+		{
+			// GlobalSize is O(1), instantly returns the buffer size even for gigabytes of data.
+			// CF_UNICODETEXT is wchar_t, so we divide by its size to get character count.
+			clipboardLen = ::GlobalSize(hData) / sizeof(wchar_t);
+		}
+		::CloseClipboard();
+	}
+	else
+	{
+		// 4. Fallback: If clipboard is locked by another process, proceed silently.
+		// Safety is important, but preventing the user from pasting at all is worse.
+		return true;
+	}
+
+	// 5. Heuristic Check: Selection is massive AND clipboard is at least 10x smaller.
+	if (totalSelLen > (clipboardLen * 10))
+	{
+		const int ret = NppDarkMode::darkMessageBoxW(pView->getHSelf(),
+			L"You are about to overwrite a very large selection with much smaller text from the clipboard.\n\nAre you sure you want to proceed?",
+			L"Large Selection Overwrite Warning",
+			MB_YESNO | MB_ICONWARNING | MB_DEFBUTTON2);
+
+		return (ret == IDYES);
+	}
+
+	return true;
+}
 
 void Notepad_plus::command(int id)
 {
@@ -642,6 +702,12 @@ void Notepad_plus::command(int id)
 			HWND focusedHwnd = ::GetFocus();
 			if (focusedHwnd == _pEditView->getHSelf())
 			{
+				// Guard against accidental massive overwrites, skipping if macro is playing
+				if (!confirmLargePaste(_pEditView, _playingBackMacro))
+				{
+					break;
+				}
+
 				size_t nbSelections = _pEditView->execute(SCI_GETSELECTIONS);
 				Buffer* buf = getCurrentBuffer();
 				bool isRO = buf->isReadOnly();


### PR DESCRIPTION
**Fixes #18249**

This Pull Request addresses the issue raised in **#18249**. It introduces a safety confirmation mechanism to prevent accidental data loss when a user unintentionally overwrites a large block of text with a much smaller clipboard content (e.g., after an accidental `Ctrl+A` or incorrect selection).

### Technical Implementation & Highlights:

1.  **High Threshold Protection:**
    The warning is only triggered if the current selection exceeds **500,000 characters**. This high threshold ensures the feature acts strictly as a "safety net" for disaster scenarios and does not interfere with normal editing workflows.

2.  **Heuristic Overwrite Check:**
    A confirmation dialog is displayed only if the selected text is significantly larger (**at least 10x**) than the clipboard content. This avoids redundant alerts when replacing large blocks with similar-sized content.

3.  **Performance Optimized ($O(1)$):**
    To ensure zero lag even with gigabytes of clipboard data, it utilizes the Win32 `GlobalSize` API to determine clipboard length instantly, rather than using $O(N)$ string length functions.

4.  **Macro Safety:**
    The confirmation dialog is automatically bypassed during macro playback (`_playingBackMacro`). This ensures that automated tasks and recorded keystrokes are never interrupted.

5.  **UI & Dark Mode Integration:**
    - Uses `NppDarkMode::darkMessageBoxW` for a consistent visual experience across all themes.
    - Implements `MB_DEFBUTTON2` (setting "No" as the default button), ensuring that an accidental `Enter` keypress safely cancels the operation.

6.  **Reliability:**
    Includes a silent fallback; if the clipboard is locked by another process, the operation proceeds without interruption to avoid blocking the user.

### Why no new setting in Preferences?

In line with Notepad++'s minimalist philosophy, I avoided adding a new toggle to the Preferences dialog to prevent UI bloat. The chosen threshold is high enough that it will only be encountered during genuine "accidental" operations. However, I am open to implementing a configurable setting if requested.

### Verification Results:

- Tested with a 1,000,000+ character selection: **Warning triggered correctly.**
- Tested with macro playback: **Bypassed correctly.**
- Tested with standard small pastes: **No interruption (as expected).**
- Verified Dark Mode compatibility: **UI remains consistent.**
