### PR TITLE
Add per-document word wrap settings

### DIFF
--- a/PowerEditor/Test/xmlValidator/tabContext.xsd
+++ b/PowerEditor/Test/xmlValidator/tabContext.xsd
@@ -11,6 +11,7 @@
                   <xs:attribute name="MenuEntryName" type="xs:string" use="optional"/>
                   <xs:attribute name="MenuItemName" type="xs:string" use="optional"/>
                   <xs:attribute name="FolderName" type="xs:string" use="optional"/>
+                  <xs:attribute name="ItemNameAs" type="xs:string" use="optional"/>
                   <xs:attribute name="id" type="xs:integer" use="optional"/>
                 </xs:complexType>
               </xs:element>

--- a/PowerEditor/installer/nativeLang/english.xml
+++ b/PowerEditor/installer/nativeLang/english.xml
@@ -470,6 +470,10 @@ Translation note:
 				<Item CMDID="44114" name="Apply Color 4"/>
 				<Item CMDID="44115" name="Apply Color 5"/>
 				<Item CMDID="44110" name="Remove Color"/>
+				<Item CMDID="5" name="Word Wrap"/>
+				<Item CMDID="44118" name="Use Global Setting"/>
+				<Item CMDID="44119" name="Off"/>
+				<Item CMDID="44120" name="On"/>
 			</TabBar>
 			<TrayIcon>
 				<Item id="43101" name="Activate"/>

--- a/PowerEditor/installer/nativeLang/english_customizable.xml
+++ b/PowerEditor/installer/nativeLang/english_customizable.xml
@@ -470,6 +470,10 @@ Translation note:
 				<Item CMDID="44114" name="Apply Color 4"/>
 				<Item CMDID="44115" name="Apply Color 5"/>
 				<Item CMDID="44110" name="Remove Color"/>
+				<Item CMDID="5" name="Word Wrap"/>
+				<Item CMDID="44118" name="Use Global Setting"/>
+				<Item CMDID="44119" name="Off"/>
+				<Item CMDID="44120" name="On"/>
 			</TabBar>
 			<TrayIcon>
 				<Item id="43101" name="Activate"/>

--- a/PowerEditor/src/MISC/Common/NppConstants.h
+++ b/PowerEditor/src/MISC/Common/NppConstants.h
@@ -85,6 +85,13 @@ enum lineWrapMethod
 	LINEWRAP_INDENT
 };
 
+enum class DocumentWrapMode : unsigned char
+{
+	useGlobal,
+	off,
+	on
+};
+
 enum lineHiliteMode
 {
 	LINEHILITE_NONE,

--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -5243,7 +5243,7 @@ void Notepad_plus::staticCheckMenuAndTB() const
 
 
 	// Wrap
-	b = _pEditView->isWrap();
+	b = NppParameters::getInstance().getSVP()._doWrap;
 	checkMenuItem(IDM_VIEW_WRAP, b);
 	_toolBar.setCheck(IDM_VIEW_WRAP, b);
 	checkMenuItem(IDM_VIEW_WRAP_SYMBOL, _pEditView->isWrapSymbolVisible());
@@ -6507,6 +6507,7 @@ void Notepad_plus::getCurrentOpenedFiles(Session & session, bool includeUntitled
 			sfi._isMonitoring = buf->isMonitoringOn();
 			sfi._individualTabColour = docTab[k]->getIndividualTabColourId(static_cast<int>(i));
 			sfi._isRTL = buf->isRTL();
+			sfi._wrapMode = buf->getWrapMode();
 
 			_invisibleEditView.execute(SCI_SETDOCPOINTER, 0, buf->getDocument());
 

--- a/PowerEditor/src/Notepad_plus.h
+++ b/PowerEditor/src/Notepad_plus.h
@@ -489,6 +489,7 @@ private:
 	void checkMacroState();
 	void checkSyncState();
 	void syncZoom();
+	void applyWrapToBuffer(Buffer* buffer);
 	void setupColorSampleBitmapsOnMainMenuItems();
 	void dropFiles(HDROP hdrop);
 	void checkModifiedDocument(bool bCheckOnlyCurrentBuffer);

--- a/PowerEditor/src/NppCommands.cpp
+++ b/PowerEditor/src/NppCommands.cpp
@@ -80,6 +80,36 @@ using namespace std;
 
 std::mutex command_mutex;
 
+
+void Notepad_plus::applyWrapToBuffer(Buffer* buffer)
+{
+	const bool isWrapped = buffer->isWrapEnabled();
+	auto applyWrapToView = [buffer, isWrapped](ScintillaEditView& view)
+	{
+		if (view.getCurrentBuffer() != buffer || view.isWrap() == isWrapped)
+			return;
+
+		// ViewMoveAtWrappingDisableFix: Disabling wrapping messes up visible lines.
+		// Save the view position now and restore it after SCN_PAINTED, as Scintilla documentation says.
+		if (!isWrapped)
+		{
+			view.saveCurrentPos();
+			view.setWrapRestoreNeeded(true);
+		}
+		view.wrap(isWrapped);
+	};
+
+	applyWrapToView(_mainEditView);
+	applyWrapToView(_subEditView);
+
+	if (_pDocMap && _pEditView->getCurrentBuffer() == buffer)
+	{
+		_pDocMap->initWrapMap();
+		_pDocMap->wrapMap();
+	}
+}
+
+
 void Notepad_plus::macroPlayback(Macro macro, std::vector<Document>* pDocs4EndUAIn)
 {
 	_playingBackMacro = true;
@@ -2717,30 +2747,39 @@ void Notepad_plus::command(int id)
 
 		case IDM_VIEW_WRAP:
 		{
-			bool isWrapped = !_pEditView->isWrap();
-			// ViewMoveAtWrappingDisableFix: Disable wrapping messes up visible lines. Therefore save view position before in IDM_VIEW_WRAP and restore after SCN_PAINTED, as Scintilla-Doc. says
-			if (!isWrapped)
-			{
-				_mainEditView.saveCurrentPos();
-				_mainEditView.setWrapRestoreNeeded(true);
-				_subEditView.saveCurrentPos();
-				_subEditView.setWrapRestoreNeeded(true);
-			}
-			_mainEditView.wrap(isWrapped);
-			_subEditView.wrap(isWrapped);
+			ScintillaViewParams& svp = (ScintillaViewParams&)(NppParameters::getInstance()).getSVP();
+			const bool isWrapped = !svp._doWrap;
+			svp._doWrap = isWrapped;
+
+			Buffer* mainBuffer = _mainEditView.getCurrentBuffer();
+			if (mainBuffer->getWrapMode() == DocumentWrapMode::useGlobal)
+				applyWrapToBuffer(mainBuffer);
+
+			Buffer* subBuffer = _subEditView.getCurrentBuffer();
+			if (subBuffer != mainBuffer && subBuffer->getWrapMode() == DocumentWrapMode::useGlobal)
+				applyWrapToBuffer(subBuffer);
+
 			_toolBar.setCheck(IDM_VIEW_WRAP, isWrapped);
 			checkMenuItem(IDM_VIEW_WRAP, isWrapped);
-
-			ScintillaViewParams & svp1 = (ScintillaViewParams &)(NppParameters::getInstance()).getSVP();
-			svp1._doWrap = isWrapped;
-
-			if (_pDocMap)
-			{
-				_pDocMap->initWrapMap();
-				_pDocMap->wrapMap();
-			}
 			break;
 		}
+
+		case IDM_VIEW_TAB_WRAP_GLOBAL:
+		case IDM_VIEW_TAB_WRAP_OFF:
+		case IDM_VIEW_TAB_WRAP_ON:
+		{
+			DocumentWrapMode wrapMode = DocumentWrapMode::useGlobal;
+			if (id == IDM_VIEW_TAB_WRAP_OFF)
+				wrapMode = DocumentWrapMode::off;
+			else if (id == IDM_VIEW_TAB_WRAP_ON)
+				wrapMode = DocumentWrapMode::on;
+
+			Buffer* buf = _pEditView->getCurrentBuffer();
+			buf->setWrapMode(wrapMode);
+			applyWrapToBuffer(buf);
+			break;
+		}
+
 		case IDM_VIEW_WRAP_SYMBOL:
 		{
 			_mainEditView.showWrapSymbol(!_pEditView->isWrapSymbolVisible());

--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2623,8 +2623,12 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 				buf->setDirty(true);
 
 			buf->setRTL(session._mainViewFiles[i]._isRTL);
+			buf->setWrapMode(session._mainViewFiles[i]._wrapMode);
 			if (i == 0 && session._activeMainIndex == 0)
+			{
 				_mainEditView.changeTextDirection(buf->isRTL());
+				_mainEditView.wrap(buf->isWrapEnabled());
+			}
 
 			_mainDocTab.setIndividualTabColour(lastOpened, session._mainViewFiles[i]._individualTabColour);
 
@@ -2760,6 +2764,9 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 				buf->setDirty(true);
 
 			buf->setRTL(session._subViewFiles[k]._isRTL);
+			buf->setWrapMode(session._subViewFiles[k]._wrapMode);
+			if (k == 0 && session._activeSubIndex == 0)
+				_subEditView.wrap(buf->isWrapEnabled());
 
 			_subDocTab.setIndividualTabColour(lastOpened, session._subViewFiles[k]._individualTabColour);
 

--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -1138,6 +1138,9 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_TAB_COLOUR_4, L"Apply Color 4", L"Apply Color to Tab"));
 					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_TAB_COLOUR_5, L"Apply Color 5", L"Apply Color to Tab"));
 					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_TAB_COLOUR_NONE, L"Remove Color", L"Apply Color to Tab"));
+					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_TAB_WRAP_GLOBAL, L"Use Global Setting", L"Word Wrap"));
+					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_TAB_WRAP_OFF, L"Off", L"Word Wrap"));
+					itemUnitArray.push_back(MenuItemUnit(IDM_VIEW_TAB_WRAP_ON, L"On", L"Word Wrap"));
 
 					// IMPORTANT: If any submenu entry is added/moved/removed, you have to change the value of tabCmSubMenuEntryPos[] in localization.cpp file
 				}
@@ -1159,6 +1162,9 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 			Buffer* buf = _pEditView->getCurrentBuffer();
 			bool isUserReadOnly = buf->getUserReadOnly();
 			_tabPopupMenu.checkItem(IDM_EDIT_TOGGLEREADONLY, isUserReadOnly);
+			_tabPopupMenu.checkItem(IDM_VIEW_TAB_WRAP_GLOBAL, buf->getWrapMode() == DocumentWrapMode::useGlobal);
+			_tabPopupMenu.checkItem(IDM_VIEW_TAB_WRAP_OFF, buf->getWrapMode() == DocumentWrapMode::off);
+			_tabPopupMenu.checkItem(IDM_VIEW_TAB_WRAP_ON, buf->getWrapMode() == DocumentWrapMode::on);
 
 			bool isSysReadOnly = buf->getFileReadOnly();
 			bool isInaccessible = buf->isInaccessible();

--- a/PowerEditor/src/Parameters.cpp
+++ b/PowerEditor/src/Parameters.cpp
@@ -3329,6 +3329,15 @@ bool NppParameters::getSessionFromXmlTree(const NppXml::Document& pSessionDoc, S
 					sfi._individualTabColour = NppXml::intAttribute(childNode, "tabColourId", -1);
 					sfi._isRTL = getBoolAttribute(childNode, "RTL");
 
+					const char* wrapMode = NppXml::attribute(childNode, "wrapMode");
+					if (wrapMode)
+					{
+						if (std::strcmp(wrapMode, "off") == 0)
+							sfi._wrapMode = DocumentWrapMode::off;
+						else if (std::strcmp(wrapMode, "on") == 0)
+							sfi._wrapMode = DocumentWrapMode::on;
+					}
+
 					for (NppXml::Element markNode = NppXml::firstChildElement(childNode, "Mark");
 						markNode;
 						markNode = NppXml::nextSiblingElement(markNode, "Mark"))
@@ -4558,6 +4567,11 @@ void NppParameters::writeSession(const Session& session, const wchar_t* fileName
 				NppXml::setAttribute(fileNameNode, "originalFileLastModifTimestampHigh", vsFile._originalFileLastModifTimestamp.dwHighDateTime);
 				NppXml::setAttribute(fileNameNode, "tabColourId", vsFile._individualTabColour);
 				setBoolAttribute(fileNameNode, "RTL", vsFile._isRTL);
+
+				const char* wrapMode = vsFile._wrapMode == DocumentWrapMode::off ? "off" :
+					vsFile._wrapMode == DocumentWrapMode::on ? "on" : "global";
+				NppXml::setAttribute(fileNameNode, "wrapMode", wrapMode);
+
 				setBoolAttribute(fileNameNode, "tabPinned", vsFile._isPinned);
 
 				// Save this info only when it's an untitled entry

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -138,6 +138,7 @@ struct sessionFileInfo : public Position
 	bool _isMonitoring = false;
 	int _individualTabColour = -1;
 	bool _isRTL = false;
+	DocumentWrapMode _wrapMode = DocumentWrapMode::useGlobal;
 	bool _isPinned = false;
 	bool _isUntitledTabRenamed = false;
 	std::wstring _backupFilePath;

--- a/PowerEditor/src/ScintillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScintillaComponent/Buffer.cpp
@@ -130,6 +130,13 @@ Buffer::Buffer(FileManager * pManager, BufferID id, Document doc, DocFileStatus 
 }
 
 
+bool Buffer::isWrapEnabled() const
+{
+	return _wrapMode == DocumentWrapMode::on ||
+		(_wrapMode == DocumentWrapMode::useGlobal && NppParameters::getInstance().getSVP()._doWrap);
+}
+
+
 void Buffer::doNotify(int mask)
 {
 	if (_canNotify)
@@ -963,16 +970,6 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 	if (nppGui._largeFileRestriction._isEnabled)
 		isLargeFile = fileSize >= nppGui._largeFileRestriction._largeFileSizeDefInByte;
 
-	// Due to the performance issue, the Word Wrap feature will be disabled if it's ON
-	if (isLargeFile && nppGui._largeFileRestriction._deactivateWordWrap)
-	{
-		bool isWrap = _pNotepadPlus->_pEditView->isWrap();
-		if (isWrap)
-		{
-			_pNotepadPlus->command(IDM_VIEW_WRAP);
-		}
-	}
-
 	bool ownDoc = false;
 	if (!doc)
 	{
@@ -1019,6 +1016,10 @@ BufferID FileManager::loadFile(const wchar_t* filename, Document doc, int encodi
 	if (loadRes)
 	{
 		Buffer* newBuf = new Buffer(this, _nextBufferID, doc, DOC_REGULAR, fullpath, isLargeFile);
+		// Due to performance concerns, disable word wrap for this large-file buffer only.
+		if (isLargeFile && nppGui._largeFileRestriction._deactivateWordWrap)
+			newBuf->setWrapMode(DocumentWrapMode::off);
+
 		BufferID id = newBuf;
 		newBuf->_id = id;
 

--- a/PowerEditor/src/ScintillaComponent/Buffer.h
+++ b/PowerEditor/src/ScintillaComponent/Buffer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <mutex>
+#include "NppConstants.h"
 #include "Utf8_16.h"
 
 
@@ -391,6 +392,10 @@ public:
 	bool isRTL() const { return _isRTL; }
 	void setRTL(bool isRTL) { _isRTL = isRTL; }
 
+	DocumentWrapMode getWrapMode() const { return _wrapMode; }
+	void setWrapMode(DocumentWrapMode wrapMode) { _wrapMode = wrapMode; }
+	bool isWrapEnabled() const;
+
 	bool isPinned() const { return _isPinned; }
 	void setPinned(bool isPinned) { _isPinned = isPinned; }
 
@@ -484,5 +489,6 @@ private:
 	bool _isInaccessible = false;
 
 	bool _isRTL = false;
+	DocumentWrapMode _wrapMode = DocumentWrapMode::useGlobal;
 	bool _isPinned = false;
 };

--- a/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp
@@ -2359,6 +2359,7 @@ void ScintillaEditView::activateBuffer(BufferID buffer, bool force)
 	execute(SCI_SETMODEVENTMASK, MODEVENTMASK_OFF);
 	execute(SCI_SETDOCPOINTER, 0, _currentBuffer->getDocument());
 	execute(SCI_SETMODEVENTMASK, MODEVENTMASK_ON);
+	wrap(_currentBuffer->isWrapEnabled());
 
 	defineDocType(_currentBuffer->getLangType());
 

--- a/PowerEditor/src/localization.cpp
+++ b/PowerEditor/src/localization.cpp
@@ -479,6 +479,7 @@ static constexpr int tabCmSubMenuEntryPos[]{
     14,   // 2  Copy to Clipboard
     15,   // 3  Move Document
     16,   // 4  Apply Color to Tab
+    17,   // 5  Word Wrap
 };
 
 

--- a/PowerEditor/src/menuCmdID.h
+++ b/PowerEditor/src/menuCmdID.h
@@ -399,6 +399,9 @@
     #define    IDM_VIEW_TAB_COLOUR_5              (IDM_VIEW + 115)
     #define    IDM_VIEW_TAB_START                 (IDM_VIEW + 116)
     #define    IDM_VIEW_TAB_END                   (IDM_VIEW + 117)
+    #define    IDM_VIEW_TAB_WRAP_GLOBAL           (IDM_VIEW + 118)
+    #define    IDM_VIEW_TAB_WRAP_OFF              (IDM_VIEW + 119)
+    #define    IDM_VIEW_TAB_WRAP_ON               (IDM_VIEW + 120)
 
     #define    IDM_VIEW_NPC                       (IDM_VIEW + 130)
     #define    IDM_VIEW_NPC_CCUNIEOL              (IDM_VIEW + 131)

--- a/PowerEditor/src/tabContextMenu_example.xml
+++ b/PowerEditor/src/tabContextMenu_example.xml
@@ -61,6 +61,9 @@ https://npp-user-manual.org/docs/config-files/#the-context-menu-tabcontextmenu-x
 		<Item FolderName="Apply Color to Tab" MenuEntryName="View" MenuItemName="Apply Color 4"/>
 		<Item FolderName="Apply Color to Tab" MenuEntryName="View" MenuItemName="Apply Color 5"/>
 		<Item FolderName="Apply Color to Tab" MenuEntryName="View" MenuItemName="Remove Color"/>
+		<Item FolderName="Word Wrap" id="44118" ItemNameAs="Use Global Setting"/>
+		<Item FolderName="Word Wrap" id="44119" ItemNameAs="Off"/>
+		<Item FolderName="Word Wrap" id="44120" ItemNameAs="On"/>
 
 	</TabContextMenu>
 </NotepadPlus>


### PR DESCRIPTION
## What and why

Word wrap was represented only by the global Scintilla view preference, and the existing command applied that value indiscriminately to both editor views. As a result, switching tabs could not preserve a document-specific choice, and opening a large file could disable wrapping globally for unrelated documents.

This change adds a persistent three-state word-wrap mode to each document buffer:

- **Use Global Setting** resolves through the existing global Word Wrap preference.
- **Off** keeps wrapping disabled for that document.
- **On** keeps wrapping enabled for that document.

The existing View menu and toolbar command remain global. Global changes update only visible documents using the global setting, while their checked state continues to represent the global preference.

## User impact

- Adds a **Word Wrap** submenu to the default tab context menu with mutually exclusive **Use Global Setting**, **Off**, and **On** choices.
- Applies the effective document setting before restoring view position when a tab becomes active.
- Synchronizes cloned documents in both editor views and refreshes Document Map wrapping.
- Persists the choice as `wrapMode="global|off|on"` in session files.
- Initializes large files with an **Off** override instead of changing the global preference.

## Compatibility

Older session files without `wrapMode`, and session files containing an unrecognized value, default to **Use Global Setting**. Untranslated languages retain the built-in English labels. No plugin API changes are introduced.

## Validation

- `python PowerEditor\Test\xmlValidator\validator_xml.py`
- `git diff --check`
- Visual Studio 2022 C++ build: Win32 Debug
- Visual Studio 2022 C++ build: x64 Release
- Isolated runtime smoke checks: independent tabs, all three modes, global isolation, cloned views, session persistence, missing/invalid session fallback, large-file isolation, wrap-disable scroll stability, and Document Map synchronization

This is intentionally a draft because issue #5232 does not currently have the contributor guide's `Accepted` label.

Fixes #5232
