### PR TITLE
Fix loading session for alone subview and doc/tab with implicit name

### DIFF
--- a/PowerEditor/src/NppIO.cpp
+++ b/PowerEditor/src/NppIO.cpp
@@ -2664,6 +2664,8 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 	switchEditViewTo(SUB_VIEW);	//open files in sub
 	int subIndex2Update = -1;
 
+	bool bQueryMainViewForClones = (session.nbMainFiles() > 0); // only if it has real docs/tabs (a view has also its implicit doc/tab otherwise)
+
 	for (size_t k = 0 ; k < session.nbSubFiles() ; )
 	{
 		const wchar_t *pFn = session._subViewFiles[k]._fileName.c_str();
@@ -2685,7 +2687,9 @@ bool Notepad_plus::loadSession(Session & session, bool isSnapshotMode, const wch
 		if (doesFileExist(pFn) || (isSnapshotMode && doesFileExist(session._subViewFiles[k]._backupFilePath.c_str())))
 		{
 			//check if already open in main. If so, clone
-			BufferID clonedBuf = _mainDocTab.findBufferByName(pFn);
+			BufferID clonedBuf = BUFFER_INVALID;
+			if (bQueryMainViewForClones)
+				clonedBuf = _mainDocTab.findBufferByName(pFn);
 			if (clonedBuf != BUFFER_INVALID)
 			{
 				loadBufferIntoView(clonedBuf, SUB_VIEW);


### PR DESCRIPTION
In an edge case, when the loaded session contained docs only for the subview and one of the docs had the same name as the implicit doc from the mainview ("new 1"), unsaved data from the subview doc backup snapshot had been lost due to invalid cloning of the mainview implicit empty doc instead.

- [x] I have read [contributing guidelines](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md)

fix #18294
