### PR TITLE
Fix Find dialog opening on wrong monitor when main window has moved

### DIFF
--- a/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
+++ b/PowerEditor/src/ScintillaComponent/FindReplaceDlg.cpp
@@ -4946,6 +4946,21 @@ void FindReplaceDlg::doDialog(DIALOG_TYPE whichType, bool isRTL, bool toShow)
 		enableReplaceFunc(whichType == REPLACE_DLG);
 
 	::SetFocus(toShow ? ::GetDlgItem(_hSelf, IDFINDWHAT) : (*_ppEditView)->getHSelf());
+
+	if (toShow)
+	{
+		// If Find is not currently on the same monitor as the main Notepad++ window
+		// (main window moved since Find was last shown, or this is the first open
+		// and the saved position was on a different monitor), recenter Find over
+		// the main window so it opens on the correct monitor.
+		RECT rc{};
+		getWindowRect(rc);
+		HMONITOR hMonFind = ::MonitorFromRect(&rc, MONITOR_DEFAULTTONEAREST);
+		HMONITOR hMonParent = ::MonitorFromWindow(_hParent, MONITOR_DEFAULTTONEAREST);
+		if (hMonFind != hMonParent)
+			goToCenter(SWP_SHOWWINDOW | SWP_NOSIZE);
+	}
+
 	StaticDialog::displayEnhanced(toShow);
 }
 


### PR DESCRIPTION
## Problem
FindReplaceDlg::create() only runs once per session, and it blindly
trusts the last saved dialog position from config. If the main
Notepad++ window is later moved to a different monitor, the Find
dialog stays stranded on the old monitor every time it's reopened.

## Fix
FindReplaceDlg::doDialog() now compares the monitor the Find dialog
is currently on against the monitor the main window is currently on,
every time the dialog is shown — not just at first creation. If they
differ, it recenters the dialog over the main window via goToCenter()
before displaying it.

## Testing
- Launched Notepad++ on Monitor 1, pressed Ctrl+F — opens correctly
  centered on Monitor 1.
- Moved the main window to Monitor 2 mid-session, pressed Ctrl+F
  again — Find now follows to Monitor 2 (previously it stayed on
  Monitor 1).