### PR TITLE
[xml] Fix Turkish translation for "Trim both and EOL to Space"

### DIFF
--- a/PowerEditor/installer/nativeLang/turkish.xml
+++ b/PowerEditor/installer/nativeLang/turkish.xml
@@ -184,7 +184,7 @@
 					<Item id="42042" name="Sondaki Boşluğu Kırp"/>
 					<Item id="42043" name="Baştaki ve Sondaki Boşluğu Kırp"/>
 					<Item id="42044" name="Satır Sonunu Boşluğa Çevir"/>
-					<Item id="42045" name="Baştaki, Sondaki ve Satır Sonu Boşluğunu Kırp"/>
+					<Item id="42045" name="Baştaki ve Sondaki Boşlukları Kırp, Satır Sonunu Boşluğa Çevir"/>
 					<Item id="42046" name="Sekmeyi Boşluğa Çevir"/>
 					<Item id="42054" name="Sekme Boşluğu (Tümünde)"/>
 					<Item id="42053" name="Sekme Boşluğu (Sonda)"/>


### PR DESCRIPTION
### Description
Fixed a translation error in `turkish.xml` under the "Blank Operations" menu.

The previous translation incorrectly used "kırp" (trim) for the EOL part and missed the "to Space" conversion, causing confusion about the menu's actual behavior.

* **Original (EN):** `Trim both and EOL to Space`
* **Old (TR):** `Baştaki, sondaki ve satır sonu boşluğunu kırp`
* **New (TR):** `Baştaki ve sondaki boşlukları kırp, satır sonunu boşluğa çevir`