### PR TITLE
Use runtime check for proxy setting rights

### DIFF
--- a/PowerEditor/src/MISC/Common/Common.cpp
+++ b/PowerEditor/src/MISC/Common/Common.cpp
@@ -2490,3 +2490,92 @@ HRESULT openInExplorerAndSelect(const wchar_t* path)
 	}
 	return hr;
 }
+
+bool needsElevation4Access(const std::wstring& path2check, bool bWriteAccess)
+{
+	namespace fs = std::filesystem;
+
+	WIN32_FILE_ATTRIBUTE_DATA attribs{};
+	attribs.dwFileAttributes = INVALID_FILE_ATTRIBUTES;
+	BOOL bGetAttribs = getFileAttributesExWithTimeout(path2check.c_str(), &attribs);
+	if (!bGetAttribs || (attribs.dwFileAttributes == INVALID_FILE_ATTRIBUTES))
+	{
+		// either the getFileAttributesExWithTimeout failed or the path2check (file or dir) does not exist
+		return false;
+	}
+
+	fs::path testFile;
+	bool fileExists = false;
+
+	if (attribs.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	{
+		// path2check is an existing dir
+		fs::path targetDir(path2check);
+		bool foundDirFile = false;
+
+		try {
+			for (const auto& entry : fs::directory_iterator(targetDir))
+			{
+				if (entry.is_regular_file())
+				{
+					// found a file there to test on
+					testFile = entry.path();
+					fileExists = true;
+					foundDirFile = true;
+					break;
+				}
+			}
+		}
+		catch (const fs::filesystem_error& e)
+		{
+			if (e.code() == std::errc::permission_denied || e.code().value() == ERROR_ACCESS_DENIED)
+			{
+				if (!bWriteAccess)
+					return true; // lack the READ permissions here for sure, needs elevation
+
+				// for bWriteAccess == true, do nothing here (proceed directly to the tempfile write test below)
+			}
+			else
+			{
+				return false; // no meaning to continue checking (network drop, etc.)
+			}
+		}
+		catch (...)
+		{
+			return false; // no meaning to continue checking (std::bad_alloc & others)
+		}
+
+		// fallback for an empty dir
+		if (!foundDirFile)
+		{
+			if (!bWriteAccess)
+				return false; // no elevation required (no exception case, we only want to check READ access and can read it - it's empty)
+
+			// generate a pseudorandom tempfile to test WRITE access
+			std::wstring tempFileName = L"test-" + std::to_wstring(::GetTickCount64()) + L".tmp";
+			testFile = targetDir / tempFileName;
+			fileExists = false;
+		}
+	}
+	else
+	{
+		// path2check is an existing file
+		testFile = path2check;
+		fileExists = true;
+	}
+
+	// test the desired access rights
+	HANDLE hFile = ::CreateFileW(testFile.c_str(), bWriteAccess ? GENERIC_WRITE : GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+		nullptr, fileExists ? OPEN_EXISTING : CREATE_NEW, fileExists ? FILE_ATTRIBUTE_NORMAL : FILE_FLAG_DELETE_ON_CLOSE, nullptr);
+	if (hFile != INVALID_HANDLE_VALUE)
+	{
+		::CloseHandle(hFile);
+		return false; // can open, no elevation required
+	}
+
+	if (::GetLastError() == ERROR_ACCESS_DENIED)
+		return true; // elevation required
+
+	// an elevation will not help us here (HW R/O, file-in-use locks, complex restrictive ACLs, etc.)
+	return false;
+}

--- a/PowerEditor/src/MISC/Common/Common.h
+++ b/PowerEditor/src/MISC/Common/Common.h
@@ -346,3 +346,6 @@ private:
 	ScopedCOMInit(const ScopedCOMInit&) = delete;
 	ScopedCOMInit& operator=(const ScopedCOMInit&) = delete;
 };
+
+
+bool needsElevation4Access(const std::wstring& path2check, bool bWriteAccess);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -3845,28 +3845,21 @@ void Notepad_plus::command(int id)
 				if (isCertifVerified)
 				{
 					wstring param;
+					bool isElevationRequired = false;
+
 					if (id == IDM_CONFUPDATERPROXY)
 					{
-						if (!_isAdministrator)
-						{
-							_nativeLangSpeaker.messageBox("GUpProxyConfNeedAdminMode",
-								_pPublicInterface->getHSelf(),
-								L"Please relaunch Notepad++ in Admin mode to configure proxy.",
-								L"Proxy Settings",
-								MB_OK | MB_APPLMODAL);
-							return;
-						}
 						param = L"-options";
+						isElevationRequired = needsElevation4Access(updaterDir, true); // proxy settings storage is ".\updater\gupOptions.xml"
 					}
 					else
-					{	
+					{
 						nppParams.buildGupParams(param);
-
 						param += L" -verbose";
 					}
-					Process updater(updaterFullPath.c_str(), param.c_str(), updaterDir.c_str());
 
-					updater.run();
+					Process updater(updaterFullPath.c_str(), param.c_str(), updaterDir.c_str());
+					updater.run(isElevationRequired);
 				}
 			}
 			break;


### PR DESCRIPTION
Determine, if the admin rights are really required for storing the GUP proxy settings (instead of the previously hardcoded admin rights). If YES, the standard Windows `runas` verb invokes the UAC prompt for the GUP action. This way allows also the portable Notepad++ setups to use the Notepad++ `menu > ? > Set Updater Proxy...`.


- [x] I have read [contributing guidelines](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md)

fix #13382
