### PR TITLE
Fix stale Updates notification caused by outdated Disabled copy

### DIFF
--- a/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
+++ b/PowerEditor/src/WinControls/PluginsAdmin/pluginsAdmin.cpp
@@ -1018,7 +1018,11 @@ bool PluginsAdminDlg::initDisabledPluginList()
 
 			// same mechanism as the Installed tab: if the on-disk version is older
 			// than the one in the plugin list, surface it on the Updates tab too
-			if (foundInAvailable && pui->_version < foundInAvailable->_version)
+			// but only if this plugin has no active (loaded) copy in _installedList.
+			int installedListIndex = 0;
+			bool hasActiveInstalledCopy = (_installedList.findPluginInfoFromFolderName(folderName, installedListIndex) != nullptr);
+
+			if (!hasActiveInstalledCopy && foundInAvailable && pui->_version < foundInAvailable->_version)
 			{
 				PluginUpdateInfo* pui2 = new PluginUpdateInfo(*foundInAvailable);
 				_updateList.pushBack(pui2);


### PR DESCRIPTION
Problem: The "Updates" tab kept showing an update notification for a plugin whose older version was present in plugins\disabled, even when the current/newer version of that plugin was already installed and active (plugins\).

Root cause: initDisabledPluginList() compared the disabled copy's version only against the version in _availableList, without checking whether the plugin already had an active entry in _installedList — which is the correct source of truth for the Updates notification (already handled in loadFromPluginInfos(), which runs earlier in the updateList() call sequence).

Fix: Before adding an entry from the disabled copy to _updateList, check whether an active copy already exists in _installedList (via findPluginInfoFromFolderName). If it does, skip adding the entry, since the Updates decision has already been made based on the Installed version.

Affected file: pluginsAdmin.cpp, method initDisabledPluginList() — 1 line removed, 5 lines added.

Fix #18312