### PR TITLE
[UDL] Fix detection of BOL and EOL in line comments

### DIFF
--- a/lexilla/lexers/LexUser.cxx
+++ b/lexilla/lexers/LexUser.cxx
@@ -1172,7 +1172,7 @@ static bool isInListNested(int nestedKey, vector<forwardStruct> & forwards, Styl
             if ((iter->_maskID != SCE_USER_MASK_NESTING_COMMENT_LINE) ||
                 (iter->_maskID == SCE_USER_MASK_NESTING_COMMENT_LINE &&
                     ((pureLC == PURE_LC_NONE) ||
-                     (pureLC == PURE_LC_BOL && (sc.chPrev == '\r' || sc.chPrev == '\n')) ||
+                     (pureLC == PURE_LC_BOL && sc.atLineStart) ||
                      (pureLC == PURE_LC_WSP && visibleChars == false))))
 
             {
@@ -1851,6 +1851,11 @@ static void ColouriseUserDoc(Sci_PositionU startPos, Sci_Position length, int in
                         // paint backward keyword and move on
                         sc.SetState(SCE_USER_STYLE_COMMENTLINE);
                         sc.Forward(iter->length());
+                        if (sc.atLineStart)
+                        {
+                            visibleChars = false;
+                            skipVisibleCheck = true;
+                        }
                         // was current line comment sequence nested, or do we start over from SCE_USER_STYLE_IDENTIFIER?
                         readLastNested(lastNestedGroup, newState, openIndex);
                         // paint end of line comment sequence
@@ -2011,7 +2016,7 @@ static void ColouriseUserDoc(Sci_PositionU startPos, Sci_Position length, int in
                 if (!commentLineOpen.empty())
                 {
                     if ((pureLC == PURE_LC_NONE) ||
-                        (pureLC == PURE_LC_BOL && (sc.chPrev == '\r' || sc.chPrev == '\n')) ||
+                        (pureLC == PURE_LC_BOL && sc.atLineStart) ||
                         (pureLC == PURE_LC_WSP && visibleChars == false) )
                     {
                         if (isInListForward(commentLineOpen, sc, ignoreCase, openIndex, skipForward))


### PR DESCRIPTION
Fixes these issues:

<img width="874" height="405" alt="image" src="https://github.com/user-attachments/assets/07bcbe01-4a57-423b-bc01-91f3eb70392c" />

In this mode, the first line is never considered a comment.

<img width="868" height="406" alt="image" src="https://github.com/user-attachments/assets/79c47e48-39bf-4e9f-af8c-9791f46e248e" />

In this mode, each even consecutive line is not considered a comment.

All of the lines on the screenshots should be green, but some of them are black. It should be fixed with this PR.

- [x] I have read [contributing guidelines](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md)

fix #9193
