### PR TITLE
Fix dark mode tone synchronization with editor background fix issue 

### DIFF
--- a/PowerEditor/src/NppDarkMode.cpp
+++ b/PowerEditor/src/NppDarkMode.cpp
@@ -1,4 +1,4 @@
-﻿// This file is part of Notepad++ project
+// This file is part of Notepad++ project
 // Copyright (C)2021 adzm / Adam D. Walling
 
 // This program is free software: you can redistribute it and/or modify
@@ -211,10 +211,10 @@ namespace NppDarkMode
 
 	// black (default)
 	static constexpr Colors darkColors{
-		HEXRGB(0x202020),   // background
-		HEXRGB(0x383838),   // softerBackground
+		HEXRGB(0x000000),   // background
+		HEXRGB(0x000000),   // softerBackground
 		HEXRGB(0x454545),   // hotBackground
-		HEXRGB(0x202020),   // pureBackground
+		HEXRGB(0x000000),   // pureBackground
 		HEXRGB(0xB00000),   // errorBackground
 		HEXRGB(0xE0E0E0),   // textColor
 		HEXRGB(0xC0C0C0),   // darkerTextColor
@@ -525,7 +525,7 @@ namespace NppDarkMode
 		HWND hwndRoot = GetAncestor(hwnd, GA_ROOTOWNER);
 
 		// wParam == true, will reset style and toolbar icon
-		::SendMessage(hwndRoot, NPPM_INTERNAL_REFRESHDARKMODE, static_cast<WPARAM>(!forceRefresh), 0);
+		::SendMessage(hwndRoot, NPPM_INTERNAL_REFRESHDARKMODE, static_cast<WPARAM>(supportedChanged || forceRefresh), 0);
 	}
 
 	void initAdvancedOptions()

--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -684,7 +684,7 @@ struct AdvancedOptions final
 	AdvOptDefaults _darkDefaults{ L"DarkModeDefault.xml", { toolBarStatusType::TB_SMALL, FluentColor::defaultColor, 0, false }, 2, false };
 	AdvOptDefaults _lightDefaults{ L"", { toolBarStatusType::TB_STANDARD, FluentColor::defaultColor, 0, false }, 0, true };
 
-	bool _enableWindowsMode = false;
+	bool _enableWindowsMode = true;
 };
 
 struct DarkModeConf final

--- a/PowerEditor/visual.net/notepadPlus.vcxproj
+++ b/PowerEditor/visual.net/notepadPlus.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -370,4 +370,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemDefinitionGroup>
+    <PostBuildEvent>
+      <Command>xcopy /Y /S /I "$(ProjectDir)..\installer\themes\*" "$(OutDir)themes\"
+copy /Y "$(ProjectDir)..\src\stylers.model.xml" "$(OutDir)stylers.model.xml"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Description

Fixes an issue where changing the Dark Mode tone did not properly update the editor background and related editor colors.


Fix #18266 