### PR TITLE
Update Slovak language items for enable/disable

### DIFF
--- a/PowerEditor/installer/nativeLang/slovak.xml
+++ b/PowerEditor/installer/nativeLang/slovak.xml
@@ -621,8 +621,8 @@
 				<Item id="5508" name="Ďa&amp;lší"/>
 				<Item id="5509" name="Verzia zoznamu doplnkov:"/>
 				<Item id="5511" name="Repozitár zoznamu doplnkov"/>
-				<Item id="5512" name="&amp;Vypnuté"/>
-				<Item id="5513" name="&amp;Zapnuté"/>
+				<Item id="5512" name="&amp;Vypnúť"/>
+				<Item id="5513" name="&amp;Zapnúť"/>
 				<Item id="2" name="Zavrieť"/>
 			</PluginsAdminDlg>
 


### PR DESCRIPTION
Just a minor change: instead of using imperative forms, the terms “Activate” and “Deactivate” were chosen in the past tense.

Maybe I'd leave the terms “Aktivovať” and “Deaktivovať” in Slovak
Alternatively: "Povoliť" and "Zakázať" they're more appropriate for add-ons.

fix f850331
