### PR TITLE
[xml] Update Corsican translation for Notepad++ 8.9.8

### DIFF
--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2026 by Patriccollu di Santa Maria è Sichè: Feb. 10th (v8.9.1+), Mar. 10th (v8.9.2+), May 17th (v8.9.5+),
-			  June 24th (v8.9.6.4+), Aug. 20th (v8.9.7+)
+			  June 24th (v8.9.6.4+), Aug. 28th (v8.9.8+)
 	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: Jan. 15th (v8.7.6), Mar. 1st (v8.7.8), Apr. 20th (v8.8),
 			  June 26th (v8.8.1+), July 24th (v8.8.3+), Sep. 30th (v8.8.5+), Dec. 12th (v8.8.9+)
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
@@ -38,7 +38,7 @@ Additionnal information about Corsican localization:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.9.7">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.9.8">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -1434,6 +1434,7 @@ Additionnal information about Corsican localization:
 					<Item id="6346" name="Fighjulata à a cartugrafia di u ducumentu"/>
 					<Item id="6360" name="Ammutulisce tutti i soni"/>
 					<Item id="6361" name="Attivà u dialogu per cunfirmà l’arregistramentu di tutti i schedarii"/>
+					<Item id="6366" name="Permette u caricamentu di i liami simbulichi nant’à u panellu di u cartulare cum’è spaziu di travagliu"/>
 				</MISC>
 			</Preference>
 			<MultiMacro title="Lancià una prucedura parechje volte">
@@ -1501,7 +1502,7 @@ Pudete attivà torna st’ozzione in u dialogu di e preferenze."/>
 				<Item id="7" name="&amp;Nò"/>
 				<Item id="4" name="S&amp;empre sì"/>
 			</DoSaveAll><!-- HowToReproduce: Check the "Enable Save All confirm dialog" checkbox in Preference->MISC, now click "Save all" -->
-			<NetworkPathWarning title="Caricamentu di a sessione Notepad++" title2="Liame file:// clicchevule">
+			<NetworkPathWarning title="Caricamentu di a sessione Notepad++" title2="Liame file:// clicchevule" title3="Caricamentu di toolbarButtonsConf.xml" title4="Caricamentu di u schedariu XML di u panellu di prughjettu">
 				<Item id="1771" name="Avertimentu apprupositu di u chjassu di reta :
 
 $STR_REPLACE$
@@ -1679,6 +1680,9 @@ Per raghjoni di sicurità, l’integrità di shortcuts.xml hà da esse verificat
 			<ShortcutsXmlTampered title="Avertimentu di sicurità" message="U schedariu shortcuts.xml pare esse statu mudificatu manualmente.
 
 Per raghjoni di sicurità, ci vole à esaminà u schedariu shortcuts.xml chì hè apertu. S’è u so cuntenutu hè currettu, impiegate l’ozzione « Cunvalidà shortcuts.xml » di u listinu « Lancià » per cunfirmallu."/>
+			<SymlinkLoadingWarning title="Avertimentu : u caricamentu di i liami simbolichi pò cagiunà un blucchime" message="L’attivazione di u caricamentu di i liami simbulichi in u cartulare cum’è spaziu di travagliu pò fà entre Notepad++ in un ciclu senza fine è si finisce da un blucchime.
+Què pò accade quandu certi liami simbolichi si facenu versu cartulari di livellu superiore o creanu referenze circulare.
+Cuntinuate solu s’è vo capite i risichi."/>
 		</MessageBox>
 		<ClipboardHistory>
 			<PanelTitle name="Cronolugia di u preme’papei"/>

--- a/PowerEditor/installer/nativeLang/corsican.xml
+++ b/PowerEditor/installer/nativeLang/corsican.xml
@@ -13,7 +13,7 @@ Additionnal information about Corsican localization:
 2. History of Corsican translation for Notepad++:
 
 	- Updated in 2026 by Patriccollu di Santa Maria è Sichè: Feb. 10th (v8.9.1+), Mar. 10th (v8.9.2+), May 17th (v8.9.5+),
-			  June 24th (v8.9.6.4+)
+			  June 24th (v8.9.6.4+), Aug. 20th (v8.9.7+)
 	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: Jan. 15th (v8.7.6), Mar. 1st (v8.7.8), Apr. 20th (v8.8),
 			  June 26th (v8.8.1+), July 24th (v8.8.3+), Sep. 30th (v8.8.5+), Dec. 12th (v8.8.9+)
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Feb. 5th (v8.6.3), Mar. 10th (v8.6.5), Apr. 30th (v8.6.6),
@@ -38,7 +38,7 @@ Additionnal information about Corsican localization:
 	https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/blob/ceppu/Prughjetti/Notepad%2B%2B/Traduzzione.md
 -->
 <NotepadPlus>
-	<Native-Langue name="Corsu" filename="corsican.xml" version="8.9.6.4">
+	<Native-Langue name="Corsu" filename="corsican.xml" version="8.9.7">
 		<Menu>
 			<Main>
 				<!-- Main Menu Entries -->
@@ -645,7 +645,7 @@ Additionnal information about Corsican localization:
 				<Item id="2" name="C&amp;hjode"/>
 			</SHA512FromTextDlg>
 
-			<PluginsAdminDlg title="Ghjestione di i moduli d’estensione" titleAvailable="Dispunibule" titleUpdates="Rinnovi" titleInstalled="Installati" titleIncompatible="Incumpatibile">
+			<PluginsAdminDlg title="Ghjestione di i moduli d’estensione" titleAvailable="Dispunibule" titleUpdates="Rinnovi" titleInstalled="Installati" titleIncompatible="Incumpatibile" titleDisabled="Disattivatu">
 				<ColumnPlugin name="Moduli d’estensione"/>
 				<ColumnVersion name="Versione"/>
 				<Item id="5501" name="&amp;Circà :"/>
@@ -655,6 +655,8 @@ Additionnal information about Corsican localization:
 				<Item id="5508" name="&amp;Seguente"/>
 				<Item id="5509" name="Versione di a lista di moduli :"/>
 				<Item id="5511" name="Dipositu di a lista di i moduli"/>
+				<Item id="5512" name="&amp;Disattivà"/>
+				<Item id="5513" name="A&amp;ttivà"/>
 				<Item id="2" name="Chjode"/>
 			</PluginsAdminDlg>
 
@@ -1347,8 +1349,8 @@ Additionnal information about Corsican localization:
 					<Item id="6252" name="Principiu"/>
 					<Item id="6255" name="Fine"/>
 					<Item id="6256" name="Permette nant’à parechje linee"/>
-					<Item id="6257" name="sta linea hè unica"/>
-					<Item id="6258" name="è avà ùn hè più sola, ci sò duie linee ;-)"/>
+					<Item id="6257" name="sta linea hè unica"/><!-- Linea assente in u schedariu inglese -->
+					<Item id="6258" name="è avà ùn hè più sola, ci sò duie linee ;-)"/><!-- idem -->
 					<Item id="6161" name="Lista di caratteri delimitatori di parolla"/>
 					<Item id="6162" name="Impiegà a lista predefinita di caratteri delimitatori di parolla tale è quale"/>
 					<Item id="6163" name="Aghjunghje u vostru caratteru cum’è una parte di parolla
@@ -1499,6 +1501,18 @@ Pudete attivà torna st’ozzione in u dialogu di e preferenze."/>
 				<Item id="7" name="&amp;Nò"/>
 				<Item id="4" name="S&amp;empre sì"/>
 			</DoSaveAll><!-- HowToReproduce: Check the "Enable Save All confirm dialog" checkbox in Preference->MISC, now click "Save all" -->
+			<NetworkPathWarning title="Caricamentu di a sessione Notepad++" title2="Liame file:// clicchevule">
+				<Item id="1771" name="Avertimentu apprupositu di u chjassu di reta :
+
+$STR_REPLACE$
+
+Caricallu sfurzerà Windows à autenticassi autumaticamente à stu servitore, ciò chì risicheghja à espone e vostre identificazioni di cunnessione Windows.
+Caricallu quantunque ?"/>
+				<Item id="2" name="&amp;Tralascià"/>
+				<Item id="6" name="&amp;Caricà"/>
+				<Item id="7" name="&amp;Sempre tralascià u chjassu di reta"/>
+				<Item id="4" name="S&amp;empre caricà u chjassu di reta"/>
+			</NetworkPathWarning>
 
 			<DebugInfo title="Infurmazioni di spannatura">
 				<Item id="1752" name="&amp;Cupià l’infurmazioni in u preme’papei"/>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** localization to take into account the following commits:

 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/a14d6ff27b3b394de73de68ff88ad44b31157521 Add "nth of count" info to incremental search
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/6d76537c6e932aafeb3b17e67f79dc910494d8c1 Make "Security Warning" for shortcuts.xml more explicit
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/bb7d108799bdbc899ca87e7481f42c2ad4f6fa5d Fix set Proxy Settings in portable mode issue
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/c9a65d9c9d56b104cd785e658d89b8f7cdffb535 Fix potential exposure of Windows login info via UNC path in session.xml
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/9d5eb7e47afc74523a2085ed25467634f6c4adc5 Fix potential exposure of Windows login info via UNC path of clickable link
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/15f32ff6a4ef37c2a860c799f478c5c6441ac574 Add plugin deactivation ability
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/f85033104f046c9e74b4ca9ee7fd2d9bbb9fba4d Update localization files

Updated on August 28<sup>th</sup> to add:
 * https://github.com/notepad-plus-plus/notepad-plus-plus/commit/c057c08028b4d40490c6e21bf87a18e95cc3e318 Update localization files

Best regards,
Patriccollu.