### PR TITLE
Support per-user installation mode (no admin rights required)

### DIFF
--- a/PowerEditor/installer/nppSetup.nsi
+++ b/PowerEditor/installer/nppSetup.nsi
@@ -31,7 +31,20 @@ SetCompressor /SOLID lzma	; This reduces installer size by approx 30~35%
 ; Installer is DPI-aware: not scaled by the DWM, no blurry text
 ManifestDPIAware true
 
+; Never request elevation at startup, so the installer can run for any user without UAC.
+; If the user picks the "all users" install mode on the InstallModePage, we relaunch
+; ourselves with ExecShell "runas" (which triggers UAC) and pass /AllUsers so the
+; elevated instance remembers the choice. See InstallModePageLeave for the relaunch logic.
+RequestExecutionLevel user
+
 Var winSysDir
+
+; Per-user vs all-users install support.
+; Declared here (before the includes below) because tools.nsh and uninstall.nsh use them.
+Var MultiUserInstallMode	; "AllUsers" or "CurrentUser"
+Var IsElevated			; "true" if the installer process runs elevated (admin)
+Var InstModeRadioAllUsers
+Var InstModeRadioCurrentUser
 
 !include "nsisInclude\winVer.nsh"
 !include "nsisInclude\globalDef.nsh"
@@ -82,6 +95,7 @@ Var runningNppDetected
 
 !insertmacro MUI_PAGE_WELCOME
 !insertmacro MUI_PAGE_LICENSE "..\..\LICENSE"
+Page custom InstallModePageCreate InstallModePageLeave
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_COMPONENTS
 page Custom ExtraOptions
@@ -123,39 +137,156 @@ InstType "Minimalist"
 
 
 
-!ifdef ARCH64 || ARCHARM64
-; this is needed for the 64-bit InstallDirRegKey patch
+; StrStr is used in .onInit to detect a user-provided "/D=" on the command line
 !include "StrFunc.nsh"
 ${StrStr} # Supportable for Install Sections and Functions
+
+; Apply the shell-var context (all/current) and registry view that match $MultiUserInstallMode.
+; SHCTX-based registry access and $LOCALAPPDATA/$APPDATA then resolve to the right place.
+Function applyInstallModeContext
+	${If} $MultiUserInstallMode == "AllUsers"
+		SetShellVarContext all
+	${Else}
+		SetShellVarContext current
+	${EndIf}
+!ifdef ARCH64 || ARCHARM64
+	${If} ${RunningX64}
+		SetRegView 64 ; 64-bit components: always use the non-redirected hive
+	${EndIf}
 !endif
+FunctionEnd
+
+; Decide the initial install mode from the elevation state, with optional /AllUsers and
+; /CurrentUser command-line overrides (mostly useful for silent installations).
+Function initInstallMode
+	UserInfo::GetAccountType
+	Pop $0
+	${If} $0 == "Admin"
+		StrCpy $IsElevated "true"
+		StrCpy $MultiUserInstallMode "AllUsers"
+	${Else}
+		StrCpy $IsElevated "false"
+		StrCpy $MultiUserInstallMode "CurrentUser"
+	${EndIf}
+
+	${GetParameters} $R0
+	ClearErrors
+	${GetOptions} $R0 "/CurrentUser" $R1
+	${IfNot} ${Errors}
+		StrCpy $MultiUserInstallMode "CurrentUser"
+	${EndIf}
+	ClearErrors
+	${GetOptions} $R0 "/AllUsers" $R1
+	${IfNot} ${Errors}
+		${If} $IsElevated == "true"
+			StrCpy $MultiUserInstallMode "AllUsers"
+		${ElseIf} ${Silent}
+			; A silent install has no page on which to offer the elevation that the GUI
+			; does, so honouring /AllUsers here would quietly turn into a per-user install
+			; while still reporting success. Fail with ERROR_ELEVATION_REQUIRED instead, so
+			; deployment scripts that only check the exit code do not get a false positive.
+			SetErrorLevel 740
+			Quit
+		${EndIf}
+	${EndIf}
+
+	Call applyInstallModeContext
+FunctionEnd
+
+; When the user switches mode, swap $INSTDIR to the new mode's default - but only if it still
+; holds the other mode's default path (a /D= or restored previous path is left untouched).
+Function updateDefaultInstDir
+!ifdef ARCH64 || ARCHARM64
+	StrCpy $R8 "$PROGRAMFILES64\${APPNAME}"
+!else
+	StrCpy $R8 "$PROGRAMFILES\${APPNAME}"
+!endif
+	StrCpy $R9 "$LOCALAPPDATA\${APPNAME}"
+	${If} $MultiUserInstallMode == "CurrentUser"
+		${If} "$INSTDIR" == "$R8"
+			StrCpy $INSTDIR "$R9"
+		${EndIf}
+	${Else}
+		${If} "$INSTDIR" == "$R9"
+			StrCpy $INSTDIR "$R8"
+		${EndIf}
+	${EndIf}
+FunctionEnd
+
+; Custom page: let the user pick all-users vs per-user installation.
+Function InstallModePageCreate
+	!insertmacro MUI_HEADER_TEXT "Choose Installation Type" "Choose for which users you want to install Notepad++."
+	nsDialogs::Create 1018
+	Pop $0
+	${If} $0 == error
+		Abort
+	${EndIf}
+
+	${NSD_CreateLabel} 0 0 100% 24u "Install Notepad++ for all users of this computer (requires administrator rights), or only for you (no administrator rights needed)."
+	Pop $0
+
+	${NSD_CreateRadioButton} 10u 34u 100% 12u "Install for &all users (requires administrator rights)"
+	Pop $InstModeRadioAllUsers
+	${NSD_CreateRadioButton} 10u 50u 100% 12u "Install just for &me (into %LOCALAPPDATA%, no administrator rights needed)"
+	Pop $InstModeRadioCurrentUser
+
+	${If} $MultiUserInstallMode == "AllUsers"
+		${NSD_Check} $InstModeRadioAllUsers
+	${Else}
+		${NSD_Check} $InstModeRadioCurrentUser
+	${EndIf}
+
+	; Both options are always selectable. If the user picks "for all users" from a
+	; non-elevated process, InstallModePageLeave triggers a UAC prompt via
+	; ExecShell "runas" and relaunches the installer elevated. Windows handles
+	; the case where the account has no admin rights at all (will prompt for an
+	; admin password) - which is friendlier than disabling the option outright.
+
+	nsDialogs::Show
+FunctionEnd
+
+Function InstallModePageLeave
+	${NSD_GetState} $InstModeRadioAllUsers $0
+	${If} $0 == ${BST_CHECKED}
+		StrCpy $MultiUserInstallMode "AllUsers"
+		; All-users install needs admin rights. If this process is not elevated, relaunch
+		; ourselves elevated (UAC prompt) and pass /AllUsers so the new instance picks up
+		; the same choice. initInstallMode applies /AllUsers AFTER /CurrentUser, so a
+		; pre-existing /CurrentUser on the cmdline is harmlessly overridden in the new
+		; (elevated) process. The current (non-elevated) process then quits.
+		${If} $IsElevated != "true"
+			${GetParameters} $R0
+			ExecShell "runas" "$EXEPATH" "/AllUsers $R0"
+			Quit	; if the user cancels UAC, the install simply aborts (standard NSIS pattern)
+		${EndIf}
+	${Else}
+		StrCpy $MultiUserInstallMode "CurrentUser"
+	${EndIf}
+	Call applyInstallModeContext
+	Call updateDefaultInstDir
+FunctionEnd
 
 Function .onInit
 
-	; --- PATCH BEGIN (it can be deleted without side-effects, when the NSIS N++ x64 installer binary becomes x64 too)---
-	;
-	; 64-bit patch for the NSIS attribute InstallDirRegKey (used in globalDef.nsh)
-	; - this is needed because of the NSIS binary, generated for 64-bit Notepad++ installations, is still a 32-bit app,
-	;   so the InstallDirRegKey checks for the irrelevant HKLM\SOFTWARE\WOW6432Node\Notepad++, explanation:
-	;   https://nsis.sourceforge.io/Reference/SetRegView
-	;
-!ifdef ARCH64 || ARCHARM64	; installation of 64 bits Notepad++ & its 64 bits components
-	${If} ${RunningX64} ; Windows 64 bits
-		System::Call kernel32::GetCommandLine()t.r0 ; get the original cmdline (where a possible "/D=..." is not hidden from us by NSIS)
-		${StrStr} $1 $0 "/D="
-		${If} "$1" == ""
-			; "/D=..." was NOT used for sure, so we can continue in this InstallDirRegKey x64 patch 
-			SetRegView 64 ; disable registry redirection
-			ReadRegStr $0 HKLM "Software\${APPNAME}" ""
-			${If} "$0" != ""
-				; a previous installation path has been detected, so offer that as the $INSTDIR
-				StrCpy $INSTDIR "$0"
-			${EndIf}
-			SetRegView 32 ; restore the original state
+	; Decide whether we install for all users (HKLM, Program Files) or just for the
+	; current user (HKCU, %LOCALAPPDATA%). This sets $MultiUserInstallMode, the shell-var
+	; context and the registry view, so all the SHCTX-based registry writes land in the
+	; right hive and no admin rights are required for a per-user install.
+	Call initInstallMode
+
+	; Read back a previous installation directory (replaces the former InstallDirRegKey).
+	; The root follows the install mode via SHCTX, and is skipped when the user passes "/D=".
+	; (The NSIS x64 installer binary is still a 32-bit app, so SetRegView - done in
+	;  initInstallMode - is required to read the non-redirected hive.)
+	System::Call kernel32::GetCommandLine()t.r0 ; original cmdline ("/D=..." is not hidden from us by NSIS here)
+	${StrStr} $1 $0 "/D="
+	${If} "$1" == ""
+		ReadRegStr $0 SHCTX "Software\${APPNAME}" ""
+		${If} "$0" != ""
+			; a previous installation path has been detected, so offer that as the $INSTDIR
+			StrCpy $INSTDIR "$0"
 		${EndIf}
 	${EndIf}
-!endif
-	;
-	; --- PATCH END ---
 
 	StrCpy $runningNppDetected "false" ; reset
 
@@ -175,7 +306,12 @@ closeRunningNppCheckDone:
 	${EndIf}
 
 	; handle the possible Silent Mode (/S) & already running Notepad++ (without this an incorrect partial installation is possible)
+	; A per-user install writes only into $LOCALAPPDATA\Notepad++ and never touches an
+	; all-users notepad++.exe, so this mutex check only matters for an all-users install.
 	IfSilent 0 notInSilentMode
+	${If} $MultiUserInstallMode != "AllUsers"
+		Goto notInSilentMode
+	${EndIf}
 	System::Call 'kernel32::OpenMutex(i 0x100000, b 0, t "nppInstance") i .R0'
 	IntCmp $R0 0 nppNotRunning
 	StrCpy $runningNppDetected "true"
@@ -240,10 +376,10 @@ relaunchNppDone:
 	InitPluginsDir			; Initializes the plug-ins dir ($PLUGINSDIR) if not already initialized.
 	Call checkCompatibility		; check unsupported OSes and CPUs
 		
-	; look for previously selected language
+	; look for previously selected language (SHCTX follows the install mode: HKLM all-users / HKCU per-user)
 	ClearErrors
 	Var /GLOBAL tempLng
-	ReadRegStr $tempLng HKLM "SOFTWARE\${APPNAME}" 'InstallerLanguage'
+	ReadRegStr $tempLng SHCTX "SOFTWARE\${APPNAME}" 'InstallerLanguage'
 	${IfNot} ${Errors}
 		StrCpy $LANGUAGE "$tempLng" ; set default language
 	${EndIf}
@@ -251,7 +387,7 @@ relaunchNppDone:
 	!insertmacro MUI_LANGDLL_DISPLAY
 
 	; save selected language to registry
-	WriteRegStr HKLM "SOFTWARE\${APPNAME}" 'InstallerLanguage' '$Language'
+	WriteRegStr SHCTX "SOFTWARE\${APPNAME}" 'InstallerLanguage' '$Language'
 
 !ifdef ARCH64 || ARCHARM64 ; x64 or ARM64 : installation of 64 bits Notepad++ & its 64 bits components
 	StrCpy $winSysDir $WINDIR\System32
@@ -261,15 +397,16 @@ relaunchNppDone:
 		; we disable registry redirection (enable access to 64-bit portion of registry)
 		; regView value is set to 64 once for all.
 		SetRegView 64
-		
-		; change to x64 install dir if needed
-		${If} "$InstDir" != ""
-			${If} "$InstDir" == "$PROGRAMFILES\${APPNAME}"
+
+		; Pick the default install dir for the chosen mode, but only when $INSTDIR is still
+		; the generic globalDef.nsh default (i.e. neither /D= nor a restored previous path).
+		${If} "$InstDir" == "$PROGRAMFILES\${APPNAME}"
+		${OrIf} "$InstDir" == ""
+			${If} $MultiUserInstallMode == "CurrentUser"
+				StrCpy $INSTDIR "$LOCALAPPDATA\${APPNAME}"
+			${Else}
 				StrCpy $INSTDIR "$PROGRAMFILES64\${APPNAME}"
 			${EndIf}
-			; else /D was used or last installation is not "$PROGRAMFILES\${APPNAME}"
-		${Else}
-			StrCpy $INSTDIR "$PROGRAMFILES64\${APPNAME}"
 		${EndIf}
 		
 		; check if 32-bit version has been installed if yes, ask user to remove it
@@ -286,6 +423,13 @@ noDelete32:
 
 !else ; installation of 32 bits Notepad++ & its 32 bits components
 	StrCpy $winSysDir $WINDIR\SysWOW64
+	; For a per-user install, default to a writable location instead of Program Files.
+	${If} $MultiUserInstallMode == "CurrentUser"
+		${If} "$InstDir" == "$PROGRAMFILES\${APPNAME}"
+		${OrIf} "$InstDir" == ""
+			StrCpy $INSTDIR "$LOCALAPPDATA\${APPNAME}"
+		${EndIf}
+	${EndIf}
 	${If} ${RunningX64}  ; Windows 64 bits
 		; check if 64-bit version has been installed if yes, ask user to remove it
 		IfFileExists $PROGRAMFILES64\${APPNAME}\notepad++.exe 0 noDelete64
@@ -364,21 +508,28 @@ ${MementoSection} "Context Menu Entry" explorerContextMenu
 !endif
 
 	; Shell context menu entry
-	WriteRegStr HKCR "*\shell\ANotepad++64" "" "Notepad++ Context menu"
-	WriteRegStr HKCR "*\shell\ANotepad++64" "ExplorerCommandHandler" "{B298D29A-A6ED-11DE-BA8C-A68E55D89593}"
-	WriteRegStr HKCR "*\shell\ANotepad++64" "NeverDefault" ""
+	; HKCR == HKLM\Software\Classes; using SHCTX\Software\Classes routes to HKLM for an
+	; all-users install and to HKCU\Software\Classes for a per-user install (no admin needed).
+	WriteRegStr SHCTX "Software\Classes\*\shell\ANotepad++64" "" "Notepad++ Context menu"
+	WriteRegStr SHCTX "Software\Classes\*\shell\ANotepad++64" "ExplorerCommandHandler" "{B298D29A-A6ED-11DE-BA8C-A68E55D89593}"
+	WriteRegStr SHCTX "Software\Classes\*\shell\ANotepad++64" "NeverDefault" ""
 
 	; CLSID registration
-	WriteRegStr HKCR "CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}" "" "notepad++"
-	WriteRegStr HKCR "CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}\InProcServer32" "" "$INSTDIR\contextMenu\NppShell.dll"
-	WriteRegStr HKCR "CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}\InProcServer32" "ThreadingModel" "Apartment"
+	WriteRegStr SHCTX "Software\Classes\CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}" "" "notepad++"
+	WriteRegStr SHCTX "Software\Classes\CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}\InProcServer32" "" "$INSTDIR\contextMenu\NppShell.dll"
+	WriteRegStr SHCTX "Software\Classes\CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}\InProcServer32" "ThreadingModel" "Apartment"
 
 	; Register MSIX for Windows 11 modern context menu
 	; Skip only for x86 Notepad++ installation on Windows 32 system
 !ifdef ARCH64 || ARCHARM64 ; x64 installer
 	Call RegisterMSIX
 !else ; 32 bits installer
-	ExecWait '"$winSysDir\regsvr32.exe" /s "$INSTDIR\contextMenu\NppShell.dll"'
+	; NppShell's DllRegisterServer writes its keys under HKLM, so regsvr32 needs admin
+	; rights and can only be used for an all-users install. A per-user install does not
+	; need it: the entries above are written through SHCTX, which routes them to HKCU.
+	${If} $MultiUserInstallMode == "AllUsers"
+		ExecWait '"$winSysDir\regsvr32.exe" /s "$INSTDIR\contextMenu\NppShell.dll"'
+	${EndIf}
 !endif
 
 ${MementoSectionEnd}

--- a/PowerEditor/installer/nsisInclude/globalDef.nsh
+++ b/PowerEditor/installer/nsisInclude/globalDef.nsh
@@ -61,7 +61,8 @@
 !define APPWEBSITE "https://notepad-plus-plus.org/"
 
 !define UNINSTALL_REG_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
-!define MEMENTO_REGISTRY_ROOT HKLM
+; SHCTX follows SetShellVarContext: HKLM for an all-users install, HKCU for a per-user install.
+!define MEMENTO_REGISTRY_ROOT SHCTX
 !define MEMENTO_REGISTRY_KEY ${UNINSTALL_REG_KEY}
 
 ; Main Install settings
@@ -69,4 +70,6 @@ Name "${APPNAMEANDVERSION}"
 
 InstallDir "$PROGRAMFILES\${APPNAME}"
 
-InstallDirRegKey HKLM "Software\${APPNAME}" ""
+; NB: InstallDirRegKey is intentionally not used here.
+; The previous installation directory is read back manually in .onInit (initInstallMode),
+; because the registry root depends on the chosen install mode (HKLM all-users / HKCU per-user).

--- a/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
+++ b/PowerEditor/installer/nsisInclude/mainSectionFuncs.nsh
@@ -371,6 +371,7 @@ FunctionEnd
 
 Function shortcutLinkManagement
 	; remove all the npp shortcuts from current user
+	SetShellVarContext current
 	Delete "$DESKTOP\Notepad++.lnk"
 	Delete "$SMPROGRAMS\Notepad++.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Notepad++.lnk"
@@ -378,11 +379,11 @@ Function shortcutLinkManagement
 	Delete "$SMPROGRAMS\${APPNAME}\Uninstall.lnk"
 	RMDir "$SMPROGRAMS\${APPNAME}"
 		
-	; detect the right of 
-	UserInfo::GetAccountType
-	Pop $1
-	StrCmp $1 "Admin" 0 +2
-	SetShellVarContext all
+	; create the shortcuts in the scope that matches the install mode
+	; (all users for an all-users install, current user for a per-user install)
+	${If} $MultiUserInstallMode == "AllUsers"
+		SetShellVarContext all
+	${EndIf}
 	
 	; set the shortcuts working directory
 	; http://nsis.sourceforge.net/Docs/Chapter4.html#createshortcut

--- a/PowerEditor/installer/nsisInclude/tools.nsh
+++ b/PowerEditor/installer/nsisInclude/tools.nsh
@@ -188,33 +188,35 @@ FunctionEnd
 
 
 Function writeInstallInfoInRegistry
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\notepad++.exe" "" "$INSTDIR\notepad++.exe"
-	
-	WriteRegStr HKLM "Software\${APPNAME}" "" "$INSTDIR"
+	; SHCTX follows the install mode: HKLM for all-users, HKCU for a per-user install.
+	WriteRegStr SHCTX "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\notepad++.exe" "" "$INSTDIR\notepad++.exe"
+
+	WriteRegStr SHCTX "Software\${APPNAME}" "" "$INSTDIR"
+	WriteRegStr SHCTX "Software\${APPNAME}" "InstallMode" "$MultiUserInstallMode" ; read back by the uninstaller
 	!ifdef ARCH64
-		WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayName" "${APPNAME} (64-bit x64)"
+		WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "DisplayName" "${APPNAME} (64-bit x64)"
 	!else ifdef ARCHARM64
-		WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayName" "${APPNAME} (ARM 64-bit)"
+		WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "DisplayName" "${APPNAME} (ARM 64-bit)"
 	!else
-		WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayName" "${APPNAME} (32-bit x86)"
+		WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "DisplayName" "${APPNAME} (32-bit x86)"
 	!endif
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "Publisher" "Notepad++ Team"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "MajorVersion" "${VERSION_MAJOR}"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "MinorVersion" "${VERSION_MINOR}"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "UninstallString" '"$INSTDIR\uninstall.exe"'
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayIcon" "$INSTDIR\notepad++.exe"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "DisplayVersion" "${APPVERSION}"
-	WriteRegStr HKLM "${UNINSTALL_REG_KEY}" "URLInfoAbout" "${APPWEBSITE}"
-	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "VersionMajor" ${VERSION_MAJOR}
-	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "VersionMinor" ${VERSION_MINOR}
-	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "NoModify" 1
-	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "NoRepair" 1
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "Publisher" "Notepad++ Team"
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "MajorVersion" "${VERSION_MAJOR}"
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "MinorVersion" "${VERSION_MINOR}"
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "UninstallString" '"$INSTDIR\uninstall.exe"'
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "DisplayIcon" "$INSTDIR\notepad++.exe"
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "DisplayVersion" "${APPVERSION}"
+	WriteRegStr SHCTX "${UNINSTALL_REG_KEY}" "URLInfoAbout" "${APPWEBSITE}"
+	WriteRegDWORD SHCTX "${UNINSTALL_REG_KEY}" "VersionMajor" ${VERSION_MAJOR}
+	WriteRegDWORD SHCTX "${UNINSTALL_REG_KEY}" "VersionMinor" ${VERSION_MINOR}
+	WriteRegDWORD SHCTX "${UNINSTALL_REG_KEY}" "NoModify" 1
+	WriteRegDWORD SHCTX "${UNINSTALL_REG_KEY}" "NoRepair" 1
 	
 	${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
 	IfErrors +3 0
 	IntFmt $0 "0x%08X" $0
-	WriteRegDWORD HKLM "${UNINSTALL_REG_KEY}" "EstimatedSize" "$0"
+	WriteRegDWORD SHCTX "${UNINSTALL_REG_KEY}" "EstimatedSize" "$0"
 	
 	WriteUninstaller "$INSTDIR\uninstall.exe"
 FunctionEnd

--- a/PowerEditor/installer/nsisInclude/uninstall.nsh
+++ b/PowerEditor/installer/nsisInclude/uninstall.nsh
@@ -26,8 +26,33 @@ Function un.onInit
 	StrCpy $winSysDir "$WINDIR\SysWOW64"
 !endif
 
+	; Detect whether this was an all-users or a per-user installation. A per-user install
+	; records itself in HKCU, an all-users one in HKLM - but both can exist side by side on
+	; the same account, so the HKCU marker alone does not tell us which installation this
+	; uninstaller belongs to. Only the one that wrote us has its recorded install path
+	; pointing at our own directory, so match on that as well. A leftover uninstaller whose
+	; per-user installation has since been reinstalled elsewhere no longer matches and is
+	; treated as all-users: it then finds nothing of its own to remove, which is the safe
+	; way round - the alternative would be deleting the current installation's HKCU keys.
+	SetShellVarContext current
+!ifdef ARCH64 || ARCHARM64
+	${If} ${RunningX64}
+		SetRegView 64
+	${EndIf}
+!endif
+	ReadRegStr $0 HKCU "Software\${APPNAME}" "InstallMode"
+	ReadRegStr $1 HKCU "Software\${APPNAME}" ""
+	${If} $0 == "CurrentUser"
+	${AndIf} $1 == "$INSTDIR"
+		StrCpy $MultiUserInstallMode "CurrentUser"
+	${Else}
+		StrCpy $MultiUserInstallMode "AllUsers"
+	${EndIf}
+
 	StrCpy $keepUserData "false"	; default value(It is must, otherwise few files such as shortcuts.xml, contextMenu.xml etc, will not be removed when $INSTDIR\doLocalConf.xml is not available.)
 	; determinate theme path for uninstall themes
+	; user config always lives in the current user's roaming %APPDATA%\Notepad++
+	SetShellVarContext current
 	StrCpy $installPath "$APPDATA\${APPNAME}"
 	StrCpy $doLocalConf "false"
 	IfFileExists $INSTDIR\doLocalConf.xml doesExist noneExist
@@ -37,6 +62,14 @@ doesExist:
 	StrCpy $doLocalConf "true"
 noneExist:
 	;MessageBox MB_OK "doLocalConf == $doLocalConf"
+
+	; From now on, use the shell-var context that matches the install mode
+	; (drives SHCTX registry access and all-users/current-user shortcut paths).
+	${If} $MultiUserInstallMode == "AllUsers"
+		SetShellVarContext all
+	${Else}
+		SetShellVarContext current
+	${EndIf}
 
 	Call un.setPathAndOptions
 FunctionEnd
@@ -70,12 +103,18 @@ Section un.explorerContextMenu
 		ExecWait '"$winSysDir\rundll32.exe" "$INSTDIR\contextmenu\NppShell.dll",CleanupDll'
 	SetRegView 64
 !else
-	ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\contextmenu\NppShell.dll"'
+	; DllUnregisterServer deletes NppShell's keys from HKLM, which a per-user uninstall
+	; neither may nor needs to do - nothing was written there. The SHCTX deletions below
+	; take care of the HKCU side.
+	${If} $MultiUserInstallMode == "AllUsers"
+		ExecWait '"$winSysDir\regsvr32.exe" /u /s "$INSTDIR\contextmenu\NppShell.dll"'
+	${EndIf}
 	SetRegView 32
 !endif
 
-    DeleteRegKey HKCR "*\shell\ANotepad++64"
-    DeleteRegKey HKCR "CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}"
+    ; SHCTX\Software\Classes == HKCR for all-users, HKCU\Software\Classes for per-user
+    DeleteRegKey SHCTX "Software\Classes\*\shell\ANotepad++64"
+    DeleteRegKey SHCTX "Software\Classes\CLSID\{B298D29A-A6ED-11DE-BA8C-A68E55D89593}"
 
     Delete "$INSTDIR\contextmenu\NppShell.dll"
     Delete "$INSTDIR\contextmenu\NppShell.msix"
@@ -199,23 +238,22 @@ Section Uninstall
 !else
 	SetRegView 32
 !endif
-	;Remove from registry...
-	DeleteRegKey HKLM "${UNINSTALL_REG_KEY}"
-	DeleteRegKey HKLM "SOFTWARE\${APPNAME}"
-	DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\notepad++.exe"
+	;Remove from registry... (SHCTX follows the install mode set in un.onInit: HKLM all-users / HKCU per-user)
+	DeleteRegKey SHCTX "${UNINSTALL_REG_KEY}"
+	DeleteRegKey SHCTX "SOFTWARE\${APPNAME}"
+	DeleteRegKey SHCTX "SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\notepad++.exe"
 
 	; Delete self
 	Delete "$INSTDIR\uninstall.exe"
 
-	; Delete Shortcuts
+	; Delete Shortcuts (in the scope that matches the install mode)
 	Delete "$SMPROGRAMS\${APPNAME}\Uninstall.lnk"
 	RMDir "$SMPROGRAMS\${APPNAME}"
-	
-	UserInfo::GetAccountType
-	Pop $1
-	StrCmp $1 "Admin" 0 +2
+
+	${If} $MultiUserInstallMode == "AllUsers"
 		SetShellVarContext all ; make context for all user
-	
+	${EndIf}
+
 	Delete "$DESKTOP\Notepad++.lnk"
 	Delete "$SMPROGRAMS\Notepad++.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Notepad++.lnk"
@@ -297,9 +335,10 @@ Section Uninstall
 		RMDir /r "$APPDATA\${APPNAME}\backup\"	; Remove backup folder recursively if not empty
 		RMDir "$APPDATA\${APPNAME}\themes\"	; has no effect as not empty at this moment, but it is taken care at un.onUninstSuccess
 		RMDir "$APPDATA\${APPNAME}"		; has no effect as not empty at this moment, but it is taken care at un.onUninstSuccess
-		
-		StrCmp $1 "Admin" 0 +2
-			SetShellVarContext all ; make context for all user
+
+		${If} $MultiUserInstallMode == "AllUsers"
+			SetShellVarContext all ; restore the all-users context for the remaining cleanup
+		${EndIf}
 	${endIf}
 	
 	; Remove remaining directories


### PR DESCRIPTION
- [x] I have read [contributing guidelines](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md)

This adds a per-user installation mode to the existing installer, so Notepad++ can be
installed on a machine where the user has no administrator rights - the case this issue
has been about since 2024.

It follows the approach @xomx described in the issue: keep one unified installer, do not
request elevation at startup, and only fire the UAC prompt if the user actually chooses to
install into a protected location. There is no second installer and no new binary: the same
three setups are produced from the same `nppSetup.nsi`.

### What the user sees

One new page, between the licence and the directory page, with two radio buttons:

| | All users (unchanged behaviour) | Just for me (new) |
|---|---|---|
| Install directory | `%ProgramFiles%\Notepad++` | `%LOCALAPPDATA%\Notepad++` |
| Registry | HKLM | HKCU |
| UAC at startup | never (see below) | never |
| UAC when installing | yes, on leaving the page | never |

Both options are always selectable. Disabling "all users" for non-elevated processes would
be wrong, because `UserInfo::GetAccountType` returns `"User"` for an administrator account
in a non-elevated session - the option would disappear for exactly the people who can use it.

### How it works

- `RequestExecutionLevel user`, so double-clicking the setup never shows a UAC prompt.
- Picking "all users" from a non-elevated process relaunches the installer through
  `ExecShell "runas"` with `/AllUsers`; the elevated instance picks the choice back up.
  Cancelling UAC simply aborts, the standard NSIS pattern.
- All registry access goes through `SHCTX`, which follows `SetShellVarContext`, so the
  mode decides HKLM vs HKCU instead of a second code path. This includes
  `Software\Classes` for the NppShell context-menu CLSID (`HKCR` is HKLM-only and would
  fail silently for a per-user install), and `MEMENTO_REGISTRY_ROOT`.
- `InstallDirRegKey` had to go: it only accepts a literal root and predates `SHCTX`. The
  previous install directory is now read back manually in `.onInit`, after the mode is known
  and unless the user passed `/D=`.
- The uninstaller records which mode installed it and cleans the matching hive and shortcut
  scope. It identifies itself by *both* the recorded mode and the recorded install path, so
  a per-user and an all-users installation can coexist without one uninstaller clearing the
  other's keys.
- **No C++ changes.** `Parameters.cpp` already switches the configuration to `%APPDATA%`
  whenever `notepad++.exe` is not under Program Files, which is exactly the per-user case.

Silent installs take `/CurrentUser` and `/AllUsers`. `/AllUsers` from a non-elevated silent
run exits with **740** (`ERROR_ELEVATION_REQUIRED`) instead of quietly falling back to a
per-user install, so a deployment script that only checks the exit code cannot get a false
positive.

### Why this touches five files

It is one feature, but the install scope is a cross-cutting property: the mode is decided in
`nppSetup.nsi`, the registry writes live in `tools.nsh`, the shortcut scope in
`mainSectionFuncs.nsh`, the Memento root in `globalDef.nsh`, and the matching cleanup in
`uninstall.nsh`. Splitting it would leave the tree in a state where the modes disagree about
where things belong. The all-users path is deliberately left behaving exactly as it does today.

### Testing

Built with NSIS 3.11: x86, x64 and ARM64 all compile with no new warnings (the x86
`warning 6010: RegisterMSIX not referenced` is present on master too).

Full per-user cycle, x64, on Windows 11 with an existing all-users installation present, so
that the two modes could be checked for interference:

| | Result |
|---|---|
| `/S /CurrentUser` | exit 0, installed into `%LOCALAPPDATA%\Notepad++` |
| `HKCU\Software\Notepad++` | `InstallMode=CurrentUser`, install path recorded |
| Uninstall entry, context-menu CLSID | present under HKCU, pointing at the per-user path |
| **HKLM** | byte-identical to the pre-install snapshot - the per-user install never touches it |
| `uninstall.exe` | carries an `asInvoker` manifest |
| Launch | starts normally |
| `uninstall.exe /S` | exit 0; install directory and all four HKCU keys removed |
| After uninstall | system back to the pre-install state; the all-users installation untouched |

No UAC prompt appeared at any point in that cycle.

`/S /AllUsers` from a non-elevated process exits with 740 and writes nothing.

### Known limitations

- On genuine 32-bit Windows, a per-user install does not get the Explorer context menu.
  `regsvr32` runs NppShell's `DllRegisterServer`, which writes under HKLM, so it is used
  for an all-users install only; and the entries the script writes itself through `SHCTX`
  carry the 64-bit key name and CLSID, which the x86 DLL does not answer to. On 64-bit
  Windows - where the 32-bit setup ships the x64 NppShell anyway - those `SHCTX` entries
  are the correct ones and the context menu works in both modes.
- The MSIX sparse package is not removed on uninstall. That is existing behaviour, not
  something this change introduces.
- The MSI packages are untouched: per @donho in #17169 the MSI is for enterprise IT
  deployment, which is a different delivery path from a user installing for themselves.

<!-- AI disclosure, as asked for in the PR template -->
This was written with the help of Claude Code (Claude Opus 5): the NSIS changes, the
review passes over them and the test runs. Every claim above was verified against a real
build rather than taken on trust.

fix #15182
