### PR TITLE
Update menu name for Encoding > Western European > OEM-US to include : CP437

### DIFF
--- a/PowerEditor/src/Notepad_plus.rc
+++ b/PowerEditor/src/Notepad_plus.rc
@@ -978,7 +978,7 @@ BEGIN
                 MENUITEM "OEM 858",             IDM_FORMAT_DOS_858
                 MENUITEM "OEM 860 : Portuguese",  IDM_FORMAT_DOS_860
                 MENUITEM "OEM 863 : French",      IDM_FORMAT_DOS_863
-                MENUITEM "OEM-US",              IDM_FORMAT_DOS_437
+                MENUITEM "OEM-US : CP437",      IDM_FORMAT_DOS_437
                 MENUITEM "Windows-1252",        IDM_FORMAT_WIN_1252
             END
 


### PR DESCRIPTION
clarify for people who only know it as CP437, by labeling it as `OEM-US : CP437` (matches the syntax of the other OEM ones above it, which clarify with space-colon-space and the description)

- [x] I have read [contributing guidelines](https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/CONTRIBUTING.md)

fix #17988
