### PR TITLE
Change Dark Mode default to "Follow Windows"

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -684,7 +684,7 @@ struct AdvancedOptions final
 	AdvOptDefaults _darkDefaults{ L"DarkModeDefault.xml", { toolBarStatusType::TB_SMALL, FluentColor::defaultColor, 0, false }, 2, false };
 	AdvOptDefaults _lightDefaults{ L"", { toolBarStatusType::TB_STANDARD, FluentColor::defaultColor, 0, false }, 0, true };
 
-	bool _enableWindowsMode = false;
+	bool _enableWindowsMode = true;
 };
 
 struct DarkModeConf final


### PR DESCRIPTION
## Problem

When Notepad++ is installed for the first time, Dark Mode defaults to
"Light mode" even if the user has Windows dark mode enabled in Settings.

## Fix

Change `_enableWindowsMode` default from `false` to `true` in
`Parameters.h` so that Notepad++ follows the Windows theme on first launch.

The existing fallback logic already handles older Windows versions safely:
- On Windows 10+: follows Windows dark/light mode automatically
- On Windows < 10: flag is reset to `false` (no change in behavior)

## Changes

One line change in `PowerEditor/src/Parameters.h`:
```cpp
// Before
bool _enableWindowsMode = false;

// After  
bool _enableWindowsMode = true;
```

Fixes #18301