### PR TITLE
[xml] Update hungarian.xml

### DIFF
--- a/PowerEditor/installer/nativeLang/hungarian.xml
+++ b/PowerEditor/installer/nativeLang/hungarian.xml
@@ -5,7 +5,7 @@
 <!-- Prohardver topic: https://prohardver.hu/tema/re_notepad/friss.html -->
 <!-- For more information see the Commits History: https://github.com/notepad-plus-plus/notepad-plus-plus/commits/master/PowerEditor/installer/nativeLang/hungarian.xml -->
 <NotepadPlus>
-	<Native-Langue name="Magyar" filename="hungarian.xml" version="8.9.6.4">
+	<Native-Langue name="Magyar" filename="hungarian.xml" version="8.9.7">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -1187,7 +1187,7 @@
 
 				<Print title="Nyomtatás">
 					<Item id="6601" name="&amp;Sorok számozásának nyomtatása"/>
-					<Item id="6616" name="La&amp;pemelés (FF) oldaltörésként"/>
+					<Item id="6616" name="La&amp;pemelés (form feed) oldaltörésként"/>
 					<Item id="6602" name="Színbeállítások"/>
 					<Item id="6603" name="Ahogy látszik (&amp;WYSIWYG)"/>
 					<Item id="6604" name="Ford&amp;ított színek"/>
@@ -1466,7 +1466,18 @@ Ebben az esetben a „Gépház” párbeszédpanel „Egyéb” szakasza alatt k
 				<Item id="7" name="&amp;Nem"/>
 				<Item id="4" name="Igen, &amp;mindig"/>
 			</DoSaveAll><!-- HowToReproduce: Check the 'Enable Save All confirm dialog' checkbox in Preference->MISC, now click 'Save all' -->
+			<NetworkPathWarning title="Notepad++-munkamenet betöltése">
+				<Item id="1771" name="Figyelmeztetés hálózati elérési úttal kapcsolatban:
 
+$STR_REPLACE$
+
+A fájl betöltése esetén a Windows automatikusan hitelesíti magát az adott szerveren, ami potenciálisan felfedheti a Windows-bejelentkezési adatait.
+Mindenképpen betölti?"/>
+				<Item id="7" name="&amp;Kihagyás"/>
+				<Item id="6" name="&amp;Betöltés"/>
+				<Item id="2" name="&amp;Hálózati útvonalak kihagyása mindig"/>
+				<Item id="4" name="Há&amp;lózati útvonalak betöltése mindig"/>
+			</NetworkPathWarning>
 			<DebugInfo title="Hibakeresési adatok">
 				<Item id="1752" name="&amp;Adatok másolása a vágólapra"/>
 				<Item id="1" name="&amp;OK"/>
@@ -1626,10 +1637,10 @@ A fájl csak olvasható, emiatt nem menthető el.
 Kérjük, törölje a dokumentum csak olvasható beállítását, majd mentse el a fájlt."/>
 			<ShortcutsXmlHMACMissing title="Biztonsági figyelmeztetés" message="A config.xml fájlból hiányoznak a shortcuts.xml biztonsági adatai.
 
-Biztonsági okokból a Notepad++ ellenőrzi a shortcuts.xml integritását. Egyéni parancsai futtatásához, kérjük, tekintse át a megnyitott shortcuts.xml fájlt. Ha a fájl tartalmát rendben találja, válassza a menüből az „A shortcuts.xml érvényesítése” lehetőséget a megerősítéshez."/>
+Biztonsági okokból a Notepad++ ellenőrzi a shortcuts.xml integritását. Egyéni parancsai futtatásához, kérjük, tekintse át a megnyitott shortcuts.xml fájlt. Ha a fájl tartalmát rendben találja, válassza a „Futtatás” menüből az „A shortcuts.xml érvényesítése” lehetőséget a megerősítéshez."/>
 			<ShortcutsXmlTampered title="Biztonsági figyelmeztetés" message="Úgy tűnik, hogy a shortcuts.xml fájl kézzel lett módosítva.
 
-Biztonsági okokból, kérjük, tekintse át a megnyitott shortcuts.xml fájlt. Ha a fájl tartalmát rendben találja, válassza a menüből az „A shortcuts.xml érvényesítése” lehetőséget a megerősítéshez."/>
+Biztonsági okokból, kérjük, tekintse át a megnyitott shortcuts.xml fájlt. Ha a fájl tartalmát rendben találja, válassza a „Futtatás” menüből az „A shortcuts.xml érvényesítése” lehetőséget a megerősítéshez."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Vágólap-előzmények"/>


### PR DESCRIPTION
Synchronize the Hungarian language file:
* Update version number – _from #18239_
* `ShortcutsXmlHMACMissing` and `ShortcutsXmlTampered`: a more specific warning message – _from #18239_
* Preserve the deletion of the `GUpProxyConfNeedAdminMode` element _(see Commit bb7d108) – from #18263_
* A clearer translation of the "Print formfeed…" setting _(FF » form feed) – from #18263_
* Translate the `NetworkPathWarning` dialog _(see Commit c9a65d9)_

_Other considerations – the following corrections are recommended for the `english*.xml` files:_
* `&ampAlways skip...` » add a semicolon (;) » `&amp;Always skip...`
* `Always load n&amp;network...` » remove the first `n` » `Always load &amp;network...`

_It is recommended to accept this PR instead of #18263._