### PR TITLE
Fix file name being selected while a CJK IME is composing in Save As dialog

### DIFF
--- a/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
+++ b/PowerEditor/src/WinControls/OpenSaveFileDialog/CustomFileDialog.cpp
@@ -21,10 +21,15 @@
 #endif
 #include <comdef.h>		// _com_error
 #include <comip.h>		// _com_ptr_t
+#include <imm.h>		// ImmGetContext, ImmGetCompositionString
 #include <unordered_map>
 #include "CustomFileDialog.h"
 #include "Parameters.h"
 #include "localization.h"
+
+#ifdef _MSC_VER
+#pragma comment(lib, "imm32.lib")	// For querying the IME composition state.
+#endif
 
 using namespace std;
 
@@ -475,6 +480,25 @@ private:
 		return fileName;
 	}
 
+	// Tells whether an IME is currently composing text in the file name edit box.
+	// Two independent sources are used, because neither one covers every IME:
+	// - the composition messages tracked in CallProcHook(),
+	// - a direct IMM query, which also catches the case where the hook was installed
+	//   after the composition had already started.
+	bool isImeComposing(HWND hwnd) const
+	{
+		if (_isImeComposing)
+			return true;
+		bool composing = false;
+		HIMC himc = ::ImmGetContext(hwnd);
+		if (himc)
+		{
+			composing = ::ImmGetCompositionString(himc, GCS_COMPSTR, nullptr, 0) > 0;
+			::ImmReleaseContext(hwnd, himc);
+		}
+		return composing;
+	}
+
 	// Modifies the file name if necesary after user confirmed input.
 	// Called after the user input but before OnFileOk() and before any name validation.
 	void onPreFileOk()
@@ -485,6 +509,9 @@ private:
 		wstring fileName = getDialogFileName(_dialog);
 		expandEnv(fileName);
 		bool nameChanged = transformPath(fileName);
+		// Remember where what the user typed ends, so that the caret can be put back
+		// there afterwards instead of leaving the whole name selected.
+		const DWORD caretPos = static_cast<DWORD>(fileName.length());
 		// Update the controls.
 		if (!doesDirectoryExist(getAbsPath(fileName).c_str()))
 		{
@@ -500,6 +527,12 @@ private:
 			// Clear the name first to ensure it's updated properly.
 			_dialog->SetFileName(L"");
 			_dialog->SetFileName(fileName.c_str());
+			// Put the caret right after the typed name (before the appended extension)
+			// instead of leaving everything selected, since the selection is implicitly
+			// modified by SetFileName() - same reason as in onTypeChange().
+			// Without this, the next keystroke would replace the whole name.
+			if (_hwndNameEdit)
+				::SendMessage(_hwndNameEdit, EM_SETSEL, caretPos, caretPos);
 		}
 	}
 
@@ -610,6 +643,15 @@ private:
 				if (it != s_handleMap.end() && it->second && hwnd == it->second->_hwndButton)
 					it->second->onPreFileOk();
 			}
+			else if (msg && (msg->message == WM_IME_STARTCOMPOSITION || msg->message == WM_IME_ENDCOMPOSITION))
+			{
+				// Keep track of the IME composition state of the file name edit box.
+				// Some IMEs end the composition only after the Enter key has been seen by
+				// the keyboard hook, so the state cannot be queried reliably from there alone.
+				auto it = s_handleMap.find(msg->hwnd);
+				if (it != s_handleMap.end() && it->second && msg->hwnd == it->second->_hwndNameEdit)
+					it->second->_isImeComposing = (msg->message == WM_IME_STARTCOMPOSITION);
+			}
 		}
 		return ::CallNextHookEx(nullptr, nCode, wParam, lParam);
 	}
@@ -624,7 +666,15 @@ private:
 				HWND hwnd = GetFocus();
 				auto it = s_handleMap.find(hwnd);
 				if (it != s_handleMap.end() && it->second && hwnd == it->second->_hwndNameEdit)
-					it->second->onPreFileOk();
+				{
+					// A CJK IME uses Enter to commit the text being composed, not to confirm
+					// the file name. Treating that Enter as a confirmation appends the extension
+					// in the middle of the name the user is still typing.
+					// The key itself is never swallowed here: it is always passed on to
+					// CallNextHookEx() below, so pressing Enter to save keeps working as before.
+					if (!it->second->isImeComposing(hwnd))
+						it->second->onPreFileOk();
+				}
 			}
 		}
 		return ::CallNextHookEx(nullptr, nCode, wParam, lParam);
@@ -646,6 +696,7 @@ private:
 	UINT _lastSelectedType = 0;  // Last selected non-wildcard file type.
 	UINT _wildcardType = 0;  // Wildcard *.* file type index (usually 1).
 	bool _isSaveAsCopy = false;
+	bool _isImeComposing = false;  // True while an IME composes text in the file name edit box.
 };
 std::unordered_map<HWND, FileDialogEventHandler*> FileDialogEventHandler::s_handleMap;
 


### PR DESCRIPTION
### Problem

In the Save As dialog with "Append extension" checked, confirming an IME
composition with Enter is treated as confirming the file name:

1. The extension is appended while the user is still typing the name.
2. `SetFileName()` implicitly selects the whole text, so the next keystroke
   replaces everything typed so far.

Depending on the IME this shows up as the whole name being wiped out, or as the
extension ending up in the middle of the name (`한글.txt글`, `測.txt是`).

### Cause

`KbdProcHook()` only checks `wParam == VK_RETURN` and that the focus is in the
file name edit box; it has no notion of an IME composition being in progress.
A CJK IME uses Enter to commit the composition, not to submit the dialog.

`onPreFileOk()` then calls `SetFileName()`, and as the comment above
`onTypeChange()` already states, *"The selection is implicitly modified by
SetFileName()"*. `onTypeChange()` compensates for this with `EM_SETSEL`;
`onPreFileOk()` did not, because it assumed the dialog was about to close.

### Fix

Two independent guards, neither of which changes what happens for users who do
not use an IME:

1. `KbdProcHook()` asks `isImeComposing()` before calling `onPreFileOk()`.
   **The Enter key is never swallowed** - it is always passed on to
   `CallNextHookEx()`, so saving with Enter behaves exactly as before.
2. `onPreFileOk()` puts the caret back after the typed name (before the appended
   extension) instead of leaving everything selected - the same compensation
   `onTypeChange()` already does.

`isImeComposing()` uses two sources, because neither covers every IME on its own:
the `WM_IME_STARTCOMPOSITION` / `WM_IME_ENDCOMPOSITION` messages tracked in the
existing `CallProcHook()`, and a direct IMM query. On the machine used for
testing the IMM query alone returned nothing for the TSF-based Microsoft IMEs,
which is why the caret guard (2) exists as well.

The Save button path (`CallProcHook()` / `BN_CLICKED`) is intentionally left
unguarded: a button click can never happen mid-composition, so the extension is
always appended there regardless of the composition state.

### Why this should not repeat #14400

The previous attempt (#13788) deferred/swallowed the Enter key when the IME was
in Korean *mode*, which broke saving entirely (#14400, #14973) and had to be
reverted (#14593). This change never interferes with key delivery and never
looks at the IME's language or mode - only at whether a composition is in
progress. Saving with Enter and with the Save button were both verified in
Korean mode (see below).

### Tests

Built from this branch (x64, Release) and compared against stock 8.9.6.4 on
Windows 11, with "Append extension" checked and file type
`Normal text file (*.txt)`. Both builds were run with
`-multiInst -nosession -noPlugin -settingsDir=...` so they could not affect each
other's configuration.

| Input | Before (stock 8.9.6.4) | After |
|---|---|---|
| Japanese (Microsoft IME): `nihon` → Space → Enter, then `go` → Space → Enter | `日本.txt` fully selected, and the second word **replaced everything**: final name `語.txt` | `日本語.txt` |
| Traditional Chinese (Microsoft Bopomofo), two words | `測.txt` fully selected; next keystroke wiped it; forcing the caret to the end produced `測.txt是` | `測試.txt` |
| Korean (Microsoft IME), `한글` | `한글.txt글` (#11582, #16772) | `한글.txt` |
| ASCII only, Enter to save | `english.txt` | `english.txt` (unchanged) |
| Korean mode, **Save button** instead of Enter | the #14400 regression made saving fail entirely | saved correctly as `저장.txt` |

Each case was verified by the file actually appearing on disk with the expected
name, not just by what the dialog displayed.

### AI disclosure

Per the note in the pull request template: this change was written with the help
of Claude Code (Claude Opus 5). The root cause analysis, the design constraints
(never swallow the key, never branch on IME language/mode), and every test result
above were reviewed and reproduced on a real machine before submitting.

---

- [x] I have read [contributing guidelines](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md)

Fix #11582, fix #16772, fix #12225, fix #12366
